### PR TITLE
Add missing clock selection for SPI6

### DIFF
--- a/data/chips/STM32H742AG.yaml
+++ b/data/chips/STM32H742AG.yaml
@@ -1430,6 +1430,7 @@ peripherals:
   SPI6:
     address: 0x58001400
     kind: SPI:spi2s2_v1_0
+    clock: APB4
     block: spi_v3/SPI
     pins:
     - pin: PB4

--- a/data/chips/STM32H742AI.yaml
+++ b/data/chips/STM32H742AI.yaml
@@ -1430,6 +1430,7 @@ peripherals:
   SPI6:
     address: 0x58001400
     kind: SPI:spi2s2_v1_0
+    clock: APB4
     block: spi_v3/SPI
     pins:
     - pin: PB4

--- a/data/chips/STM32H742BG.yaml
+++ b/data/chips/STM32H742BG.yaml
@@ -1512,6 +1512,7 @@ peripherals:
   SPI6:
     address: 0x58001400
     kind: SPI:spi2s2_v1_0
+    clock: APB4
     block: spi_v3/SPI
     pins:
     - pin: PA4

--- a/data/chips/STM32H742BI.yaml
+++ b/data/chips/STM32H742BI.yaml
@@ -1512,6 +1512,7 @@ peripherals:
   SPI6:
     address: 0x58001400
     kind: SPI:spi2s2_v1_0
+    clock: APB4
     block: spi_v3/SPI
     pins:
     - pin: PA4

--- a/data/chips/STM32H742IG.yaml
+++ b/data/chips/STM32H742IG.yaml
@@ -1494,6 +1494,7 @@ peripherals:
   SPI6:
     address: 0x58001400
     kind: SPI:spi2s2_v1_0
+    clock: APB4
     block: spi_v3/SPI
     pins:
     - pin: PA4

--- a/data/chips/STM32H742II.yaml
+++ b/data/chips/STM32H742II.yaml
@@ -1494,6 +1494,7 @@ peripherals:
   SPI6:
     address: 0x58001400
     kind: SPI:spi2s2_v1_0
+    clock: APB4
     block: spi_v3/SPI
     pins:
     - pin: PA4

--- a/data/chips/STM32H742VG.yaml
+++ b/data/chips/STM32H742VG.yaml
@@ -1124,6 +1124,7 @@ peripherals:
   SPI6:
     address: 0x58001400
     kind: SPI:spi2s2_v1_0
+    clock: APB4
     block: spi_v3/SPI
     pins:
     - pin: PA4

--- a/data/chips/STM32H742VI.yaml
+++ b/data/chips/STM32H742VI.yaml
@@ -1124,6 +1124,7 @@ peripherals:
   SPI6:
     address: 0x58001400
     kind: SPI:spi2s2_v1_0
+    clock: APB4
     block: spi_v3/SPI
     pins:
     - pin: PA4

--- a/data/chips/STM32H742XG.yaml
+++ b/data/chips/STM32H742XG.yaml
@@ -1548,6 +1548,7 @@ peripherals:
   SPI6:
     address: 0x58001400
     kind: SPI:spi2s2_v1_0
+    clock: APB4
     block: spi_v3/SPI
     pins:
     - pin: PB5

--- a/data/chips/STM32H742XI.yaml
+++ b/data/chips/STM32H742XI.yaml
@@ -1548,6 +1548,7 @@ peripherals:
   SPI6:
     address: 0x58001400
     kind: SPI:spi2s2_v1_0
+    clock: APB4
     block: spi_v3/SPI
     pins:
     - pin: PB5

--- a/data/chips/STM32H742ZG.yaml
+++ b/data/chips/STM32H742ZG.yaml
@@ -1330,6 +1330,7 @@ peripherals:
   SPI6:
     address: 0x58001400
     kind: SPI:spi2s2_v1_0
+    clock: APB4
     block: spi_v3/SPI
     pins:
     - pin: PA4

--- a/data/chips/STM32H742ZI.yaml
+++ b/data/chips/STM32H742ZI.yaml
@@ -1330,6 +1330,7 @@ peripherals:
   SPI6:
     address: 0x58001400
     kind: SPI:spi2s2_v1_0
+    clock: APB4
     block: spi_v3/SPI
     pins:
     - pin: PA4

