### PR TITLE
Match all timers to a GP16 timer

### DIFF
--- a/data/chips/STM32F030C6.yaml
+++ b/data/chips/STM32F030C6.yaml
@@ -63,18 +63,23 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci2_v2_2

--- a/data/chips/STM32F030C8.yaml
+++ b/data/chips/STM32F030C8.yaml
@@ -71,24 +71,31 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci2_v2_2

--- a/data/chips/STM32F030CC.yaml
+++ b/data/chips/STM32F030CC.yaml
@@ -71,27 +71,35 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci3_v1_0

--- a/data/chips/STM32F030F4.yaml
+++ b/data/chips/STM32F030F4.yaml
@@ -63,18 +63,23 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci2_v2_2

--- a/data/chips/STM32F030K6.yaml
+++ b/data/chips/STM32F030K6.yaml
@@ -63,18 +63,23 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci2_v2_2

--- a/data/chips/STM32F030R8.yaml
+++ b/data/chips/STM32F030R8.yaml
@@ -71,24 +71,31 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci2_v2_2

--- a/data/chips/STM32F030RC.yaml
+++ b/data/chips/STM32F030RC.yaml
@@ -71,27 +71,35 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci3_v1_0

--- a/data/chips/STM32F031C4.yaml
+++ b/data/chips/STM32F031C4.yaml
@@ -60,21 +60,27 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci2_v2_2

--- a/data/chips/STM32F031C6.yaml
+++ b/data/chips/STM32F031C6.yaml
@@ -60,21 +60,27 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci2_v2_2

--- a/data/chips/STM32F031E6.yaml
+++ b/data/chips/STM32F031E6.yaml
@@ -60,21 +60,27 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci2_v2_2

--- a/data/chips/STM32F031F4.yaml
+++ b/data/chips/STM32F031F4.yaml
@@ -60,21 +60,27 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci2_v2_2

--- a/data/chips/STM32F031F6.yaml
+++ b/data/chips/STM32F031F6.yaml
@@ -60,21 +60,27 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci2_v2_2

--- a/data/chips/STM32F031G4.yaml
+++ b/data/chips/STM32F031G4.yaml
@@ -60,21 +60,27 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci2_v2_2

--- a/data/chips/STM32F031G6.yaml
+++ b/data/chips/STM32F031G6.yaml
@@ -60,21 +60,27 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci2_v2_2

--- a/data/chips/STM32F031K4.yaml
+++ b/data/chips/STM32F031K4.yaml
@@ -60,21 +60,27 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci2_v2_2

--- a/data/chips/STM32F031K6.yaml
+++ b/data/chips/STM32F031K6.yaml
@@ -62,21 +62,27 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci2_v2_2

--- a/data/chips/STM32F038C6.yaml
+++ b/data/chips/STM32F038C6.yaml
@@ -60,21 +60,27 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci2_v2_2

--- a/data/chips/STM32F038E6.yaml
+++ b/data/chips/STM32F038E6.yaml
@@ -60,21 +60,27 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci2_v2_2

--- a/data/chips/STM32F038F6.yaml
+++ b/data/chips/STM32F038F6.yaml
@@ -60,21 +60,27 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci2_v2_2

--- a/data/chips/STM32F038G6.yaml
+++ b/data/chips/STM32F038G6.yaml
@@ -60,21 +60,27 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci2_v2_2

--- a/data/chips/STM32F038K6.yaml
+++ b/data/chips/STM32F038K6.yaml
@@ -60,21 +60,27 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci2_v2_2

--- a/data/chips/STM32F042C4.yaml
+++ b/data/chips/STM32F042C4.yaml
@@ -70,21 +70,27 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32F042C6.yaml
+++ b/data/chips/STM32F042C6.yaml
@@ -70,21 +70,27 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32F042F4.yaml
+++ b/data/chips/STM32F042F4.yaml
@@ -64,21 +64,27 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32F042F6.yaml
+++ b/data/chips/STM32F042F6.yaml
@@ -64,21 +64,27 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32F042G4.yaml
+++ b/data/chips/STM32F042G4.yaml
@@ -64,21 +64,27 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32F042G6.yaml
+++ b/data/chips/STM32F042G6.yaml
@@ -64,21 +64,27 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32F042K4.yaml
+++ b/data/chips/STM32F042K4.yaml
@@ -66,21 +66,27 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32F042K6.yaml
+++ b/data/chips/STM32F042K6.yaml
@@ -66,21 +66,27 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32F042T6.yaml
+++ b/data/chips/STM32F042T6.yaml
@@ -64,21 +64,27 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32F048C6.yaml
+++ b/data/chips/STM32F048C6.yaml
@@ -64,21 +64,27 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32F048G6.yaml
+++ b/data/chips/STM32F048G6.yaml
@@ -60,21 +60,27 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32F048T6.yaml
+++ b/data/chips/STM32F048T6.yaml
@@ -60,21 +60,27 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32F051C4.yaml
+++ b/data/chips/STM32F051C4.yaml
@@ -75,27 +75,35 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32F051C6.yaml
+++ b/data/chips/STM32F051C6.yaml
@@ -75,27 +75,35 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32F051C8.yaml
+++ b/data/chips/STM32F051C8.yaml
@@ -83,27 +83,35 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32F051K4.yaml
+++ b/data/chips/STM32F051K4.yaml
@@ -75,27 +75,35 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32F051K6.yaml
+++ b/data/chips/STM32F051K6.yaml
@@ -75,27 +75,35 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32F051K8.yaml
+++ b/data/chips/STM32F051K8.yaml
@@ -75,27 +75,35 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32F051R4.yaml
+++ b/data/chips/STM32F051R4.yaml
@@ -77,27 +77,35 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32F051R6.yaml
+++ b/data/chips/STM32F051R6.yaml
@@ -77,27 +77,35 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32F051R8.yaml
+++ b/data/chips/STM32F051R8.yaml
@@ -83,27 +83,35 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32F051T8.yaml
+++ b/data/chips/STM32F051T8.yaml
@@ -73,27 +73,35 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32F058C8.yaml
+++ b/data/chips/STM32F058C8.yaml
@@ -81,27 +81,35 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32F058R8.yaml
+++ b/data/chips/STM32F058R8.yaml
@@ -83,27 +83,35 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32F058T8.yaml
+++ b/data/chips/STM32F058T8.yaml
@@ -73,27 +73,35 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32F070C6.yaml
+++ b/data/chips/STM32F070C6.yaml
@@ -63,18 +63,23 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci2_v2_2

--- a/data/chips/STM32F070CB.yaml
+++ b/data/chips/STM32F070CB.yaml
@@ -71,27 +71,35 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci2_v2_2

--- a/data/chips/STM32F070F6.yaml
+++ b/data/chips/STM32F070F6.yaml
@@ -63,18 +63,23 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci2_v2_2

--- a/data/chips/STM32F070RB.yaml
+++ b/data/chips/STM32F070RB.yaml
@@ -71,27 +71,35 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci2_v2_2

--- a/data/chips/STM32F071C8.yaml
+++ b/data/chips/STM32F071C8.yaml
@@ -85,30 +85,39 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32F071CB.yaml
+++ b/data/chips/STM32F071CB.yaml
@@ -87,30 +87,39 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32F071RB.yaml
+++ b/data/chips/STM32F071RB.yaml
@@ -83,30 +83,39 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32F071V8.yaml
+++ b/data/chips/STM32F071V8.yaml
@@ -85,30 +85,39 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32F071VB.yaml
+++ b/data/chips/STM32F071VB.yaml
@@ -85,30 +85,39 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32F072C8.yaml
+++ b/data/chips/STM32F072C8.yaml
@@ -89,30 +89,39 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32F072CB.yaml
+++ b/data/chips/STM32F072CB.yaml
@@ -91,30 +91,39 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32F072R8.yaml
+++ b/data/chips/STM32F072R8.yaml
@@ -87,30 +87,39 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32F072RB.yaml
+++ b/data/chips/STM32F072RB.yaml
@@ -91,30 +91,39 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32F072V8.yaml
+++ b/data/chips/STM32F072V8.yaml
@@ -89,30 +89,39 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32F072VB.yaml
+++ b/data/chips/STM32F072VB.yaml
@@ -89,30 +89,39 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32F078CB.yaml
+++ b/data/chips/STM32F078CB.yaml
@@ -87,30 +87,39 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32F078RB.yaml
+++ b/data/chips/STM32F078RB.yaml
@@ -85,30 +85,39 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32F078VB.yaml
+++ b/data/chips/STM32F078VB.yaml
@@ -85,30 +85,39 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32F091CB.yaml
+++ b/data/chips/STM32F091CB.yaml
@@ -92,30 +92,39 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32F091CC.yaml
+++ b/data/chips/STM32F091CC.yaml
@@ -92,30 +92,39 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32F091RB.yaml
+++ b/data/chips/STM32F091RB.yaml
@@ -90,30 +90,39 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32F091RC.yaml
+++ b/data/chips/STM32F091RC.yaml
@@ -94,30 +94,39 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32F091VB.yaml
+++ b/data/chips/STM32F091VB.yaml
@@ -90,30 +90,39 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32F091VC.yaml
+++ b/data/chips/STM32F091VC.yaml
@@ -92,30 +92,39 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32F098CC.yaml
+++ b/data/chips/STM32F098CC.yaml
@@ -92,30 +92,39 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32F098RC.yaml
+++ b/data/chips/STM32F098RC.yaml
@@ -94,30 +94,39 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32F098VC.yaml
+++ b/data/chips/STM32F098VC.yaml
@@ -92,30 +92,39 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32F100C4.yaml
+++ b/data/chips/STM32F100C4.yaml
@@ -64,27 +64,35 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci2_v1_2_F1

--- a/data/chips/STM32F100C6.yaml
+++ b/data/chips/STM32F100C6.yaml
@@ -64,27 +64,35 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci2_v1_2_F1

--- a/data/chips/STM32F100C8.yaml
+++ b/data/chips/STM32F100C8.yaml
@@ -72,30 +72,39 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci2_v1_2_F1

--- a/data/chips/STM32F100CB.yaml
+++ b/data/chips/STM32F100CB.yaml
@@ -72,30 +72,39 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci2_v1_2_F1

--- a/data/chips/STM32F100R4.yaml
+++ b/data/chips/STM32F100R4.yaml
@@ -66,27 +66,35 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci2_v1_2_F1

--- a/data/chips/STM32F100R6.yaml
+++ b/data/chips/STM32F100R6.yaml
@@ -66,27 +66,35 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci2_v1_2_F1

--- a/data/chips/STM32F100R8.yaml
+++ b/data/chips/STM32F100R8.yaml
@@ -74,30 +74,39 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci2_v1_2_F1

--- a/data/chips/STM32F100RB.yaml
+++ b/data/chips/STM32F100RB.yaml
@@ -74,30 +74,39 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci2_v1_2_F1

--- a/data/chips/STM32F100RC.yaml
+++ b/data/chips/STM32F100RC.yaml
@@ -85,42 +85,55 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2_F1

--- a/data/chips/STM32F100RD.yaml
+++ b/data/chips/STM32F100RD.yaml
@@ -85,42 +85,55 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2_F1

--- a/data/chips/STM32F100RE.yaml
+++ b/data/chips/STM32F100RE.yaml
@@ -85,42 +85,55 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2_F1

--- a/data/chips/STM32F100V8.yaml
+++ b/data/chips/STM32F100V8.yaml
@@ -72,30 +72,39 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci2_v1_2_F1

--- a/data/chips/STM32F100VB.yaml
+++ b/data/chips/STM32F100VB.yaml
@@ -72,30 +72,39 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci2_v1_2_F1

--- a/data/chips/STM32F100VC.yaml
+++ b/data/chips/STM32F100VC.yaml
@@ -85,42 +85,55 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2_F1

--- a/data/chips/STM32F100VD.yaml
+++ b/data/chips/STM32F100VD.yaml
@@ -85,42 +85,55 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2_F1

--- a/data/chips/STM32F100VE.yaml
+++ b/data/chips/STM32F100VE.yaml
@@ -85,42 +85,55 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2_F1

--- a/data/chips/STM32F100ZC.yaml
+++ b/data/chips/STM32F100ZC.yaml
@@ -85,42 +85,55 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2_F1

--- a/data/chips/STM32F100ZD.yaml
+++ b/data/chips/STM32F100ZD.yaml
@@ -85,42 +85,55 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2_F1

--- a/data/chips/STM32F100ZE.yaml
+++ b/data/chips/STM32F100ZE.yaml
@@ -85,42 +85,55 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2_F1

--- a/data/chips/STM32F101C4.yaml
+++ b/data/chips/STM32F101C4.yaml
@@ -57,9 +57,11 @@ peripherals:
   TIM2:
     address: 0x40000000
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci2_v1_1

--- a/data/chips/STM32F101C6.yaml
+++ b/data/chips/STM32F101C6.yaml
@@ -57,9 +57,11 @@ peripherals:
   TIM2:
     address: 0x40000000
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci2_v1_1

--- a/data/chips/STM32F101C8.yaml
+++ b/data/chips/STM32F101C8.yaml
@@ -70,12 +70,15 @@ peripherals:
   TIM2:
     address: 0x40000000
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci2_v1_1

--- a/data/chips/STM32F101CB.yaml
+++ b/data/chips/STM32F101CB.yaml
@@ -70,12 +70,15 @@ peripherals:
   TIM2:
     address: 0x40000000
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci2_v1_1

--- a/data/chips/STM32F101R4.yaml
+++ b/data/chips/STM32F101R4.yaml
@@ -57,9 +57,11 @@ peripherals:
   TIM2:
     address: 0x40000000
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci2_v1_1

--- a/data/chips/STM32F101R6.yaml
+++ b/data/chips/STM32F101R6.yaml
@@ -57,9 +57,11 @@ peripherals:
   TIM2:
     address: 0x40000000
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci2_v1_1

--- a/data/chips/STM32F101R8.yaml
+++ b/data/chips/STM32F101R8.yaml
@@ -68,12 +68,15 @@ peripherals:
   TIM2:
     address: 0x40000000
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci2_v1_1

--- a/data/chips/STM32F101RB.yaml
+++ b/data/chips/STM32F101RB.yaml
@@ -70,12 +70,15 @@ peripherals:
   TIM2:
     address: 0x40000000
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci2_v1_1

--- a/data/chips/STM32F101RC.yaml
+++ b/data/chips/STM32F101RC.yaml
@@ -85,21 +85,27 @@ peripherals:
   TIM2:
     address: 0x40000000
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_1

--- a/data/chips/STM32F101RD.yaml
+++ b/data/chips/STM32F101RD.yaml
@@ -85,21 +85,27 @@ peripherals:
   TIM2:
     address: 0x40000000
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_1

--- a/data/chips/STM32F101RE.yaml
+++ b/data/chips/STM32F101RE.yaml
@@ -85,21 +85,27 @@ peripherals:
   TIM2:
     address: 0x40000000
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_1

--- a/data/chips/STM32F101RF.yaml
+++ b/data/chips/STM32F101RF.yaml
@@ -85,39 +85,51 @@ peripherals:
   TIM10:
     address: 0x40015000
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40015400
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014c00
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_1

--- a/data/chips/STM32F101RG.yaml
+++ b/data/chips/STM32F101RG.yaml
@@ -85,39 +85,51 @@ peripherals:
   TIM10:
     address: 0x40015000
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40015400
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014c00
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_1

--- a/data/chips/STM32F101T4.yaml
+++ b/data/chips/STM32F101T4.yaml
@@ -57,9 +57,11 @@ peripherals:
   TIM2:
     address: 0x40000000
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci2_v1_1

--- a/data/chips/STM32F101T6.yaml
+++ b/data/chips/STM32F101T6.yaml
@@ -57,9 +57,11 @@ peripherals:
   TIM2:
     address: 0x40000000
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci2_v1_1

--- a/data/chips/STM32F101T8.yaml
+++ b/data/chips/STM32F101T8.yaml
@@ -60,12 +60,15 @@ peripherals:
   TIM2:
     address: 0x40000000
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci2_v1_1

--- a/data/chips/STM32F101TB.yaml
+++ b/data/chips/STM32F101TB.yaml
@@ -60,12 +60,15 @@ peripherals:
   TIM2:
     address: 0x40000000
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci2_v1_1

--- a/data/chips/STM32F101V8.yaml
+++ b/data/chips/STM32F101V8.yaml
@@ -68,12 +68,15 @@ peripherals:
   TIM2:
     address: 0x40000000
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci2_v1_1

--- a/data/chips/STM32F101VB.yaml
+++ b/data/chips/STM32F101VB.yaml
@@ -68,12 +68,15 @@ peripherals:
   TIM2:
     address: 0x40000000
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci2_v1_1

--- a/data/chips/STM32F101VC.yaml
+++ b/data/chips/STM32F101VC.yaml
@@ -85,21 +85,27 @@ peripherals:
   TIM2:
     address: 0x40000000
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_1

--- a/data/chips/STM32F101VD.yaml
+++ b/data/chips/STM32F101VD.yaml
@@ -85,21 +85,27 @@ peripherals:
   TIM2:
     address: 0x40000000
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_1

--- a/data/chips/STM32F101VE.yaml
+++ b/data/chips/STM32F101VE.yaml
@@ -85,21 +85,27 @@ peripherals:
   TIM2:
     address: 0x40000000
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_1

--- a/data/chips/STM32F101VF.yaml
+++ b/data/chips/STM32F101VF.yaml
@@ -85,39 +85,51 @@ peripherals:
   TIM10:
     address: 0x40015000
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40015400
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014c00
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_1

--- a/data/chips/STM32F101VG.yaml
+++ b/data/chips/STM32F101VG.yaml
@@ -85,39 +85,51 @@ peripherals:
   TIM10:
     address: 0x40015000
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40015400
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014c00
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_1

--- a/data/chips/STM32F101ZC.yaml
+++ b/data/chips/STM32F101ZC.yaml
@@ -85,21 +85,27 @@ peripherals:
   TIM2:
     address: 0x40000000
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_1

--- a/data/chips/STM32F101ZD.yaml
+++ b/data/chips/STM32F101ZD.yaml
@@ -85,21 +85,27 @@ peripherals:
   TIM2:
     address: 0x40000000
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_1

--- a/data/chips/STM32F101ZE.yaml
+++ b/data/chips/STM32F101ZE.yaml
@@ -85,21 +85,27 @@ peripherals:
   TIM2:
     address: 0x40000000
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_1

--- a/data/chips/STM32F101ZF.yaml
+++ b/data/chips/STM32F101ZF.yaml
@@ -85,39 +85,51 @@ peripherals:
   TIM10:
     address: 0x40015000
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40015400
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014c00
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_1

--- a/data/chips/STM32F101ZG.yaml
+++ b/data/chips/STM32F101ZG.yaml
@@ -85,39 +85,51 @@ peripherals:
   TIM10:
     address: 0x40015000
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40015400
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014c00
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_1

--- a/data/chips/STM32F102C4.yaml
+++ b/data/chips/STM32F102C4.yaml
@@ -57,9 +57,11 @@ peripherals:
   TIM2:
     address: 0x40000000
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci2_v1_1

--- a/data/chips/STM32F102C6.yaml
+++ b/data/chips/STM32F102C6.yaml
@@ -57,9 +57,11 @@ peripherals:
   TIM2:
     address: 0x40000000
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci2_v1_1

--- a/data/chips/STM32F102C8.yaml
+++ b/data/chips/STM32F102C8.yaml
@@ -65,12 +65,15 @@ peripherals:
   TIM2:
     address: 0x40000000
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci2_v1_1

--- a/data/chips/STM32F102CB.yaml
+++ b/data/chips/STM32F102CB.yaml
@@ -65,12 +65,15 @@ peripherals:
   TIM2:
     address: 0x40000000
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci2_v1_1

--- a/data/chips/STM32F102R4.yaml
+++ b/data/chips/STM32F102R4.yaml
@@ -57,9 +57,11 @@ peripherals:
   TIM2:
     address: 0x40000000
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci2_v1_1

--- a/data/chips/STM32F102R6.yaml
+++ b/data/chips/STM32F102R6.yaml
@@ -57,9 +57,11 @@ peripherals:
   TIM2:
     address: 0x40000000
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci2_v1_1

--- a/data/chips/STM32F102R8.yaml
+++ b/data/chips/STM32F102R8.yaml
@@ -65,12 +65,15 @@ peripherals:
   TIM2:
     address: 0x40000000
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci2_v1_1

--- a/data/chips/STM32F102RB.yaml
+++ b/data/chips/STM32F102RB.yaml
@@ -65,12 +65,15 @@ peripherals:
   TIM2:
     address: 0x40000000
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci2_v1_1

--- a/data/chips/STM32F103C4.yaml
+++ b/data/chips/STM32F103C4.yaml
@@ -60,12 +60,15 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci2_v1_1

--- a/data/chips/STM32F103C6.yaml
+++ b/data/chips/STM32F103C6.yaml
@@ -62,12 +62,15 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci2_v1_1

--- a/data/chips/STM32F103C8.yaml
+++ b/data/chips/STM32F103C8.yaml
@@ -71,15 +71,19 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci2_v1_1

--- a/data/chips/STM32F103CB.yaml
+++ b/data/chips/STM32F103CB.yaml
@@ -73,15 +73,19 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci2_v1_1

--- a/data/chips/STM32F103R4.yaml
+++ b/data/chips/STM32F103R4.yaml
@@ -62,12 +62,15 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci2_v1_1

--- a/data/chips/STM32F103R6.yaml
+++ b/data/chips/STM32F103R6.yaml
@@ -62,12 +62,15 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci2_v1_1

--- a/data/chips/STM32F103R8.yaml
+++ b/data/chips/STM32F103R8.yaml
@@ -73,15 +73,19 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci2_v1_1

--- a/data/chips/STM32F103RB.yaml
+++ b/data/chips/STM32F103RB.yaml
@@ -73,15 +73,19 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci2_v1_1

--- a/data/chips/STM32F103RC.yaml
+++ b/data/chips/STM32F103RC.yaml
@@ -97,27 +97,35 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_1

--- a/data/chips/STM32F103RD.yaml
+++ b/data/chips/STM32F103RD.yaml
@@ -97,27 +97,35 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_1

--- a/data/chips/STM32F103RE.yaml
+++ b/data/chips/STM32F103RE.yaml
@@ -97,27 +97,35 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_1

--- a/data/chips/STM32F103RF.yaml
+++ b/data/chips/STM32F103RF.yaml
@@ -95,45 +95,59 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40015000
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40015400
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014c00
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_1

--- a/data/chips/STM32F103RG.yaml
+++ b/data/chips/STM32F103RG.yaml
@@ -95,45 +95,59 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40015000
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40015400
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014c00
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_1

--- a/data/chips/STM32F103T4.yaml
+++ b/data/chips/STM32F103T4.yaml
@@ -60,12 +60,15 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci2_v1_1

--- a/data/chips/STM32F103T6.yaml
+++ b/data/chips/STM32F103T6.yaml
@@ -60,12 +60,15 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci2_v1_1

--- a/data/chips/STM32F103T8.yaml
+++ b/data/chips/STM32F103T8.yaml
@@ -63,15 +63,19 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci2_v1_1

--- a/data/chips/STM32F103TB.yaml
+++ b/data/chips/STM32F103TB.yaml
@@ -63,15 +63,19 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci2_v1_1

--- a/data/chips/STM32F103V8.yaml
+++ b/data/chips/STM32F103V8.yaml
@@ -73,15 +73,19 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci2_v1_1

--- a/data/chips/STM32F103VB.yaml
+++ b/data/chips/STM32F103VB.yaml
@@ -75,15 +75,19 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci2_v1_1

--- a/data/chips/STM32F103VC.yaml
+++ b/data/chips/STM32F103VC.yaml
@@ -97,27 +97,35 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_1

--- a/data/chips/STM32F103VD.yaml
+++ b/data/chips/STM32F103VD.yaml
@@ -97,27 +97,35 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_1

--- a/data/chips/STM32F103VE.yaml
+++ b/data/chips/STM32F103VE.yaml
@@ -97,27 +97,35 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_1

--- a/data/chips/STM32F103VF.yaml
+++ b/data/chips/STM32F103VF.yaml
@@ -95,45 +95,59 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40015000
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40015400
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014c00
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_1

--- a/data/chips/STM32F103VG.yaml
+++ b/data/chips/STM32F103VG.yaml
@@ -95,45 +95,59 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40015000
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40015400
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014c00
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_1

--- a/data/chips/STM32F103ZC.yaml
+++ b/data/chips/STM32F103ZC.yaml
@@ -97,27 +97,35 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_1

--- a/data/chips/STM32F103ZD.yaml
+++ b/data/chips/STM32F103ZD.yaml
@@ -97,27 +97,35 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_1

--- a/data/chips/STM32F103ZE.yaml
+++ b/data/chips/STM32F103ZE.yaml
@@ -97,27 +97,35 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_1

--- a/data/chips/STM32F103ZF.yaml
+++ b/data/chips/STM32F103ZF.yaml
@@ -97,45 +97,59 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40015000
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40015400
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014c00
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_1

--- a/data/chips/STM32F103ZG.yaml
+++ b/data/chips/STM32F103ZG.yaml
@@ -97,45 +97,59 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40015000
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40015400
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014c00
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_1

--- a/data/chips/STM32F105R8.yaml
+++ b/data/chips/STM32F105R8.yaml
@@ -88,24 +88,31 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_1

--- a/data/chips/STM32F105RB.yaml
+++ b/data/chips/STM32F105RB.yaml
@@ -88,24 +88,31 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_1

--- a/data/chips/STM32F105RC.yaml
+++ b/data/chips/STM32F105RC.yaml
@@ -88,24 +88,31 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_1

--- a/data/chips/STM32F105V8.yaml
+++ b/data/chips/STM32F105V8.yaml
@@ -90,24 +90,31 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_1

--- a/data/chips/STM32F105VB.yaml
+++ b/data/chips/STM32F105VB.yaml
@@ -90,24 +90,31 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_1

--- a/data/chips/STM32F105VC.yaml
+++ b/data/chips/STM32F105VC.yaml
@@ -88,24 +88,31 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_1

--- a/data/chips/STM32F107RB.yaml
+++ b/data/chips/STM32F107RB.yaml
@@ -87,24 +87,31 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_1