--- a/data/chips/STM32H743AG.yaml
+++ b/data/chips/STM32H743AG.yaml
@@ -1640,6 +1640,7 @@ peripherals:
   SPI6:
     address: 0x58001400
     kind: SPI:spi2s2_v1_0
+    clock: APB4
     block: spi_v3/SPI
     pins:
     - pin: PB4

--- a/data/chips/STM32H743AI.yaml
+++ b/data/chips/STM32H743AI.yaml
@@ -1640,6 +1640,7 @@ peripherals:
   SPI6:
     address: 0x58001400
     kind: SPI:spi2s2_v1_0
+    clock: APB4
     block: spi_v3/SPI
     pins:
     - pin: PB4

--- a/data/chips/STM32H743BG.yaml
+++ b/data/chips/STM32H743BG.yaml
@@ -1830,6 +1830,7 @@ peripherals:
   SPI6:
     address: 0x58001400
     kind: SPI:spi2s2_v1_0
+    clock: APB4
     block: spi_v3/SPI
     pins:
     - pin: PA4

--- a/data/chips/STM32H743BI.yaml
+++ b/data/chips/STM32H743BI.yaml
@@ -1830,6 +1830,7 @@ peripherals:
   SPI6:
     address: 0x58001400
     kind: SPI:spi2s2_v1_0
+    clock: APB4
     block: spi_v3/SPI
     pins:
     - pin: PA4

--- a/data/chips/STM32H743IG.yaml
+++ b/data/chips/STM32H743IG.yaml
@@ -1724,6 +1724,7 @@ peripherals:
   SPI6:
     address: 0x58001400
     kind: SPI:spi2s2_v1_0
+    clock: APB4
     block: spi_v3/SPI
     pins:
     - pin: PA4

--- a/data/chips/STM32H743II.yaml
+++ b/data/chips/STM32H743II.yaml
@@ -1724,6 +1724,7 @@ peripherals:
   SPI6:
     address: 0x58001400
     kind: SPI:spi2s2_v1_0
+    clock: APB4
     block: spi_v3/SPI
     pins:
     - pin: PA4

--- a/data/chips/STM32H743VG.yaml
+++ b/data/chips/STM32H743VG.yaml
@@ -1247,6 +1247,7 @@ peripherals:
   SPI6:
     address: 0x58001400
     kind: SPI:spi2s2_v1_0
+    clock: APB4
     block: spi_v3/SPI
     pins:
     - pin: PA4

--- a/data/chips/STM32H743VI.yaml
+++ b/data/chips/STM32H743VI.yaml
@@ -1247,6 +1247,7 @@ peripherals:
   SPI6:
     address: 0x58001400
     kind: SPI:spi2s2_v1_0
+    clock: APB4
     block: spi_v3/SPI
     pins:
     - pin: PA4

--- a/data/chips/STM32H743XG.yaml
+++ b/data/chips/STM32H743XG.yaml
@@ -1866,6 +1866,7 @@ peripherals:
   SPI6:
     address: 0x58001400
     kind: SPI:spi2s2_v1_0
+    clock: APB4
     block: spi_v3/SPI
     pins:
     - pin: PB5

--- a/data/chips/STM32H743XI.yaml
+++ b/data/chips/STM32H743XI.yaml
@@ -1866,6 +1866,7 @@ peripherals:
   SPI6:
     address: 0x58001400
     kind: SPI:spi2s2_v1_0
+    clock: APB4
     block: spi_v3/SPI
     pins:
     - pin: PB5

--- a/data/chips/STM32H743ZG.yaml
+++ b/data/chips/STM32H743ZG.yaml
@@ -1486,6 +1486,7 @@ peripherals:
   SPI6:
     address: 0x58001400
     kind: SPI:spi2s2_v1_0
+    clock: APB4
     block: spi_v3/SPI
     pins:
     - pin: PA4

--- a/data/chips/STM32H743ZI.yaml
+++ b/data/chips/STM32H743ZI.yaml
@@ -1486,6 +1486,7 @@ peripherals:
   SPI6:
     address: 0x58001400
     kind: SPI:spi2s2_v1_0
+    clock: APB4
     block: spi_v3/SPI
     pins:
     - pin: PA4

--- a/data/chips/STM32H745BG.yaml
+++ b/data/chips/STM32H745BG.yaml
@@ -1770,6 +1770,7 @@ peripherals:
   SPI6:
     address: 0x58001400
     kind: SPI:spi2s2_v1_0