--- a/data/chips/STM32F107RC.yaml
+++ b/data/chips/STM32F107RC.yaml
@@ -87,24 +87,31 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_1

--- a/data/chips/STM32F107VB.yaml
+++ b/data/chips/STM32F107VB.yaml
@@ -87,24 +87,31 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_1

--- a/data/chips/STM32F107VC.yaml
+++ b/data/chips/STM32F107VC.yaml
@@ -89,24 +89,31 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F1:gptimer2_v1_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_1

--- a/data/chips/STM32F205RB.yaml
+++ b/data/chips/STM32F205RB.yaml
@@ -119,45 +119,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32F205RC.yaml
+++ b/data/chips/STM32F205RC.yaml
@@ -119,45 +119,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32F205RE.yaml
+++ b/data/chips/STM32F205RE.yaml
@@ -121,45 +121,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32F205RF.yaml
+++ b/data/chips/STM32F205RF.yaml
@@ -119,45 +119,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32F205RG.yaml
+++ b/data/chips/STM32F205RG.yaml
@@ -123,45 +123,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32F205VB.yaml
+++ b/data/chips/STM32F205VB.yaml
@@ -119,45 +119,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32F205VC.yaml
+++ b/data/chips/STM32F205VC.yaml
@@ -119,45 +119,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32F205VE.yaml
+++ b/data/chips/STM32F205VE.yaml
@@ -119,45 +119,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32F205VF.yaml
+++ b/data/chips/STM32F205VF.yaml
@@ -119,45 +119,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32F205VG.yaml
+++ b/data/chips/STM32F205VG.yaml
@@ -119,45 +119,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32F205ZC.yaml
+++ b/data/chips/STM32F205ZC.yaml
@@ -119,45 +119,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32F205ZE.yaml
+++ b/data/chips/STM32F205ZE.yaml
@@ -119,45 +119,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32F205ZF.yaml
+++ b/data/chips/STM32F205ZF.yaml
@@ -119,45 +119,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32F205ZG.yaml
+++ b/data/chips/STM32F205ZG.yaml
@@ -119,45 +119,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32F207IC.yaml
+++ b/data/chips/STM32F207IC.yaml
@@ -127,45 +127,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32F207IE.yaml
+++ b/data/chips/STM32F207IE.yaml
@@ -127,45 +127,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32F207IF.yaml
+++ b/data/chips/STM32F207IF.yaml
@@ -127,45 +127,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32F207IG.yaml
+++ b/data/chips/STM32F207IG.yaml
@@ -127,45 +127,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32F207VC.yaml
+++ b/data/chips/STM32F207VC.yaml
@@ -125,45 +125,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32F207VE.yaml
+++ b/data/chips/STM32F207VE.yaml
@@ -125,45 +125,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32F207VF.yaml
+++ b/data/chips/STM32F207VF.yaml
@@ -125,45 +125,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32F207VG.yaml
+++ b/data/chips/STM32F207VG.yaml
@@ -125,45 +125,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32F207ZC.yaml
+++ b/data/chips/STM32F207ZC.yaml
@@ -125,45 +125,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32F207ZE.yaml
+++ b/data/chips/STM32F207ZE.yaml
@@ -125,45 +125,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32F207ZF.yaml
+++ b/data/chips/STM32F207ZF.yaml
@@ -125,45 +125,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32F207ZG.yaml
+++ b/data/chips/STM32F207ZG.yaml
@@ -125,45 +125,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32F215RE.yaml
+++ b/data/chips/STM32F215RE.yaml
@@ -125,45 +125,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32F215RG.yaml
+++ b/data/chips/STM32F215RG.yaml
@@ -125,45 +125,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32F215VE.yaml
+++ b/data/chips/STM32F215VE.yaml
@@ -125,45 +125,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32F215VG.yaml
+++ b/data/chips/STM32F215VG.yaml
@@ -125,45 +125,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32F215ZE.yaml
+++ b/data/chips/STM32F215ZE.yaml
@@ -125,45 +125,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32F215ZG.yaml
+++ b/data/chips/STM32F215ZG.yaml
@@ -125,45 +125,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32F217IE.yaml
+++ b/data/chips/STM32F217IE.yaml
@@ -133,45 +133,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32F217IG.yaml
+++ b/data/chips/STM32F217IG.yaml
@@ -133,45 +133,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32F217VE.yaml
+++ b/data/chips/STM32F217VE.yaml
@@ -131,45 +131,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32F217VG.yaml
+++ b/data/chips/STM32F217VG.yaml
@@ -131,45 +131,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32F217ZE.yaml
+++ b/data/chips/STM32F217ZE.yaml
@@ -131,45 +131,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32F217ZG.yaml
+++ b/data/chips/STM32F217ZG.yaml
@@ -131,45 +131,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8F2:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32F301C6.yaml
+++ b/data/chips/STM32F301C6.yaml
@@ -90,21 +90,27 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32F301C8.yaml
+++ b/data/chips/STM32F301C8.yaml
@@ -92,21 +92,27 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32F301K6.yaml
+++ b/data/chips/STM32F301K6.yaml
@@ -89,21 +89,27 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32F301K8.yaml
+++ b/data/chips/STM32F301K8.yaml
@@ -89,21 +89,27 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32F301R6.yaml
+++ b/data/chips/STM32F301R6.yaml
@@ -90,21 +90,27 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32F301R8.yaml
+++ b/data/chips/STM32F301R8.yaml
@@ -90,21 +90,27 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32F302C6.yaml
+++ b/data/chips/STM32F302C6.yaml
@@ -94,21 +94,27 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32F302C8.yaml
+++ b/data/chips/STM32F302C8.yaml
@@ -96,21 +96,27 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32F302CB.yaml
+++ b/data/chips/STM32F302CB.yaml
@@ -109,27 +109,35 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32F302CC.yaml
+++ b/data/chips/STM32F302CC.yaml
@@ -109,27 +109,35 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32F302K6.yaml
+++ b/data/chips/STM32F302K6.yaml
@@ -91,21 +91,27 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32F302K8.yaml
+++ b/data/chips/STM32F302K8.yaml
@@ -91,21 +91,27 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32F302R6.yaml
+++ b/data/chips/STM32F302R6.yaml
@@ -94,21 +94,27 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32F302R8.yaml
+++ b/data/chips/STM32F302R8.yaml
@@ -94,21 +94,27 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32F302RB.yaml
+++ b/data/chips/STM32F302RB.yaml
@@ -109,27 +109,35 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32F302RC.yaml
+++ b/data/chips/STM32F302RC.yaml
@@ -109,27 +109,35 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32F302RD.yaml
+++ b/data/chips/STM32F302RD.yaml
@@ -121,27 +121,35 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32F302RE.yaml
+++ b/data/chips/STM32F302RE.yaml
@@ -121,27 +121,35 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32F302VB.yaml
+++ b/data/chips/STM32F302VB.yaml
@@ -109,27 +109,35 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32F302VC.yaml
+++ b/data/chips/STM32F302VC.yaml
@@ -111,27 +111,35 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32F302VD.yaml
+++ b/data/chips/STM32F302VD.yaml
@@ -127,27 +127,35 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32F302VE.yaml
+++ b/data/chips/STM32F302VE.yaml
@@ -127,27 +127,35 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32F302ZD.yaml
+++ b/data/chips/STM32F302ZD.yaml
@@ -125,27 +125,35 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32F302ZE.yaml
+++ b/data/chips/STM32F302ZE.yaml
@@ -125,27 +125,35 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32F303C6.yaml
+++ b/data/chips/STM32F303C6.yaml
@@ -90,27 +90,35 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32F303C8.yaml
+++ b/data/chips/STM32F303C8.yaml
@@ -92,27 +92,35 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32F303CB.yaml
+++ b/data/chips/STM32F303CB.yaml
@@ -130,33 +130,43 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32F303CC.yaml
+++ b/data/chips/STM32F303CC.yaml
@@ -130,33 +130,43 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32F303K6.yaml
+++ b/data/chips/STM32F303K6.yaml
@@ -89,27 +89,35 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32F303K8.yaml
+++ b/data/chips/STM32F303K8.yaml
@@ -89,27 +89,35 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32F303R6.yaml
+++ b/data/chips/STM32F303R6.yaml
@@ -90,27 +90,35 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32F303R8.yaml
+++ b/data/chips/STM32F303R8.yaml
@@ -90,27 +90,35 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32F303RB.yaml
+++ b/data/chips/STM32F303RB.yaml
@@ -130,33 +130,43 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32F303RC.yaml
+++ b/data/chips/STM32F303RC.yaml
@@ -130,33 +130,43 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32F303RD.yaml
+++ b/data/chips/STM32F303RD.yaml
@@ -144,33 +144,43 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32F303RE.yaml
+++ b/data/chips/STM32F303RE.yaml
@@ -144,33 +144,43 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32F303VB.yaml
+++ b/data/chips/STM32F303VB.yaml
@@ -130,33 +130,43 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32F303VC.yaml
+++ b/data/chips/STM32F303VC.yaml
@@ -132,33 +132,43 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32F303VD.yaml
+++ b/data/chips/STM32F303VD.yaml
@@ -150,36 +150,47 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM20:
     address: 0x40015000
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32F303VE.yaml
+++ b/data/chips/STM32F303VE.yaml
@@ -152,36 +152,47 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM20:
     address: 0x40015000
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32F303ZD.yaml
+++ b/data/chips/STM32F303ZD.yaml
@@ -148,36 +148,47 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM20:
     address: 0x40015000
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32F303ZE.yaml
+++ b/data/chips/STM32F303ZE.yaml
@@ -148,36 +148,47 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM20:
     address: 0x40015000
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32F318C8.yaml
+++ b/data/chips/STM32F318C8.yaml
@@ -92,21 +92,27 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32F318K8.yaml
+++ b/data/chips/STM32F318K8.yaml
@@ -87,21 +87,27 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32F328C8.yaml
+++ b/data/chips/STM32F328C8.yaml
@@ -90,27 +90,35 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32F334C4.yaml
+++ b/data/chips/STM32F334C4.yaml
@@ -93,27 +93,35 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32F334C6.yaml
+++ b/data/chips/STM32F334C6.yaml
@@ -93,27 +93,35 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32F334C8.yaml
+++ b/data/chips/STM32F334C8.yaml
@@ -95,27 +95,35 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32F334K4.yaml
+++ b/data/chips/STM32F334K4.yaml
@@ -92,27 +92,35 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32F334K6.yaml
+++ b/data/chips/STM32F334K6.yaml
@@ -92,27 +92,35 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32F334K8.yaml
+++ b/data/chips/STM32F334K8.yaml
@@ -92,27 +92,35 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32F334R6.yaml
+++ b/data/chips/STM32F334R6.yaml
@@ -93,27 +93,35 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32F334R8.yaml
+++ b/data/chips/STM32F334R8.yaml
@@ -93,27 +93,35 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32F358CC.yaml
+++ b/data/chips/STM32F358CC.yaml
@@ -130,33 +130,43 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32F358RC.yaml
+++ b/data/chips/STM32F358RC.yaml
@@ -130,33 +130,43 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32F358VC.yaml
+++ b/data/chips/STM32F358VC.yaml
@@ -130,33 +130,43 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32F373C8.yaml
+++ b/data/chips/STM32F373C8.yaml
@@ -112,45 +112,59 @@ peripherals:
   TIM12:
     address: 0x40001800
     kind: TIM1_8F37:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8F37:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F37:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8F37:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8F37:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8F37:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM18:
     address: 0x40009c00
     kind: TIM6_7F37:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM19:
     address: 0x40015c00
     kind: TIM1_8F37:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F37:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F37:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F37:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F37:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F37:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F37:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32F373CB.yaml
+++ b/data/chips/STM32F373CB.yaml
@@ -112,45 +112,59 @@ peripherals:
   TIM12:
     address: 0x40001800
     kind: TIM1_8F37:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8F37:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F37:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8F37:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8F37:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8F37:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM18:
     address: 0x40009c00
     kind: TIM6_7F37:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM19:
     address: 0x40015c00
     kind: TIM1_8F37:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F37:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F37:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F37:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F37:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F37:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F37:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32F373CC.yaml
+++ b/data/chips/STM32F373CC.yaml
@@ -112,45 +112,59 @@ peripherals:
   TIM12:
     address: 0x40001800
     kind: TIM1_8F37:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8F37:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F37:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8F37:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8F37:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8F37:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM18:
     address: 0x40009c00
     kind: TIM6_7F37:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM19:
     address: 0x40015c00
     kind: TIM1_8F37:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F37:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F37:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F37:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F37:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F37:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F37:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32F373R8.yaml
+++ b/data/chips/STM32F373R8.yaml
@@ -112,45 +112,59 @@ peripherals:
   TIM12:
     address: 0x40001800
     kind: TIM1_8F37:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8F37:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F37:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8F37:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8F37:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8F37:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM18:
     address: 0x40009c00
     kind: TIM6_7F37:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM19:
     address: 0x40015c00
     kind: TIM1_8F37:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F37:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F37:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F37:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F37:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F37:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F37:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32F373RB.yaml
+++ b/data/chips/STM32F373RB.yaml
@@ -112,45 +112,59 @@ peripherals:
   TIM12:
     address: 0x40001800
     kind: TIM1_8F37:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8F37:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F37:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8F37:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8F37:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8F37:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM18:
     address: 0x40009c00
     kind: TIM6_7F37:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM19:
     address: 0x40015c00
     kind: TIM1_8F37:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F37:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F37:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F37:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F37:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F37:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F37:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32F373RC.yaml
+++ b/data/chips/STM32F373RC.yaml
@@ -112,45 +112,59 @@ peripherals:
   TIM12:
     address: 0x40001800
     kind: TIM1_8F37:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8F37:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F37:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8F37:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8F37:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8F37:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM18:
     address: 0x40009c00
     kind: TIM6_7F37:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM19:
     address: 0x40015c00
     kind: TIM1_8F37:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F37:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F37:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F37:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F37:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F37:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F37:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32F373V8.yaml
+++ b/data/chips/STM32F373V8.yaml
@@ -114,45 +114,59 @@ peripherals:
   TIM12:
     address: 0x40001800
     kind: TIM1_8F37:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8F37:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F37:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8F37:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8F37:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8F37:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM18:
     address: 0x40009c00
     kind: TIM6_7F37:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM19:
     address: 0x40015c00
     kind: TIM1_8F37:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F37:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F37:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F37:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F37:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F37:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F37:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32F373VB.yaml
+++ b/data/chips/STM32F373VB.yaml
@@ -114,45 +114,59 @@ peripherals:
   TIM12:
     address: 0x40001800
     kind: TIM1_8F37:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8F37:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F37:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8F37:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8F37:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8F37:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM18:
     address: 0x40009c00
     kind: TIM6_7F37:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM19:
     address: 0x40015c00
     kind: TIM1_8F37:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F37:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F37:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F37:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F37:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F37:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F37:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32F373VC.yaml
+++ b/data/chips/STM32F373VC.yaml
@@ -114,45 +114,59 @@ peripherals:
   TIM12:
     address: 0x40001800
     kind: TIM1_8F37:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8F37:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F37:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8F37:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8F37:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8F37:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM18:
     address: 0x40009c00
     kind: TIM6_7F37:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM19:
     address: 0x40015c00
     kind: TIM1_8F37:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F37:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F37:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F37:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F37:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F37:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F37:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32F378CC.yaml
+++ b/data/chips/STM32F378CC.yaml
@@ -112,45 +112,59 @@ peripherals:
   TIM12:
     address: 0x40001800
     kind: TIM1_8F37:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8F37:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F37:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8F37:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8F37:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8F37:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM18:
     address: 0x40009c00
     kind: TIM6_7F37:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM19:
     address: 0x40015c00
     kind: TIM1_8F37:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F37:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F37:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F37:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F37:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F37:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F37:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32F378RC.yaml
+++ b/data/chips/STM32F378RC.yaml
@@ -114,45 +114,59 @@ peripherals:
   TIM12:
     address: 0x40001800
     kind: TIM1_8F37:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8F37:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F37:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8F37:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8F37:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8F37:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM18:
     address: 0x40009c00
     kind: TIM6_7F37:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM19:
     address: 0x40015c00
     kind: TIM1_8F37:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F37:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F37:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F37:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F37:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F37:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F37:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32F378VC.yaml
+++ b/data/chips/STM32F378VC.yaml
@@ -114,45 +114,59 @@ peripherals:
   TIM12:
     address: 0x40001800
     kind: TIM1_8F37:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8F37:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F37:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8F37:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8F37:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8F37:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM18:
     address: 0x40009c00
     kind: TIM6_7F37:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM19:
     address: 0x40015c00
     kind: TIM1_8F37:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F37:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F37:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F37:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F37:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F37:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F37:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32F398VE.yaml
+++ b/data/chips/STM32F398VE.yaml
@@ -148,36 +148,47 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM20:
     address: 0x40015000
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8F3:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32F401CB.yaml
+++ b/data/chips/STM32F401CB.yaml
@@ -91,27 +91,35 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40011000
     kind: USART:sci2_v1_2

--- a/data/chips/STM32F401CC.yaml
+++ b/data/chips/STM32F401CC.yaml
@@ -93,27 +93,35 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40011000
     kind: USART:sci2_v1_2

--- a/data/chips/STM32F401CD.yaml
+++ b/data/chips/STM32F401CD.yaml
@@ -91,27 +91,35 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40011000
     kind: USART:sci2_v1_2

--- a/data/chips/STM32F401CE.yaml
+++ b/data/chips/STM32F401CE.yaml
@@ -91,27 +91,35 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40011000
     kind: USART:sci2_v1_2

--- a/data/chips/STM32F401RB.yaml
+++ b/data/chips/STM32F401RB.yaml
@@ -93,27 +93,35 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40011000
     kind: USART:sci2_v1_2

--- a/data/chips/STM32F401RC.yaml
+++ b/data/chips/STM32F401RC.yaml
@@ -93,27 +93,35 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40011000
     kind: USART:sci2_v1_2

--- a/data/chips/STM32F401RD.yaml
+++ b/data/chips/STM32F401RD.yaml
@@ -93,27 +93,35 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40011000
     kind: USART:sci2_v1_2

--- a/data/chips/STM32F401RE.yaml
+++ b/data/chips/STM32F401RE.yaml
@@ -93,27 +93,35 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40011000
     kind: USART:sci2_v1_2

--- a/data/chips/STM32F401VB.yaml
+++ b/data/chips/STM32F401VB.yaml
@@ -100,27 +100,35 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40011000
     kind: USART:sci2_v1_2

--- a/data/chips/STM32F401VC.yaml
+++ b/data/chips/STM32F401VC.yaml
@@ -100,27 +100,35 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40011000
     kind: USART:sci2_v1_2

--- a/data/chips/STM32F401VD.yaml
+++ b/data/chips/STM32F401VD.yaml
@@ -100,27 +100,35 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40011000
     kind: USART:sci2_v1_2

--- a/data/chips/STM32F401VE.yaml
+++ b/data/chips/STM32F401VE.yaml
@@ -100,27 +100,35 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40011000
     kind: USART:sci2_v1_2

--- a/data/chips/STM32F405OE.yaml
+++ b/data/chips/STM32F405OE.yaml
@@ -123,45 +123,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32F405OG.yaml
+++ b/data/chips/STM32F405OG.yaml
@@ -123,45 +123,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32F405RG.yaml
+++ b/data/chips/STM32F405RG.yaml
@@ -123,45 +123,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32F405VG.yaml
+++ b/data/chips/STM32F405VG.yaml
@@ -123,45 +123,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32F405ZG.yaml
+++ b/data/chips/STM32F405ZG.yaml
@@ -123,45 +123,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32F407IE.yaml
+++ b/data/chips/STM32F407IE.yaml
@@ -131,45 +131,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32F407IG.yaml
+++ b/data/chips/STM32F407IG.yaml
@@ -131,45 +131,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32F407VE.yaml
+++ b/data/chips/STM32F407VE.yaml
@@ -129,45 +129,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32F407VG.yaml
+++ b/data/chips/STM32F407VG.yaml
@@ -129,45 +129,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32F407ZE.yaml
+++ b/data/chips/STM32F407ZE.yaml
@@ -129,45 +129,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32F407ZG.yaml
+++ b/data/chips/STM32F407ZG.yaml
@@ -129,45 +129,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32F410C8.yaml
+++ b/data/chips/STM32F410C8.yaml
@@ -91,18 +91,23 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40011000
     kind: USART:sci2_v1_2

--- a/data/chips/STM32F410CB.yaml
+++ b/data/chips/STM32F410CB.yaml
@@ -91,18 +91,23 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40011000
     kind: USART:sci2_v1_2

--- a/data/chips/STM32F410R8.yaml
+++ b/data/chips/STM32F410R8.yaml
@@ -91,18 +91,23 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40011000
     kind: USART:sci2_v1_2

--- a/data/chips/STM32F410RB.yaml
+++ b/data/chips/STM32F410RB.yaml
@@ -91,18 +91,23 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40011000
     kind: USART:sci2_v1_2

--- a/data/chips/STM32F410T8.yaml
+++ b/data/chips/STM32F410T8.yaml
@@ -81,18 +81,23 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40011000
     kind: USART:sci2_v1_2

--- a/data/chips/STM32F410TB.yaml
+++ b/data/chips/STM32F410TB.yaml
@@ -81,18 +81,23 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40011000
     kind: USART:sci2_v1_2

--- a/data/chips/STM32F411CC.yaml
+++ b/data/chips/STM32F411CC.yaml
@@ -105,27 +105,35 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40011000
     kind: USART:sci2_v1_2

--- a/data/chips/STM32F411CE.yaml
+++ b/data/chips/STM32F411CE.yaml
@@ -105,27 +105,35 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40011000
     kind: USART:sci2_v1_2

--- a/data/chips/STM32F411RC.yaml
+++ b/data/chips/STM32F411RC.yaml
@@ -103,27 +103,35 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40011000
     kind: USART:sci2_v1_2

--- a/data/chips/STM32F411RE.yaml
+++ b/data/chips/STM32F411RE.yaml
@@ -103,27 +103,35 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40011000
     kind: USART:sci2_v1_2

--- a/data/chips/STM32F411VC.yaml
+++ b/data/chips/STM32F411VC.yaml
@@ -105,27 +105,35 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40011000
     kind: USART:sci2_v1_2

--- a/data/chips/STM32F411VE.yaml
+++ b/data/chips/STM32F411VE.yaml
@@ -105,27 +105,35 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40011000
     kind: USART:sci2_v1_2

--- a/data/chips/STM32F412CE.yaml
+++ b/data/chips/STM32F412CE.yaml
@@ -113,45 +113,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40011000
     kind: USART:sci2_v1_2

--- a/data/chips/STM32F412CG.yaml
+++ b/data/chips/STM32F412CG.yaml
@@ -113,45 +113,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40011000
     kind: USART:sci2_v1_2

--- a/data/chips/STM32F412RE.yaml
+++ b/data/chips/STM32F412RE.yaml
@@ -123,45 +123,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40011000
     kind: USART:sci2_v1_2

--- a/data/chips/STM32F412RG.yaml
+++ b/data/chips/STM32F412RG.yaml
@@ -123,45 +123,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40011000
     kind: USART:sci2_v1_2

--- a/data/chips/STM32F412VE.yaml
+++ b/data/chips/STM32F412VE.yaml
@@ -130,45 +130,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40011000
     kind: USART:sci2_v1_2

--- a/data/chips/STM32F412VG.yaml
+++ b/data/chips/STM32F412VG.yaml
@@ -130,45 +130,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40011000
     kind: USART:sci2_v1_2

--- a/data/chips/STM32F412ZE.yaml
+++ b/data/chips/STM32F412ZE.yaml
@@ -130,45 +130,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40011000
     kind: USART:sci2_v1_2

--- a/data/chips/STM32F412ZG.yaml
+++ b/data/chips/STM32F412ZG.yaml
@@ -130,45 +130,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40011000
     kind: USART:sci2_v1_2

--- a/data/chips/STM32F413CG.yaml
+++ b/data/chips/STM32F413CG.yaml
@@ -141,45 +141,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32F413CH.yaml
+++ b/data/chips/STM32F413CH.yaml
@@ -141,45 +141,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32F413MG.yaml
+++ b/data/chips/STM32F413MG.yaml
@@ -144,45 +144,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32F413MH.yaml
+++ b/data/chips/STM32F413MH.yaml
@@ -144,45 +144,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32F413RG.yaml
+++ b/data/chips/STM32F413RG.yaml
@@ -144,45 +144,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32F413RH.yaml
+++ b/data/chips/STM32F413RH.yaml
@@ -144,45 +144,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32F413VG.yaml
+++ b/data/chips/STM32F413VG.yaml
@@ -146,45 +146,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART10:
     address: 0x40011c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32F413VH.yaml
+++ b/data/chips/STM32F413VH.yaml
@@ -146,45 +146,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART10:
     address: 0x40011c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32F413ZG.yaml
+++ b/data/chips/STM32F413ZG.yaml
@@ -146,45 +146,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART10:
     address: 0x40011c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32F413ZH.yaml
+++ b/data/chips/STM32F413ZH.yaml
@@ -146,45 +146,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART10:
     address: 0x40011c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32F415OG.yaml
+++ b/data/chips/STM32F415OG.yaml
@@ -129,45 +129,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32F415RG.yaml
+++ b/data/chips/STM32F415RG.yaml
@@ -129,45 +129,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32F415VG.yaml
+++ b/data/chips/STM32F415VG.yaml
@@ -129,45 +129,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32F415ZG.yaml
+++ b/data/chips/STM32F415ZG.yaml
@@ -129,45 +129,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32F417IE.yaml
+++ b/data/chips/STM32F417IE.yaml
@@ -137,45 +137,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32F417IG.yaml
+++ b/data/chips/STM32F417IG.yaml
@@ -137,45 +137,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32F417VE.yaml
+++ b/data/chips/STM32F417VE.yaml
@@ -135,45 +135,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32F417VG.yaml
+++ b/data/chips/STM32F417VG.yaml
@@ -135,45 +135,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32F417ZE.yaml
+++ b/data/chips/STM32F417ZE.yaml
@@ -135,45 +135,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32F417ZG.yaml
+++ b/data/chips/STM32F417ZG.yaml
@@ -135,45 +135,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32F423CH.yaml
+++ b/data/chips/STM32F423CH.yaml
@@ -144,45 +144,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32F423MH.yaml
+++ b/data/chips/STM32F423MH.yaml
@@ -147,45 +147,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32F423RH.yaml
+++ b/data/chips/STM32F423RH.yaml
@@ -147,45 +147,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32F423VH.yaml
+++ b/data/chips/STM32F423VH.yaml
@@ -149,45 +149,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART10:
     address: 0x40011c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32F423ZH.yaml