+    clock: APB4
     block: spi_v3/SPI
     pins:
     - pin: PA4

--- a/data/chips/STM32H745BI.yaml
+++ b/data/chips/STM32H745BI.yaml
@@ -1770,6 +1770,7 @@ peripherals:
   SPI6:
     address: 0x58001400
     kind: SPI:spi2s2_v1_0
+    clock: APB4
     block: spi_v3/SPI
     pins:
     - pin: PA4

--- a/data/chips/STM32H745IG.yaml
+++ b/data/chips/STM32H745IG.yaml
@@ -1524,6 +1524,7 @@ peripherals:
   SPI6:
     address: 0x58001400
     kind: SPI:spi2s2_v1_0
+    clock: APB4
     block: spi_v3/SPI
     pins:
     - pin: PA4

--- a/data/chips/STM32H745II.yaml
+++ b/data/chips/STM32H745II.yaml
@@ -1524,6 +1524,7 @@ peripherals:
   SPI6:
     address: 0x58001400
     kind: SPI:spi2s2_v1_0
+    clock: APB4
     block: spi_v3/SPI
     pins:
     - pin: PA4

--- a/data/chips/STM32H745XG.yaml
+++ b/data/chips/STM32H745XG.yaml
@@ -1869,6 +1869,7 @@ peripherals:
   SPI6:
     address: 0x58001400
     kind: SPI:spi2s2_v1_0
+    clock: APB4
     block: spi_v3/SPI
     pins:
     - pin: PB5

--- a/data/chips/STM32H745XI.yaml
+++ b/data/chips/STM32H745XI.yaml
@@ -1869,6 +1869,7 @@ peripherals:
   SPI6:
     address: 0x58001400
     kind: SPI:spi2s2_v1_0
+    clock: APB4
     block: spi_v3/SPI
     pins:
     - pin: PB5

--- a/data/chips/STM32H745ZG.yaml
+++ b/data/chips/STM32H745ZG.yaml
@@ -1456,6 +1456,7 @@ peripherals:
   SPI6:
     address: 0x58001400
     kind: SPI:spi2s2_v1_0
+    clock: APB4
     block: spi_v3/SPI
     pins:
     - pin: PA4

--- a/data/chips/STM32H745ZI.yaml
+++ b/data/chips/STM32H745ZI.yaml
@@ -1456,6 +1456,7 @@ peripherals:
   SPI6:
     address: 0x58001400
     kind: SPI:spi2s2_v1_0
+    clock: APB4
     block: spi_v3/SPI
     pins:
     - pin: PA4

--- a/data/chips/STM32H747AG.yaml
+++ b/data/chips/STM32H747AG.yaml
@@ -1489,6 +1489,7 @@ peripherals:
   SPI6:
     address: 0x58001400
     kind: SPI:spi2s2_v1_0
+    clock: APB4
     block: spi_v3/SPI
     pins:
     - pin: PB5

--- a/data/chips/STM32H747AI.yaml
+++ b/data/chips/STM32H747AI.yaml
@@ -1489,6 +1489,7 @@ peripherals:
   SPI6:
     address: 0x58001400
     kind: SPI:spi2s2_v1_0
+    clock: APB4
     block: spi_v3/SPI
     pins:
     - pin: PB5

--- a/data/chips/STM32H747BG.yaml
+++ b/data/chips/STM32H747BG.yaml
@@ -1731,6 +1731,7 @@ peripherals:
   SPI6:
     address: 0x58001400
     kind: SPI:spi2s2_v1_0
+    clock: APB4
     block: spi_v3/SPI
     pins:
     - pin: PA4

--- a/data/chips/STM32H747BI.yaml
+++ b/data/chips/STM32H747BI.yaml
@@ -1731,6 +1731,7 @@ peripherals:
   SPI6:
     address: 0x58001400
     kind: SPI:spi2s2_v1_0
+    clock: APB4
     block: spi_v3/SPI
     pins:
     - pin: PA4

--- a/data/chips/STM32H747IG.yaml
+++ b/data/chips/STM32H747IG.yaml
@@ -1489,6 +1489,7 @@ peripherals:
   SPI6:
     address: 0x58001400
     kind: SPI:spi2s2_v1_0
+    clock: APB4
     block: spi_v3/SPI
     pins:
     - pin: PA4

--- a/data/chips/STM32H747II.yaml
+++ b/data/chips/STM32H747II.yaml
@@ -1489,6 +1489,7 @@ peripherals:
   SPI6:
     address: 0x58001400
     kind: SPI:spi2s2_v1_0
+    clock: APB4
     block: spi_v3/SPI
     pins:
     - pin: PA4

--- a/data/chips/STM32H747XG.yaml
+++ b/data/chips/STM32H747XG.yaml
@@ -1869,6 +1869,7 @@ peripherals:
   SPI6:
     address: 0x58001400
     kind: SPI:spi2s2_v1_0
+    clock: APB4
     block: spi_v3/SPI
     pins:
     - pin: PB5

--- a/data/chips/STM32H747XI.yaml
+++ b/data/chips/STM32H747XI.yaml
@@ -1869,6 +1869,7 @@ peripherals:
   SPI6:
     address: 0x58001400
     kind: SPI:spi2s2_v1_0
+    clock: APB4
     block: spi_v3/SPI
     pins:
     - pin: PB5

--- a/data/chips/STM32H747ZI.yaml
+++ b/data/chips/STM32H747ZI.yaml
@@ -1305,6 +1305,7 @@ peripherals:
   SPI6:
     address: 0x58001400
     kind: SPI:spi2s2_v1_0
+    clock: APB4
     block: spi_v3/SPI
     pins:
     - pin: PA15

--- a/data/chips/STM32H750IB.yaml
+++ b/data/chips/STM32H750IB.yaml
@@ -1722,6 +1722,7 @@ peripherals:
   SPI6:
     address: 0x58001400
     kind: SPI:spi2s2_v1_0
+    clock: APB4
     block: spi_v3/SPI
     pins:
     - pin: PA4

--- a/data/chips/STM32H750VB.yaml
+++ b/data/chips/STM32H750VB.yaml
@@ -1251,6 +1251,7 @@ peripherals:
   SPI6:
     address: 0x58001400
     kind: SPI:spi2s2_v1_0
+    clock: APB4
     block: spi_v3/SPI
     pins:
     - pin: PA4

--- a/data/chips/STM32H750XB.yaml
+++ b/data/chips/STM32H750XB.yaml
@@ -1872,6 +1872,7 @@ peripherals:
   SPI6:
     address: 0x58001400
     kind: SPI:spi2s2_v1_0
+    clock: APB4
     block: spi_v3/SPI
     pins:
     - pin: PB5

--- a/data/chips/STM32H750ZB.yaml
+++ b/data/chips/STM32H750ZB.yaml
@@ -1492,6 +1492,7 @@ peripherals:
   SPI6:
     address: 0x58001400
     kind: SPI:spi2s2_v1_0
+    clock: APB4
     block: spi_v3/SPI
     pins:
     - pin: PA4

--- a/data/chips/STM32H753AI.yaml
+++ b/data/chips/STM32H753AI.yaml
@@ -1646,6 +1646,7 @@ peripherals:
   SPI6:
     address: 0x58001400
     kind: SPI:spi2s2_v1_0
+    clock: APB4
     block: spi_v3/SPI
     pins:
     - pin: PB4

--- a/data/chips/STM32H753BI.yaml
+++ b/data/chips/STM32H753BI.yaml
@@ -1836,6 +1836,7 @@ peripherals:
   SPI6:
     address: 0x58001400
     kind: SPI:spi2s2_v1_0
+    clock: APB4
     block: spi_v3/SPI
     pins:
     - pin: PA4

--- a/data/chips/STM32H753II.yaml
+++ b/data/chips/STM32H753II.yaml
@@ -1730,6 +1730,7 @@ peripherals:
   SPI6:
     address: 0x58001400
     kind: SPI:spi2s2_v1_0
+    clock: APB4
     block: spi_v3/SPI
     pins:
     - pin: PA4

--- a/data/chips/STM32H753VI.yaml
+++ b/data/chips/STM32H753VI.yaml
@@ -1253,6 +1253,7 @@ peripherals:
   SPI6:
     address: 0x58001400
     kind: SPI:spi2s2_v1_0
+    clock: APB4
     block: spi_v3/SPI
     pins:
     - pin: PA4