+++ b/data/chips/STM32F423ZH.yaml
@@ -149,45 +149,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART10:
     address: 0x40011c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32F427AG.yaml
+++ b/data/chips/STM32F427AG.yaml
@@ -152,45 +152,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32F427AI.yaml
+++ b/data/chips/STM32F427AI.yaml
@@ -152,45 +152,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32F427IG.yaml
+++ b/data/chips/STM32F427IG.yaml
@@ -159,45 +159,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32F427II.yaml
+++ b/data/chips/STM32F427II.yaml
@@ -159,45 +159,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32F427VG.yaml
+++ b/data/chips/STM32F427VG.yaml
@@ -147,45 +147,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32F427VI.yaml
+++ b/data/chips/STM32F427VI.yaml
@@ -147,45 +147,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32F427ZG.yaml
+++ b/data/chips/STM32F427ZG.yaml
@@ -157,45 +157,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32F427ZI.yaml
+++ b/data/chips/STM32F427ZI.yaml
@@ -157,45 +157,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32F429AG.yaml
+++ b/data/chips/STM32F429AG.yaml
@@ -155,45 +155,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32F429AI.yaml
+++ b/data/chips/STM32F429AI.yaml
@@ -155,45 +155,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32F429BE.yaml
+++ b/data/chips/STM32F429BE.yaml
@@ -160,45 +160,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32F429BG.yaml
+++ b/data/chips/STM32F429BG.yaml
@@ -160,45 +160,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32F429BI.yaml
+++ b/data/chips/STM32F429BI.yaml
@@ -160,45 +160,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32F429IE.yaml
+++ b/data/chips/STM32F429IE.yaml
@@ -162,45 +162,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32F429IG.yaml
+++ b/data/chips/STM32F429IG.yaml
@@ -162,45 +162,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32F429II.yaml
+++ b/data/chips/STM32F429II.yaml
@@ -162,45 +162,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32F429NE.yaml
+++ b/data/chips/STM32F429NE.yaml
@@ -160,45 +160,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32F429NG.yaml
+++ b/data/chips/STM32F429NG.yaml
@@ -160,45 +160,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32F429NI.yaml
+++ b/data/chips/STM32F429NI.yaml
@@ -160,45 +160,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32F429VE.yaml
+++ b/data/chips/STM32F429VE.yaml
@@ -150,45 +150,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32F429VG.yaml
+++ b/data/chips/STM32F429VG.yaml
@@ -150,45 +150,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32F429VI.yaml
+++ b/data/chips/STM32F429VI.yaml
@@ -150,45 +150,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32F429ZE.yaml
+++ b/data/chips/STM32F429ZE.yaml
@@ -160,45 +160,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32F429ZG.yaml
+++ b/data/chips/STM32F429ZG.yaml
@@ -162,45 +162,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32F429ZI.yaml
+++ b/data/chips/STM32F429ZI.yaml
@@ -162,45 +162,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32F437AI.yaml
+++ b/data/chips/STM32F437AI.yaml
@@ -158,45 +158,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32F437IG.yaml
+++ b/data/chips/STM32F437IG.yaml
@@ -165,45 +165,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32F437II.yaml
+++ b/data/chips/STM32F437II.yaml
@@ -165,45 +165,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32F437VG.yaml
+++ b/data/chips/STM32F437VG.yaml
@@ -153,45 +153,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32F437VI.yaml
+++ b/data/chips/STM32F437VI.yaml
@@ -153,45 +153,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32F437ZG.yaml
+++ b/data/chips/STM32F437ZG.yaml
@@ -163,45 +163,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32F437ZI.yaml
+++ b/data/chips/STM32F437ZI.yaml
@@ -163,45 +163,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32F439AI.yaml
+++ b/data/chips/STM32F439AI.yaml
@@ -161,45 +161,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32F439BG.yaml
+++ b/data/chips/STM32F439BG.yaml
@@ -166,45 +166,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32F439BI.yaml
+++ b/data/chips/STM32F439BI.yaml
@@ -166,45 +166,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32F439IG.yaml
+++ b/data/chips/STM32F439IG.yaml
@@ -168,45 +168,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32F439II.yaml
+++ b/data/chips/STM32F439II.yaml
@@ -168,45 +168,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32F439NG.yaml
+++ b/data/chips/STM32F439NG.yaml
@@ -166,45 +166,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32F439NI.yaml
+++ b/data/chips/STM32F439NI.yaml
@@ -166,45 +166,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32F439VG.yaml
+++ b/data/chips/STM32F439VG.yaml
@@ -156,45 +156,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32F439VI.yaml
+++ b/data/chips/STM32F439VI.yaml
@@ -156,45 +156,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32F439ZG.yaml
+++ b/data/chips/STM32F439ZG.yaml
@@ -168,45 +168,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32F439ZI.yaml
+++ b/data/chips/STM32F439ZI.yaml
@@ -168,45 +168,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32F446MC.yaml
+++ b/data/chips/STM32F446MC.yaml
@@ -140,45 +140,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32F446ME.yaml
+++ b/data/chips/STM32F446ME.yaml
@@ -140,45 +140,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32F446RC.yaml
+++ b/data/chips/STM32F446RC.yaml
@@ -132,45 +132,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32F446RE.yaml
+++ b/data/chips/STM32F446RE.yaml
@@ -132,45 +132,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32F446VC.yaml
+++ b/data/chips/STM32F446VC.yaml
@@ -140,45 +140,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32F446VE.yaml
+++ b/data/chips/STM32F446VE.yaml
@@ -140,45 +140,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32F446ZC.yaml
+++ b/data/chips/STM32F446ZC.yaml
@@ -144,45 +144,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32F446ZE.yaml
+++ b/data/chips/STM32F446ZE.yaml
@@ -144,45 +144,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32F469AE.yaml
+++ b/data/chips/STM32F469AE.yaml
@@ -152,45 +152,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32F469AG.yaml
+++ b/data/chips/STM32F469AG.yaml
@@ -152,45 +152,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32F469AI.yaml
+++ b/data/chips/STM32F469AI.yaml
@@ -152,45 +152,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32F469BE.yaml
+++ b/data/chips/STM32F469BE.yaml
@@ -157,45 +157,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32F469BG.yaml
+++ b/data/chips/STM32F469BG.yaml
@@ -157,45 +157,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32F469BI.yaml
+++ b/data/chips/STM32F469BI.yaml
@@ -157,45 +157,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32F469IE.yaml
+++ b/data/chips/STM32F469IE.yaml
@@ -159,45 +159,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32F469IG.yaml
+++ b/data/chips/STM32F469IG.yaml
@@ -159,45 +159,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32F469II.yaml
+++ b/data/chips/STM32F469II.yaml
@@ -159,45 +159,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32F469NE.yaml
+++ b/data/chips/STM32F469NE.yaml
@@ -157,45 +157,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32F469NG.yaml
+++ b/data/chips/STM32F469NG.yaml
@@ -157,45 +157,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32F469NI.yaml
+++ b/data/chips/STM32F469NI.yaml
@@ -157,45 +157,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32F469VE.yaml
+++ b/data/chips/STM32F469VE.yaml
@@ -146,45 +146,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32F469VG.yaml
+++ b/data/chips/STM32F469VG.yaml
@@ -146,45 +146,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32F469VI.yaml
+++ b/data/chips/STM32F469VI.yaml
@@ -146,45 +146,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32F469ZE.yaml
+++ b/data/chips/STM32F469ZE.yaml
@@ -146,45 +146,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32F469ZG.yaml
+++ b/data/chips/STM32F469ZG.yaml
@@ -146,45 +146,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32F469ZI.yaml
+++ b/data/chips/STM32F469ZI.yaml
@@ -146,45 +146,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32F479AG.yaml
+++ b/data/chips/STM32F479AG.yaml
@@ -158,45 +158,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32F479AI.yaml
+++ b/data/chips/STM32F479AI.yaml
@@ -158,45 +158,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32F479BG.yaml
+++ b/data/chips/STM32F479BG.yaml
@@ -163,45 +163,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32F479BI.yaml
+++ b/data/chips/STM32F479BI.yaml
@@ -163,45 +163,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32F479IG.yaml
+++ b/data/chips/STM32F479IG.yaml
@@ -165,45 +165,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32F479II.yaml
+++ b/data/chips/STM32F479II.yaml
@@ -165,45 +165,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32F479NG.yaml
+++ b/data/chips/STM32F479NG.yaml
@@ -163,45 +163,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32F479NI.yaml
+++ b/data/chips/STM32F479NI.yaml
@@ -163,45 +163,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32F479VG.yaml
+++ b/data/chips/STM32F479VG.yaml
@@ -152,45 +152,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32F479VI.yaml
+++ b/data/chips/STM32F479VI.yaml
@@ -152,45 +152,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32F479ZG.yaml
+++ b/data/chips/STM32F479ZG.yaml
@@ -152,45 +152,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32F479ZI.yaml
+++ b/data/chips/STM32F479ZI.yaml
@@ -152,45 +152,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32F722IC.yaml
+++ b/data/chips/STM32F722IC.yaml
@@ -143,45 +143,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v2_1

--- a/data/chips/STM32F722IE.yaml
+++ b/data/chips/STM32F722IE.yaml
@@ -143,45 +143,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v2_1

--- a/data/chips/STM32F722RC.yaml
+++ b/data/chips/STM32F722RC.yaml
@@ -126,45 +126,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v2_1

--- a/data/chips/STM32F722RE.yaml
+++ b/data/chips/STM32F722RE.yaml
@@ -126,45 +126,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v2_1

--- a/data/chips/STM32F722VC.yaml
+++ b/data/chips/STM32F722VC.yaml
@@ -137,45 +137,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v2_1

--- a/data/chips/STM32F722VE.yaml
+++ b/data/chips/STM32F722VE.yaml
@@ -137,45 +137,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v2_1

--- a/data/chips/STM32F722ZC.yaml
+++ b/data/chips/STM32F722ZC.yaml
@@ -141,45 +141,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v2_1

--- a/data/chips/STM32F722ZE.yaml
+++ b/data/chips/STM32F722ZE.yaml
@@ -141,45 +141,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v2_1

--- a/data/chips/STM32F723IC.yaml
+++ b/data/chips/STM32F723IC.yaml
@@ -143,45 +143,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v2_1

--- a/data/chips/STM32F723IE.yaml
+++ b/data/chips/STM32F723IE.yaml
@@ -143,45 +143,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v2_1

--- a/data/chips/STM32F723VC.yaml
+++ b/data/chips/STM32F723VC.yaml
@@ -135,42 +135,55 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v2_1

--- a/data/chips/STM32F723VE.yaml
+++ b/data/chips/STM32F723VE.yaml
@@ -135,42 +135,55 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v2_1

--- a/data/chips/STM32F723ZC.yaml
+++ b/data/chips/STM32F723ZC.yaml
@@ -143,42 +143,55 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v2_1

--- a/data/chips/STM32F723ZE.yaml
+++ b/data/chips/STM32F723ZE.yaml
@@ -143,42 +143,55 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v2_1

--- a/data/chips/STM32F730I8.yaml
+++ b/data/chips/STM32F730I8.yaml
@@ -144,45 +144,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v2_1

--- a/data/chips/STM32F730R8.yaml
+++ b/data/chips/STM32F730R8.yaml
@@ -129,45 +129,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v2_1

--- a/data/chips/STM32F730V8.yaml
+++ b/data/chips/STM32F730V8.yaml
@@ -140,45 +140,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v2_1

--- a/data/chips/STM32F730Z8.yaml
+++ b/data/chips/STM32F730Z8.yaml
@@ -144,42 +144,55 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v2_1

--- a/data/chips/STM32F732IE.yaml
+++ b/data/chips/STM32F732IE.yaml
@@ -146,45 +146,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v2_1

--- a/data/chips/STM32F732RE.yaml
+++ b/data/chips/STM32F732RE.yaml
@@ -129,45 +129,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v2_1

--- a/data/chips/STM32F732VE.yaml
+++ b/data/chips/STM32F732VE.yaml
@@ -140,45 +140,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v2_1

--- a/data/chips/STM32F732ZE.yaml
+++ b/data/chips/STM32F732ZE.yaml
@@ -144,45 +144,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v2_1

--- a/data/chips/STM32F733IE.yaml
+++ b/data/chips/STM32F733IE.yaml
@@ -146,45 +146,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v2_1

--- a/data/chips/STM32F733VE.yaml
+++ b/data/chips/STM32F733VE.yaml
@@ -138,42 +138,55 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v2_1

--- a/data/chips/STM32F733ZE.yaml
+++ b/data/chips/STM32F733ZE.yaml
@@ -146,42 +146,55 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v2_1

--- a/data/chips/STM32F745IE.yaml
+++ b/data/chips/STM32F745IE.yaml
@@ -170,45 +170,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v2_1

--- a/data/chips/STM32F745IG.yaml
+++ b/data/chips/STM32F745IG.yaml
@@ -170,45 +170,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v2_1

--- a/data/chips/STM32F745VE.yaml
+++ b/data/chips/STM32F745VE.yaml
@@ -162,45 +162,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v2_1

--- a/data/chips/STM32F745VG.yaml
+++ b/data/chips/STM32F745VG.yaml
@@ -162,45 +162,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v2_1

--- a/data/chips/STM32F745ZE.yaml
+++ b/data/chips/STM32F745ZE.yaml
@@ -168,45 +168,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v2_1

--- a/data/chips/STM32F745ZG.yaml
+++ b/data/chips/STM32F745ZG.yaml
@@ -168,45 +168,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v2_1

--- a/data/chips/STM32F746BE.yaml
+++ b/data/chips/STM32F746BE.yaml
@@ -171,45 +171,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v2_1

--- a/data/chips/STM32F746BG.yaml
+++ b/data/chips/STM32F746BG.yaml
@@ -171,45 +171,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v2_1

--- a/data/chips/STM32F746IE.yaml
+++ b/data/chips/STM32F746IE.yaml
@@ -173,45 +173,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v2_1

--- a/data/chips/STM32F746IG.yaml
+++ b/data/chips/STM32F746IG.yaml
@@ -173,45 +173,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v2_1

--- a/data/chips/STM32F746NE.yaml
+++ b/data/chips/STM32F746NE.yaml
@@ -171,45 +171,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v2_1

--- a/data/chips/STM32F746NG.yaml
+++ b/data/chips/STM32F746NG.yaml
@@ -171,45 +171,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v2_1

--- a/data/chips/STM32F746VE.yaml
+++ b/data/chips/STM32F746VE.yaml
@@ -165,45 +165,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v2_1

--- a/data/chips/STM32F746VG.yaml
+++ b/data/chips/STM32F746VG.yaml
@@ -165,45 +165,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v2_1

--- a/data/chips/STM32F746ZE.yaml
+++ b/data/chips/STM32F746ZE.yaml
@@ -173,45 +173,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v2_1

--- a/data/chips/STM32F746ZG.yaml
+++ b/data/chips/STM32F746ZG.yaml
@@ -173,45 +173,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v2_1

--- a/data/chips/STM32F750N8.yaml
+++ b/data/chips/STM32F750N8.yaml
@@ -177,45 +177,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v2_1

--- a/data/chips/STM32F750V8.yaml
+++ b/data/chips/STM32F750V8.yaml
@@ -169,45 +169,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v2_1

--- a/data/chips/STM32F750Z8.yaml
+++ b/data/chips/STM32F750Z8.yaml
@@ -177,45 +177,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v2_1

--- a/data/chips/STM32F756BG.yaml
+++ b/data/chips/STM32F756BG.yaml
@@ -177,45 +177,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v2_1

--- a/data/chips/STM32F756IG.yaml
+++ b/data/chips/STM32F756IG.yaml
@@ -179,45 +179,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v2_1

--- a/data/chips/STM32F756NG.yaml
+++ b/data/chips/STM32F756NG.yaml
@@ -177,45 +177,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v2_1

--- a/data/chips/STM32F756VG.yaml
+++ b/data/chips/STM32F756VG.yaml
@@ -171,45 +171,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v2_1

--- a/data/chips/STM32F756ZG.yaml
+++ b/data/chips/STM32F756ZG.yaml
@@ -179,45 +179,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8F7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v2_1

--- a/data/chips/STM32F765BG.yaml
+++ b/data/chips/STM32F765BG.yaml
@@ -186,45 +186,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v2_1

--- a/data/chips/STM32F765BI.yaml
+++ b/data/chips/STM32F765BI.yaml
@@ -186,45 +186,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v2_1

--- a/data/chips/STM32F765IG.yaml
+++ b/data/chips/STM32F765IG.yaml
@@ -188,45 +188,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v2_1

--- a/data/chips/STM32F765II.yaml
+++ b/data/chips/STM32F765II.yaml
@@ -188,45 +188,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v2_1

--- a/data/chips/STM32F765NG.yaml
+++ b/data/chips/STM32F765NG.yaml
@@ -186,45 +186,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v2_1

--- a/data/chips/STM32F765NI.yaml
+++ b/data/chips/STM32F765NI.yaml
@@ -186,45 +186,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v2_1

--- a/data/chips/STM32F765VG.yaml
+++ b/data/chips/STM32F765VG.yaml
@@ -184,45 +184,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v2_1

--- a/data/chips/STM32F765VI.yaml
+++ b/data/chips/STM32F765VI.yaml
@@ -184,45 +184,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v2_1

--- a/data/chips/STM32F765ZG.yaml
+++ b/data/chips/STM32F765ZG.yaml
@@ -186,45 +186,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v2_1

--- a/data/chips/STM32F765ZI.yaml
+++ b/data/chips/STM32F765ZI.yaml
@@ -186,45 +186,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v2_1

--- a/data/chips/STM32F767BG.yaml
+++ b/data/chips/STM32F767BG.yaml
@@ -192,45 +192,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v2_1

--- a/data/chips/STM32F767BI.yaml
+++ b/data/chips/STM32F767BI.yaml
@@ -192,45 +192,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v2_1

--- a/data/chips/STM32F767IG.yaml
+++ b/data/chips/STM32F767IG.yaml
@@ -194,45 +194,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v2_1

--- a/data/chips/STM32F767II.yaml
+++ b/data/chips/STM32F767II.yaml
@@ -194,45 +194,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v2_1

--- a/data/chips/STM32F767NG.yaml
+++ b/data/chips/STM32F767NG.yaml
@@ -192,45 +192,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v2_1

--- a/data/chips/STM32F767NI.yaml
+++ b/data/chips/STM32F767NI.yaml
@@ -192,45 +192,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v2_1

--- a/data/chips/STM32F767VG.yaml
+++ b/data/chips/STM32F767VG.yaml
@@ -190,45 +190,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v2_1

--- a/data/chips/STM32F767VI.yaml
+++ b/data/chips/STM32F767VI.yaml
@@ -190,45 +190,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v2_1

--- a/data/chips/STM32F767ZG.yaml
+++ b/data/chips/STM32F767ZG.yaml
@@ -192,45 +192,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v2_1

--- a/data/chips/STM32F767ZI.yaml
+++ b/data/chips/STM32F767ZI.yaml
@@ -192,45 +192,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v2_1

--- a/data/chips/STM32F768AI.yaml
+++ b/data/chips/STM32F768AI.yaml
@@ -185,45 +185,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v2_1

--- a/data/chips/STM32F769AG.yaml
+++ b/data/chips/STM32F769AG.yaml
@@ -185,45 +185,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v2_1

--- a/data/chips/STM32F769AI.yaml
+++ b/data/chips/STM32F769AI.yaml
@@ -185,45 +185,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v2_1

--- a/data/chips/STM32F769BG.yaml
+++ b/data/chips/STM32F769BG.yaml
@@ -192,45 +192,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v2_1

--- a/data/chips/STM32F769BI.yaml
+++ b/data/chips/STM32F769BI.yaml
@@ -192,45 +192,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v2_1

--- a/data/chips/STM32F769IG.yaml
+++ b/data/chips/STM32F769IG.yaml
@@ -192,45 +192,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v2_1

--- a/data/chips/STM32F769II.yaml
+++ b/data/chips/STM32F769II.yaml
@@ -192,45 +192,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v2_1

--- a/data/chips/STM32F769NG.yaml
+++ b/data/chips/STM32F769NG.yaml
@@ -192,45 +192,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v2_1

--- a/data/chips/STM32F769NI.yaml
+++ b/data/chips/STM32F769NI.yaml
@@ -192,45 +192,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v2_1

--- a/data/chips/STM32F777BI.yaml
+++ b/data/chips/STM32F777BI.yaml
@@ -198,45 +198,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v2_1

--- a/data/chips/STM32F777II.yaml
+++ b/data/chips/STM32F777II.yaml
@@ -200,45 +200,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v2_1

--- a/data/chips/STM32F777NI.yaml
+++ b/data/chips/STM32F777NI.yaml
@@ -198,45 +198,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v2_1

--- a/data/chips/STM32F777VI.yaml
+++ b/data/chips/STM32F777VI.yaml
@@ -196,45 +196,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v2_1

--- a/data/chips/STM32F777ZI.yaml
+++ b/data/chips/STM32F777ZI.yaml
@@ -198,45 +198,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v2_1

--- a/data/chips/STM32F778AI.yaml
+++ b/data/chips/STM32F778AI.yaml
@@ -191,45 +191,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v2_1

--- a/data/chips/STM32F779AI.yaml
+++ b/data/chips/STM32F779AI.yaml
@@ -191,45 +191,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v2_1

--- a/data/chips/STM32F779BI.yaml
+++ b/data/chips/STM32F779BI.yaml
@@ -198,45 +198,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v2_1

--- a/data/chips/STM32F779II.yaml
+++ b/data/chips/STM32F779II.yaml
@@ -198,45 +198,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v2_1

--- a/data/chips/STM32F779NI.yaml
+++ b/data/chips/STM32F779NI.yaml
@@ -198,45 +198,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM10:
     address: 0x40014400
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40014800
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40014000
     kind: TIM1_8F77:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v2_1

--- a/data/chips/STM32G030C6.yaml
+++ b/data/chips/STM32G030C6.yaml
@@ -68,18 +68,23 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci3_v2_1

--- a/data/chips/STM32G030C8.yaml
+++ b/data/chips/STM32G030C8.yaml
@@ -68,18 +68,23 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci3_v2_1

--- a/data/chips/STM32G030F6.yaml
+++ b/data/chips/STM32G030F6.yaml
@@ -68,18 +68,23 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci3_v2_1

--- a/data/chips/STM32G030J6.yaml
+++ b/data/chips/STM32G030J6.yaml
@@ -68,18 +68,23 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci3_v2_1

--- a/data/chips/STM32G030K6.yaml
+++ b/data/chips/STM32G030K6.yaml
@@ -68,18 +68,23 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci3_v2_1

--- a/data/chips/STM32G030K8.yaml
+++ b/data/chips/STM32G030K8.yaml
@@ -68,18 +68,23 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci3_v2_1

--- a/data/chips/STM32G031C4.yaml
+++ b/data/chips/STM32G031C4.yaml
@@ -82,21 +82,27 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci3_v2_1

--- a/data/chips/STM32G031C6.yaml
+++ b/data/chips/STM32G031C6.yaml
@@ -82,21 +82,27 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci3_v2_1

--- a/data/chips/STM32G031C8.yaml
+++ b/data/chips/STM32G031C8.yaml
@@ -82,21 +82,27 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci3_v2_1

--- a/data/chips/STM32G031F4.yaml
+++ b/data/chips/STM32G031F4.yaml
@@ -80,21 +80,27 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci3_v2_1

--- a/data/chips/STM32G031F6.yaml
+++ b/data/chips/STM32G031F6.yaml
@@ -80,21 +80,27 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci3_v2_1

--- a/data/chips/STM32G031F8.yaml
+++ b/data/chips/STM32G031F8.yaml
@@ -80,21 +80,27 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci3_v2_1

--- a/data/chips/STM32G031G4.yaml
+++ b/data/chips/STM32G031G4.yaml
@@ -80,21 +80,27 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci3_v2_1

--- a/data/chips/STM32G031G6.yaml
+++ b/data/chips/STM32G031G6.yaml
@@ -80,21 +80,27 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci3_v2_1

--- a/data/chips/STM32G031G8.yaml
+++ b/data/chips/STM32G031G8.yaml
@@ -80,21 +80,27 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci3_v2_1

--- a/data/chips/STM32G031J4.yaml
+++ b/data/chips/STM32G031J4.yaml
@@ -80,21 +80,27 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci3_v2_1

--- a/data/chips/STM32G031J6.yaml
+++ b/data/chips/STM32G031J6.yaml
@@ -80,21 +80,27 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci3_v2_1

--- a/data/chips/STM32G031K4.yaml
+++ b/data/chips/STM32G031K4.yaml
@@ -82,21 +82,27 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci3_v2_1

--- a/data/chips/STM32G031K6.yaml
+++ b/data/chips/STM32G031K6.yaml
@@ -82,21 +82,27 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci3_v2_1

--- a/data/chips/STM32G031K8.yaml
+++ b/data/chips/STM32G031K8.yaml
@@ -82,21 +82,27 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci3_v2_1

--- a/data/chips/STM32G031Y8.yaml
+++ b/data/chips/STM32G031Y8.yaml
@@ -80,21 +80,27 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci3_v2_1

--- a/data/chips/STM32G041C6.yaml
+++ b/data/chips/STM32G041C6.yaml
@@ -89,21 +89,27 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci3_v2_1

--- a/data/chips/STM32G041C8.yaml
+++ b/data/chips/STM32G041C8.yaml
@@ -89,21 +89,27 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci3_v2_1

--- a/data/chips/STM32G041F6.yaml
+++ b/data/chips/STM32G041F6.yaml
@@ -87,21 +87,27 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci3_v2_1

--- a/data/chips/STM32G041F8.yaml
+++ b/data/chips/STM32G041F8.yaml
@@ -87,21 +87,27 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci3_v2_1

--- a/data/chips/STM32G041G6.yaml
+++ b/data/chips/STM32G041G6.yaml
@@ -87,21 +87,27 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci3_v2_1

--- a/data/chips/STM32G041G8.yaml
+++ b/data/chips/STM32G041G8.yaml
@@ -87,21 +87,27 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci3_v2_1

--- a/data/chips/STM32G041J6.yaml
+++ b/data/chips/STM32G041J6.yaml
@@ -87,21 +87,27 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci3_v2_1