--- a/data/chips/STM32H753XI.yaml
+++ b/data/chips/STM32H753XI.yaml
@@ -1872,6 +1872,7 @@ peripherals:
   SPI6:
     address: 0x58001400
     kind: SPI:spi2s2_v1_0
+    clock: APB4
     block: spi_v3/SPI
     pins:
     - pin: PB5

--- a/data/chips/STM32H753ZI.yaml
+++ b/data/chips/STM32H753ZI.yaml
@@ -1492,6 +1492,7 @@ peripherals:
   SPI6:
     address: 0x58001400
     kind: SPI:spi2s2_v1_0
+    clock: APB4
     block: spi_v3/SPI
     pins:
     - pin: PA4

--- a/data/chips/STM32H755BI.yaml
+++ b/data/chips/STM32H755BI.yaml
@@ -1776,6 +1776,7 @@ peripherals:
   SPI6:
     address: 0x58001400
     kind: SPI:spi2s2_v1_0
+    clock: APB4
     block: spi_v3/SPI
     pins:
     - pin: PA4

--- a/data/chips/STM32H755II.yaml
+++ b/data/chips/STM32H755II.yaml
@@ -1530,6 +1530,7 @@ peripherals:
   SPI6:
     address: 0x58001400
     kind: SPI:spi2s2_v1_0
+    clock: APB4
     block: spi_v3/SPI
     pins:
     - pin: PA4

--- a/data/chips/STM32H755XI.yaml
+++ b/data/chips/STM32H755XI.yaml
@@ -1875,6 +1875,7 @@ peripherals:
   SPI6:
     address: 0x58001400
     kind: SPI:spi2s2_v1_0
+    clock: APB4
     block: spi_v3/SPI
     pins:
     - pin: PB5

--- a/data/chips/STM32H755ZI.yaml
+++ b/data/chips/STM32H755ZI.yaml
@@ -1462,6 +1462,7 @@ peripherals:
   SPI6:
     address: 0x58001400
     kind: SPI:spi2s2_v1_0
+    clock: APB4
     block: spi_v3/SPI
     pins:
     - pin: PA4

--- a/data/chips/STM32H757AI.yaml
+++ b/data/chips/STM32H757AI.yaml
@@ -1495,6 +1495,7 @@ peripherals:
   SPI6:
     address: 0x58001400
     kind: SPI:spi2s2_v1_0
+    clock: APB4
     block: spi_v3/SPI
     pins:
     - pin: PB5

--- a/data/chips/STM32H757BI.yaml
+++ b/data/chips/STM32H757BI.yaml
@@ -1737,6 +1737,7 @@ peripherals:
   SPI6:
     address: 0x58001400
     kind: SPI:spi2s2_v1_0
+    clock: APB4
     block: spi_v3/SPI
     pins:
     - pin: PA4

--- a/data/chips/STM32H757II.yaml
+++ b/data/chips/STM32H757II.yaml
@@ -1495,6 +1495,7 @@ peripherals:
   SPI6:
     address: 0x58001400
     kind: SPI:spi2s2_v1_0
+    clock: APB4
     block: spi_v3/SPI
     pins:
     - pin: PA4

--- a/data/chips/STM32H757XI.yaml
+++ b/data/chips/STM32H757XI.yaml
@@ -1875,6 +1875,7 @@ peripherals:
   SPI6:
     address: 0x58001400
     kind: SPI:spi2s2_v1_0
+    clock: APB4
     block: spi_v3/SPI
     pins:
     - pin: PB5

--- a/data/chips/STM32H757ZI.yaml
+++ b/data/chips/STM32H757ZI.yaml
@@ -1311,6 +1311,7 @@ peripherals:
   SPI6:
     address: 0x58001400
     kind: SPI:spi2s2_v1_0
+    clock: APB4
     block: spi_v3/SPI
     pins:
     - pin: PA15

--- a/parse.py
+++ b/parse.py
@@ -454,6 +454,8 @@ def parse_chips():
 
             if pname in clocks[rcc]:
                 p['clock'] = clocks[rcc][pname]
+            elif chip['family'] == 'STM32H7' and pname == "SPI6":
+                p['clock'] = "APB4"
             # else:
                 #print( f'peri {pname} -> no clock')
 


### PR DESCRIPTION
According to the reference manual, SPI6 is enabled in APB4, but the APB4Freq_Value peripheral list is not including SPI6.