--- a/data/chips/STM32G041K6.yaml
+++ b/data/chips/STM32G041K6.yaml
@@ -89,21 +89,27 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci3_v2_1

--- a/data/chips/STM32G041K8.yaml
+++ b/data/chips/STM32G041K8.yaml
@@ -89,21 +89,27 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci3_v2_1

--- a/data/chips/STM32G041Y8.yaml
+++ b/data/chips/STM32G041Y8.yaml
@@ -87,21 +87,27 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci3_v2_1

--- a/data/chips/STM32G050C6.yaml
+++ b/data/chips/STM32G050C6.yaml
@@ -68,27 +68,35 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci3_v2_1

--- a/data/chips/STM32G050C8.yaml
+++ b/data/chips/STM32G050C8.yaml
@@ -68,27 +68,35 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci3_v2_1

--- a/data/chips/STM32G050F6.yaml
+++ b/data/chips/STM32G050F6.yaml
@@ -68,27 +68,35 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci3_v2_1

--- a/data/chips/STM32G050K6.yaml
+++ b/data/chips/STM32G050K6.yaml
@@ -68,27 +68,35 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci3_v2_1

--- a/data/chips/STM32G050K8.yaml
+++ b/data/chips/STM32G050K8.yaml
@@ -68,27 +68,35 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci3_v2_1

--- a/data/chips/STM32G051C6.yaml
+++ b/data/chips/STM32G051C6.yaml
@@ -92,30 +92,39 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci3_v2_1

--- a/data/chips/STM32G051C8.yaml
+++ b/data/chips/STM32G051C8.yaml
@@ -92,30 +92,39 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci3_v2_1

--- a/data/chips/STM32G051F6.yaml
+++ b/data/chips/STM32G051F6.yaml
@@ -90,30 +90,39 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci3_v2_1

--- a/data/chips/STM32G051F8.yaml
+++ b/data/chips/STM32G051F8.yaml
@@ -92,30 +92,39 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci3_v2_1

--- a/data/chips/STM32G051G6.yaml
+++ b/data/chips/STM32G051G6.yaml
@@ -90,30 +90,39 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci3_v2_1

--- a/data/chips/STM32G051G8.yaml
+++ b/data/chips/STM32G051G8.yaml
@@ -90,30 +90,39 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci3_v2_1

--- a/data/chips/STM32G051K6.yaml
+++ b/data/chips/STM32G051K6.yaml
@@ -92,30 +92,39 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci3_v2_1

--- a/data/chips/STM32G051K8.yaml
+++ b/data/chips/STM32G051K8.yaml
@@ -92,30 +92,39 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci3_v2_1

--- a/data/chips/STM32G061C6.yaml
+++ b/data/chips/STM32G061C6.yaml
@@ -99,30 +99,39 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci3_v2_1

--- a/data/chips/STM32G061C8.yaml
+++ b/data/chips/STM32G061C8.yaml
@@ -99,30 +99,39 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci3_v2_1

--- a/data/chips/STM32G061F6.yaml
+++ b/data/chips/STM32G061F6.yaml
@@ -97,30 +97,39 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci3_v2_1

--- a/data/chips/STM32G061F8.yaml
+++ b/data/chips/STM32G061F8.yaml
@@ -99,30 +99,39 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci3_v2_1

--- a/data/chips/STM32G061G6.yaml
+++ b/data/chips/STM32G061G6.yaml
@@ -97,30 +97,39 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci3_v2_1

--- a/data/chips/STM32G061G8.yaml
+++ b/data/chips/STM32G061G8.yaml
@@ -97,30 +97,39 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci3_v2_1

--- a/data/chips/STM32G061K6.yaml
+++ b/data/chips/STM32G061K6.yaml
@@ -99,30 +99,39 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci3_v2_1

--- a/data/chips/STM32G061K8.yaml
+++ b/data/chips/STM32G061K8.yaml
@@ -99,30 +99,39 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci3_v2_1

--- a/data/chips/STM32G070CB.yaml
+++ b/data/chips/STM32G070CB.yaml
@@ -70,27 +70,35 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci3_v2_1

--- a/data/chips/STM32G070KB.yaml
+++ b/data/chips/STM32G070KB.yaml
@@ -70,27 +70,35 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci3_v2_1

--- a/data/chips/STM32G070RB.yaml
+++ b/data/chips/STM32G070RB.yaml
@@ -70,27 +70,35 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci3_v2_1

--- a/data/chips/STM32G071C6.yaml
+++ b/data/chips/STM32G071C6.yaml
@@ -94,30 +94,39 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UCPD1:
     address: 0x4000a000
     kind: UCPD:ucpd_v1_0

--- a/data/chips/STM32G071C8.yaml
+++ b/data/chips/STM32G071C8.yaml
@@ -94,30 +94,39 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UCPD1:
     address: 0x4000a000
     kind: UCPD:ucpd_v1_0

--- a/data/chips/STM32G071CB.yaml
+++ b/data/chips/STM32G071CB.yaml
@@ -94,30 +94,39 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UCPD1:
     address: 0x4000a000
     kind: UCPD:ucpd_v1_0

--- a/data/chips/STM32G071EB.yaml
+++ b/data/chips/STM32G071EB.yaml
@@ -92,30 +92,39 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci3_v2_1

--- a/data/chips/STM32G071G6.yaml
+++ b/data/chips/STM32G071G6.yaml
@@ -92,30 +92,39 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci3_v2_1

--- a/data/chips/STM32G071G8.yaml
+++ b/data/chips/STM32G071G8.yaml
@@ -94,30 +94,39 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UCPD1:
     address: 0x4000a000
     kind: UCPD:ucpd_v1_0

--- a/data/chips/STM32G071GB.yaml
+++ b/data/chips/STM32G071GB.yaml
@@ -94,30 +94,39 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UCPD1:
     address: 0x4000a000
     kind: UCPD:ucpd_v1_0

--- a/data/chips/STM32G071K6.yaml
+++ b/data/chips/STM32G071K6.yaml
@@ -94,30 +94,39 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UCPD1:
     address: 0x4000a000
     kind: UCPD:ucpd_v1_0

--- a/data/chips/STM32G071K8.yaml
+++ b/data/chips/STM32G071K8.yaml
@@ -98,30 +98,39 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UCPD1:
     address: 0x4000a000
     kind: UCPD:ucpd_v1_0

--- a/data/chips/STM32G071KB.yaml
+++ b/data/chips/STM32G071KB.yaml
@@ -98,30 +98,39 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UCPD1:
     address: 0x4000a000
     kind: UCPD:ucpd_v1_0

--- a/data/chips/STM32G071R6.yaml
+++ b/data/chips/STM32G071R6.yaml
@@ -92,30 +92,39 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UCPD1:
     address: 0x4000a000
     kind: UCPD:ucpd_v1_0

--- a/data/chips/STM32G071R8.yaml
+++ b/data/chips/STM32G071R8.yaml
@@ -92,30 +92,39 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UCPD1:
     address: 0x4000a000
     kind: UCPD:ucpd_v1_0

--- a/data/chips/STM32G071RB.yaml
+++ b/data/chips/STM32G071RB.yaml
@@ -94,30 +94,39 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UCPD1:
     address: 0x4000a000
     kind: UCPD:ucpd_v1_0

--- a/data/chips/STM32G081CB.yaml
+++ b/data/chips/STM32G081CB.yaml
@@ -101,30 +101,39 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UCPD1:
     address: 0x4000a000
     kind: UCPD:ucpd_v1_0

--- a/data/chips/STM32G081EB.yaml
+++ b/data/chips/STM32G081EB.yaml
@@ -99,30 +99,39 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci3_v2_1

--- a/data/chips/STM32G081GB.yaml
+++ b/data/chips/STM32G081GB.yaml
@@ -101,30 +101,39 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UCPD1:
     address: 0x4000a000
     kind: UCPD:ucpd_v1_0

--- a/data/chips/STM32G081KB.yaml
+++ b/data/chips/STM32G081KB.yaml
@@ -105,30 +105,39 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UCPD1:
     address: 0x4000a000
     kind: UCPD:ucpd_v1_0

--- a/data/chips/STM32G081RB.yaml
+++ b/data/chips/STM32G081RB.yaml
@@ -101,30 +101,39 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UCPD1:
     address: 0x4000a000
     kind: UCPD:ucpd_v1_0

--- a/data/chips/STM32G0B0CE.yaml
+++ b/data/chips/STM32G0B0CE.yaml
@@ -81,30 +81,39 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci3_v2_1

--- a/data/chips/STM32G0B0KE.yaml
+++ b/data/chips/STM32G0B0KE.yaml
@@ -81,30 +81,39 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci3_v2_1

--- a/data/chips/STM32G0B0RE.yaml
+++ b/data/chips/STM32G0B0RE.yaml
@@ -81,30 +81,39 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci3_v2_1

--- a/data/chips/STM32G0B0VE.yaml
+++ b/data/chips/STM32G0B0VE.yaml
@@ -81,30 +81,39 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci3_v2_1

--- a/data/chips/STM32G0B1CB.yaml
+++ b/data/chips/STM32G0B1CB.yaml
@@ -121,33 +121,43 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UCPD1:
     address: 0x4000a000
     kind: UCPD:ucpd_v1_0

--- a/data/chips/STM32G0B1CC.yaml
+++ b/data/chips/STM32G0B1CC.yaml
@@ -121,33 +121,43 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UCPD1:
     address: 0x4000a000
     kind: UCPD:ucpd_v1_0

--- a/data/chips/STM32G0B1CE.yaml
+++ b/data/chips/STM32G0B1CE.yaml
@@ -121,33 +121,43 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UCPD1:
     address: 0x4000a000
     kind: UCPD:ucpd_v1_0

--- a/data/chips/STM32G0B1KB.yaml
+++ b/data/chips/STM32G0B1KB.yaml
@@ -121,33 +121,43 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UCPD1:
     address: 0x4000a000
     kind: UCPD:ucpd_v1_0

--- a/data/chips/STM32G0B1KC.yaml
+++ b/data/chips/STM32G0B1KC.yaml
@@ -121,33 +121,43 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UCPD1:
     address: 0x4000a000
     kind: UCPD:ucpd_v1_0

--- a/data/chips/STM32G0B1KE.yaml
+++ b/data/chips/STM32G0B1KE.yaml
@@ -121,33 +121,43 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UCPD1:
     address: 0x4000a000
     kind: UCPD:ucpd_v1_0

--- a/data/chips/STM32G0B1MB.yaml
+++ b/data/chips/STM32G0B1MB.yaml
@@ -115,33 +115,43 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UCPD1:
     address: 0x4000a000
     kind: UCPD:ucpd_v1_0

--- a/data/chips/STM32G0B1MC.yaml
+++ b/data/chips/STM32G0B1MC.yaml
@@ -115,33 +115,43 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UCPD1:
     address: 0x4000a000
     kind: UCPD:ucpd_v1_0

--- a/data/chips/STM32G0B1ME.yaml
+++ b/data/chips/STM32G0B1ME.yaml
@@ -115,33 +115,43 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UCPD1:
     address: 0x4000a000
     kind: UCPD:ucpd_v1_0

--- a/data/chips/STM32G0B1NE.yaml
+++ b/data/chips/STM32G0B1NE.yaml
@@ -115,33 +115,43 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UCPD1:
     address: 0x4000a000
     kind: UCPD:ucpd_v1_0

--- a/data/chips/STM32G0B1RB.yaml
+++ b/data/chips/STM32G0B1RB.yaml
@@ -119,33 +119,43 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UCPD1:
     address: 0x4000a000
     kind: UCPD:ucpd_v1_0

--- a/data/chips/STM32G0B1RC.yaml
+++ b/data/chips/STM32G0B1RC.yaml
@@ -119,33 +119,43 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UCPD1:
     address: 0x4000a000
     kind: UCPD:ucpd_v1_0

--- a/data/chips/STM32G0B1RE.yaml
+++ b/data/chips/STM32G0B1RE.yaml
@@ -119,33 +119,43 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UCPD1:
     address: 0x4000a000
     kind: UCPD:ucpd_v1_0

--- a/data/chips/STM32G0B1VB.yaml
+++ b/data/chips/STM32G0B1VB.yaml
@@ -117,33 +117,43 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UCPD1:
     address: 0x4000a000
     kind: UCPD:ucpd_v1_0

--- a/data/chips/STM32G0B1VC.yaml
+++ b/data/chips/STM32G0B1VC.yaml
@@ -117,33 +117,43 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UCPD1:
     address: 0x4000a000
     kind: UCPD:ucpd_v1_0

--- a/data/chips/STM32G0B1VE.yaml
+++ b/data/chips/STM32G0B1VE.yaml
@@ -117,33 +117,43 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UCPD1:
     address: 0x4000a000
     kind: UCPD:ucpd_v1_0

--- a/data/chips/STM32G0C1CC.yaml
+++ b/data/chips/STM32G0C1CC.yaml
@@ -128,33 +128,43 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UCPD1:
     address: 0x4000a000
     kind: UCPD:ucpd_v1_0

--- a/data/chips/STM32G0C1CE.yaml
+++ b/data/chips/STM32G0C1CE.yaml
@@ -128,33 +128,43 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UCPD1:
     address: 0x4000a000
     kind: UCPD:ucpd_v1_0

--- a/data/chips/STM32G0C1KC.yaml
+++ b/data/chips/STM32G0C1KC.yaml
@@ -128,33 +128,43 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UCPD1:
     address: 0x4000a000
     kind: UCPD:ucpd_v1_0

--- a/data/chips/STM32G0C1KE.yaml
+++ b/data/chips/STM32G0C1KE.yaml
@@ -128,33 +128,43 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UCPD1:
     address: 0x4000a000
     kind: UCPD:ucpd_v1_0

--- a/data/chips/STM32G0C1MC.yaml
+++ b/data/chips/STM32G0C1MC.yaml
@@ -122,33 +122,43 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UCPD1:
     address: 0x4000a000
     kind: UCPD:ucpd_v1_0

--- a/data/chips/STM32G0C1ME.yaml
+++ b/data/chips/STM32G0C1ME.yaml
@@ -122,33 +122,43 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UCPD1:
     address: 0x4000a000
     kind: UCPD:ucpd_v1_0

--- a/data/chips/STM32G0C1NE.yaml
+++ b/data/chips/STM32G0C1NE.yaml
@@ -122,33 +122,43 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UCPD1:
     address: 0x4000a000
     kind: UCPD:ucpd_v1_0

--- a/data/chips/STM32G0C1RC.yaml
+++ b/data/chips/STM32G0C1RC.yaml
@@ -126,33 +126,43 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UCPD1:
     address: 0x4000a000
     kind: UCPD:ucpd_v1_0

--- a/data/chips/STM32G0C1RE.yaml
+++ b/data/chips/STM32G0C1RE.yaml
@@ -126,33 +126,43 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UCPD1:
     address: 0x4000a000
     kind: UCPD:ucpd_v1_0

--- a/data/chips/STM32G0C1VC.yaml
+++ b/data/chips/STM32G0C1VC.yaml
@@ -124,33 +124,43 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UCPD1:
     address: 0x4000a000
     kind: UCPD:ucpd_v1_0

--- a/data/chips/STM32G0C1VE.yaml
+++ b/data/chips/STM32G0C1VE.yaml
@@ -124,33 +124,43 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7G0:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UCPD1:
     address: 0x4000a000
     kind: UCPD:ucpd_v1_0

--- a/data/chips/STM32G431C6.yaml
+++ b/data/chips/STM32G431C6.yaml
@@ -146,33 +146,43 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   UCPD1:
     address: 0x4000a000
     kind: UCPD:ucpd_v1_0

--- a/data/chips/STM32G431C8.yaml
+++ b/data/chips/STM32G431C8.yaml
@@ -146,33 +146,43 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   UCPD1:
     address: 0x4000a000
     kind: UCPD:ucpd_v1_0

--- a/data/chips/STM32G431CB.yaml
+++ b/data/chips/STM32G431CB.yaml
@@ -148,33 +148,43 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   UCPD1:
     address: 0x4000a000
     kind: UCPD:ucpd_v1_0

--- a/data/chips/STM32G431K6.yaml
+++ b/data/chips/STM32G431K6.yaml
@@ -146,33 +146,43 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   UCPD1:
     address: 0x4000a000
     kind: UCPD:ucpd_v1_0

--- a/data/chips/STM32G431K8.yaml
+++ b/data/chips/STM32G431K8.yaml
@@ -146,33 +146,43 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   UCPD1:
     address: 0x4000a000
     kind: UCPD:ucpd_v1_0

--- a/data/chips/STM32G431KB.yaml
+++ b/data/chips/STM32G431KB.yaml
@@ -146,33 +146,43 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   UCPD1:
     address: 0x4000a000
     kind: UCPD:ucpd_v1_0

--- a/data/chips/STM32G431M6.yaml
+++ b/data/chips/STM32G431M6.yaml
@@ -144,33 +144,43 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_1

--- a/data/chips/STM32G431M8.yaml
+++ b/data/chips/STM32G431M8.yaml
@@ -144,33 +144,43 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_1

--- a/data/chips/STM32G431MB.yaml
+++ b/data/chips/STM32G431MB.yaml
@@ -144,33 +144,43 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_1

--- a/data/chips/STM32G431R6.yaml
+++ b/data/chips/STM32G431R6.yaml
@@ -146,33 +146,43 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_1

--- a/data/chips/STM32G431R8.yaml
+++ b/data/chips/STM32G431R8.yaml
@@ -146,33 +146,43 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_1

--- a/data/chips/STM32G431RB.yaml
+++ b/data/chips/STM32G431RB.yaml
@@ -146,33 +146,43 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_1

--- a/data/chips/STM32G431V6.yaml
+++ b/data/chips/STM32G431V6.yaml
@@ -144,33 +144,43 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_1

--- a/data/chips/STM32G431V8.yaml
+++ b/data/chips/STM32G431V8.yaml
@@ -144,33 +144,43 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_1

--- a/data/chips/STM32G431VB.yaml
+++ b/data/chips/STM32G431VB.yaml
@@ -144,33 +144,43 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_1

--- a/data/chips/STM32G441CB.yaml
+++ b/data/chips/STM32G441CB.yaml
@@ -151,33 +151,43 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   UCPD1:
     address: 0x4000a000
     kind: UCPD:ucpd_v1_0

--- a/data/chips/STM32G441KB.yaml
+++ b/data/chips/STM32G441KB.yaml
@@ -149,33 +149,43 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   UCPD1:
     address: 0x4000a000
     kind: UCPD:ucpd_v1_0

--- a/data/chips/STM32G441MB.yaml
+++ b/data/chips/STM32G441MB.yaml
@@ -147,33 +147,43 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_1

--- a/data/chips/STM32G441RB.yaml
+++ b/data/chips/STM32G441RB.yaml
@@ -149,33 +149,43 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_1

--- a/data/chips/STM32G441VB.yaml
+++ b/data/chips/STM32G441VB.yaml
@@ -147,33 +147,43 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_1

--- a/data/chips/STM32G471CC.yaml
+++ b/data/chips/STM32G471CC.yaml
@@ -156,36 +156,47 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   UCPD1:
     address: 0x4000a000
     kind: UCPD:ucpd_v1_0

--- a/data/chips/STM32G471CE.yaml
+++ b/data/chips/STM32G471CE.yaml
@@ -156,36 +156,47 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   UCPD1:
     address: 0x4000a000
     kind: UCPD:ucpd_v1_0

--- a/data/chips/STM32G471MC.yaml
+++ b/data/chips/STM32G471MC.yaml
@@ -158,36 +158,47 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_1

--- a/data/chips/STM32G471ME.yaml
+++ b/data/chips/STM32G471ME.yaml
@@ -160,36 +160,47 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_1

--- a/data/chips/STM32G471QC.yaml
+++ b/data/chips/STM32G471QC.yaml
@@ -158,36 +158,47 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_1

--- a/data/chips/STM32G471QE.yaml
+++ b/data/chips/STM32G471QE.yaml
@@ -158,36 +158,47 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_1

--- a/data/chips/STM32G471RC.yaml
+++ b/data/chips/STM32G471RC.yaml
@@ -154,36 +154,47 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_1

--- a/data/chips/STM32G471RE.yaml
+++ b/data/chips/STM32G471RE.yaml
@@ -154,36 +154,47 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_1

--- a/data/chips/STM32G471VC.yaml
+++ b/data/chips/STM32G471VC.yaml
@@ -162,36 +162,47 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_1

--- a/data/chips/STM32G471VE.yaml
+++ b/data/chips/STM32G471VE.yaml
@@ -162,36 +162,47 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_1

--- a/data/chips/STM32G473CB.yaml
+++ b/data/chips/STM32G473CB.yaml
@@ -189,39 +189,51 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM20:
     address: 0x40015000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   UCPD1:
     address: 0x4000a000
     kind: UCPD:ucpd_v1_0

--- a/data/chips/STM32G473CC.yaml
+++ b/data/chips/STM32G473CC.yaml
@@ -189,39 +189,51 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM20:
     address: 0x40015000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   UCPD1:
     address: 0x4000a000
     kind: UCPD:ucpd_v1_0

--- a/data/chips/STM32G473CE.yaml
+++ b/data/chips/STM32G473CE.yaml
@@ -189,39 +189,51 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM20:
     address: 0x40015000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   UCPD1:
     address: 0x4000a000
     kind: UCPD:ucpd_v1_0

--- a/data/chips/STM32G473MB.yaml
+++ b/data/chips/STM32G473MB.yaml
@@ -191,39 +191,51 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM20:
     address: 0x40015000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_1

--- a/data/chips/STM32G473MC.yaml
+++ b/data/chips/STM32G473MC.yaml
@@ -191,39 +191,51 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM20:
     address: 0x40015000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_1

--- a/data/chips/STM32G473ME.yaml
+++ b/data/chips/STM32G473ME.yaml
@@ -193,39 +193,51 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM20:
     address: 0x40015000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_1

--- a/data/chips/STM32G473PB.yaml
+++ b/data/chips/STM32G473PB.yaml
@@ -191,39 +191,51 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM20:
     address: 0x40015000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_1

--- a/data/chips/STM32G473PC.yaml
+++ b/data/chips/STM32G473PC.yaml
@@ -191,39 +191,51 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM20:
     address: 0x40015000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_1

--- a/data/chips/STM32G473PE.yaml
+++ b/data/chips/STM32G473PE.yaml
@@ -191,39 +191,51 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM20:
     address: 0x40015000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_1

--- a/data/chips/STM32G473QB.yaml
+++ b/data/chips/STM32G473QB.yaml
@@ -191,39 +191,51 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM20:
     address: 0x40015000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_1

--- a/data/chips/STM32G473QC.yaml
+++ b/data/chips/STM32G473QC.yaml
@@ -191,39 +191,51 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM20:
     address: 0x40015000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_1

--- a/data/chips/STM32G473QE.yaml
+++ b/data/chips/STM32G473QE.yaml
@@ -191,39 +191,51 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM20:
     address: 0x40015000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_1

--- a/data/chips/STM32G473RB.yaml
+++ b/data/chips/STM32G473RB.yaml
@@ -187,39 +187,51 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM20:
     address: 0x40015000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_1

--- a/data/chips/STM32G473RC.yaml
+++ b/data/chips/STM32G473RC.yaml
@@ -187,39 +187,51 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM20:
     address: 0x40015000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_1

--- a/data/chips/STM32G473RE.yaml
+++ b/data/chips/STM32G473RE.yaml
@@ -187,39 +187,51 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM20:
     address: 0x40015000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_1

--- a/data/chips/STM32G473VB.yaml
+++ b/data/chips/STM32G473VB.yaml
@@ -195,39 +195,51 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM20:
     address: 0x40015000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_1

--- a/data/chips/STM32G473VC.yaml
+++ b/data/chips/STM32G473VC.yaml
@@ -195,39 +195,51 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM20:
     address: 0x40015000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_1

--- a/data/chips/STM32G473VE.yaml
+++ b/data/chips/STM32G473VE.yaml
@@ -195,39 +195,51 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM20:
     address: 0x40015000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_1

--- a/data/chips/STM32G474CB.yaml
+++ b/data/chips/STM32G474CB.yaml
@@ -192,39 +192,51 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM20:
     address: 0x40015000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   UCPD1:
     address: 0x4000a000
     kind: UCPD:ucpd_v1_0

--- a/data/chips/STM32G474CC.yaml
+++ b/data/chips/STM32G474CC.yaml
@@ -192,39 +192,51 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM20:
     address: 0x40015000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   UCPD1:
     address: 0x4000a000
     kind: UCPD:ucpd_v1_0

--- a/data/chips/STM32G474CE.yaml
+++ b/data/chips/STM32G474CE.yaml
@@ -192,39 +192,51 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM20:
     address: 0x40015000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   UCPD1:
     address: 0x4000a000
     kind: UCPD:ucpd_v1_0

--- a/data/chips/STM32G474MB.yaml
+++ b/data/chips/STM32G474MB.yaml
@@ -194,39 +194,51 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM20:
     address: 0x40015000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_1

--- a/data/chips/STM32G474MC.yaml
+++ b/data/chips/STM32G474MC.yaml
@@ -194,39 +194,51 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM20:
     address: 0x40015000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_1

--- a/data/chips/STM32G474ME.yaml
+++ b/data/chips/STM32G474ME.yaml
@@ -196,39 +196,51 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM20:
     address: 0x40015000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_1

--- a/data/chips/STM32G474PB.yaml
+++ b/data/chips/STM32G474PB.yaml
@@ -194,39 +194,51 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM20:
     address: 0x40015000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_1

--- a/data/chips/STM32G474PC.yaml
+++ b/data/chips/STM32G474PC.yaml
@@ -194,39 +194,51 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM20:
     address: 0x40015000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_1

--- a/data/chips/STM32G474PE.yaml
+++ b/data/chips/STM32G474PE.yaml
@@ -194,39 +194,51 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM20:
     address: 0x40015000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_1

--- a/data/chips/STM32G474QB.yaml
+++ b/data/chips/STM32G474QB.yaml
@@ -194,39 +194,51 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM20:
     address: 0x40015000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_1

--- a/data/chips/STM32G474QC.yaml
+++ b/data/chips/STM32G474QC.yaml
@@ -194,39 +194,51 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM20:
     address: 0x40015000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_1

--- a/data/chips/STM32G474QE.yaml
+++ b/data/chips/STM32G474QE.yaml
@@ -194,39 +194,51 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM20:
     address: 0x40015000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_1

--- a/data/chips/STM32G474RB.yaml
+++ b/data/chips/STM32G474RB.yaml
@@ -190,39 +190,51 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM20:
     address: 0x40015000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_1

--- a/data/chips/STM32G474RC.yaml
+++ b/data/chips/STM32G474RC.yaml
@@ -190,39 +190,51 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM20:
     address: 0x40015000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_1

--- a/data/chips/STM32G474RE.yaml
+++ b/data/chips/STM32G474RE.yaml
@@ -190,39 +190,51 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM20:
     address: 0x40015000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_1

--- a/data/chips/STM32G474VB.yaml
+++ b/data/chips/STM32G474VB.yaml
@@ -198,39 +198,51 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM20:
     address: 0x40015000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_1

--- a/data/chips/STM32G474VC.yaml
+++ b/data/chips/STM32G474VC.yaml
@@ -198,39 +198,51 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM20:
     address: 0x40015000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_1

--- a/data/chips/STM32G474VE.yaml
+++ b/data/chips/STM32G474VE.yaml
@@ -198,39 +198,51 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM20:
     address: 0x40015000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_1

--- a/data/chips/STM32G483CE.yaml
+++ b/data/chips/STM32G483CE.yaml
@@ -192,39 +192,51 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM20:
     address: 0x40015000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   UCPD1:
     address: 0x4000a000
     kind: UCPD:ucpd_v1_0

--- a/data/chips/STM32G483ME.yaml
+++ b/data/chips/STM32G483ME.yaml
@@ -196,39 +196,51 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM20:
     address: 0x40015000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_1

--- a/data/chips/STM32G483PE.yaml
+++ b/data/chips/STM32G483PE.yaml
@@ -194,39 +194,51 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM20:
     address: 0x40015000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_1

--- a/data/chips/STM32G483QE.yaml
+++ b/data/chips/STM32G483QE.yaml
@@ -194,39 +194,51 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM20:
     address: 0x40015000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_1

--- a/data/chips/STM32G483RE.yaml
+++ b/data/chips/STM32G483RE.yaml
@@ -190,39 +190,51 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM20:
     address: 0x40015000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_1

--- a/data/chips/STM32G483VE.yaml
+++ b/data/chips/STM32G483VE.yaml
@@ -198,39 +198,51 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM20:
     address: 0x40015000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_1

--- a/data/chips/STM32G484CE.yaml
+++ b/data/chips/STM32G484CE.yaml
@@ -195,39 +195,51 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM20:
     address: 0x40015000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   UCPD1:
     address: 0x4000a000
     kind: UCPD:ucpd_v1_0

--- a/data/chips/STM32G484ME.yaml
+++ b/data/chips/STM32G484ME.yaml
@@ -199,39 +199,51 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM20:
     address: 0x40015000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_1

--- a/data/chips/STM32G484PE.yaml
+++ b/data/chips/STM32G484PE.yaml
@@ -197,39 +197,51 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM20:
     address: 0x40015000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_1

--- a/data/chips/STM32G484QE.yaml
+++ b/data/chips/STM32G484QE.yaml
@@ -197,39 +197,51 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM20:
     address: 0x40015000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_1

--- a/data/chips/STM32G484RE.yaml
+++ b/data/chips/STM32G484RE.yaml
@@ -193,39 +193,51 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM20:
     address: 0x40015000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_1

--- a/data/chips/STM32G484VE.yaml
+++ b/data/chips/STM32G484VE.yaml
@@ -201,39 +201,51 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM20:
     address: 0x40015000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_1

--- a/data/chips/STM32G491CC.yaml
+++ b/data/chips/STM32G491CC.yaml
@@ -155,40 +155,51 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8G4:gptimer2_v4_x
     clock: APB2
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G4:gptimer2_v4_x
     clock: APB2
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G4:gptimer2_v4_x
     clock: APB2
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM20:
     address: 0x40015000
     kind: TIM1_8G4:gptimer2_v4_x
     clock: APB2
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   UCPD1:
     address: 0x4000a000
     kind: UCPD:ucpd_v1_0

--- a/data/chips/STM32G491CE.yaml
+++ b/data/chips/STM32G491CE.yaml
@@ -155,40 +155,51 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8G4:gptimer2_v4_x
     clock: APB2
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G4:gptimer2_v4_x
     clock: APB2
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G4:gptimer2_v4_x
     clock: APB2
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM20:
     address: 0x40015000
     kind: TIM1_8G4:gptimer2_v4_x
     clock: APB2
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   UCPD1:
     address: 0x4000a000
     kind: UCPD:ucpd_v1_0

--- a/data/chips/STM32G491KC.yaml
+++ b/data/chips/STM32G491KC.yaml
@@ -153,40 +153,51 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8G4:gptimer2_v4_x
     clock: APB2
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G4:gptimer2_v4_x
     clock: APB2
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G4:gptimer2_v4_x
     clock: APB2
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM20:
     address: 0x40015000
     kind: TIM1_8G4:gptimer2_v4_x
     clock: APB2
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   UCPD1:
     address: 0x4000a000
     kind: UCPD:ucpd_v1_0

--- a/data/chips/STM32G491KE.yaml
+++ b/data/chips/STM32G491KE.yaml
@@ -153,40 +153,51 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8G4:gptimer2_v4_x
     clock: APB2
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G4:gptimer2_v4_x
     clock: APB2
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G4:gptimer2_v4_x
     clock: APB2
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM20:
     address: 0x40015000
     kind: TIM1_8G4:gptimer2_v4_x
     clock: APB2
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   UCPD1:
     address: 0x4000a000
     kind: UCPD:ucpd_v1_0

--- a/data/chips/STM32G491MC.yaml
+++ b/data/chips/STM32G491MC.yaml
@@ -155,40 +155,51 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8G4:gptimer2_v4_x
     clock: APB2
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G4:gptimer2_v4_x
     clock: APB2
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G4:gptimer2_v4_x
     clock: APB2
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM20:
     address: 0x40015000
     kind: TIM1_8G4:gptimer2_v4_x
     clock: APB2
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_1

--- a/data/chips/STM32G491ME.yaml
+++ b/data/chips/STM32G491ME.yaml
@@ -155,40 +155,51 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8G4:gptimer2_v4_x
     clock: APB2
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G4:gptimer2_v4_x
     clock: APB2
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G4:gptimer2_v4_x
     clock: APB2
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM20:
     address: 0x40015000
     kind: TIM1_8G4:gptimer2_v4_x
     clock: APB2
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_1

--- a/data/chips/STM32G491RC.yaml
+++ b/data/chips/STM32G491RC.yaml
@@ -155,40 +155,51 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8G4:gptimer2_v4_x
     clock: APB2
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G4:gptimer2_v4_x
     clock: APB2
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G4:gptimer2_v4_x
     clock: APB2
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM20:
     address: 0x40015000
     kind: TIM1_8G4:gptimer2_v4_x
     clock: APB2
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_1

--- a/data/chips/STM32G491RE.yaml
+++ b/data/chips/STM32G491RE.yaml
@@ -157,40 +157,51 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8G4:gptimer2_v4_x
     clock: APB2
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G4:gptimer2_v4_x
     clock: APB2
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G4:gptimer2_v4_x
     clock: APB2
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM20:
     address: 0x40015000
     kind: TIM1_8G4:gptimer2_v4_x
     clock: APB2
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_1

--- a/data/chips/STM32G491VC.yaml
+++ b/data/chips/STM32G491VC.yaml
@@ -153,40 +153,51 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8G4:gptimer2_v4_x
     clock: APB2
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G4:gptimer2_v4_x
     clock: APB2
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G4:gptimer2_v4_x
     clock: APB2
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM20:
     address: 0x40015000
     kind: TIM1_8G4:gptimer2_v4_x
     clock: APB2
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_1

--- a/data/chips/STM32G491VE.yaml
+++ b/data/chips/STM32G491VE.yaml
@@ -153,40 +153,51 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8G4:gptimer2_v4_x
     clock: APB2
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G4:gptimer2_v4_x
     clock: APB2
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G4:gptimer2_v4_x
     clock: APB2
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM20:
     address: 0x40015000
     kind: TIM1_8G4:gptimer2_v4_x
     clock: APB2
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_1

--- a/data/chips/STM32G4A1CE.yaml
+++ b/data/chips/STM32G4A1CE.yaml
@@ -158,40 +158,51 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8G4:gptimer2_v4_x
     clock: APB2
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G4:gptimer2_v4_x
     clock: APB2
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G4:gptimer2_v4_x
     clock: APB2
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM20:
     address: 0x40015000
     kind: TIM1_8G4:gptimer2_v4_x
     clock: APB2
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   UCPD1:
     address: 0x4000a000
     kind: UCPD:ucpd_v1_0

--- a/data/chips/STM32G4A1KE.yaml
+++ b/data/chips/STM32G4A1KE.yaml
@@ -156,40 +156,51 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8G4:gptimer2_v4_x
     clock: APB2
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G4:gptimer2_v4_x
     clock: APB2
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G4:gptimer2_v4_x
     clock: APB2
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM20:
     address: 0x40015000
     kind: TIM1_8G4:gptimer2_v4_x
     clock: APB2
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   UCPD1:
     address: 0x4000a000
     kind: UCPD:ucpd_v1_0

--- a/data/chips/STM32G4A1ME.yaml
+++ b/data/chips/STM32G4A1ME.yaml
@@ -158,40 +158,51 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8G4:gptimer2_v4_x
     clock: APB2
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G4:gptimer2_v4_x
     clock: APB2
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G4:gptimer2_v4_x
     clock: APB2
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM20:
     address: 0x40015000
     kind: TIM1_8G4:gptimer2_v4_x
     clock: APB2
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_1

--- a/data/chips/STM32G4A1RE.yaml
+++ b/data/chips/STM32G4A1RE.yaml
@@ -160,40 +160,51 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8G4:gptimer2_v4_x
     clock: APB2
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G4:gptimer2_v4_x
     clock: APB2
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G4:gptimer2_v4_x
     clock: APB2
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM20:
     address: 0x40015000
     kind: TIM1_8G4:gptimer2_v4_x
     clock: APB2
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_1

--- a/data/chips/STM32G4A1VE.yaml
+++ b/data/chips/STM32G4A1VE.yaml
@@ -156,40 +156,51 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8G4:gptimer2_v4_x
     clock: APB2
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G4:gptimer2_v4_x
     clock: APB2
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G4:gptimer2_v4_x
     clock: APB2
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM20:
     address: 0x40015000
     kind: TIM1_8G4:gptimer2_v4_x
     clock: APB2
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_1

--- a/data/chips/STM32GBK1CB.yaml
+++ b/data/chips/STM32GBK1CB.yaml
@@ -144,33 +144,43 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8G4:gptimer2_v4_x
+    block: timer_v1/TIM_GP16
   UCPD1:
     address: 0x4000a000
     kind: UCPD:ucpd_v1_0

--- a/data/chips/STM32H723VE.yaml
+++ b/data/chips/STM32H723VE.yaml
@@ -250,51 +250,67 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM23:
     address: 0x4000e000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM24:
     address: 0x4000e400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_0

--- a/data/chips/STM32H723VG.yaml
+++ b/data/chips/STM32H723VG.yaml
@@ -250,51 +250,67 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM23:
     address: 0x4000e000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM24:
     address: 0x4000e400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_0

--- a/data/chips/STM32H723ZE.yaml
+++ b/data/chips/STM32H723ZE.yaml
@@ -255,51 +255,67 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM23:
     address: 0x4000e000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM24:
     address: 0x4000e400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_0

--- a/data/chips/STM32H723ZG.yaml
+++ b/data/chips/STM32H723ZG.yaml
@@ -255,51 +255,67 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM23:
     address: 0x4000e000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM24:
     address: 0x4000e400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_0

--- a/data/chips/STM32H725AE.yaml
+++ b/data/chips/STM32H725AE.yaml
@@ -253,51 +253,67 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM23:
     address: 0x4000e000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM24:
     address: 0x4000e400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_0

--- a/data/chips/STM32H725AG.yaml
+++ b/data/chips/STM32H725AG.yaml
@@ -253,51 +253,67 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM23:
     address: 0x4000e000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM24:
     address: 0x4000e400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_0

--- a/data/chips/STM32H725IE.yaml
+++ b/data/chips/STM32H725IE.yaml
@@ -255,51 +255,67 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM23:
     address: 0x4000e000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM24:
     address: 0x4000e400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_0

--- a/data/chips/STM32H725IG.yaml
+++ b/data/chips/STM32H725IG.yaml
@@ -255,51 +255,67 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM23:
     address: 0x4000e000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM24:
     address: 0x4000e400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_0

--- a/data/chips/STM32H725RE.yaml
+++ b/data/chips/STM32H725RE.yaml
@@ -224,51 +224,67 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM23:
     address: 0x4000e000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM24:
     address: 0x4000e400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_0

--- a/data/chips/STM32H725RG.yaml
+++ b/data/chips/STM32H725RG.yaml
@@ -224,51 +224,67 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM23:
     address: 0x4000e000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM24:
     address: 0x4000e400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_0

--- a/data/chips/STM32H725VE.yaml
+++ b/data/chips/STM32H725VE.yaml
@@ -250,51 +250,67 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM23:
     address: 0x4000e000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM24:
     address: 0x4000e400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_0

--- a/data/chips/STM32H725VG.yaml
+++ b/data/chips/STM32H725VG.yaml
@@ -252,51 +252,67 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM23:
     address: 0x4000e000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM24:
     address: 0x4000e400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_0

--- a/data/chips/STM32H725ZE.yaml
+++ b/data/chips/STM32H725ZE.yaml
@@ -253,51 +253,67 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM23:
     address: 0x4000e000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM24:
     address: 0x4000e400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_0

--- a/data/chips/STM32H725ZG.yaml
+++ b/data/chips/STM32H725ZG.yaml
@@ -253,51 +253,67 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM23:
     address: 0x4000e000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM24:
     address: 0x4000e400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_0

--- a/data/chips/STM32H730AB.yaml
+++ b/data/chips/STM32H730AB.yaml
@@ -265,51 +265,67 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM23:
     address: 0x4000e000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM24:
     address: 0x4000e400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_0

--- a/data/chips/STM32H730IB.yaml
+++ b/data/chips/STM32H730IB.yaml
@@ -267,51 +267,67 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM23:
     address: 0x4000e000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM24:
     address: 0x4000e400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_0

--- a/data/chips/STM32H730VB.yaml
+++ b/data/chips/STM32H730VB.yaml
@@ -262,51 +262,67 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM23:
     address: 0x4000e000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM24:
     address: 0x4000e400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_0

--- a/data/chips/STM32H730ZB.yaml
+++ b/data/chips/STM32H730ZB.yaml
@@ -267,51 +267,67 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM23:
     address: 0x4000e000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM24:
     address: 0x4000e400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_0

--- a/data/chips/STM32H733VG.yaml
+++ b/data/chips/STM32H733VG.yaml
@@ -262,51 +262,67 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM23:
     address: 0x4000e000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM24:
     address: 0x4000e400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_0

--- a/data/chips/STM32H733ZG.yaml
+++ b/data/chips/STM32H733ZG.yaml
@@ -267,51 +267,67 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM23:
     address: 0x4000e000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM24:
     address: 0x4000e400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_0

--- a/data/chips/STM32H735AG.yaml
+++ b/data/chips/STM32H735AG.yaml
@@ -265,51 +265,67 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM23:
     address: 0x4000e000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM24:
     address: 0x4000e400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_0

--- a/data/chips/STM32H735IG.yaml
+++ b/data/chips/STM32H735IG.yaml
@@ -267,51 +267,67 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM23:
     address: 0x4000e000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM24:
     address: 0x4000e400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_0

--- a/data/chips/STM32H735RG.yaml
+++ b/data/chips/STM32H735RG.yaml
@@ -236,51 +236,67 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM23:
     address: 0x4000e000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM24:
     address: 0x4000e400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_0

--- a/data/chips/STM32H735VG.yaml
+++ b/data/chips/STM32H735VG.yaml
@@ -264,51 +264,67 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM23:
     address: 0x4000e000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM24:
     address: 0x4000e400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_0

--- a/data/chips/STM32H735ZG.yaml
+++ b/data/chips/STM32H735ZG.yaml
@@ -265,51 +265,67 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM23:
     address: 0x4000e000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM24:
     address: 0x4000e400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_0

--- a/data/chips/STM32H742AG.yaml
+++ b/data/chips/STM32H742AG.yaml
@@ -225,45 +225,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_0

--- a/data/chips/STM32H742AI.yaml
+++ b/data/chips/STM32H742AI.yaml
@@ -225,45 +225,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_0

--- a/data/chips/STM32H742BG.yaml
+++ b/data/chips/STM32H742BG.yaml
@@ -225,45 +225,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_0

--- a/data/chips/STM32H742BI.yaml
+++ b/data/chips/STM32H742BI.yaml
@@ -225,45 +225,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_0

--- a/data/chips/STM32H742IG.yaml
+++ b/data/chips/STM32H742IG.yaml
@@ -227,45 +227,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_0

--- a/data/chips/STM32H742II.yaml
+++ b/data/chips/STM32H742II.yaml
@@ -227,45 +227,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_0

--- a/data/chips/STM32H742VG.yaml
+++ b/data/chips/STM32H742VG.yaml
@@ -222,45 +222,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_0

--- a/data/chips/STM32H742VI.yaml
+++ b/data/chips/STM32H742VI.yaml
@@ -222,45 +222,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_0

--- a/data/chips/STM32H742XG.yaml
+++ b/data/chips/STM32H742XG.yaml
@@ -225,45 +225,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_0

--- a/data/chips/STM32H742XI.yaml
+++ b/data/chips/STM32H742XI.yaml
@@ -225,45 +225,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_0

--- a/data/chips/STM32H742ZG.yaml
+++ b/data/chips/STM32H742ZG.yaml
@@ -225,45 +225,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_0

--- a/data/chips/STM32H742ZI.yaml
+++ b/data/chips/STM32H742ZI.yaml
@@ -225,45 +225,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_0

--- a/data/chips/STM32H743AG.yaml
+++ b/data/chips/STM32H743AG.yaml
@@ -231,45 +231,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_0

--- a/data/chips/STM32H743AI.yaml
+++ b/data/chips/STM32H743AI.yaml
@@ -231,45 +231,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_0

--- a/data/chips/STM32H743BG.yaml
+++ b/data/chips/STM32H743BG.yaml
@@ -231,45 +231,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_0

--- a/data/chips/STM32H743BI.yaml
+++ b/data/chips/STM32H743BI.yaml
@@ -231,45 +231,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_0

--- a/data/chips/STM32H743IG.yaml
+++ b/data/chips/STM32H743IG.yaml
@@ -233,45 +233,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_0

--- a/data/chips/STM32H743II.yaml
+++ b/data/chips/STM32H743II.yaml
@@ -233,45 +233,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_0

--- a/data/chips/STM32H743VG.yaml
+++ b/data/chips/STM32H743VG.yaml
@@ -228,45 +228,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_0

--- a/data/chips/STM32H743VI.yaml
+++ b/data/chips/STM32H743VI.yaml
@@ -228,45 +228,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_0

--- a/data/chips/STM32H743XG.yaml
+++ b/data/chips/STM32H743XG.yaml
@@ -231,45 +231,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_0

--- a/data/chips/STM32H743XI.yaml
+++ b/data/chips/STM32H743XI.yaml
@@ -231,45 +231,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_0

--- a/data/chips/STM32H743ZG.yaml
+++ b/data/chips/STM32H743ZG.yaml
@@ -231,45 +231,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_0

--- a/data/chips/STM32H743ZI.yaml
+++ b/data/chips/STM32H743ZI.yaml
@@ -231,45 +231,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_0

--- a/data/chips/STM32H745BG.yaml
+++ b/data/chips/STM32H745BG.yaml
@@ -236,45 +236,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_0

--- a/data/chips/STM32H745BI.yaml
+++ b/data/chips/STM32H745BI.yaml
@@ -236,45 +236,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_0

--- a/data/chips/STM32H745IG.yaml
+++ b/data/chips/STM32H745IG.yaml
@@ -238,45 +238,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_0

--- a/data/chips/STM32H745II.yaml
+++ b/data/chips/STM32H745II.yaml
@@ -238,45 +238,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_0

--- a/data/chips/STM32H745XG.yaml
+++ b/data/chips/STM32H745XG.yaml
@@ -236,45 +236,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_0

--- a/data/chips/STM32H745XI.yaml
+++ b/data/chips/STM32H745XI.yaml
@@ -236,45 +236,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_0

--- a/data/chips/STM32H745ZG.yaml
+++ b/data/chips/STM32H745ZG.yaml
@@ -236,45 +236,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_0

--- a/data/chips/STM32H745ZI.yaml
+++ b/data/chips/STM32H745ZI.yaml
@@ -236,45 +236,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_0

--- a/data/chips/STM32H747AG.yaml
+++ b/data/chips/STM32H747AG.yaml
@@ -236,45 +236,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_0

--- a/data/chips/STM32H747AI.yaml
+++ b/data/chips/STM32H747AI.yaml
@@ -236,45 +236,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_0

--- a/data/chips/STM32H747BG.yaml
+++ b/data/chips/STM32H747BG.yaml
@@ -236,45 +236,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_0

--- a/data/chips/STM32H747BI.yaml
+++ b/data/chips/STM32H747BI.yaml
@@ -236,45 +236,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_0

--- a/data/chips/STM32H747IG.yaml
+++ b/data/chips/STM32H747IG.yaml
@@ -236,45 +236,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_0

--- a/data/chips/STM32H747II.yaml
+++ b/data/chips/STM32H747II.yaml
@@ -236,45 +236,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_0

--- a/data/chips/STM32H747XG.yaml
+++ b/data/chips/STM32H747XG.yaml
@@ -236,45 +236,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_0

--- a/data/chips/STM32H747XI.yaml
+++ b/data/chips/STM32H747XI.yaml
@@ -236,45 +236,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_0

--- a/data/chips/STM32H747ZI.yaml
+++ b/data/chips/STM32H747ZI.yaml
@@ -231,45 +231,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_0

--- a/data/chips/STM32H750IB.yaml
+++ b/data/chips/STM32H750IB.yaml
@@ -239,45 +239,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_0

--- a/data/chips/STM32H750VB.yaml
+++ b/data/chips/STM32H750VB.yaml
@@ -232,45 +232,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_0

--- a/data/chips/STM32H750XB.yaml
+++ b/data/chips/STM32H750XB.yaml
@@ -237,45 +237,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_0

--- a/data/chips/STM32H750ZB.yaml
+++ b/data/chips/STM32H750ZB.yaml
@@ -237,45 +237,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_0

--- a/data/chips/STM32H753AI.yaml
+++ b/data/chips/STM32H753AI.yaml
@@ -237,45 +237,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_0

--- a/data/chips/STM32H753BI.yaml
+++ b/data/chips/STM32H753BI.yaml
@@ -237,45 +237,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_0

--- a/data/chips/STM32H753II.yaml
+++ b/data/chips/STM32H753II.yaml
@@ -239,45 +239,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_0

--- a/data/chips/STM32H753VI.yaml
+++ b/data/chips/STM32H753VI.yaml
@@ -234,45 +234,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_0

--- a/data/chips/STM32H753XI.yaml
+++ b/data/chips/STM32H753XI.yaml
@@ -237,45 +237,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_0

--- a/data/chips/STM32H753ZI.yaml
+++ b/data/chips/STM32H753ZI.yaml
@@ -237,45 +237,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_0

--- a/data/chips/STM32H755BI.yaml
+++ b/data/chips/STM32H755BI.yaml
@@ -242,45 +242,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_0

--- a/data/chips/STM32H755II.yaml
+++ b/data/chips/STM32H755II.yaml
@@ -244,45 +244,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_0

--- a/data/chips/STM32H755XI.yaml
+++ b/data/chips/STM32H755XI.yaml
@@ -242,45 +242,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_0

--- a/data/chips/STM32H755ZI.yaml
+++ b/data/chips/STM32H755ZI.yaml
@@ -242,45 +242,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_0

--- a/data/chips/STM32H757AI.yaml
+++ b/data/chips/STM32H757AI.yaml
@@ -242,45 +242,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_0

--- a/data/chips/STM32H757BI.yaml
+++ b/data/chips/STM32H757BI.yaml
@@ -242,45 +242,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_0

--- a/data/chips/STM32H757II.yaml
+++ b/data/chips/STM32H757II.yaml
@@ -242,45 +242,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_0

--- a/data/chips/STM32H757XI.yaml
+++ b/data/chips/STM32H757XI.yaml
@@ -242,45 +242,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_0

--- a/data/chips/STM32H757ZI.yaml
+++ b/data/chips/STM32H757ZI.yaml
@@ -237,45 +237,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_0

--- a/data/chips/STM32H7A3AG.yaml
+++ b/data/chips/STM32H7A3AG.yaml
@@ -245,45 +245,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_0

--- a/data/chips/STM32H7A3AI.yaml
+++ b/data/chips/STM32H7A3AI.yaml
@@ -245,45 +245,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_0

--- a/data/chips/STM32H7A3IG.yaml
+++ b/data/chips/STM32H7A3IG.yaml
@@ -251,45 +251,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_0

--- a/data/chips/STM32H7A3II.yaml
+++ b/data/chips/STM32H7A3II.yaml
@@ -251,45 +251,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_0

--- a/data/chips/STM32H7A3LG.yaml
+++ b/data/chips/STM32H7A3LG.yaml
@@ -245,45 +245,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_0

--- a/data/chips/STM32H7A3LI.yaml
+++ b/data/chips/STM32H7A3LI.yaml
@@ -245,45 +245,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_0

--- a/data/chips/STM32H7A3NG.yaml
+++ b/data/chips/STM32H7A3NG.yaml
@@ -245,45 +245,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_0

--- a/data/chips/STM32H7A3NI.yaml
+++ b/data/chips/STM32H7A3NI.yaml
@@ -245,45 +245,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_0

--- a/data/chips/STM32H7A3QI.yaml
+++ b/data/chips/STM32H7A3QI.yaml
@@ -240,45 +240,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_0

--- a/data/chips/STM32H7A3RG.yaml
+++ b/data/chips/STM32H7A3RG.yaml
@@ -215,45 +215,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_0

--- a/data/chips/STM32H7A3RI.yaml
+++ b/data/chips/STM32H7A3RI.yaml
@@ -215,45 +215,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_0

--- a/data/chips/STM32H7A3VG.yaml
+++ b/data/chips/STM32H7A3VG.yaml
@@ -246,45 +246,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_0

--- a/data/chips/STM32H7A3VI.yaml
+++ b/data/chips/STM32H7A3VI.yaml
@@ -246,45 +246,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_0

--- a/data/chips/STM32H7A3ZG.yaml
+++ b/data/chips/STM32H7A3ZG.yaml
@@ -247,45 +247,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_0

--- a/data/chips/STM32H7A3ZI.yaml
+++ b/data/chips/STM32H7A3ZI.yaml
@@ -247,45 +247,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_0

--- a/data/chips/STM32H7B0AB.yaml
+++ b/data/chips/STM32H7B0AB.yaml
@@ -257,45 +257,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_0

--- a/data/chips/STM32H7B0IB.yaml
+++ b/data/chips/STM32H7B0IB.yaml
@@ -259,45 +259,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_0

--- a/data/chips/STM32H7B0RB.yaml
+++ b/data/chips/STM32H7B0RB.yaml
@@ -224,45 +224,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_0

--- a/data/chips/STM32H7B0VB.yaml
+++ b/data/chips/STM32H7B0VB.yaml
@@ -249,45 +249,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_0

--- a/data/chips/STM32H7B0ZB.yaml
+++ b/data/chips/STM32H7B0ZB.yaml
@@ -257,45 +257,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_0

--- a/data/chips/STM32H7B3AI.yaml
+++ b/data/chips/STM32H7B3AI.yaml
@@ -257,45 +257,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_0

--- a/data/chips/STM32H7B3II.yaml
+++ b/data/chips/STM32H7B3II.yaml
@@ -263,45 +263,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_0

--- a/data/chips/STM32H7B3LI.yaml
+++ b/data/chips/STM32H7B3LI.yaml
@@ -257,45 +257,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_0

--- a/data/chips/STM32H7B3NI.yaml
+++ b/data/chips/STM32H7B3NI.yaml
@@ -257,45 +257,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_0

--- a/data/chips/STM32H7B3QI.yaml
+++ b/data/chips/STM32H7B3QI.yaml
@@ -249,45 +249,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_0

--- a/data/chips/STM32H7B3RI.yaml
+++ b/data/chips/STM32H7B3RI.yaml
@@ -224,45 +224,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_0

--- a/data/chips/STM32H7B3VI.yaml
+++ b/data/chips/STM32H7B3VI.yaml
@@ -255,45 +255,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_0

--- a/data/chips/STM32H7B3ZI.yaml
+++ b/data/chips/STM32H7B3ZI.yaml
@@ -259,45 +259,59 @@ peripherals:
   TIM1:
     address: 0x40010000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM12:
     address: 0x40001800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM13:
     address: 0x40001c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM14:
     address: 0x40002000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40010400
     kind: TIM1_8H7:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v3_0

--- a/data/chips/STM32L010C6.yaml
+++ b/data/chips/STM32L010C6.yaml
@@ -68,9 +68,11 @@ peripherals:
   TIM2:
     address: 0x40000000
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM21:
     address: 0x40010800
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART2:
     address: 0x40004400
     kind: USART:sci3_v1_1

--- a/data/chips/STM32L010F4.yaml
+++ b/data/chips/STM32L010F4.yaml
@@ -65,9 +65,11 @@ peripherals:
   TIM2:
     address: 0x40000000
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM21:
     address: 0x40010800
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART2:
     address: 0x40004400
     kind: USART:sci3_v1_1

--- a/data/chips/STM32L010K4.yaml
+++ b/data/chips/STM32L010K4.yaml
@@ -65,9 +65,11 @@ peripherals:
   TIM2:
     address: 0x40000000
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM21:
     address: 0x40010800
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART2:
     address: 0x40004400
     kind: USART:sci3_v1_1

--- a/data/chips/STM32L010K8.yaml
+++ b/data/chips/STM32L010K8.yaml
@@ -68,9 +68,11 @@ peripherals:
   TIM2:
     address: 0x40000000
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM21:
     address: 0x40010800
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART2:
     address: 0x40004400
     kind: USART:sci3_v1_1

--- a/data/chips/STM32L010R8.yaml
+++ b/data/chips/STM32L010R8.yaml
@@ -71,9 +71,11 @@ peripherals:
   TIM2:
     address: 0x40000000
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM21:
     address: 0x40010800
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART2:
     address: 0x40004400
     kind: USART:sci3_v1_1

--- a/data/chips/STM32L010RB.yaml
+++ b/data/chips/STM32L010RB.yaml
@@ -74,12 +74,15 @@ peripherals:
   TIM2:
     address: 0x40000000
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM21:
     address: 0x40010800
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM22:
     address: 0x40011400
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART2:
     address: 0x40004400
     kind: USART:sci3_v1_1

--- a/data/chips/STM32L011D3.yaml
+++ b/data/chips/STM32L011D3.yaml
@@ -71,9 +71,11 @@ peripherals:
   TIM2:
     address: 0x40000000
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM21:
     address: 0x40010800
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART2:
     address: 0x40004400
     kind: USART:sci3_v1_1

--- a/data/chips/STM32L011D4.yaml
+++ b/data/chips/STM32L011D4.yaml
@@ -71,9 +71,11 @@ peripherals:
   TIM2:
     address: 0x40000000
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM21:
     address: 0x40010800
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART2:
     address: 0x40004400
     kind: USART:sci3_v1_1

--- a/data/chips/STM32L011E3.yaml
+++ b/data/chips/STM32L011E3.yaml
@@ -71,9 +71,11 @@ peripherals:
   TIM2:
     address: 0x40000000
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM21:
     address: 0x40010800
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART2:
     address: 0x40004400
     kind: USART:sci3_v1_1

--- a/data/chips/STM32L011E4.yaml
+++ b/data/chips/STM32L011E4.yaml
@@ -71,9 +71,11 @@ peripherals:
   TIM2:
     address: 0x40000000
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM21:
     address: 0x40010800
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART2:
     address: 0x40004400
     kind: USART:sci3_v1_1

--- a/data/chips/STM32L011F3.yaml
+++ b/data/chips/STM32L011F3.yaml
@@ -73,9 +73,11 @@ peripherals:
   TIM2:
     address: 0x40000000
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM21:
     address: 0x40010800
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART2:
     address: 0x40004400
     kind: USART:sci3_v1_1

--- a/data/chips/STM32L011F4.yaml
+++ b/data/chips/STM32L011F4.yaml
@@ -73,9 +73,11 @@ peripherals:
   TIM2:
     address: 0x40000000
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM21:
     address: 0x40010800
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART2:
     address: 0x40004400
     kind: USART:sci3_v1_1

--- a/data/chips/STM32L011G3.yaml
+++ b/data/chips/STM32L011G3.yaml
@@ -71,9 +71,11 @@ peripherals:
   TIM2:
     address: 0x40000000
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM21:
     address: 0x40010800
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART2:
     address: 0x40004400
     kind: USART:sci3_v1_1

--- a/data/chips/STM32L011G4.yaml
+++ b/data/chips/STM32L011G4.yaml
@@ -71,9 +71,11 @@ peripherals:
   TIM2:
     address: 0x40000000
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM21:
     address: 0x40010800
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART2:
     address: 0x40004400
     kind: USART:sci3_v1_1

--- a/data/chips/STM32L011K3.yaml
+++ b/data/chips/STM32L011K3.yaml
@@ -73,9 +73,11 @@ peripherals:
   TIM2:
     address: 0x40000000
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM21:
     address: 0x40010800
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART2:
     address: 0x40004400
     kind: USART:sci3_v1_1

--- a/data/chips/STM32L011K4.yaml
+++ b/data/chips/STM32L011K4.yaml
@@ -73,9 +73,11 @@ peripherals:
   TIM2:
     address: 0x40000000
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM21:
     address: 0x40010800
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART2:
     address: 0x40004400
     kind: USART:sci3_v1_1

--- a/data/chips/STM32L021D4.yaml
+++ b/data/chips/STM32L021D4.yaml
@@ -74,9 +74,11 @@ peripherals:
   TIM2:
     address: 0x40000000
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM21:
     address: 0x40010800
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART2:
     address: 0x40004400
     kind: USART:sci3_v1_1

--- a/data/chips/STM32L021F4.yaml
+++ b/data/chips/STM32L021F4.yaml
@@ -76,9 +76,11 @@ peripherals:
   TIM2:
     address: 0x40000000
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM21:
     address: 0x40010800
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART2:
     address: 0x40004400
     kind: USART:sci3_v1_1

--- a/data/chips/STM32L021G4.yaml
+++ b/data/chips/STM32L021G4.yaml
@@ -74,9 +74,11 @@ peripherals:
   TIM2:
     address: 0x40000000
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM21:
     address: 0x40010800
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART2:
     address: 0x40004400
     kind: USART:sci3_v1_1

--- a/data/chips/STM32L021K4.yaml
+++ b/data/chips/STM32L021K4.yaml
@@ -76,9 +76,11 @@ peripherals:
   TIM2:
     address: 0x40000000
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM21:
     address: 0x40010800
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART2:
     address: 0x40004400
     kind: USART:sci3_v1_1

--- a/data/chips/STM32L031C4.yaml
+++ b/data/chips/STM32L031C4.yaml
@@ -76,12 +76,15 @@ peripherals:
   TIM2:
     address: 0x40000000
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM21:
     address: 0x40010800
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM22:
     address: 0x40011400
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART2:
     address: 0x40004400
     kind: USART:sci3_v1_1

--- a/data/chips/STM32L031C6.yaml
+++ b/data/chips/STM32L031C6.yaml
@@ -76,12 +76,15 @@ peripherals:
   TIM2:
     address: 0x40000000
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM21:
     address: 0x40010800
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM22:
     address: 0x40011400
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART2:
     address: 0x40004400
     kind: USART:sci3_v1_1

--- a/data/chips/STM32L031E4.yaml
+++ b/data/chips/STM32L031E4.yaml
@@ -74,12 +74,15 @@ peripherals:
   TIM2:
     address: 0x40000000
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM21:
     address: 0x40010800
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM22:
     address: 0x40011400
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART2:
     address: 0x40004400
     kind: USART:sci3_v1_1

--- a/data/chips/STM32L031E6.yaml
+++ b/data/chips/STM32L031E6.yaml
@@ -74,12 +74,15 @@ peripherals:
   TIM2:
     address: 0x40000000
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM21:
     address: 0x40010800
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM22:
     address: 0x40011400
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART2:
     address: 0x40004400
     kind: USART:sci3_v1_1

--- a/data/chips/STM32L031F4.yaml
+++ b/data/chips/STM32L031F4.yaml
@@ -74,12 +74,15 @@ peripherals:
   TIM2:
     address: 0x40000000
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM21:
     address: 0x40010800
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM22:
     address: 0x40011400
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART2:
     address: 0x40004400
     kind: USART:sci3_v1_1

--- a/data/chips/STM32L031F6.yaml
+++ b/data/chips/STM32L031F6.yaml
@@ -74,12 +74,15 @@ peripherals:
   TIM2:
     address: 0x40000000
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM21:
     address: 0x40010800
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM22:
     address: 0x40011400
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART2:
     address: 0x40004400
     kind: USART:sci3_v1_1

--- a/data/chips/STM32L031G4.yaml
+++ b/data/chips/STM32L031G4.yaml
@@ -74,12 +74,15 @@ peripherals:
   TIM2:
     address: 0x40000000
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM21:
     address: 0x40010800
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM22:
     address: 0x40011400
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART2:
     address: 0x40004400
     kind: USART:sci3_v1_1

--- a/data/chips/STM32L031G6.yaml
+++ b/data/chips/STM32L031G6.yaml
@@ -76,12 +76,15 @@ peripherals:
   TIM2:
     address: 0x40000000
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM21:
     address: 0x40010800
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM22:
     address: 0x40011400
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART2:
     address: 0x40004400
     kind: USART:sci3_v1_1

--- a/data/chips/STM32L031K4.yaml
+++ b/data/chips/STM32L031K4.yaml
@@ -76,12 +76,15 @@ peripherals:
   TIM2:
     address: 0x40000000
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM21:
     address: 0x40010800
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM22:
     address: 0x40011400
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART2:
     address: 0x40004400
     kind: USART:sci3_v1_1

--- a/data/chips/STM32L031K6.yaml
+++ b/data/chips/STM32L031K6.yaml
@@ -76,12 +76,15 @@ peripherals:
   TIM2:
     address: 0x40000000
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM21:
     address: 0x40010800
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM22:
     address: 0x40011400
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART2:
     address: 0x40004400
     kind: USART:sci3_v1_1

--- a/data/chips/STM32L041C4.yaml
+++ b/data/chips/STM32L041C4.yaml
@@ -77,12 +77,15 @@ peripherals:
   TIM2:
     address: 0x40000000
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM21:
     address: 0x40010800
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM22:
     address: 0x40011400
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART2:
     address: 0x40004400
     kind: USART:sci3_v1_1

--- a/data/chips/STM32L041C6.yaml
+++ b/data/chips/STM32L041C6.yaml
@@ -79,12 +79,15 @@ peripherals:
   TIM2:
     address: 0x40000000
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM21:
     address: 0x40010800
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM22:
     address: 0x40011400
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART2:
     address: 0x40004400
     kind: USART:sci3_v1_1

--- a/data/chips/STM32L041E6.yaml
+++ b/data/chips/STM32L041E6.yaml
@@ -77,12 +77,15 @@ peripherals:
   TIM2:
     address: 0x40000000
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM21:
     address: 0x40010800
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM22:
     address: 0x40011400
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART2:
     address: 0x40004400
     kind: USART:sci3_v1_1

--- a/data/chips/STM32L041F6.yaml
+++ b/data/chips/STM32L041F6.yaml
@@ -77,12 +77,15 @@ peripherals:
   TIM2:
     address: 0x40000000
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM21:
     address: 0x40010800
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM22:
     address: 0x40011400
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART2:
     address: 0x40004400
     kind: USART:sci3_v1_1

--- a/data/chips/STM32L041G6.yaml
+++ b/data/chips/STM32L041G6.yaml
@@ -79,12 +79,15 @@ peripherals:
   TIM2:
     address: 0x40000000
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM21:
     address: 0x40010800
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM22:
     address: 0x40011400
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART2:
     address: 0x40004400
     kind: USART:sci3_v1_1

--- a/data/chips/STM32L041K6.yaml
+++ b/data/chips/STM32L041K6.yaml
@@ -79,12 +79,15 @@ peripherals:
   TIM2:
     address: 0x40000000
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM21:
     address: 0x40010800
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM22:
     address: 0x40011400
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART2:
     address: 0x40004400
     kind: USART:sci3_v1_1

--- a/data/chips/STM32L051C6.yaml
+++ b/data/chips/STM32L051C6.yaml
@@ -87,15 +87,19 @@ peripherals:
   TIM2:
     address: 0x40000000
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM21:
     address: 0x40010800
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM22:
     address: 0x40011400
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci3_v1_1

--- a/data/chips/STM32L051C8.yaml
+++ b/data/chips/STM32L051C8.yaml
@@ -87,15 +87,19 @@ peripherals:
   TIM2:
     address: 0x40000000
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM21:
     address: 0x40010800
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM22:
     address: 0x40011400
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci3_v1_1

--- a/data/chips/STM32L051K6.yaml
+++ b/data/chips/STM32L051K6.yaml
@@ -76,15 +76,19 @@ peripherals:
   TIM2:
     address: 0x40000000
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM21:
     address: 0x40010800
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM22:
     address: 0x40011400
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci3_v1_1

--- a/data/chips/STM32L051K8.yaml
+++ b/data/chips/STM32L051K8.yaml
@@ -76,15 +76,19 @@ peripherals:
   TIM2:
     address: 0x40000000
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM21:
     address: 0x40010800
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM22:
     address: 0x40011400
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci3_v1_1

--- a/data/chips/STM32L051R6.yaml
+++ b/data/chips/STM32L051R6.yaml
@@ -87,15 +87,19 @@ peripherals:
   TIM2:
     address: 0x40000000
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM21:
     address: 0x40010800
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM22:
     address: 0x40011400
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci3_v1_1

--- a/data/chips/STM32L051R8.yaml
+++ b/data/chips/STM32L051R8.yaml
@@ -87,15 +87,19 @@ peripherals:
   TIM2:
     address: 0x40000000
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM21:
     address: 0x40010800
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM22:
     address: 0x40011400
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci3_v1_1

--- a/data/chips/STM32L051T6.yaml
+++ b/data/chips/STM32L051T6.yaml
@@ -81,15 +81,19 @@ peripherals:
   TIM2:
     address: 0x40000000
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM21:
     address: 0x40010800
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM22:
     address: 0x40011400
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci3_v1_1

--- a/data/chips/STM32L051T8.yaml
+++ b/data/chips/STM32L051T8.yaml
@@ -81,15 +81,19 @@ peripherals:
   TIM2:
     address: 0x40000000
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM21:
     address: 0x40010800
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM22:
     address: 0x40011400
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci3_v1_1

--- a/data/chips/STM32L052C6.yaml
+++ b/data/chips/STM32L052C6.yaml
@@ -94,15 +94,19 @@ peripherals:
   TIM2:
     address: 0x40000000
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM21:
     address: 0x40010800
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM22:
     address: 0x40011400
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L052C8.yaml
+++ b/data/chips/STM32L052C8.yaml
@@ -94,15 +94,19 @@ peripherals:
   TIM2:
     address: 0x40000000
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM21:
     address: 0x40010800
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM22:
     address: 0x40011400
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L052K6.yaml
+++ b/data/chips/STM32L052K6.yaml
@@ -83,15 +83,19 @@ peripherals:
   TIM2:
     address: 0x40000000
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM21:
     address: 0x40010800
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM22:
     address: 0x40011400
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L052K8.yaml
+++ b/data/chips/STM32L052K8.yaml
@@ -83,15 +83,19 @@ peripherals:
   TIM2:
     address: 0x40000000
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM21:
     address: 0x40010800
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM22:
     address: 0x40011400
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L052R6.yaml
+++ b/data/chips/STM32L052R6.yaml
@@ -94,15 +94,19 @@ peripherals:
   TIM2:
     address: 0x40000000
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM21:
     address: 0x40010800
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM22:
     address: 0x40011400
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L052R8.yaml
+++ b/data/chips/STM32L052R8.yaml
@@ -94,15 +94,19 @@ peripherals:
   TIM2:
     address: 0x40000000
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM21:
     address: 0x40010800
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM22:
     address: 0x40011400
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L052T6.yaml
+++ b/data/chips/STM32L052T6.yaml
@@ -88,15 +88,19 @@ peripherals:
   TIM2:
     address: 0x40000000
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM21:
     address: 0x40010800
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM22:
     address: 0x40011400
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L052T8.yaml
+++ b/data/chips/STM32L052T8.yaml
@@ -90,15 +90,19 @@ peripherals:
   TIM2:
     address: 0x40000000
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM21:
     address: 0x40010800
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM22:
     address: 0x40011400
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L053C6.yaml
+++ b/data/chips/STM32L053C6.yaml
@@ -97,15 +97,19 @@ peripherals:
   TIM2:
     address: 0x40000000
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM21:
     address: 0x40010800
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM22:
     address: 0x40011400
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L053C8.yaml
+++ b/data/chips/STM32L053C8.yaml
@@ -97,15 +97,19 @@ peripherals:
   TIM2:
     address: 0x40000000
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM21:
     address: 0x40010800
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM22:
     address: 0x40011400
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L053R6.yaml
+++ b/data/chips/STM32L053R6.yaml
@@ -97,15 +97,19 @@ peripherals:
   TIM2:
     address: 0x40000000
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM21:
     address: 0x40010800
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM22:
     address: 0x40011400
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L053R8.yaml
+++ b/data/chips/STM32L053R8.yaml
@@ -97,15 +97,19 @@ peripherals:
   TIM2:
     address: 0x40000000
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM21:
     address: 0x40010800
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM22:
     address: 0x40011400
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L062C8.yaml
+++ b/data/chips/STM32L062C8.yaml
@@ -95,15 +95,19 @@ peripherals:
   TIM2:
     address: 0x40000000
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM21:
     address: 0x40010800
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM22:
     address: 0x40011400
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L062K8.yaml
+++ b/data/chips/STM32L062K8.yaml
@@ -86,15 +86,19 @@ peripherals:
   TIM2:
     address: 0x40000000
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM21:
     address: 0x40010800
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM22:
     address: 0x40011400
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L063C8.yaml
+++ b/data/chips/STM32L063C8.yaml
@@ -100,15 +100,19 @@ peripherals:
   TIM2:
     address: 0x40000000
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM21:
     address: 0x40010800
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM22:
     address: 0x40011400
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L063R8.yaml
+++ b/data/chips/STM32L063R8.yaml
@@ -98,15 +98,19 @@ peripherals:
   TIM2:
     address: 0x40000000
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM21:
     address: 0x40010800
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM22:
     address: 0x40011400
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L071C8.yaml
+++ b/data/chips/STM32L071C8.yaml
@@ -94,21 +94,27 @@ peripherals:
   TIM2:
     address: 0x40000000
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM21:
     address: 0x40010800
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM22:
     address: 0x40011400
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci3_v1_1

--- a/data/chips/STM32L071CB.yaml
+++ b/data/chips/STM32L071CB.yaml
@@ -96,21 +96,27 @@ peripherals:
   TIM2:
     address: 0x40000000
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM21:
     address: 0x40010800
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM22:
     address: 0x40011400
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci3_v1_1

--- a/data/chips/STM32L071CZ.yaml
+++ b/data/chips/STM32L071CZ.yaml
@@ -96,21 +96,27 @@ peripherals:
   TIM2:
     address: 0x40000000
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM21:
     address: 0x40010800
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM22:
     address: 0x40011400
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci3_v1_1

--- a/data/chips/STM32L071K8.yaml
+++ b/data/chips/STM32L071K8.yaml
@@ -84,21 +84,27 @@ peripherals:
   TIM2:
     address: 0x40000000
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM21:
     address: 0x40010800
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM22:
     address: 0x40011400
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci3_v1_1

--- a/data/chips/STM32L071KB.yaml
+++ b/data/chips/STM32L071KB.yaml
@@ -86,21 +86,27 @@ peripherals:
   TIM2:
     address: 0x40000000
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM21:
     address: 0x40010800
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM22:
     address: 0x40011400
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci3_v1_1

--- a/data/chips/STM32L071KZ.yaml
+++ b/data/chips/STM32L071KZ.yaml
@@ -86,21 +86,27 @@ peripherals:
   TIM2:
     address: 0x40000000
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM21:
     address: 0x40010800
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM22:
     address: 0x40011400
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci3_v1_1

--- a/data/chips/STM32L071RB.yaml
+++ b/data/chips/STM32L071RB.yaml
@@ -94,21 +94,27 @@ peripherals:
   TIM2:
     address: 0x40000000
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM21:
     address: 0x40010800
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM22:
     address: 0x40011400
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci3_v1_1

--- a/data/chips/STM32L071RZ.yaml
+++ b/data/chips/STM32L071RZ.yaml
@@ -94,21 +94,27 @@ peripherals:
   TIM2:
     address: 0x40000000
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM21:
     address: 0x40010800
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM22:
     address: 0x40011400
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci3_v1_1

--- a/data/chips/STM32L071V8.yaml
+++ b/data/chips/STM32L071V8.yaml
@@ -94,21 +94,27 @@ peripherals:
   TIM2:
     address: 0x40000000
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM21:
     address: 0x40010800
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM22:
     address: 0x40011400
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci3_v1_1

--- a/data/chips/STM32L071VB.yaml
+++ b/data/chips/STM32L071VB.yaml
@@ -94,21 +94,27 @@ peripherals:
   TIM2:
     address: 0x40000000
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM21:
     address: 0x40010800
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM22:
     address: 0x40011400
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci3_v1_1

--- a/data/chips/STM32L071VZ.yaml
+++ b/data/chips/STM32L071VZ.yaml
@@ -94,21 +94,27 @@ peripherals:
   TIM2:
     address: 0x40000000
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM21:
     address: 0x40010800
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM22:
     address: 0x40011400
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci3_v1_1

--- a/data/chips/STM32L072CB.yaml
+++ b/data/chips/STM32L072CB.yaml
@@ -103,21 +103,27 @@ peripherals:
   TIM2:
     address: 0x40000000
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM21:
     address: 0x40010800
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM22:
     address: 0x40011400
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L072CZ.yaml
+++ b/data/chips/STM32L072CZ.yaml
@@ -105,21 +105,27 @@ peripherals:
   TIM2:
     address: 0x40000000
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM21:
     address: 0x40010800
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM22:
     address: 0x40011400
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L072KB.yaml
+++ b/data/chips/STM32L072KB.yaml
@@ -93,21 +93,27 @@ peripherals:
   TIM2:
     address: 0x40000000
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM21:
     address: 0x40010800
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM22:
     address: 0x40011400
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L072KZ.yaml
+++ b/data/chips/STM32L072KZ.yaml
@@ -93,21 +93,27 @@ peripherals:
   TIM2:
     address: 0x40000000
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM21:
     address: 0x40010800
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM22:
     address: 0x40011400
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L072RB.yaml
+++ b/data/chips/STM32L072RB.yaml
@@ -103,21 +103,27 @@ peripherals:
   TIM2:
     address: 0x40000000
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM21:
     address: 0x40010800
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM22:
     address: 0x40011400
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L072RZ.yaml
+++ b/data/chips/STM32L072RZ.yaml
@@ -103,21 +103,27 @@ peripherals:
   TIM2:
     address: 0x40000000
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM21:
     address: 0x40010800
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM22:
     address: 0x40011400
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L072V8.yaml
+++ b/data/chips/STM32L072V8.yaml
@@ -101,21 +101,27 @@ peripherals:
   TIM2:
     address: 0x40000000
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM21:
     address: 0x40010800
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM22:
     address: 0x40011400
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L072VB.yaml
+++ b/data/chips/STM32L072VB.yaml
@@ -101,21 +101,27 @@ peripherals:
   TIM2:
     address: 0x40000000
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM21:
     address: 0x40010800
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM22:
     address: 0x40011400
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L072VZ.yaml
+++ b/data/chips/STM32L072VZ.yaml
@@ -101,21 +101,27 @@ peripherals:
   TIM2:
     address: 0x40000000
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM21:
     address: 0x40010800
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM22:
     address: 0x40011400
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L073CB.yaml
+++ b/data/chips/STM32L073CB.yaml
@@ -104,21 +104,27 @@ peripherals:
   TIM2:
     address: 0x40000000
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM21:
     address: 0x40010800
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM22:
     address: 0x40011400
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L073CZ.yaml
+++ b/data/chips/STM32L073CZ.yaml
@@ -106,21 +106,27 @@ peripherals:
   TIM2:
     address: 0x40000000
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM21:
     address: 0x40010800
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM22:
     address: 0x40011400
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L073RB.yaml
+++ b/data/chips/STM32L073RB.yaml
@@ -104,21 +104,27 @@ peripherals:
   TIM2:
     address: 0x40000000
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM21:
     address: 0x40010800
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM22:
     address: 0x40011400
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L073RZ.yaml
+++ b/data/chips/STM32L073RZ.yaml
@@ -106,21 +106,27 @@ peripherals:
   TIM2:
     address: 0x40000000
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM21:
     address: 0x40010800
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM22:
     address: 0x40011400
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L073V8.yaml
+++ b/data/chips/STM32L073V8.yaml
@@ -104,21 +104,27 @@ peripherals:
   TIM2:
     address: 0x40000000
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM21:
     address: 0x40010800
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM22:
     address: 0x40011400
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L073VB.yaml
+++ b/data/chips/STM32L073VB.yaml
@@ -104,21 +104,27 @@ peripherals:
   TIM2:
     address: 0x40000000
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM21:
     address: 0x40010800
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM22:
     address: 0x40011400
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L073VZ.yaml
+++ b/data/chips/STM32L073VZ.yaml
@@ -104,21 +104,27 @@ peripherals:
   TIM2:
     address: 0x40000000
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM21:
     address: 0x40010800
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM22:
     address: 0x40011400
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L081CB.yaml
+++ b/data/chips/STM32L081CB.yaml
@@ -95,21 +95,27 @@ peripherals:
   TIM2:
     address: 0x40000000
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM21:
     address: 0x40010800
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM22:
     address: 0x40011400
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci3_v1_1

--- a/data/chips/STM32L081CZ.yaml
+++ b/data/chips/STM32L081CZ.yaml
@@ -97,21 +97,27 @@ peripherals:
   TIM2:
     address: 0x40000000
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM21:
     address: 0x40010800
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM22:
     address: 0x40011400
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci3_v1_1

--- a/data/chips/STM32L081KZ.yaml
+++ b/data/chips/STM32L081KZ.yaml
@@ -89,21 +89,27 @@ peripherals:
   TIM2:
     address: 0x40000000
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM21:
     address: 0x40010800
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM22:
     address: 0x40011400
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci3_v1_1

--- a/data/chips/STM32L082CZ.yaml
+++ b/data/chips/STM32L082CZ.yaml
@@ -104,21 +104,27 @@ peripherals:
   TIM2:
     address: 0x40000000
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM21:
     address: 0x40010800
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM22:
     address: 0x40011400
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L082KB.yaml
+++ b/data/chips/STM32L082KB.yaml
@@ -96,21 +96,27 @@ peripherals:
   TIM2:
     address: 0x40000000
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM21:
     address: 0x40010800
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM22:
     address: 0x40011400
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L082KZ.yaml
+++ b/data/chips/STM32L082KZ.yaml
@@ -96,21 +96,27 @@ peripherals:
   TIM2:
     address: 0x40000000
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM21:
     address: 0x40010800
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM22:
     address: 0x40011400
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L083CB.yaml
+++ b/data/chips/STM32L083CB.yaml
@@ -105,21 +105,27 @@ peripherals:
   TIM2:
     address: 0x40000000
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM21:
     address: 0x40010800
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM22:
     address: 0x40011400
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L083CZ.yaml
+++ b/data/chips/STM32L083CZ.yaml
@@ -107,21 +107,27 @@ peripherals:
   TIM2:
     address: 0x40000000
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM21:
     address: 0x40010800
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM22:
     address: 0x40011400
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L083RB.yaml
+++ b/data/chips/STM32L083RB.yaml
@@ -107,21 +107,27 @@ peripherals:
   TIM2:
     address: 0x40000000
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM21:
     address: 0x40010800
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM22:
     address: 0x40011400
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L083RZ.yaml
+++ b/data/chips/STM32L083RZ.yaml
@@ -107,21 +107,27 @@ peripherals:
   TIM2:
     address: 0x40000000
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM21:
     address: 0x40010800
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM22:
     address: 0x40011400
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L083V8.yaml
+++ b/data/chips/STM32L083V8.yaml
@@ -107,21 +107,27 @@ peripherals:
   TIM2:
     address: 0x40000000
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM21:
     address: 0x40010800
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM22:
     address: 0x40011400
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L083VB.yaml
+++ b/data/chips/STM32L083VB.yaml
@@ -107,21 +107,27 @@ peripherals:
   TIM2:
     address: 0x40000000
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM21:
     address: 0x40010800
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM22:
     address: 0x40011400
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L083VZ.yaml
+++ b/data/chips/STM32L083VZ.yaml
@@ -107,21 +107,27 @@ peripherals:
   TIM2:
     address: 0x40000000
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM21:
     address: 0x40010800
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM22:
     address: 0x40011400
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L0:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L100C6-A.yaml
+++ b/data/chips/STM32L100C6-A.yaml
@@ -87,27 +87,35 @@ peripherals:
   TIM10:
     address: 0x40010c00
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40011000
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40010800
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci2_v1_2

--- a/data/chips/STM32L100C6.yaml
+++ b/data/chips/STM32L100C6.yaml
@@ -85,27 +85,35 @@ peripherals:
   TIM10:
     address: 0x40010c00
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40011000
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40010800
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci2_v1_2

--- a/data/chips/STM32L100R8-A.yaml
+++ b/data/chips/STM32L100R8-A.yaml
@@ -87,27 +87,35 @@ peripherals:
   TIM10:
     address: 0x40010c00
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40011000
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40010800
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci2_v1_2

--- a/data/chips/STM32L100R8.yaml
+++ b/data/chips/STM32L100R8.yaml
@@ -85,27 +85,35 @@ peripherals:
   TIM10:
     address: 0x40010c00
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40011000
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40010800
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci2_v1_2

--- a/data/chips/STM32L100RB-A.yaml
+++ b/data/chips/STM32L100RB-A.yaml
@@ -87,27 +87,35 @@ peripherals:
   TIM10:
     address: 0x40010c00
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40011000
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40010800
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci2_v1_2

--- a/data/chips/STM32L100RB.yaml
+++ b/data/chips/STM32L100RB.yaml
@@ -85,27 +85,35 @@ peripherals:
   TIM10:
     address: 0x40010c00
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40011000
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40010800
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci2_v1_2

--- a/data/chips/STM32L100RC.yaml
+++ b/data/chips/STM32L100RC.yaml
@@ -95,27 +95,35 @@ peripherals:
   TIM10:
     address: 0x40010c00
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40011000
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40010800
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci2_v1_2

--- a/data/chips/STM32L151C6-A.yaml
+++ b/data/chips/STM32L151C6-A.yaml
@@ -89,27 +89,35 @@ peripherals:
   TIM10:
     address: 0x40010c00
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40011000
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40010800
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci2_v1_2

--- a/data/chips/STM32L151C6.yaml
+++ b/data/chips/STM32L151C6.yaml
@@ -87,27 +87,35 @@ peripherals:
   TIM10:
     address: 0x40010c00
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40011000
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40010800
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci2_v1_2

--- a/data/chips/STM32L151C8-A.yaml
+++ b/data/chips/STM32L151C8-A.yaml
@@ -89,27 +89,35 @@ peripherals:
   TIM10:
     address: 0x40010c00
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40011000
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40010800
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci2_v1_2

--- a/data/chips/STM32L151C8.yaml
+++ b/data/chips/STM32L151C8.yaml
@@ -87,27 +87,35 @@ peripherals:
   TIM10:
     address: 0x40010c00
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40011000
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40010800
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci2_v1_2

--- a/data/chips/STM32L151CB-A.yaml
+++ b/data/chips/STM32L151CB-A.yaml
@@ -89,27 +89,35 @@ peripherals:
   TIM10:
     address: 0x40010c00
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40011000
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40010800
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci2_v1_2

--- a/data/chips/STM32L151CB.yaml
+++ b/data/chips/STM32L151CB.yaml
@@ -87,27 +87,35 @@ peripherals:
   TIM10:
     address: 0x40010c00
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40011000
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40010800
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci2_v1_2

--- a/data/chips/STM32L151CC.yaml
+++ b/data/chips/STM32L151CC.yaml
@@ -103,30 +103,39 @@ peripherals:
   TIM10:
     address: 0x40010c00
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40011000
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40010800
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci2_v1_2

--- a/data/chips/STM32L151QC.yaml
+++ b/data/chips/STM32L151QC.yaml
@@ -107,30 +107,39 @@ peripherals:
   TIM10:
     address: 0x40010c00
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40011000
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40010800
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci2_v1_2

--- a/data/chips/STM32L151QD.yaml
+++ b/data/chips/STM32L151QD.yaml
@@ -114,30 +114,39 @@ peripherals:
   TIM10:
     address: 0x40010c00
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40011000
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40010800
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32L151QE.yaml
+++ b/data/chips/STM32L151QE.yaml
@@ -107,30 +107,39 @@ peripherals:
   TIM10:
     address: 0x40010c00
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40011000
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40010800
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32L151R6-A.yaml
+++ b/data/chips/STM32L151R6-A.yaml
@@ -89,27 +89,35 @@ peripherals:
   TIM10:
     address: 0x40010c00
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40011000
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40010800
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci2_v1_2

--- a/data/chips/STM32L151R6.yaml
+++ b/data/chips/STM32L151R6.yaml
@@ -87,27 +87,35 @@ peripherals:
   TIM10:
     address: 0x40010c00
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40011000
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40010800
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci2_v1_2

--- a/data/chips/STM32L151R8-A.yaml
+++ b/data/chips/STM32L151R8-A.yaml
@@ -89,27 +89,35 @@ peripherals:
   TIM10:
     address: 0x40010c00
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40011000
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40010800
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci2_v1_2

--- a/data/chips/STM32L151R8.yaml
+++ b/data/chips/STM32L151R8.yaml
@@ -87,27 +87,35 @@ peripherals:
   TIM10:
     address: 0x40010c00
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40011000
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40010800
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci2_v1_2

--- a/data/chips/STM32L151RB-A.yaml
+++ b/data/chips/STM32L151RB-A.yaml
@@ -89,27 +89,35 @@ peripherals:
   TIM10:
     address: 0x40010c00
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40011000
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40010800
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci2_v1_2

--- a/data/chips/STM32L151RB.yaml
+++ b/data/chips/STM32L151RB.yaml
@@ -87,27 +87,35 @@ peripherals:
   TIM10:
     address: 0x40010c00
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40011000
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40010800
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci2_v1_2

--- a/data/chips/STM32L151RC-A.yaml
+++ b/data/chips/STM32L151RC-A.yaml
@@ -107,30 +107,39 @@ peripherals:
   TIM10:
     address: 0x40010c00
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40011000
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40010800
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci2_v1_2

--- a/data/chips/STM32L151RC.yaml
+++ b/data/chips/STM32L151RC.yaml
@@ -103,30 +103,39 @@ peripherals:
   TIM10:
     address: 0x40010c00
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40011000
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40010800
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci2_v1_2

--- a/data/chips/STM32L151RD.yaml
+++ b/data/chips/STM32L151RD.yaml
@@ -116,30 +116,39 @@ peripherals:
   TIM10:
     address: 0x40010c00
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40011000
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40010800
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32L151RE.yaml
+++ b/data/chips/STM32L151RE.yaml
@@ -107,30 +107,39 @@ peripherals:
   TIM10:
     address: 0x40010c00
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40011000
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40010800
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32L151UC.yaml
+++ b/data/chips/STM32L151UC.yaml
@@ -101,30 +101,39 @@ peripherals:
   TIM10:
     address: 0x40010c00
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40011000
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40010800
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci2_v1_2

--- a/data/chips/STM32L151V8-A.yaml
+++ b/data/chips/STM32L151V8-A.yaml
@@ -89,27 +89,35 @@ peripherals:
   TIM10:
     address: 0x40010c00
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40011000
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40010800
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci2_v1_2

--- a/data/chips/STM32L151V8.yaml
+++ b/data/chips/STM32L151V8.yaml
@@ -87,27 +87,35 @@ peripherals:
   TIM10:
     address: 0x40010c00
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40011000
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40010800
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci2_v1_2

--- a/data/chips/STM32L151VB-A.yaml
+++ b/data/chips/STM32L151VB-A.yaml
@@ -89,27 +89,35 @@ peripherals:
   TIM10:
     address: 0x40010c00
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40011000
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40010800
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci2_v1_2

--- a/data/chips/STM32L151VB.yaml
+++ b/data/chips/STM32L151VB.yaml
@@ -87,27 +87,35 @@ peripherals:
   TIM10:
     address: 0x40010c00
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40011000
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40010800
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci2_v1_2

--- a/data/chips/STM32L151VC-A.yaml
+++ b/data/chips/STM32L151VC-A.yaml
@@ -107,30 +107,39 @@ peripherals:
   TIM10:
     address: 0x40010c00
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40011000
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40010800
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci2_v1_2

--- a/data/chips/STM32L151VC.yaml
+++ b/data/chips/STM32L151VC.yaml
@@ -103,30 +103,39 @@ peripherals:
   TIM10:
     address: 0x40010c00
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40011000
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40010800
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci2_v1_2

--- a/data/chips/STM32L151VD-X.yaml
+++ b/data/chips/STM32L151VD-X.yaml
@@ -109,30 +109,39 @@ peripherals:
   TIM10:
     address: 0x40010c00
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40011000
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40010800
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32L151VD.yaml
+++ b/data/chips/STM32L151VD.yaml
@@ -114,30 +114,39 @@ peripherals:
   TIM10:
     address: 0x40010c00
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40011000
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40010800
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32L151VE.yaml
+++ b/data/chips/STM32L151VE.yaml
@@ -109,30 +109,39 @@ peripherals:
   TIM10:
     address: 0x40010c00
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40011000
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40010800
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32L151ZC.yaml
+++ b/data/chips/STM32L151ZC.yaml
@@ -107,30 +107,39 @@ peripherals:
   TIM10:
     address: 0x40010c00
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40011000
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40010800
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci2_v1_2

--- a/data/chips/STM32L151ZD.yaml
+++ b/data/chips/STM32L151ZD.yaml
@@ -114,30 +114,39 @@ peripherals:
   TIM10:
     address: 0x40010c00
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40011000
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40010800
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32L151ZE.yaml
+++ b/data/chips/STM32L151ZE.yaml
@@ -107,30 +107,39 @@ peripherals:
   TIM10:
     address: 0x40010c00
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40011000
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40010800
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32L152C6-A.yaml
+++ b/data/chips/STM32L152C6-A.yaml
@@ -92,27 +92,35 @@ peripherals:
   TIM10:
     address: 0x40010c00
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40011000
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40010800
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci2_v1_2

--- a/data/chips/STM32L152C6.yaml
+++ b/data/chips/STM32L152C6.yaml
@@ -90,27 +90,35 @@ peripherals:
   TIM10:
     address: 0x40010c00
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40011000
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40010800
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci2_v1_2

--- a/data/chips/STM32L152C8-A.yaml
+++ b/data/chips/STM32L152C8-A.yaml
@@ -92,27 +92,35 @@ peripherals:
   TIM10:
     address: 0x40010c00
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40011000
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40010800
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci2_v1_2

--- a/data/chips/STM32L152C8.yaml
+++ b/data/chips/STM32L152C8.yaml
@@ -90,27 +90,35 @@ peripherals:
   TIM10:
     address: 0x40010c00
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40011000
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40010800
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci2_v1_2

--- a/data/chips/STM32L152CB-A.yaml
+++ b/data/chips/STM32L152CB-A.yaml
@@ -92,27 +92,35 @@ peripherals:
   TIM10:
     address: 0x40010c00
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40011000
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40010800
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci2_v1_2

--- a/data/chips/STM32L152CB.yaml
+++ b/data/chips/STM32L152CB.yaml
@@ -90,27 +90,35 @@ peripherals:
   TIM10:
     address: 0x40010c00
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40011000
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40010800
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci2_v1_2

--- a/data/chips/STM32L152CC.yaml
+++ b/data/chips/STM32L152CC.yaml
@@ -106,30 +106,39 @@ peripherals:
   TIM10:
     address: 0x40010c00
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40011000
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40010800
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci2_v1_2

--- a/data/chips/STM32L152QC.yaml
+++ b/data/chips/STM32L152QC.yaml
@@ -110,30 +110,39 @@ peripherals:
   TIM10:
     address: 0x40010c00
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40011000
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40010800
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci2_v1_2

--- a/data/chips/STM32L152QD.yaml
+++ b/data/chips/STM32L152QD.yaml
@@ -117,30 +117,39 @@ peripherals:
   TIM10:
     address: 0x40010c00
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40011000
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40010800
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32L152QE.yaml
+++ b/data/chips/STM32L152QE.yaml
@@ -110,30 +110,39 @@ peripherals:
   TIM10:
     address: 0x40010c00
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40011000
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40010800
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32L152R6-A.yaml
+++ b/data/chips/STM32L152R6-A.yaml
@@ -92,27 +92,35 @@ peripherals:
   TIM10:
     address: 0x40010c00
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40011000
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40010800
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci2_v1_2

--- a/data/chips/STM32L152R6.yaml
+++ b/data/chips/STM32L152R6.yaml
@@ -90,27 +90,35 @@ peripherals:
   TIM10:
     address: 0x40010c00
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40011000
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40010800
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci2_v1_2

--- a/data/chips/STM32L152R8-A.yaml
+++ b/data/chips/STM32L152R8-A.yaml
@@ -92,27 +92,35 @@ peripherals:
   TIM10:
     address: 0x40010c00
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40011000
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40010800
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci2_v1_2

--- a/data/chips/STM32L152R8.yaml
+++ b/data/chips/STM32L152R8.yaml
@@ -90,27 +90,35 @@ peripherals:
   TIM10:
     address: 0x40010c00
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40011000
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40010800
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci2_v1_2

--- a/data/chips/STM32L152RB-A.yaml
+++ b/data/chips/STM32L152RB-A.yaml
@@ -92,27 +92,35 @@ peripherals:
   TIM10:
     address: 0x40010c00
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40011000
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40010800
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci2_v1_2

--- a/data/chips/STM32L152RB.yaml
+++ b/data/chips/STM32L152RB.yaml
@@ -90,27 +90,35 @@ peripherals:
   TIM10:
     address: 0x40010c00
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40011000
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40010800
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci2_v1_2

--- a/data/chips/STM32L152RC-A.yaml
+++ b/data/chips/STM32L152RC-A.yaml
@@ -110,30 +110,39 @@ peripherals:
   TIM10:
     address: 0x40010c00
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40011000
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40010800
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci2_v1_2

--- a/data/chips/STM32L152RC.yaml
+++ b/data/chips/STM32L152RC.yaml
@@ -104,30 +104,39 @@ peripherals:
   TIM10:
     address: 0x40010c00
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40011000
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40010800
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci2_v1_2

--- a/data/chips/STM32L152RD.yaml
+++ b/data/chips/STM32L152RD.yaml
@@ -119,30 +119,39 @@ peripherals:
   TIM10:
     address: 0x40010c00
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40011000
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40010800
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32L152RE.yaml
+++ b/data/chips/STM32L152RE.yaml
@@ -110,30 +110,39 @@ peripherals:
   TIM10:
     address: 0x40010c00
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40011000
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40010800
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32L152UC.yaml
+++ b/data/chips/STM32L152UC.yaml
@@ -104,30 +104,39 @@ peripherals:
   TIM10:
     address: 0x40010c00
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40011000
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40010800
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci2_v1_2

--- a/data/chips/STM32L152V8-A.yaml
+++ b/data/chips/STM32L152V8-A.yaml
@@ -92,27 +92,35 @@ peripherals:
   TIM10:
     address: 0x40010c00
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40011000
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40010800
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci2_v1_2

--- a/data/chips/STM32L152V8.yaml
+++ b/data/chips/STM32L152V8.yaml
@@ -90,27 +90,35 @@ peripherals:
   TIM10:
     address: 0x40010c00
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40011000
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40010800
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci2_v1_2

--- a/data/chips/STM32L152VB-A.yaml
+++ b/data/chips/STM32L152VB-A.yaml
@@ -92,27 +92,35 @@ peripherals:
   TIM10:
     address: 0x40010c00
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40011000
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40010800
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci2_v1_2

--- a/data/chips/STM32L152VB.yaml
+++ b/data/chips/STM32L152VB.yaml
@@ -90,27 +90,35 @@ peripherals:
   TIM10:
     address: 0x40010c00
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40011000
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40010800
     kind: TIM1_8L1:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci2_v1_2

--- a/data/chips/STM32L152VC-A.yaml
+++ b/data/chips/STM32L152VC-A.yaml
@@ -110,30 +110,39 @@ peripherals:
   TIM10:
     address: 0x40010c00
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40011000
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40010800
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci2_v1_2

--- a/data/chips/STM32L152VC.yaml
+++ b/data/chips/STM32L152VC.yaml
@@ -106,30 +106,39 @@ peripherals:
   TIM10:
     address: 0x40010c00
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40011000
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40010800
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci2_v1_2

--- a/data/chips/STM32L152VD-X.yaml
+++ b/data/chips/STM32L152VD-X.yaml
@@ -110,30 +110,39 @@ peripherals:
   TIM10:
     address: 0x40010c00
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40011000
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40010800
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32L152VD.yaml
+++ b/data/chips/STM32L152VD.yaml
@@ -117,30 +117,39 @@ peripherals:
   TIM10:
     address: 0x40010c00
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40011000
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40010800
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32L152VE.yaml
+++ b/data/chips/STM32L152VE.yaml
@@ -112,30 +112,39 @@ peripherals:
   TIM10:
     address: 0x40010c00
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40011000
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40010800
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32L152ZC.yaml
+++ b/data/chips/STM32L152ZC.yaml
@@ -110,30 +110,39 @@ peripherals:
   TIM10:
     address: 0x40010c00
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40011000
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40010800
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci2_v1_2

--- a/data/chips/STM32L152ZD.yaml
+++ b/data/chips/STM32L152ZD.yaml
@@ -117,30 +117,39 @@ peripherals:
   TIM10:
     address: 0x40010c00
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40011000
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40010800
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32L152ZE.yaml
+++ b/data/chips/STM32L152ZE.yaml
@@ -110,30 +110,39 @@ peripherals:
   TIM10:
     address: 0x40010c00
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40011000
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40010800
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32L162QC.yaml
+++ b/data/chips/STM32L162QC.yaml
@@ -113,30 +113,39 @@ peripherals:
   TIM10:
     address: 0x40010c00
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40011000
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40010800
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci2_v1_2

--- a/data/chips/STM32L162QD.yaml
+++ b/data/chips/STM32L162QD.yaml
@@ -120,30 +120,39 @@ peripherals:
   TIM10:
     address: 0x40010c00
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40011000
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40010800
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32L162RC-A.yaml
+++ b/data/chips/STM32L162RC-A.yaml
@@ -113,30 +113,39 @@ peripherals:
   TIM10:
     address: 0x40010c00
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40011000
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40010800
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci2_v1_2

--- a/data/chips/STM32L162RC.yaml
+++ b/data/chips/STM32L162RC.yaml
@@ -107,30 +107,39 @@ peripherals:
   TIM10:
     address: 0x40010c00
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40011000
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40010800
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci2_v1_2

--- a/data/chips/STM32L162RD.yaml
+++ b/data/chips/STM32L162RD.yaml
@@ -122,30 +122,39 @@ peripherals:
   TIM10:
     address: 0x40010c00
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40011000
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40010800
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32L162RE.yaml
+++ b/data/chips/STM32L162RE.yaml
@@ -113,30 +113,39 @@ peripherals:
   TIM10:
     address: 0x40010c00
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40011000
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40010800
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32L162VC-A.yaml
+++ b/data/chips/STM32L162VC-A.yaml
@@ -113,30 +113,39 @@ peripherals:
   TIM10:
     address: 0x40010c00
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40011000
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40010800
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci2_v1_2

--- a/data/chips/STM32L162VC.yaml
+++ b/data/chips/STM32L162VC.yaml
@@ -109,30 +109,39 @@ peripherals:
   TIM10:
     address: 0x40010c00
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40011000
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40010800
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci2_v1_2

--- a/data/chips/STM32L162VD-X.yaml
+++ b/data/chips/STM32L162VD-X.yaml
@@ -113,30 +113,39 @@ peripherals:
   TIM10:
     address: 0x40010c00
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40011000
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40010800
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32L162VD.yaml
+++ b/data/chips/STM32L162VD.yaml
@@ -120,30 +120,39 @@ peripherals:
   TIM10:
     address: 0x40010c00
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40011000
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40010800
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32L162VE.yaml
+++ b/data/chips/STM32L162VE.yaml
@@ -115,30 +115,39 @@ peripherals:
   TIM10:
     address: 0x40010c00
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40011000
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40010800
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32L162ZC.yaml
+++ b/data/chips/STM32L162ZC.yaml
@@ -113,30 +113,39 @@ peripherals:
   TIM10:
     address: 0x40010c00
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40011000
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40010800
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci2_v1_2

--- a/data/chips/STM32L162ZD.yaml
+++ b/data/chips/STM32L162ZD.yaml
@@ -120,30 +120,39 @@ peripherals:
   TIM10:
     address: 0x40010c00
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40011000
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40010800
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32L162ZE.yaml
+++ b/data/chips/STM32L162ZE.yaml
@@ -113,30 +113,39 @@ peripherals:
   TIM10:
     address: 0x40010c00
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM11:
     address: 0x40011000
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   TIM9:
     address: 0x40010800
     kind: TIM1_8L1Cat345:gptimer2_v2_x
+    block: timer_v1/TIM_GP16
   UART4:
     address: 0x40004c00
     kind: UART:sci2_v1_2

--- a/data/chips/STM32L412C8.yaml
+++ b/data/chips/STM32L412C8.yaml
@@ -109,18 +109,23 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L412CB.yaml
+++ b/data/chips/STM32L412CB.yaml
@@ -113,18 +113,23 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L412K8.yaml
+++ b/data/chips/STM32L412K8.yaml
@@ -101,18 +101,23 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L412KB.yaml
+++ b/data/chips/STM32L412KB.yaml
@@ -101,18 +101,23 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L412R8.yaml
+++ b/data/chips/STM32L412R8.yaml
@@ -109,18 +109,23 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L412RB.yaml
+++ b/data/chips/STM32L412RB.yaml
@@ -113,18 +113,23 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L412T8.yaml
+++ b/data/chips/STM32L412T8.yaml
@@ -99,18 +99,23 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L412TB.yaml
+++ b/data/chips/STM32L412TB.yaml
@@ -101,18 +101,23 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L422CB.yaml
+++ b/data/chips/STM32L422CB.yaml
@@ -112,18 +112,23 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L422KB.yaml
+++ b/data/chips/STM32L422KB.yaml
@@ -104,18 +104,23 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L422RB.yaml
+++ b/data/chips/STM32L422RB.yaml
@@ -112,18 +112,23 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L422TB.yaml
+++ b/data/chips/STM32L422TB.yaml
@@ -102,18 +102,23 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L431CB.yaml
+++ b/data/chips/STM32L431CB.yaml
@@ -135,21 +135,27 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L431CC.yaml
+++ b/data/chips/STM32L431CC.yaml
@@ -135,21 +135,27 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L431KB.yaml
+++ b/data/chips/STM32L431KB.yaml
@@ -122,21 +122,27 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L431KC.yaml
+++ b/data/chips/STM32L431KC.yaml
@@ -122,21 +122,27 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L431RB.yaml
+++ b/data/chips/STM32L431RB.yaml
@@ -138,21 +138,27 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L431RC.yaml
+++ b/data/chips/STM32L431RC.yaml
@@ -138,21 +138,27 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L431VC.yaml
+++ b/data/chips/STM32L431VC.yaml
@@ -136,21 +136,27 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L432KB.yaml
+++ b/data/chips/STM32L432KB.yaml
@@ -116,21 +116,27 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L432KC.yaml
+++ b/data/chips/STM32L432KC.yaml
@@ -116,21 +116,27 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L433CB.yaml
+++ b/data/chips/STM32L433CB.yaml
@@ -139,21 +139,27 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L433CC.yaml
+++ b/data/chips/STM32L433CC.yaml
@@ -139,21 +139,27 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L433RB.yaml
+++ b/data/chips/STM32L433RB.yaml
@@ -142,21 +142,27 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L433RC.yaml
+++ b/data/chips/STM32L433RC.yaml
@@ -144,21 +144,27 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L433VC.yaml
+++ b/data/chips/STM32L433VC.yaml
@@ -140,21 +140,27 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L442KC.yaml
+++ b/data/chips/STM32L442KC.yaml
@@ -119,21 +119,27 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L443CC.yaml
+++ b/data/chips/STM32L443CC.yaml
@@ -142,21 +142,27 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L443RC.yaml
+++ b/data/chips/STM32L443RC.yaml
@@ -145,21 +145,27 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L443VC.yaml
+++ b/data/chips/STM32L443VC.yaml
@@ -143,21 +143,27 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L451CC.yaml
+++ b/data/chips/STM32L451CC.yaml
@@ -128,21 +128,27 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L451CE.yaml
+++ b/data/chips/STM32L451CE.yaml
@@ -130,21 +130,27 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L451RC.yaml
+++ b/data/chips/STM32L451RC.yaml
@@ -135,21 +135,27 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L451RE.yaml
+++ b/data/chips/STM32L451RE.yaml
@@ -135,21 +135,27 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L451VC.yaml
+++ b/data/chips/STM32L451VC.yaml
@@ -133,21 +133,27 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L451VE.yaml
+++ b/data/chips/STM32L451VE.yaml
@@ -133,21 +133,27 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L452CC.yaml
+++ b/data/chips/STM32L452CC.yaml
@@ -128,21 +128,27 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L452CE.yaml
+++ b/data/chips/STM32L452CE.yaml
@@ -130,21 +130,27 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L452RC.yaml
+++ b/data/chips/STM32L452RC.yaml
@@ -135,21 +135,27 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L452RE.yaml
+++ b/data/chips/STM32L452RE.yaml
@@ -137,21 +137,27 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L452VC.yaml
+++ b/data/chips/STM32L452VC.yaml
@@ -133,21 +133,27 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L452VE.yaml
+++ b/data/chips/STM32L452VE.yaml
@@ -133,21 +133,27 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L462CE.yaml
+++ b/data/chips/STM32L462CE.yaml
@@ -133,21 +133,27 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L462RE.yaml
+++ b/data/chips/STM32L462RE.yaml
@@ -138,21 +138,27 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L462VE.yaml
+++ b/data/chips/STM32L462VE.yaml
@@ -136,21 +136,27 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L471QE.yaml
+++ b/data/chips/STM32L471QE.yaml
@@ -149,36 +149,47 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L471QG.yaml
+++ b/data/chips/STM32L471QG.yaml
@@ -149,36 +149,47 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L471RE.yaml
+++ b/data/chips/STM32L471RE.yaml
@@ -149,36 +149,47 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L471RG.yaml
+++ b/data/chips/STM32L471RG.yaml
@@ -149,36 +149,47 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L471VE.yaml
+++ b/data/chips/STM32L471VE.yaml
@@ -149,36 +149,47 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L471VG.yaml
+++ b/data/chips/STM32L471VG.yaml
@@ -149,36 +149,47 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L471ZE.yaml
+++ b/data/chips/STM32L471ZE.yaml
@@ -151,36 +151,47 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L471ZG.yaml
+++ b/data/chips/STM32L471ZG.yaml
@@ -151,36 +151,47 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L475RC.yaml
+++ b/data/chips/STM32L475RC.yaml
@@ -149,36 +149,47 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L475RE.yaml
+++ b/data/chips/STM32L475RE.yaml
@@ -149,36 +149,47 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L475RG.yaml
+++ b/data/chips/STM32L475RG.yaml
@@ -149,36 +149,47 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L475VC.yaml
+++ b/data/chips/STM32L475VC.yaml
@@ -149,36 +149,47 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L475VE.yaml
+++ b/data/chips/STM32L475VE.yaml
@@ -149,36 +149,47 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L475VG.yaml
+++ b/data/chips/STM32L475VG.yaml
@@ -149,36 +149,47 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L476JE.yaml
+++ b/data/chips/STM32L476JE.yaml
@@ -153,36 +153,47 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L476JG.yaml
+++ b/data/chips/STM32L476JG.yaml
@@ -155,36 +155,47 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L476ME.yaml
+++ b/data/chips/STM32L476ME.yaml
@@ -153,36 +153,47 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L476MG.yaml
+++ b/data/chips/STM32L476MG.yaml
@@ -153,36 +153,47 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L476QE.yaml
+++ b/data/chips/STM32L476QE.yaml
@@ -153,36 +153,47 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L476QG.yaml
+++ b/data/chips/STM32L476QG.yaml
@@ -153,36 +153,47 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L476RC.yaml
+++ b/data/chips/STM32L476RC.yaml
@@ -153,36 +153,47 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L476RE.yaml
+++ b/data/chips/STM32L476RE.yaml
@@ -153,36 +153,47 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L476RG.yaml
+++ b/data/chips/STM32L476RG.yaml
@@ -153,36 +153,47 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L476VC.yaml
+++ b/data/chips/STM32L476VC.yaml
@@ -153,36 +153,47 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L476VE.yaml
+++ b/data/chips/STM32L476VE.yaml
@@ -153,36 +153,47 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L476VG.yaml
+++ b/data/chips/STM32L476VG.yaml
@@ -153,36 +153,47 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L476ZE.yaml
+++ b/data/chips/STM32L476ZE.yaml
@@ -153,36 +153,47 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L476ZG.yaml
+++ b/data/chips/STM32L476ZG.yaml
@@ -157,36 +157,47 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L485JC.yaml
+++ b/data/chips/STM32L485JC.yaml
@@ -152,36 +152,47 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L485JE.yaml
+++ b/data/chips/STM32L485JE.yaml
@@ -152,36 +152,47 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L486JG.yaml
+++ b/data/chips/STM32L486JG.yaml
@@ -156,36 +156,47 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L486QG.yaml
+++ b/data/chips/STM32L486QG.yaml
@@ -156,36 +156,47 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L486RG.yaml
+++ b/data/chips/STM32L486RG.yaml
@@ -156,36 +156,47 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L486VG.yaml
+++ b/data/chips/STM32L486VG.yaml
@@ -156,36 +156,47 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L486ZG.yaml
+++ b/data/chips/STM32L486ZG.yaml
@@ -156,36 +156,47 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L496AE.yaml
+++ b/data/chips/STM32L496AE.yaml
@@ -173,36 +173,47 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L496AG.yaml
+++ b/data/chips/STM32L496AG.yaml
@@ -175,36 +175,47 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L496QE.yaml
+++ b/data/chips/STM32L496QE.yaml
@@ -173,36 +173,47 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L496QG.yaml
+++ b/data/chips/STM32L496QG.yaml
@@ -175,36 +175,47 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L496RE.yaml
+++ b/data/chips/STM32L496RE.yaml
@@ -173,36 +173,47 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L496RG.yaml
+++ b/data/chips/STM32L496RG.yaml
@@ -175,36 +175,47 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L496VE.yaml
+++ b/data/chips/STM32L496VE.yaml
@@ -173,36 +173,47 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L496VG.yaml
+++ b/data/chips/STM32L496VG.yaml
@@ -179,36 +179,47 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L496WG.yaml
+++ b/data/chips/STM32L496WG.yaml
@@ -173,36 +173,47 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L496ZE.yaml
+++ b/data/chips/STM32L496ZE.yaml
@@ -173,36 +173,47 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L496ZG.yaml
+++ b/data/chips/STM32L496ZG.yaml
@@ -175,36 +175,47 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L4A6AG.yaml
+++ b/data/chips/STM32L4A6AG.yaml
@@ -181,36 +181,47 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L4A6QG.yaml
+++ b/data/chips/STM32L4A6QG.yaml
@@ -181,36 +181,47 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L4A6RG.yaml
+++ b/data/chips/STM32L4A6RG.yaml
@@ -181,36 +181,47 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L4A6VG.yaml
+++ b/data/chips/STM32L4A6VG.yaml
@@ -185,36 +185,47 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L4A6ZG.yaml
+++ b/data/chips/STM32L4A6ZG.yaml
@@ -181,36 +181,47 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L4P5AE.yaml
+++ b/data/chips/STM32L4P5AE.yaml
@@ -178,36 +178,47 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L4P5AG.yaml
+++ b/data/chips/STM32L4P5AG.yaml
@@ -180,36 +180,47 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L4P5CE.yaml
+++ b/data/chips/STM32L4P5CE.yaml
@@ -170,36 +170,47 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L4P5CG.yaml
+++ b/data/chips/STM32L4P5CG.yaml
@@ -174,36 +174,47 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L4P5QE.yaml
+++ b/data/chips/STM32L4P5QE.yaml
@@ -178,36 +178,47 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L4P5QG.yaml
+++ b/data/chips/STM32L4P5QG.yaml
@@ -180,36 +180,47 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L4P5RE.yaml
+++ b/data/chips/STM32L4P5RE.yaml
@@ -178,36 +178,47 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L4P5RG.yaml
+++ b/data/chips/STM32L4P5RG.yaml
@@ -180,36 +180,47 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L4P5VE.yaml
+++ b/data/chips/STM32L4P5VE.yaml
@@ -180,36 +180,47 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L4P5VG.yaml
+++ b/data/chips/STM32L4P5VG.yaml
@@ -184,36 +184,47 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L4P5ZE.yaml
+++ b/data/chips/STM32L4P5ZE.yaml
@@ -178,36 +178,47 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L4P5ZG.yaml
+++ b/data/chips/STM32L4P5ZG.yaml
@@ -180,36 +180,47 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L4Q5AG.yaml
+++ b/data/chips/STM32L4Q5AG.yaml
@@ -186,36 +186,47 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L4Q5CG.yaml
+++ b/data/chips/STM32L4Q5CG.yaml
@@ -180,36 +180,47 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L4Q5QG.yaml
+++ b/data/chips/STM32L4Q5QG.yaml
@@ -186,36 +186,47 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L4Q5RG.yaml
+++ b/data/chips/STM32L4Q5RG.yaml
@@ -186,36 +186,47 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L4Q5VG.yaml
+++ b/data/chips/STM32L4Q5VG.yaml
@@ -190,36 +190,47 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L4Q5ZG.yaml
+++ b/data/chips/STM32L4Q5ZG.yaml
@@ -186,36 +186,47 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L4R5AG.yaml
+++ b/data/chips/STM32L4R5AG.yaml
@@ -162,36 +162,47 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L4R5AI.yaml
+++ b/data/chips/STM32L4R5AI.yaml
@@ -162,36 +162,47 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L4R5QG.yaml
+++ b/data/chips/STM32L4R5QG.yaml
@@ -162,36 +162,47 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L4R5QI.yaml
+++ b/data/chips/STM32L4R5QI.yaml
@@ -162,36 +162,47 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L4R5VG.yaml
+++ b/data/chips/STM32L4R5VG.yaml
@@ -162,36 +162,47 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L4R5VI.yaml
+++ b/data/chips/STM32L4R5VI.yaml
@@ -162,36 +162,47 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L4R5ZG.yaml
+++ b/data/chips/STM32L4R5ZG.yaml
@@ -164,36 +164,47 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L4R5ZI.yaml
+++ b/data/chips/STM32L4R5ZI.yaml
@@ -166,36 +166,47 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L4R7AI.yaml
+++ b/data/chips/STM32L4R7AI.yaml
@@ -168,36 +168,47 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L4R7VI.yaml
+++ b/data/chips/STM32L4R7VI.yaml
@@ -168,36 +168,47 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L4R7ZI.yaml
+++ b/data/chips/STM32L4R7ZI.yaml
@@ -168,36 +168,47 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L4R9AG.yaml
+++ b/data/chips/STM32L4R9AG.yaml
@@ -168,36 +168,47 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L4R9AI.yaml
+++ b/data/chips/STM32L4R9AI.yaml
@@ -168,36 +168,47 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L4R9VG.yaml
+++ b/data/chips/STM32L4R9VG.yaml
@@ -168,36 +168,47 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L4R9VI.yaml
+++ b/data/chips/STM32L4R9VI.yaml
@@ -168,36 +168,47 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L4R9ZG.yaml
+++ b/data/chips/STM32L4R9ZG.yaml
@@ -172,36 +172,47 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L4R9ZI.yaml
+++ b/data/chips/STM32L4R9ZI.yaml
@@ -174,36 +174,47 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L4S5AI.yaml
+++ b/data/chips/STM32L4S5AI.yaml
@@ -168,36 +168,47 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L4S5QI.yaml
+++ b/data/chips/STM32L4S5QI.yaml
@@ -168,36 +168,47 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L4S5VI.yaml
+++ b/data/chips/STM32L4S5VI.yaml
@@ -168,36 +168,47 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L4S5ZI.yaml
+++ b/data/chips/STM32L4S5ZI.yaml
@@ -170,36 +170,47 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L4S7AI.yaml
+++ b/data/chips/STM32L4S7AI.yaml
@@ -174,36 +174,47 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L4S7VI.yaml
+++ b/data/chips/STM32L4S7VI.yaml
@@ -174,36 +174,47 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L4S7ZI.yaml
+++ b/data/chips/STM32L4S7ZI.yaml
@@ -174,36 +174,47 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L4S9AI.yaml
+++ b/data/chips/STM32L4S9AI.yaml
@@ -174,36 +174,47 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L4S9VI.yaml
+++ b/data/chips/STM32L4S9VI.yaml
@@ -174,36 +174,47 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L4S9ZI.yaml
+++ b/data/chips/STM32L4S9ZI.yaml
@@ -178,36 +178,47 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8L4:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L552CC.yaml
+++ b/data/chips/STM32L552CC.yaml
@@ -158,36 +158,47 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L552CE.yaml
+++ b/data/chips/STM32L552CE.yaml
@@ -162,36 +162,47 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L552ME.yaml
+++ b/data/chips/STM32L552ME.yaml
@@ -163,36 +163,47 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L552QC.yaml
+++ b/data/chips/STM32L552QC.yaml
@@ -161,36 +161,47 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L552QE.yaml
+++ b/data/chips/STM32L552QE.yaml
@@ -165,36 +165,47 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L552RC.yaml
+++ b/data/chips/STM32L552RC.yaml
@@ -161,36 +161,47 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L552RE.yaml
+++ b/data/chips/STM32L552RE.yaml
@@ -165,36 +165,47 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L552VC.yaml
+++ b/data/chips/STM32L552VC.yaml
@@ -161,36 +161,47 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L552VE.yaml
+++ b/data/chips/STM32L552VE.yaml
@@ -163,36 +163,47 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L552ZC.yaml
+++ b/data/chips/STM32L552ZC.yaml
@@ -161,36 +161,47 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L552ZE.yaml
+++ b/data/chips/STM32L552ZE.yaml
@@ -163,36 +163,47 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L562CE.yaml
+++ b/data/chips/STM32L562CE.yaml
@@ -171,36 +171,47 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L562ME.yaml
+++ b/data/chips/STM32L562ME.yaml
@@ -172,36 +172,47 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L562QE.yaml
+++ b/data/chips/STM32L562QE.yaml
@@ -174,36 +174,47 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L562RE.yaml
+++ b/data/chips/STM32L562RE.yaml
@@ -174,36 +174,47 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L562VE.yaml
+++ b/data/chips/STM32L562VE.yaml
@@ -172,36 +172,47 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32L562ZE.yaml
+++ b/data/chips/STM32L562ZE.yaml
@@ -172,36 +172,47 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM15:
     address: 0x40014000
     kind: TIM1_8L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM3:
     address: 0x40000400
     kind: TIM1_8L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM4:
     address: 0x40000800
     kind: TIM1_8L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM5:
     address: 0x40000c00
     kind: TIM1_8L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM6:
     address: 0x40001000
     kind: TIM6_7L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM7:
     address: 0x40001400
     kind: TIM6_7L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM8:
     address: 0x40013400
     kind: TIM1_8L5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32WB10CC.yaml
+++ b/data/chips/STM32WB10CC.yaml
@@ -86,9 +86,11 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8WB5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8WB5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32WB15CC.yaml
+++ b/data/chips/STM32WB15CC.yaml
@@ -96,9 +96,11 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8WB5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8WB5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32WB30CE.yaml
+++ b/data/chips/STM32WB30CE.yaml
@@ -86,15 +86,19 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8WB5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8WB5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8WB5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8WB5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci3_v2_1

--- a/data/chips/STM32WB35CC.yaml
+++ b/data/chips/STM32WB35CC.yaml
@@ -112,15 +112,19 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8WB5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8WB5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8WB5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8WB5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci3_v2_1

--- a/data/chips/STM32WB35CE.yaml
+++ b/data/chips/STM32WB35CE.yaml
@@ -112,15 +112,19 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8WB5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8WB5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8WB5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8WB5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci3_v2_1

--- a/data/chips/STM32WB50CG.yaml
+++ b/data/chips/STM32WB50CG.yaml
@@ -86,15 +86,19 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8WB5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8WB5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8WB5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8WB5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci3_v2_1

--- a/data/chips/STM32WB55CC.yaml
+++ b/data/chips/STM32WB55CC.yaml
@@ -118,15 +118,19 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8WB5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8WB5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8WB5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8WB5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci3_v2_1

--- a/data/chips/STM32WB55CE.yaml
+++ b/data/chips/STM32WB55CE.yaml
@@ -118,15 +118,19 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8WB5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8WB5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8WB5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8WB5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci3_v2_1

--- a/data/chips/STM32WB55CG.yaml
+++ b/data/chips/STM32WB55CG.yaml
@@ -118,15 +118,19 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8WB5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8WB5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8WB5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8WB5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci3_v2_1

--- a/data/chips/STM32WB55RC.yaml
+++ b/data/chips/STM32WB55RC.yaml
@@ -122,15 +122,19 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8WB5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8WB5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8WB5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8WB5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32WB55RE.yaml
+++ b/data/chips/STM32WB55RE.yaml
@@ -122,15 +122,19 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8WB5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8WB5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8WB5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8WB5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32WB55RG.yaml
+++ b/data/chips/STM32WB55RG.yaml
@@ -122,15 +122,19 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8WB5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8WB5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8WB5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8WB5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32WB55VC.yaml
+++ b/data/chips/STM32WB55VC.yaml
@@ -124,15 +124,19 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8WB5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8WB5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8WB5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8WB5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32WB55VE.yaml
+++ b/data/chips/STM32WB55VE.yaml
@@ -124,15 +124,19 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8WB5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8WB5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8WB5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8WB5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32WB55VG.yaml
+++ b/data/chips/STM32WB55VG.yaml
@@ -124,15 +124,19 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8WB5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8WB5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8WB5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8WB5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32WB55VY.yaml
+++ b/data/chips/STM32WB55VY.yaml
@@ -122,15 +122,19 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8WB5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8WB5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8WB5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8WB5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32WB5MMG.yaml
+++ b/data/chips/STM32WB5MMG.yaml
@@ -119,15 +119,19 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8WB5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8WB5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8WB5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8WB5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TSC:
     address: 0x40024000
     kind: TSC:tsc1_v1_0

--- a/data/chips/STM32WL54CC.yaml
+++ b/data/chips/STM32WL54CC.yaml
@@ -117,15 +117,19 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8WL5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8WL5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8WL5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8WL5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci3_v2_1

--- a/data/chips/STM32WL54JC.yaml
+++ b/data/chips/STM32WL54JC.yaml
@@ -117,15 +117,19 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8WL5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8WL5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8WL5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8WL5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci3_v2_1

--- a/data/chips/STM32WL55CC.yaml
+++ b/data/chips/STM32WL55CC.yaml
@@ -117,15 +117,19 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8WL5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8WL5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8WL5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8WL5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci3_v2_1

--- a/data/chips/STM32WL55JC.yaml
+++ b/data/chips/STM32WL55JC.yaml
@@ -117,15 +117,19 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8WL5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8WL5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8WL5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8WL5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci3_v2_1

--- a/data/chips/STM32WL55UC.yaml
+++ b/data/chips/STM32WL55UC.yaml
@@ -117,15 +117,19 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8WL5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8WL5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8WL5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8WL5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci3_v2_1

--- a/data/chips/STM32WLE4C8.yaml
+++ b/data/chips/STM32WLE4C8.yaml
@@ -112,15 +112,19 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8WL5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8WL5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8WL5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8WL5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci3_v2_1

--- a/data/chips/STM32WLE4CB.yaml
+++ b/data/chips/STM32WLE4CB.yaml
@@ -112,15 +112,19 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8WL5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8WL5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8WL5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8WL5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci3_v2_1

--- a/data/chips/STM32WLE4CC.yaml
+++ b/data/chips/STM32WLE4CC.yaml
@@ -112,15 +112,19 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8WL5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8WL5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8WL5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8WL5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci3_v2_1

--- a/data/chips/STM32WLE4J8.yaml
+++ b/data/chips/STM32WLE4J8.yaml
@@ -112,15 +112,19 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8WL5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8WL5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8WL5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8WL5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci3_v2_1

--- a/data/chips/STM32WLE4JB.yaml
+++ b/data/chips/STM32WLE4JB.yaml
@@ -112,15 +112,19 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8WL5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8WL5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8WL5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8WL5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci3_v2_1

--- a/data/chips/STM32WLE4JC.yaml
+++ b/data/chips/STM32WLE4JC.yaml
@@ -112,15 +112,19 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8WL5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8WL5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8WL5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8WL5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci3_v2_1

--- a/data/chips/STM32WLE5C8.yaml
+++ b/data/chips/STM32WLE5C8.yaml
@@ -112,15 +112,19 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8WL5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8WL5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8WL5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8WL5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci3_v2_1

--- a/data/chips/STM32WLE5CB.yaml
+++ b/data/chips/STM32WLE5CB.yaml
@@ -112,15 +112,19 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8WL5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8WL5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8WL5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8WL5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci3_v2_1

--- a/data/chips/STM32WLE5CC.yaml
+++ b/data/chips/STM32WLE5CC.yaml
@@ -112,15 +112,19 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8WL5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8WL5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8WL5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8WL5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci3_v2_1

--- a/data/chips/STM32WLE5J8.yaml
+++ b/data/chips/STM32WLE5J8.yaml
@@ -112,15 +112,19 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8WL5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8WL5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8WL5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8WL5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci3_v2_1

--- a/data/chips/STM32WLE5JB.yaml
+++ b/data/chips/STM32WLE5JB.yaml
@@ -112,15 +112,19 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8WL5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8WL5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8WL5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8WL5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci3_v2_1

--- a/data/chips/STM32WLE5JC.yaml
+++ b/data/chips/STM32WLE5JC.yaml
@@ -112,15 +112,19 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8WL5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8WL5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8WL5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8WL5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci3_v2_1

--- a/data/chips/STM32WLE5U8.yaml
+++ b/data/chips/STM32WLE5U8.yaml
@@ -112,15 +112,19 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8WL5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8WL5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8WL5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8WL5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci3_v2_1

--- a/data/chips/STM32WLE5UB.yaml
+++ b/data/chips/STM32WLE5UB.yaml
@@ -112,15 +112,19 @@ peripherals:
   TIM1:
     address: 0x40012c00
     kind: TIM1_8WL5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM16:
     address: 0x40014400
     kind: TIM1_8WL5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM17:
     address: 0x40014800
     kind: TIM1_8WL5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   TIM2:
     address: 0x40000000
     kind: TIM1_8WL5:gptimer2_v3_x
+    block: timer_v1/TIM_GP16
   USART1:
     address: 0x40013800
     kind: USART:sci3_v2_1

--- a/parse.py
+++ b/parse.py
@@ -244,6 +244,7 @@ perimap = [
     ('.*:STM32H7_pwr_v1_0', 'pwr_h7/PWR'),
     ('.*:STM32H7_flash_v1_0', 'flash_h7/FLASH'),
     ('.*:STM32H7_dbgmcu_v1_0', 'dbgmcu_h7/DBGMCU'),
+    ('.*TIM\d.*:gptimer.*', 'timer_v1/TIM_GP16'),
 ]
 
 


### PR DESCRIPTION
This isn't ideal, but for now we don't have data information to really distinguish between timers, but this will be useful to implement an embassy "rtc" using the correct timers.