### PR TITLE
[#52]: Fix missing I2C

### DIFF
--- a/data/chips/STM32F030C6.yaml
+++ b/data/chips/STM32F030C6.yaml
@@ -81,6 +81,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB10
         signal: SCL

--- a/data/chips/STM32F030C8.yaml
+++ b/data/chips/STM32F030C8.yaml
@@ -81,6 +81,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB5
         signal: SMBA
@@ -106,6 +107,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB10
         signal: SCL

--- a/data/chips/STM32F030CC.yaml
+++ b/data/chips/STM32F030CC.yaml
@@ -81,6 +81,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF0
         signal: SDA

--- a/data/chips/STM32F030F4.yaml
+++ b/data/chips/STM32F030F4.yaml
@@ -79,6 +79,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA9
         signal: SCL

--- a/data/chips/STM32F030K6.yaml
+++ b/data/chips/STM32F030K6.yaml
@@ -81,6 +81,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA9
         signal: SCL

--- a/data/chips/STM32F030R8.yaml
+++ b/data/chips/STM32F030R8.yaml
@@ -93,6 +93,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB5
         signal: SMBA
@@ -118,6 +119,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB10
         signal: SCL

--- a/data/chips/STM32F030RC.yaml
+++ b/data/chips/STM32F030RC.yaml
@@ -93,6 +93,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF0
         signal: SDA

--- a/data/chips/STM32F031C4.yaml
+++ b/data/chips/STM32F031C4.yaml
@@ -78,6 +78,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB10
         signal: SCL

--- a/data/chips/STM32F031C6.yaml
+++ b/data/chips/STM32F031C6.yaml
@@ -78,6 +78,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB10
         signal: SCL

--- a/data/chips/STM32F031E6.yaml
+++ b/data/chips/STM32F031E6.yaml
@@ -78,6 +78,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB7
         signal: SDA

--- a/data/chips/STM32F031F4.yaml
+++ b/data/chips/STM32F031F4.yaml
@@ -76,6 +76,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA9
         signal: SCL

--- a/data/chips/STM32F031F6.yaml
+++ b/data/chips/STM32F031F6.yaml
@@ -76,6 +76,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA9
         signal: SCL

--- a/data/chips/STM32F031G4.yaml
+++ b/data/chips/STM32F031G4.yaml
@@ -78,6 +78,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA9
         signal: SCL

--- a/data/chips/STM32F031G6.yaml
+++ b/data/chips/STM32F031G6.yaml
@@ -78,6 +78,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA9
         signal: SCL

--- a/data/chips/STM32F031K4.yaml
+++ b/data/chips/STM32F031K4.yaml
@@ -78,6 +78,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA9
         signal: SCL

--- a/data/chips/STM32F031K6.yaml
+++ b/data/chips/STM32F031K6.yaml
@@ -80,6 +80,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA9
         signal: SCL

--- a/data/chips/STM32F038C6.yaml
+++ b/data/chips/STM32F038C6.yaml
@@ -78,6 +78,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB10
         signal: SCL

--- a/data/chips/STM32F038E6.yaml
+++ b/data/chips/STM32F038E6.yaml
@@ -78,6 +78,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB7
         signal: SDA

--- a/data/chips/STM32F038F6.yaml
+++ b/data/chips/STM32F038F6.yaml
@@ -74,6 +74,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA9
         signal: SCL

--- a/data/chips/STM32F038G6.yaml
+++ b/data/chips/STM32F038G6.yaml
@@ -76,6 +76,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA9
         signal: SCL

--- a/data/chips/STM32F038K6.yaml
+++ b/data/chips/STM32F038K6.yaml
@@ -78,6 +78,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA9
         signal: SCL

--- a/data/chips/STM32F042C4.yaml
+++ b/data/chips/STM32F042C4.yaml
@@ -100,6 +100,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF0
         signal: SDA

--- a/data/chips/STM32F042C6.yaml
+++ b/data/chips/STM32F042C6.yaml
@@ -100,6 +100,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF0
         signal: SDA

--- a/data/chips/STM32F042F4.yaml
+++ b/data/chips/STM32F042F4.yaml
@@ -93,6 +93,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB8
         signal: SCL

--- a/data/chips/STM32F042F6.yaml
+++ b/data/chips/STM32F042F6.yaml
@@ -93,6 +93,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB8
         signal: SCL

--- a/data/chips/STM32F042G4.yaml
+++ b/data/chips/STM32F042G4.yaml
@@ -95,6 +95,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB8
         signal: SCL

--- a/data/chips/STM32F042G6.yaml
+++ b/data/chips/STM32F042G6.yaml
@@ -95,6 +95,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB8
         signal: SCL

--- a/data/chips/STM32F042K4.yaml
+++ b/data/chips/STM32F042K4.yaml
@@ -97,6 +97,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF0
         signal: SDA

--- a/data/chips/STM32F042K6.yaml
+++ b/data/chips/STM32F042K6.yaml
@@ -97,6 +97,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF0
         signal: SDA

--- a/data/chips/STM32F042T6.yaml
+++ b/data/chips/STM32F042T6.yaml
@@ -95,6 +95,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA12
         signal: SDA

--- a/data/chips/STM32F048C6.yaml
+++ b/data/chips/STM32F048C6.yaml
@@ -81,6 +81,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF0
         signal: SDA

--- a/data/chips/STM32F048G6.yaml
+++ b/data/chips/STM32F048G6.yaml
@@ -79,6 +79,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB8
         signal: SCL

--- a/data/chips/STM32F048T6.yaml
+++ b/data/chips/STM32F048T6.yaml
@@ -81,6 +81,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA12
         signal: SDA

--- a/data/chips/STM32F051C4.yaml
+++ b/data/chips/STM32F051C4.yaml
@@ -143,6 +143,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB5
         signal: SMBA

--- a/data/chips/STM32F051C6.yaml
+++ b/data/chips/STM32F051C6.yaml
@@ -143,6 +143,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB5
         signal: SMBA

--- a/data/chips/STM32F051C8.yaml
+++ b/data/chips/STM32F051C8.yaml
@@ -143,6 +143,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB5
         signal: SMBA
@@ -168,6 +169,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB10
         signal: SCL

--- a/data/chips/STM32F051K4.yaml
+++ b/data/chips/STM32F051K4.yaml
@@ -143,6 +143,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB5
         signal: SMBA

--- a/data/chips/STM32F051K6.yaml
+++ b/data/chips/STM32F051K6.yaml
@@ -143,6 +143,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB5
         signal: SMBA

--- a/data/chips/STM32F051K8.yaml
+++ b/data/chips/STM32F051K8.yaml
@@ -143,6 +143,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB5
         signal: SMBA

--- a/data/chips/STM32F051R4.yaml
+++ b/data/chips/STM32F051R4.yaml
@@ -153,6 +153,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB5
         signal: SMBA

--- a/data/chips/STM32F051R6.yaml
+++ b/data/chips/STM32F051R6.yaml
@@ -153,6 +153,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB5
         signal: SMBA

--- a/data/chips/STM32F051R8.yaml
+++ b/data/chips/STM32F051R8.yaml
@@ -155,6 +155,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB5
         signal: SMBA
@@ -180,6 +181,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB10
         signal: SCL

--- a/data/chips/STM32F051T8.yaml
+++ b/data/chips/STM32F051T8.yaml
@@ -141,6 +141,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB7
         signal: SDA

--- a/data/chips/STM32F058C8.yaml
+++ b/data/chips/STM32F058C8.yaml
@@ -141,6 +141,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB5
         signal: SMBA
@@ -166,6 +167,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB10
         signal: SCL

--- a/data/chips/STM32F058R8.yaml
+++ b/data/chips/STM32F058R8.yaml
@@ -155,6 +155,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB5
         signal: SMBA
@@ -180,6 +181,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB10
         signal: SCL

--- a/data/chips/STM32F058T8.yaml
+++ b/data/chips/STM32F058T8.yaml
@@ -141,6 +141,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB7
         signal: SDA

--- a/data/chips/STM32F070C6.yaml
+++ b/data/chips/STM32F070C6.yaml
@@ -81,6 +81,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF0
         signal: SDA

--- a/data/chips/STM32F070CB.yaml
+++ b/data/chips/STM32F070CB.yaml
@@ -81,6 +81,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB5
         signal: SMBA

--- a/data/chips/STM32F070F6.yaml
+++ b/data/chips/STM32F070F6.yaml
@@ -79,6 +79,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF0
         signal: SDA

--- a/data/chips/STM32F070RB.yaml
+++ b/data/chips/STM32F070RB.yaml
@@ -93,6 +93,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB5
         signal: SMBA

--- a/data/chips/STM32F071C8.yaml
+++ b/data/chips/STM32F071C8.yaml
@@ -144,6 +144,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB5
         signal: SMBA

--- a/data/chips/STM32F071CB.yaml
+++ b/data/chips/STM32F071CB.yaml
@@ -146,6 +146,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB5
         signal: SMBA

--- a/data/chips/STM32F071RB.yaml
+++ b/data/chips/STM32F071RB.yaml
@@ -154,6 +154,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB5
         signal: SMBA

--- a/data/chips/STM32F071V8.yaml
+++ b/data/chips/STM32F071V8.yaml
@@ -156,6 +156,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB5
         signal: SMBA

--- a/data/chips/STM32F071VB.yaml
+++ b/data/chips/STM32F071VB.yaml
@@ -156,6 +156,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB5
         signal: SMBA

--- a/data/chips/STM32F072C8.yaml
+++ b/data/chips/STM32F072C8.yaml
@@ -161,6 +161,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB5
         signal: SMBA

--- a/data/chips/STM32F072CB.yaml
+++ b/data/chips/STM32F072CB.yaml
@@ -163,6 +163,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB5
         signal: SMBA

--- a/data/chips/STM32F072R8.yaml
+++ b/data/chips/STM32F072R8.yaml
@@ -171,6 +171,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB5
         signal: SMBA

--- a/data/chips/STM32F072RB.yaml
+++ b/data/chips/STM32F072RB.yaml
@@ -175,6 +175,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB9
         signal: SDA

--- a/data/chips/STM32F072V8.yaml
+++ b/data/chips/STM32F072V8.yaml
@@ -179,6 +179,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB5
         signal: SMBA

--- a/data/chips/STM32F072VB.yaml
+++ b/data/chips/STM32F072VB.yaml
@@ -179,6 +179,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB5
         signal: SMBA

--- a/data/chips/STM32F078CB.yaml
+++ b/data/chips/STM32F078CB.yaml
@@ -146,6 +146,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB5
         signal: SMBA

--- a/data/chips/STM32F078RB.yaml
+++ b/data/chips/STM32F078RB.yaml
@@ -156,6 +156,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB5
         signal: SMBA

--- a/data/chips/STM32F078VB.yaml
+++ b/data/chips/STM32F078VB.yaml
@@ -156,6 +156,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB5
         signal: SMBA

--- a/data/chips/STM32F091CB.yaml
+++ b/data/chips/STM32F091CB.yaml
@@ -164,6 +164,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF0
         signal: SDA

--- a/data/chips/STM32F091CC.yaml
+++ b/data/chips/STM32F091CC.yaml
@@ -164,6 +164,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF0
         signal: SDA

--- a/data/chips/STM32F091RB.yaml
+++ b/data/chips/STM32F091RB.yaml
@@ -174,6 +174,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF0
         signal: SDA

--- a/data/chips/STM32F091RC.yaml
+++ b/data/chips/STM32F091RC.yaml
@@ -178,6 +178,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB6
         signal: SCL

--- a/data/chips/STM32F091VB.yaml
+++ b/data/chips/STM32F091VB.yaml
@@ -180,6 +180,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF0
         signal: SDA

--- a/data/chips/STM32F091VC.yaml
+++ b/data/chips/STM32F091VC.yaml
@@ -182,6 +182,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB8
         signal: SCL

--- a/data/chips/STM32F098CC.yaml
+++ b/data/chips/STM32F098CC.yaml
@@ -164,6 +164,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF0
         signal: SDA

--- a/data/chips/STM32F098RC.yaml
+++ b/data/chips/STM32F098RC.yaml
@@ -178,6 +178,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB6
         signal: SCL

--- a/data/chips/STM32F098VC.yaml
+++ b/data/chips/STM32F098VC.yaml
@@ -182,6 +182,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF0
         signal: SDA

--- a/data/chips/STM32F301C6.yaml
+++ b/data/chips/STM32F301C6.yaml
@@ -136,6 +136,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA14
         signal: SDA
@@ -167,6 +168,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF0
         signal: SDA
@@ -195,6 +197,7 @@ cores:
       address: 0x40007800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA8
         signal: SCL

--- a/data/chips/STM32F301C8.yaml
+++ b/data/chips/STM32F301C8.yaml
@@ -138,6 +138,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA14
         signal: SDA
@@ -169,6 +170,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA10
         signal: SDA
@@ -197,6 +199,7 @@ cores:
       address: 0x40007800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB5
         signal: SDA

--- a/data/chips/STM32F301K6.yaml
+++ b/data/chips/STM32F301K6.yaml
@@ -111,6 +111,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA14
         signal: SDA
@@ -136,6 +137,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF0
         signal: SDA
@@ -161,6 +163,7 @@ cores:
       address: 0x40007800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA8
         signal: SCL

--- a/data/chips/STM32F301K8.yaml
+++ b/data/chips/STM32F301K8.yaml
@@ -111,6 +111,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA14
         signal: SDA
@@ -136,6 +137,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF0
         signal: SDA
@@ -161,6 +163,7 @@ cores:
       address: 0x40007800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA8
         signal: SCL

--- a/data/chips/STM32F301R6.yaml
+++ b/data/chips/STM32F301R6.yaml
@@ -147,6 +147,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA14
         signal: SDA
@@ -178,6 +179,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF0
         signal: SDA
@@ -206,6 +208,7 @@ cores:
       address: 0x40007800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PC9
         signal: SDA

--- a/data/chips/STM32F301R8.yaml
+++ b/data/chips/STM32F301R8.yaml
@@ -147,6 +147,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA14
         signal: SDA
@@ -178,6 +179,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF0
         signal: SDA
@@ -206,6 +208,7 @@ cores:
       address: 0x40007800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PC9
         signal: SDA

--- a/data/chips/STM32F302C6.yaml
+++ b/data/chips/STM32F302C6.yaml
@@ -153,6 +153,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA14
         signal: SDA
@@ -184,6 +185,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF0
         signal: SDA
@@ -212,6 +214,7 @@ cores:
       address: 0x40007800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA8
         signal: SCL

--- a/data/chips/STM32F302C8.yaml
+++ b/data/chips/STM32F302C8.yaml
@@ -155,6 +155,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA14
         signal: SDA
@@ -186,6 +187,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA10
         signal: SDA
@@ -214,6 +216,7 @@ cores:
       address: 0x40007800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB5
         signal: SDA

--- a/data/chips/STM32F302CB.yaml
+++ b/data/chips/STM32F302CB.yaml
@@ -199,6 +199,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA14
         signal: SDA
@@ -230,6 +231,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF0
         signal: SDA

--- a/data/chips/STM32F302CC.yaml
+++ b/data/chips/STM32F302CC.yaml
@@ -199,6 +199,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA14
         signal: SDA
@@ -230,6 +231,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF0
         signal: SDA

--- a/data/chips/STM32F302K6.yaml
+++ b/data/chips/STM32F302K6.yaml
@@ -120,6 +120,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA14
         signal: SDA
@@ -145,6 +146,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF0
         signal: SDA
@@ -170,6 +172,7 @@ cores:
       address: 0x40007800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA8
         signal: SCL

--- a/data/chips/STM32F302K8.yaml
+++ b/data/chips/STM32F302K8.yaml
@@ -120,6 +120,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA14
         signal: SDA
@@ -145,6 +146,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF0
         signal: SDA
@@ -170,6 +172,7 @@ cores:
       address: 0x40007800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA8
         signal: SCL

--- a/data/chips/STM32F302R6.yaml
+++ b/data/chips/STM32F302R6.yaml
@@ -164,6 +164,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA14
         signal: SDA
@@ -195,6 +196,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF0
         signal: SDA
@@ -223,6 +225,7 @@ cores:
       address: 0x40007800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PC9
         signal: SDA

--- a/data/chips/STM32F302R8.yaml
+++ b/data/chips/STM32F302R8.yaml
@@ -164,6 +164,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA14
         signal: SDA
@@ -195,6 +196,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF0
         signal: SDA
@@ -223,6 +225,7 @@ cores:
       address: 0x40007800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PC9
         signal: SDA

--- a/data/chips/STM32F302RB.yaml
+++ b/data/chips/STM32F302RB.yaml
@@ -227,6 +227,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA14
         signal: SDA
@@ -258,6 +259,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF0
         signal: SDA

--- a/data/chips/STM32F302RC.yaml
+++ b/data/chips/STM32F302RC.yaml
@@ -227,6 +227,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA14
         signal: SDA
@@ -258,6 +259,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF0
         signal: SDA

--- a/data/chips/STM32F302RD.yaml
+++ b/data/chips/STM32F302RD.yaml
@@ -229,6 +229,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA14
         signal: SDA
@@ -260,6 +261,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF0
         signal: SDA
@@ -288,6 +290,7 @@ cores:
       address: 0x40007800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PC9
         signal: SDA

--- a/data/chips/STM32F302RE.yaml
+++ b/data/chips/STM32F302RE.yaml
@@ -229,6 +229,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA14
         signal: SDA
@@ -260,6 +261,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF0
         signal: SDA
@@ -288,6 +290,7 @@ cores:
       address: 0x40007800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PC9
         signal: SDA

--- a/data/chips/STM32F302VB.yaml
+++ b/data/chips/STM32F302VB.yaml
@@ -245,6 +245,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA14
         signal: SDA
@@ -276,6 +277,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF0
         signal: SDA

--- a/data/chips/STM32F302VC.yaml
+++ b/data/chips/STM32F302VC.yaml
@@ -242,6 +242,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB5
         signal: SMBA
@@ -273,6 +274,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF6
         signal: SCL

--- a/data/chips/STM32F302VD.yaml
+++ b/data/chips/STM32F302VD.yaml
@@ -245,6 +245,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA14
         signal: SDA
@@ -276,6 +277,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF0
         signal: SDA
@@ -307,6 +309,7 @@ cores:
       address: 0x40007800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PC9
         signal: SDA

--- a/data/chips/STM32F302VE.yaml
+++ b/data/chips/STM32F302VE.yaml
@@ -245,6 +245,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA14
         signal: SDA
@@ -276,6 +277,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF0
         signal: SDA
@@ -307,6 +309,7 @@ cores:
       address: 0x40007800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PC9
         signal: SDA

--- a/data/chips/STM32F302ZD.yaml
+++ b/data/chips/STM32F302ZD.yaml
@@ -248,6 +248,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA14
         signal: SDA
@@ -279,6 +280,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF6
         signal: SCL
@@ -310,6 +312,7 @@ cores:
       address: 0x40007800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PC9
         signal: SDA

--- a/data/chips/STM32F302ZE.yaml
+++ b/data/chips/STM32F302ZE.yaml
@@ -248,6 +248,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA14
         signal: SDA
@@ -279,6 +280,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF6
         signal: SCL
@@ -310,6 +312,7 @@ cores:
       address: 0x40007800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PC9
         signal: SDA

--- a/data/chips/STM32F303C6.yaml
+++ b/data/chips/STM32F303C6.yaml
@@ -183,6 +183,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA14
         signal: SDA

--- a/data/chips/STM32F303C8.yaml
+++ b/data/chips/STM32F303C8.yaml
@@ -193,6 +193,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA14
         signal: SDA

--- a/data/chips/STM32F303CB.yaml
+++ b/data/chips/STM32F303CB.yaml
@@ -267,6 +267,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA14
         signal: SDA
@@ -298,6 +299,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF0
         signal: SDA

--- a/data/chips/STM32F303CC.yaml
+++ b/data/chips/STM32F303CC.yaml
@@ -267,6 +267,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA14
         signal: SDA
@@ -298,6 +299,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF0
         signal: SDA

--- a/data/chips/STM32F303K6.yaml
+++ b/data/chips/STM32F303K6.yaml
@@ -146,6 +146,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA14
         signal: SDA

--- a/data/chips/STM32F303K8.yaml
+++ b/data/chips/STM32F303K8.yaml
@@ -146,6 +146,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA14
         signal: SDA

--- a/data/chips/STM32F303R6.yaml
+++ b/data/chips/STM32F303R6.yaml
@@ -206,6 +206,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA14
         signal: SDA

--- a/data/chips/STM32F303R8.yaml
+++ b/data/chips/STM32F303R8.yaml
@@ -206,6 +206,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA14
         signal: SDA

--- a/data/chips/STM32F303RB.yaml
+++ b/data/chips/STM32F303RB.yaml
@@ -308,6 +308,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA14
         signal: SDA
@@ -339,6 +340,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF0
         signal: SDA

--- a/data/chips/STM32F303RC.yaml
+++ b/data/chips/STM32F303RC.yaml
@@ -308,6 +308,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA14
         signal: SDA
@@ -339,6 +340,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF0
         signal: SDA

--- a/data/chips/STM32F303RD.yaml
+++ b/data/chips/STM32F303RD.yaml
@@ -310,6 +310,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA14
         signal: SDA
@@ -341,6 +342,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF0
         signal: SDA
@@ -369,6 +371,7 @@ cores:
       address: 0x40007800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PC9
         signal: SDA

--- a/data/chips/STM32F303RE.yaml
+++ b/data/chips/STM32F303RE.yaml
@@ -310,6 +310,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA14
         signal: SDA
@@ -341,6 +342,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF0
         signal: SDA
@@ -369,6 +371,7 @@ cores:
       address: 0x40007800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PC9
         signal: SDA

--- a/data/chips/STM32F303VB.yaml
+++ b/data/chips/STM32F303VB.yaml
@@ -378,6 +378,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA14
         signal: SDA
@@ -409,6 +410,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF0
         signal: SDA

--- a/data/chips/STM32F303VC.yaml
+++ b/data/chips/STM32F303VC.yaml
@@ -363,6 +363,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB5
         signal: SMBA
@@ -394,6 +395,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF6
         signal: SCL

--- a/data/chips/STM32F303VD.yaml
+++ b/data/chips/STM32F303VD.yaml
@@ -374,6 +374,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA14
         signal: SDA
@@ -405,6 +406,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF0
         signal: SDA
@@ -436,6 +438,7 @@ cores:
       address: 0x40007800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PC9
         signal: SDA

--- a/data/chips/STM32F303VE.yaml
+++ b/data/chips/STM32F303VE.yaml
@@ -364,6 +364,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB5
         signal: SMBA
@@ -395,6 +396,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF6
         signal: SCL
@@ -426,6 +428,7 @@ cores:
       address: 0x40007800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB5
         signal: SDA

--- a/data/chips/STM32F303ZD.yaml
+++ b/data/chips/STM32F303ZD.yaml
@@ -377,6 +377,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA14
         signal: SDA
@@ -408,6 +409,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF6
         signal: SCL
@@ -439,6 +441,7 @@ cores:
       address: 0x40007800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PC9
         signal: SDA

--- a/data/chips/STM32F303ZE.yaml
+++ b/data/chips/STM32F303ZE.yaml
@@ -377,6 +377,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA14
         signal: SDA
@@ -408,6 +409,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF6
         signal: SCL
@@ -439,6 +441,7 @@ cores:
       address: 0x40007800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PC9
         signal: SDA

--- a/data/chips/STM32F318C8.yaml
+++ b/data/chips/STM32F318C8.yaml
@@ -136,6 +136,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA14
         signal: SDA
@@ -167,6 +168,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA10
         signal: SDA
@@ -195,6 +197,7 @@ cores:
       address: 0x40007800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB5
         signal: SDA

--- a/data/chips/STM32F318K8.yaml
+++ b/data/chips/STM32F318K8.yaml
@@ -109,6 +109,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA14
         signal: SDA
@@ -131,6 +132,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF0
         signal: SDA
@@ -156,6 +158,7 @@ cores:
       address: 0x40007800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA8
         signal: SCL

--- a/data/chips/STM32F328C8.yaml
+++ b/data/chips/STM32F328C8.yaml
@@ -179,6 +179,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA14
         signal: SDA

--- a/data/chips/STM32F334C4.yaml
+++ b/data/chips/STM32F334C4.yaml
@@ -269,6 +269,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA14
         signal: SDA

--- a/data/chips/STM32F334C6.yaml
+++ b/data/chips/STM32F334C6.yaml
@@ -269,6 +269,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA14
         signal: SDA

--- a/data/chips/STM32F334C8.yaml
+++ b/data/chips/STM32F334C8.yaml
@@ -282,6 +282,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA14
         signal: SDA

--- a/data/chips/STM32F334K4.yaml
+++ b/data/chips/STM32F334K4.yaml
@@ -202,6 +202,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA14
         signal: SDA

--- a/data/chips/STM32F334K6.yaml
+++ b/data/chips/STM32F334K6.yaml
@@ -202,6 +202,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA14
         signal: SDA

--- a/data/chips/STM32F334K8.yaml
+++ b/data/chips/STM32F334K8.yaml
@@ -202,6 +202,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA14
         signal: SDA

--- a/data/chips/STM32F334R6.yaml
+++ b/data/chips/STM32F334R6.yaml
@@ -310,6 +310,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA14
         signal: SDA

--- a/data/chips/STM32F334R8.yaml
+++ b/data/chips/STM32F334R8.yaml
@@ -310,6 +310,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA14
         signal: SDA

--- a/data/chips/STM32F358CC.yaml
+++ b/data/chips/STM32F358CC.yaml
@@ -263,6 +263,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA14
         signal: SDA
@@ -294,6 +295,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF0
         signal: SDA

--- a/data/chips/STM32F358RC.yaml
+++ b/data/chips/STM32F358RC.yaml
@@ -304,6 +304,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA14
         signal: SDA
@@ -335,6 +336,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF0
         signal: SDA

--- a/data/chips/STM32F358VC.yaml
+++ b/data/chips/STM32F358VC.yaml
@@ -374,6 +374,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA14
         signal: SDA
@@ -405,6 +406,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF0
         signal: SDA

--- a/data/chips/STM32F373C8.yaml
+++ b/data/chips/STM32F373C8.yaml
@@ -162,6 +162,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA14
         signal: SDA
@@ -193,6 +194,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF0
         signal: SDA

--- a/data/chips/STM32F373CB.yaml
+++ b/data/chips/STM32F373CB.yaml
@@ -162,6 +162,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA14
         signal: SDA
@@ -193,6 +194,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF0
         signal: SDA

--- a/data/chips/STM32F373CC.yaml
+++ b/data/chips/STM32F373CC.yaml
@@ -162,6 +162,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA14
         signal: SDA
@@ -193,6 +194,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF0
         signal: SDA

--- a/data/chips/STM32F373R8.yaml
+++ b/data/chips/STM32F373R8.yaml
@@ -179,6 +179,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA14
         signal: SDA
@@ -210,6 +211,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF0
         signal: SDA

--- a/data/chips/STM32F373RB.yaml
+++ b/data/chips/STM32F373RB.yaml
@@ -179,6 +179,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA14
         signal: SDA
@@ -210,6 +211,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF0
         signal: SDA

--- a/data/chips/STM32F373RC.yaml
+++ b/data/chips/STM32F373RC.yaml
@@ -179,6 +179,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA14
         signal: SDA
@@ -210,6 +211,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF0
         signal: SDA

--- a/data/chips/STM32F373V8.yaml
+++ b/data/chips/STM32F373V8.yaml
@@ -187,6 +187,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA14
         signal: SDA
@@ -218,6 +219,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF0
         signal: SDA

--- a/data/chips/STM32F373VB.yaml
+++ b/data/chips/STM32F373VB.yaml
@@ -187,6 +187,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA14
         signal: SDA
@@ -218,6 +219,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF0
         signal: SDA

--- a/data/chips/STM32F373VC.yaml
+++ b/data/chips/STM32F373VC.yaml
@@ -187,6 +187,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA14
         signal: SDA
@@ -218,6 +219,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF0
         signal: SDA

--- a/data/chips/STM32F378CC.yaml
+++ b/data/chips/STM32F378CC.yaml
@@ -162,6 +162,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA14
         signal: SDA
@@ -193,6 +194,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF0
         signal: SDA

--- a/data/chips/STM32F378RC.yaml
+++ b/data/chips/STM32F378RC.yaml
@@ -181,6 +181,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA14
         signal: SDA
@@ -212,6 +213,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF7
         signal: SDA

--- a/data/chips/STM32F378VC.yaml
+++ b/data/chips/STM32F378VC.yaml
@@ -187,6 +187,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA14
         signal: SDA
@@ -218,6 +219,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF0
         signal: SDA

--- a/data/chips/STM32F398VE.yaml
+++ b/data/chips/STM32F398VE.yaml
@@ -368,6 +368,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA14
         signal: SDA
@@ -399,6 +400,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF0
         signal: SDA
@@ -430,6 +432,7 @@ cores:
       address: 0x40007800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PC9
         signal: SDA

--- a/data/chips/STM32G030C6.yaml
+++ b/data/chips/STM32G030C6.yaml
@@ -95,6 +95,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PA1
         signal: SMBA
@@ -133,6 +134,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PB10
         signal: SCL

--- a/data/chips/STM32G030C8.yaml
+++ b/data/chips/STM32G030C8.yaml
@@ -95,6 +95,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PA1
         signal: SMBA
@@ -133,6 +134,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PB10
         signal: SCL

--- a/data/chips/STM32G030F6.yaml
+++ b/data/chips/STM32G030F6.yaml
@@ -95,6 +95,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PB7
         signal: SDA
@@ -127,6 +128,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PA11
         signal: SCL

--- a/data/chips/STM32G030J6.yaml
+++ b/data/chips/STM32G030J6.yaml
@@ -83,6 +83,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PB7
         signal: SDA
@@ -115,6 +116,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PA11
         signal: SCL

--- a/data/chips/STM32G030K6.yaml
+++ b/data/chips/STM32G030K6.yaml
@@ -95,6 +95,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PB9
         signal: SDA
@@ -133,6 +134,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PA11
         signal: SCL

--- a/data/chips/STM32G030K8.yaml
+++ b/data/chips/STM32G030K8.yaml
@@ -95,6 +95,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PB9
         signal: SDA
@@ -133,6 +134,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PA11
         signal: SCL

--- a/data/chips/STM32G031C4.yaml
+++ b/data/chips/STM32G031C4.yaml
@@ -99,6 +99,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PA1
         signal: SMBA
@@ -137,6 +138,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PB10
         signal: SCL

--- a/data/chips/STM32G031C6.yaml
+++ b/data/chips/STM32G031C6.yaml
@@ -99,6 +99,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PA1
         signal: SMBA
@@ -137,6 +138,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PB10
         signal: SCL

--- a/data/chips/STM32G031C8.yaml
+++ b/data/chips/STM32G031C8.yaml
@@ -99,6 +99,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PA1
         signal: SMBA
@@ -137,6 +138,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PB10
         signal: SCL

--- a/data/chips/STM32G031F4.yaml
+++ b/data/chips/STM32G031F4.yaml
@@ -95,6 +95,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PB7
         signal: SDA
@@ -127,6 +128,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PA11
         signal: SCL

--- a/data/chips/STM32G031F6.yaml
+++ b/data/chips/STM32G031F6.yaml
@@ -95,6 +95,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PB7
         signal: SDA
@@ -127,6 +128,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PA11
         signal: SCL

--- a/data/chips/STM32G031F8.yaml
+++ b/data/chips/STM32G031F8.yaml
@@ -95,6 +95,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PB7
         signal: SDA
@@ -127,6 +128,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PA11
         signal: SCL

--- a/data/chips/STM32G031G4.yaml
+++ b/data/chips/STM32G031G4.yaml
@@ -93,6 +93,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PA1
         signal: SMBA
@@ -122,6 +123,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PA11
         signal: SCL

--- a/data/chips/STM32G031G6.yaml
+++ b/data/chips/STM32G031G6.yaml
@@ -93,6 +93,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PA1
         signal: SMBA
@@ -122,6 +123,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PA11
         signal: SCL

--- a/data/chips/STM32G031G8.yaml
+++ b/data/chips/STM32G031G8.yaml
@@ -93,6 +93,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PA1
         signal: SMBA
@@ -122,6 +123,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PA11
         signal: SCL

--- a/data/chips/STM32G031J4.yaml
+++ b/data/chips/STM32G031J4.yaml
@@ -83,6 +83,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PB7
         signal: SDA
@@ -115,6 +116,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PA11
         signal: SCL

--- a/data/chips/STM32G031J6.yaml
+++ b/data/chips/STM32G031J6.yaml
@@ -83,6 +83,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PB7
         signal: SDA
@@ -115,6 +116,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PA11
         signal: SCL

--- a/data/chips/STM32G031K4.yaml
+++ b/data/chips/STM32G031K4.yaml
@@ -97,6 +97,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PB9
         signal: SDA
@@ -135,6 +136,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PA11
         signal: SCL

--- a/data/chips/STM32G031K6.yaml
+++ b/data/chips/STM32G031K6.yaml
@@ -97,6 +97,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PB9
         signal: SDA
@@ -135,6 +136,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PA11
         signal: SCL

--- a/data/chips/STM32G031K8.yaml
+++ b/data/chips/STM32G031K8.yaml
@@ -97,6 +97,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PB9
         signal: SDA
@@ -135,6 +136,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PA11
         signal: SCL

--- a/data/chips/STM32G031Y8.yaml
+++ b/data/chips/STM32G031Y8.yaml
@@ -95,6 +95,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PB7
         signal: SDA
@@ -127,6 +128,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PA12
         signal: SDA

--- a/data/chips/STM32G041C6.yaml
+++ b/data/chips/STM32G041C6.yaml
@@ -105,6 +105,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PA1
         signal: SMBA
@@ -143,6 +144,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PB10
         signal: SCL

--- a/data/chips/STM32G041C8.yaml
+++ b/data/chips/STM32G041C8.yaml
@@ -105,6 +105,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PA1
         signal: SMBA
@@ -143,6 +144,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PB10
         signal: SCL

--- a/data/chips/STM32G041F6.yaml
+++ b/data/chips/STM32G041F6.yaml
@@ -101,6 +101,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PB7
         signal: SDA
@@ -133,6 +134,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PA11
         signal: SCL

--- a/data/chips/STM32G041F8.yaml
+++ b/data/chips/STM32G041F8.yaml
@@ -101,6 +101,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PB7
         signal: SDA
@@ -133,6 +134,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PA11
         signal: SCL

--- a/data/chips/STM32G041G6.yaml
+++ b/data/chips/STM32G041G6.yaml
@@ -99,6 +99,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PA1
         signal: SMBA
@@ -128,6 +129,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PA11
         signal: SCL

--- a/data/chips/STM32G041G8.yaml
+++ b/data/chips/STM32G041G8.yaml
@@ -99,6 +99,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PA1
         signal: SMBA
@@ -128,6 +129,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PA11
         signal: SCL

--- a/data/chips/STM32G041J6.yaml
+++ b/data/chips/STM32G041J6.yaml
@@ -89,6 +89,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PB7
         signal: SDA
@@ -121,6 +122,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PA11
         signal: SCL

--- a/data/chips/STM32G041K6.yaml
+++ b/data/chips/STM32G041K6.yaml
@@ -103,6 +103,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PB9
         signal: SDA
@@ -141,6 +142,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PA11
         signal: SCL

--- a/data/chips/STM32G041K8.yaml
+++ b/data/chips/STM32G041K8.yaml
@@ -103,6 +103,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PB9
         signal: SDA
@@ -141,6 +142,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PA11
         signal: SCL

--- a/data/chips/STM32G041Y8.yaml
+++ b/data/chips/STM32G041Y8.yaml
@@ -101,6 +101,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PB7
         signal: SDA
@@ -133,6 +134,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PA12
         signal: SDA

--- a/data/chips/STM32G050C6.yaml
+++ b/data/chips/STM32G050C6.yaml
@@ -95,6 +95,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PA1
         signal: SMBA
@@ -133,6 +134,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PB10
         signal: SCL

--- a/data/chips/STM32G050C8.yaml
+++ b/data/chips/STM32G050C8.yaml
@@ -95,6 +95,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PA1
         signal: SMBA
@@ -133,6 +134,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PB10
         signal: SCL

--- a/data/chips/STM32G050F6.yaml
+++ b/data/chips/STM32G050F6.yaml
@@ -89,6 +89,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PB7
         signal: SDA
@@ -121,6 +122,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PA11
         signal: SCL

--- a/data/chips/STM32G050K6.yaml
+++ b/data/chips/STM32G050K6.yaml
@@ -89,6 +89,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PB9
         signal: SDA
@@ -127,6 +128,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PA11
         signal: SCL

--- a/data/chips/STM32G050K8.yaml
+++ b/data/chips/STM32G050K8.yaml
@@ -89,6 +89,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PB9
         signal: SDA
@@ -127,6 +128,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PA11
         signal: SCL

--- a/data/chips/STM32G051C6.yaml
+++ b/data/chips/STM32G051C6.yaml
@@ -168,6 +168,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PA1
         signal: SMBA
@@ -206,6 +207,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PB10
         signal: SCL

--- a/data/chips/STM32G051C8.yaml
+++ b/data/chips/STM32G051C8.yaml
@@ -168,6 +168,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PA1
         signal: SMBA
@@ -206,6 +207,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PB10
         signal: SCL

--- a/data/chips/STM32G051F6.yaml
+++ b/data/chips/STM32G051F6.yaml
@@ -154,6 +154,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PB7
         signal: SDA
@@ -186,6 +187,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PA11
         signal: SCL

--- a/data/chips/STM32G051F8.yaml
+++ b/data/chips/STM32G051F8.yaml
@@ -156,6 +156,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PA10
         signal: SDA
@@ -188,6 +189,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PA12
         signal: SDA

--- a/data/chips/STM32G051G6.yaml
+++ b/data/chips/STM32G051G6.yaml
@@ -150,6 +150,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PA1
         signal: SMBA
@@ -179,6 +180,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PA11
         signal: SCL

--- a/data/chips/STM32G051G8.yaml
+++ b/data/chips/STM32G051G8.yaml
@@ -150,6 +150,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PA1
         signal: SMBA
@@ -179,6 +180,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PA11
         signal: SCL

--- a/data/chips/STM32G051K6.yaml
+++ b/data/chips/STM32G051K6.yaml
@@ -156,6 +156,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PB9
         signal: SDA
@@ -194,6 +195,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PA11
         signal: SCL

--- a/data/chips/STM32G051K8.yaml
+++ b/data/chips/STM32G051K8.yaml
@@ -156,6 +156,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PB9
         signal: SDA
@@ -194,6 +195,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PA11
         signal: SCL

--- a/data/chips/STM32G061C6.yaml
+++ b/data/chips/STM32G061C6.yaml
@@ -174,6 +174,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PA1
         signal: SMBA
@@ -212,6 +213,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PB10
         signal: SCL

--- a/data/chips/STM32G061C8.yaml
+++ b/data/chips/STM32G061C8.yaml
@@ -174,6 +174,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PA1
         signal: SMBA
@@ -212,6 +213,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PB10
         signal: SCL

--- a/data/chips/STM32G061F6.yaml
+++ b/data/chips/STM32G061F6.yaml
@@ -160,6 +160,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PB7
         signal: SDA
@@ -192,6 +193,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PA11
         signal: SCL

--- a/data/chips/STM32G061F8.yaml
+++ b/data/chips/STM32G061F8.yaml
@@ -162,6 +162,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PA10
         signal: SDA
@@ -194,6 +195,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PA12
         signal: SDA

--- a/data/chips/STM32G061G6.yaml
+++ b/data/chips/STM32G061G6.yaml
@@ -156,6 +156,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PA1
         signal: SMBA
@@ -185,6 +186,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PA11
         signal: SCL

--- a/data/chips/STM32G061G8.yaml
+++ b/data/chips/STM32G061G8.yaml
@@ -156,6 +156,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PA1
         signal: SMBA
@@ -185,6 +186,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PA11
         signal: SCL

--- a/data/chips/STM32G061K6.yaml
+++ b/data/chips/STM32G061K6.yaml
@@ -162,6 +162,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PB9
         signal: SDA
@@ -200,6 +201,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PA11
         signal: SCL

--- a/data/chips/STM32G061K8.yaml
+++ b/data/chips/STM32G061K8.yaml
@@ -162,6 +162,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PB9
         signal: SDA
@@ -200,6 +201,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PA11
         signal: SCL

--- a/data/chips/STM32G070CB.yaml
+++ b/data/chips/STM32G070CB.yaml
@@ -91,6 +91,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PA1
         signal: SMBA
@@ -129,6 +130,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PB10
         signal: SCL

--- a/data/chips/STM32G070KB.yaml
+++ b/data/chips/STM32G070KB.yaml
@@ -85,6 +85,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PB9
         signal: SDA
@@ -123,6 +124,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PA11
         signal: SCL

--- a/data/chips/STM32G070RB.yaml
+++ b/data/chips/STM32G070RB.yaml
@@ -95,6 +95,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PA1
         signal: SMBA
@@ -133,6 +134,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PB10
         signal: SCL

--- a/data/chips/STM32G071C6.yaml
+++ b/data/chips/STM32G071C6.yaml
@@ -158,6 +158,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PA1
         signal: SMBA
@@ -196,6 +197,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PB10
         signal: SCL

--- a/data/chips/STM32G071C8.yaml
+++ b/data/chips/STM32G071C8.yaml
@@ -164,6 +164,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PA1
         signal: SMBA
@@ -202,6 +203,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PB10
         signal: SCL

--- a/data/chips/STM32G071CB.yaml
+++ b/data/chips/STM32G071CB.yaml
@@ -164,6 +164,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PA1
         signal: SMBA
@@ -202,6 +203,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PB10
         signal: SCL

--- a/data/chips/STM32G071EB.yaml
+++ b/data/chips/STM32G071EB.yaml
@@ -142,6 +142,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PB5
         signal: SMBA
@@ -171,6 +172,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PA12
         signal: SDA

--- a/data/chips/STM32G071G6.yaml
+++ b/data/chips/STM32G071G6.yaml
@@ -140,6 +140,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PA1
         signal: SMBA
@@ -169,6 +170,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PA11
         signal: SCL

--- a/data/chips/STM32G071G8.yaml
+++ b/data/chips/STM32G071G8.yaml
@@ -137,6 +137,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PA1
         signal: SMBA
@@ -163,6 +164,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PA11
         signal: SCL

--- a/data/chips/STM32G071GB.yaml
+++ b/data/chips/STM32G071GB.yaml
@@ -137,6 +137,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PA1
         signal: SMBA
@@ -163,6 +164,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PA11
         signal: SCL

--- a/data/chips/STM32G071K6.yaml
+++ b/data/chips/STM32G071K6.yaml
@@ -146,6 +146,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PB9
         signal: SDA
@@ -184,6 +185,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PA11
         signal: SCL

--- a/data/chips/STM32G071K8.yaml
+++ b/data/chips/STM32G071K8.yaml
@@ -145,6 +145,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PB9
         signal: SDA
@@ -180,6 +181,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PA11
         signal: SCL

--- a/data/chips/STM32G071KB.yaml
+++ b/data/chips/STM32G071KB.yaml
@@ -145,6 +145,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PB9
         signal: SDA
@@ -180,6 +181,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PA11
         signal: SCL

--- a/data/chips/STM32G071R6.yaml
+++ b/data/chips/STM32G071R6.yaml
@@ -164,6 +164,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PA1
         signal: SMBA
@@ -202,6 +203,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PB10
         signal: SCL

--- a/data/chips/STM32G071R8.yaml
+++ b/data/chips/STM32G071R8.yaml
@@ -170,6 +170,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PA1
         signal: SMBA
@@ -208,6 +209,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PB10
         signal: SCL

--- a/data/chips/STM32G071RB.yaml
+++ b/data/chips/STM32G071RB.yaml
@@ -172,6 +172,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PB7
         signal: SDA
@@ -210,6 +211,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PA12
         signal: SDA

--- a/data/chips/STM32G081CB.yaml
+++ b/data/chips/STM32G081CB.yaml
@@ -170,6 +170,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PA1
         signal: SMBA
@@ -208,6 +209,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PB10
         signal: SCL

--- a/data/chips/STM32G081EB.yaml
+++ b/data/chips/STM32G081EB.yaml
@@ -148,6 +148,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PB5
         signal: SMBA
@@ -177,6 +178,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PA12
         signal: SDA

--- a/data/chips/STM32G081GB.yaml
+++ b/data/chips/STM32G081GB.yaml
@@ -143,6 +143,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PA1
         signal: SMBA
@@ -169,6 +170,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PA11
         signal: SCL

--- a/data/chips/STM32G081KB.yaml
+++ b/data/chips/STM32G081KB.yaml
@@ -151,6 +151,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PB9
         signal: SDA
@@ -186,6 +187,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PA11
         signal: SCL

--- a/data/chips/STM32G081RB.yaml
+++ b/data/chips/STM32G081RB.yaml
@@ -178,6 +178,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PA1
         signal: SMBA
@@ -216,6 +217,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PB10
         signal: SCL

--- a/data/chips/STM32G0B0CE.yaml
+++ b/data/chips/STM32G0B0CE.yaml
@@ -97,6 +97,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PA1
         signal: SMBA
@@ -135,6 +136,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PA6
         signal: SDA
@@ -194,6 +196,7 @@ cores:
       address: 0x40008800
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PA6
         signal: SDA

--- a/data/chips/STM32G0B0KE.yaml
+++ b/data/chips/STM32G0B0KE.yaml
@@ -91,6 +91,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PB9
         signal: SDA
@@ -129,6 +130,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PA6
         signal: SDA
@@ -173,6 +175,7 @@ cores:
       address: 0x40008800
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PA6
         signal: SDA

--- a/data/chips/STM32G0B0RE.yaml
+++ b/data/chips/STM32G0B0RE.yaml
@@ -101,6 +101,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PA1
         signal: SMBA
@@ -139,6 +140,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PA6
         signal: SDA
@@ -198,6 +200,7 @@ cores:
       address: 0x40008800
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PC0
         signal: SCL

--- a/data/chips/STM32G0B0VE.yaml
+++ b/data/chips/STM32G0B0VE.yaml
@@ -101,6 +101,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PB9
         signal: SDA
@@ -139,6 +140,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PA6
         signal: SDA
@@ -198,6 +200,7 @@ cores:
       address: 0x40008800
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PC0
         signal: SCL

--- a/data/chips/STM32G0B1CB.yaml
+++ b/data/chips/STM32G0B1CB.yaml
@@ -232,6 +232,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PA1
         signal: SMBA
@@ -270,6 +271,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PA6
         signal: SDA
@@ -329,6 +331,7 @@ cores:
       address: 0x40008800
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PA6
         signal: SDA

--- a/data/chips/STM32G0B1CC.yaml
+++ b/data/chips/STM32G0B1CC.yaml
@@ -232,6 +232,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PA1
         signal: SMBA
@@ -270,6 +271,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PA6
         signal: SDA
@@ -329,6 +331,7 @@ cores:
       address: 0x40008800
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PA6
         signal: SDA

--- a/data/chips/STM32G0B1CE.yaml
+++ b/data/chips/STM32G0B1CE.yaml
@@ -232,6 +232,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PA1
         signal: SMBA
@@ -270,6 +271,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PA6
         signal: SDA
@@ -329,6 +331,7 @@ cores:
       address: 0x40008800
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PA6
         signal: SDA

--- a/data/chips/STM32G0B1KB.yaml
+++ b/data/chips/STM32G0B1KB.yaml
@@ -198,6 +198,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PB9
         signal: SDA
@@ -233,6 +234,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PA6
         signal: SDA
@@ -268,6 +270,7 @@ cores:
       address: 0x40008800
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PA6
         signal: SDA

--- a/data/chips/STM32G0B1KC.yaml
+++ b/data/chips/STM32G0B1KC.yaml
@@ -198,6 +198,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PB9
         signal: SDA
@@ -233,6 +234,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PA6
         signal: SDA
@@ -268,6 +270,7 @@ cores:
       address: 0x40008800
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PA6
         signal: SDA

--- a/data/chips/STM32G0B1KE.yaml
+++ b/data/chips/STM32G0B1KE.yaml
@@ -198,6 +198,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PB9
         signal: SDA
@@ -233,6 +234,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PA6
         signal: SDA
@@ -268,6 +270,7 @@ cores:
       address: 0x40008800
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PA6
         signal: SDA

--- a/data/chips/STM32G0B1MB.yaml
+++ b/data/chips/STM32G0B1MB.yaml
@@ -272,6 +272,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PB9
         signal: SDA
@@ -310,6 +311,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PA6
         signal: SDA
@@ -369,6 +371,7 @@ cores:
       address: 0x40008800
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PC0
         signal: SCL

--- a/data/chips/STM32G0B1MC.yaml
+++ b/data/chips/STM32G0B1MC.yaml
@@ -272,6 +272,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PB9
         signal: SDA
@@ -310,6 +311,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PA6
         signal: SDA
@@ -369,6 +371,7 @@ cores:
       address: 0x40008800
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PC0
         signal: SCL

--- a/data/chips/STM32G0B1ME.yaml
+++ b/data/chips/STM32G0B1ME.yaml
@@ -272,6 +272,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PB9
         signal: SDA
@@ -310,6 +311,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PA6
         signal: SDA
@@ -369,6 +371,7 @@ cores:
       address: 0x40008800
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PC0
         signal: SCL

--- a/data/chips/STM32G0B1NE.yaml
+++ b/data/chips/STM32G0B1NE.yaml
@@ -234,6 +234,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PB5
         signal: SMBA
@@ -272,6 +273,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PA15
         signal: SMBA
@@ -331,6 +333,7 @@ cores:
       address: 0x40008800
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PB3
         signal: SCL

--- a/data/chips/STM32G0B1RB.yaml
+++ b/data/chips/STM32G0B1RB.yaml
@@ -260,6 +260,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PA1
         signal: SMBA
@@ -298,6 +299,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PA6
         signal: SDA
@@ -357,6 +359,7 @@ cores:
       address: 0x40008800
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PC0
         signal: SCL

--- a/data/chips/STM32G0B1RC.yaml
+++ b/data/chips/STM32G0B1RC.yaml
@@ -260,6 +260,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PA1
         signal: SMBA
@@ -298,6 +299,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PA6
         signal: SDA
@@ -357,6 +359,7 @@ cores:
       address: 0x40008800
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PC0
         signal: SCL

--- a/data/chips/STM32G0B1RE.yaml
+++ b/data/chips/STM32G0B1RE.yaml
@@ -260,6 +260,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PA1
         signal: SMBA
@@ -298,6 +299,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PA6
         signal: SDA
@@ -357,6 +359,7 @@ cores:
       address: 0x40008800
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PC0
         signal: SCL

--- a/data/chips/STM32G0B1VB.yaml
+++ b/data/chips/STM32G0B1VB.yaml
@@ -274,6 +274,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PB9
         signal: SDA
@@ -312,6 +313,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PA6
         signal: SDA
@@ -371,6 +373,7 @@ cores:
       address: 0x40008800
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PC0
         signal: SCL

--- a/data/chips/STM32G0B1VC.yaml
+++ b/data/chips/STM32G0B1VC.yaml
@@ -274,6 +274,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PB9
         signal: SDA
@@ -312,6 +313,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PA6
         signal: SDA
@@ -371,6 +373,7 @@ cores:
       address: 0x40008800
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PC0
         signal: SCL

--- a/data/chips/STM32G0B1VE.yaml
+++ b/data/chips/STM32G0B1VE.yaml
@@ -274,6 +274,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PB9
         signal: SDA
@@ -312,6 +313,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PA6
         signal: SDA
@@ -371,6 +373,7 @@ cores:
       address: 0x40008800
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PC0
         signal: SCL

--- a/data/chips/STM32G0C1CC.yaml
+++ b/data/chips/STM32G0C1CC.yaml
@@ -238,6 +238,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PA1
         signal: SMBA
@@ -276,6 +277,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PA6
         signal: SDA
@@ -335,6 +337,7 @@ cores:
       address: 0x40008800
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PA6
         signal: SDA

--- a/data/chips/STM32G0C1CE.yaml
+++ b/data/chips/STM32G0C1CE.yaml
@@ -238,6 +238,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PA1
         signal: SMBA
@@ -276,6 +277,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PA6
         signal: SDA
@@ -335,6 +337,7 @@ cores:
       address: 0x40008800
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PA6
         signal: SDA

--- a/data/chips/STM32G0C1KC.yaml
+++ b/data/chips/STM32G0C1KC.yaml
@@ -204,6 +204,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PB9
         signal: SDA
@@ -239,6 +240,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PA6
         signal: SDA
@@ -274,6 +276,7 @@ cores:
       address: 0x40008800
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PA6
         signal: SDA

--- a/data/chips/STM32G0C1KE.yaml
+++ b/data/chips/STM32G0C1KE.yaml
@@ -204,6 +204,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PB9
         signal: SDA
@@ -239,6 +240,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PA6
         signal: SDA
@@ -274,6 +276,7 @@ cores:
       address: 0x40008800
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PA6
         signal: SDA

--- a/data/chips/STM32G0C1MC.yaml
+++ b/data/chips/STM32G0C1MC.yaml
@@ -278,6 +278,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PB9
         signal: SDA
@@ -316,6 +317,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PA6
         signal: SDA
@@ -375,6 +377,7 @@ cores:
       address: 0x40008800
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PC0
         signal: SCL

--- a/data/chips/STM32G0C1ME.yaml
+++ b/data/chips/STM32G0C1ME.yaml
@@ -278,6 +278,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PB9
         signal: SDA
@@ -316,6 +317,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PA6
         signal: SDA
@@ -375,6 +377,7 @@ cores:
       address: 0x40008800
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PC0
         signal: SCL

--- a/data/chips/STM32G0C1NE.yaml
+++ b/data/chips/STM32G0C1NE.yaml
@@ -240,6 +240,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PB5
         signal: SMBA
@@ -278,6 +279,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PA15
         signal: SMBA
@@ -337,6 +339,7 @@ cores:
       address: 0x40008800
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PB3
         signal: SCL

--- a/data/chips/STM32G0C1RC.yaml
+++ b/data/chips/STM32G0C1RC.yaml
@@ -266,6 +266,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PA1
         signal: SMBA
@@ -304,6 +305,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PA6
         signal: SDA
@@ -363,6 +365,7 @@ cores:
       address: 0x40008800
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PC0
         signal: SCL

--- a/data/chips/STM32G0C1RE.yaml
+++ b/data/chips/STM32G0C1RE.yaml
@@ -266,6 +266,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PA1
         signal: SMBA
@@ -304,6 +305,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PA6
         signal: SDA
@@ -363,6 +365,7 @@ cores:
       address: 0x40008800
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PC0
         signal: SCL

--- a/data/chips/STM32G0C1VC.yaml
+++ b/data/chips/STM32G0C1VC.yaml
@@ -280,6 +280,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PB9
         signal: SDA
@@ -318,6 +319,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PA6
         signal: SDA
@@ -377,6 +379,7 @@ cores:
       address: 0x40008800
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PC0
         signal: SCL

--- a/data/chips/STM32G0C1VE.yaml
+++ b/data/chips/STM32G0C1VE.yaml
@@ -280,6 +280,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PB9
         signal: SDA
@@ -318,6 +319,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PA6
         signal: SDA
@@ -377,6 +379,7 @@ cores:
       address: 0x40008800
       kind: I2C:i2c2_v1_1
       clock: APB
+      block: i2c_v2/I2C
       pins:
       - pin: PC0
         signal: SCL

--- a/data/chips/STM32G431C6.yaml
+++ b/data/chips/STM32G431C6.yaml
@@ -249,6 +249,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA13
         signal: SCL
@@ -278,6 +279,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF0
         signal: SDA
@@ -304,6 +306,7 @@ cores:
       address: 0x40007800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB2
         signal: SMBA

--- a/data/chips/STM32G431C8.yaml
+++ b/data/chips/STM32G431C8.yaml
@@ -249,6 +249,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA13
         signal: SCL
@@ -278,6 +279,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF0
         signal: SDA
@@ -304,6 +306,7 @@ cores:
       address: 0x40007800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB2
         signal: SMBA

--- a/data/chips/STM32G431CB.yaml
+++ b/data/chips/STM32G431CB.yaml
@@ -251,6 +251,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA15
         signal: SCL
@@ -280,6 +281,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA10
         signal: SMBA
@@ -306,6 +308,7 @@ cores:
       address: 0x40007800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PC11
         signal: SDA

--- a/data/chips/STM32G431K6.yaml
+++ b/data/chips/STM32G431K6.yaml
@@ -214,6 +214,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA13
         signal: SCL
@@ -240,6 +241,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF0
         signal: SDA
@@ -260,6 +262,7 @@ cores:
       address: 0x40007800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA8
         signal: SCL

--- a/data/chips/STM32G431K8.yaml
+++ b/data/chips/STM32G431K8.yaml
@@ -214,6 +214,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA13
         signal: SCL
@@ -240,6 +241,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF0
         signal: SDA
@@ -260,6 +262,7 @@ cores:
       address: 0x40007800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA8
         signal: SCL

--- a/data/chips/STM32G431KB.yaml
+++ b/data/chips/STM32G431KB.yaml
@@ -214,6 +214,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA13
         signal: SCL
@@ -240,6 +241,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF0
         signal: SDA
@@ -260,6 +262,7 @@ cores:
       address: 0x40007800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA8
         signal: SCL

--- a/data/chips/STM32G431M6.yaml
+++ b/data/chips/STM32G431M6.yaml
@@ -282,6 +282,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA13
         signal: SCL
@@ -311,6 +312,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF0
         signal: SDA
@@ -337,6 +339,7 @@ cores:
       address: 0x40007800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB2
         signal: SMBA

--- a/data/chips/STM32G431M8.yaml
+++ b/data/chips/STM32G431M8.yaml
@@ -282,6 +282,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA13
         signal: SCL
@@ -311,6 +312,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF0
         signal: SDA
@@ -337,6 +339,7 @@ cores:
       address: 0x40007800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB2
         signal: SMBA

--- a/data/chips/STM32G431MB.yaml
+++ b/data/chips/STM32G431MB.yaml
@@ -282,6 +282,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA13
         signal: SCL
@@ -311,6 +312,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF0
         signal: SDA
@@ -337,6 +339,7 @@ cores:
       address: 0x40007800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB2
         signal: SMBA

--- a/data/chips/STM32G431R6.yaml
+++ b/data/chips/STM32G431R6.yaml
@@ -274,6 +274,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA13
         signal: SCL
@@ -303,6 +304,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF0
         signal: SDA
@@ -329,6 +331,7 @@ cores:
       address: 0x40007800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB2
         signal: SMBA

--- a/data/chips/STM32G431R8.yaml
+++ b/data/chips/STM32G431R8.yaml
@@ -274,6 +274,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA13
         signal: SCL
@@ -303,6 +304,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF0
         signal: SDA
@@ -329,6 +331,7 @@ cores:
       address: 0x40007800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB2
         signal: SMBA

--- a/data/chips/STM32G431RB.yaml
+++ b/data/chips/STM32G431RB.yaml
@@ -274,6 +274,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA13
         signal: SCL
@@ -303,6 +304,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF0
         signal: SDA
@@ -329,6 +331,7 @@ cores:
       address: 0x40007800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB2
         signal: SMBA

--- a/data/chips/STM32G431V6.yaml
+++ b/data/chips/STM32G431V6.yaml
@@ -282,6 +282,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA13
         signal: SCL
@@ -311,6 +312,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF0
         signal: SDA
@@ -340,6 +342,7 @@ cores:
       address: 0x40007800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB2
         signal: SMBA

--- a/data/chips/STM32G431V8.yaml
+++ b/data/chips/STM32G431V8.yaml
@@ -282,6 +282,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA13
         signal: SCL
@@ -311,6 +312,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF0
         signal: SDA
@@ -340,6 +342,7 @@ cores:
       address: 0x40007800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB2
         signal: SMBA

--- a/data/chips/STM32G431VB.yaml
+++ b/data/chips/STM32G431VB.yaml
@@ -282,6 +282,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA13
         signal: SCL
@@ -311,6 +312,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF0
         signal: SDA
@@ -340,6 +342,7 @@ cores:
       address: 0x40007800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB2
         signal: SMBA

--- a/data/chips/STM32G441CB.yaml
+++ b/data/chips/STM32G441CB.yaml
@@ -257,6 +257,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA15
         signal: SCL
@@ -286,6 +287,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA10
         signal: SMBA
@@ -312,6 +314,7 @@ cores:
       address: 0x40007800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PC11
         signal: SDA

--- a/data/chips/STM32G441KB.yaml
+++ b/data/chips/STM32G441KB.yaml
@@ -220,6 +220,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA13
         signal: SCL
@@ -246,6 +247,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF0
         signal: SDA
@@ -266,6 +268,7 @@ cores:
       address: 0x40007800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA8
         signal: SCL

--- a/data/chips/STM32G441MB.yaml
+++ b/data/chips/STM32G441MB.yaml
@@ -288,6 +288,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA13
         signal: SCL
@@ -317,6 +318,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF0
         signal: SDA
@@ -343,6 +345,7 @@ cores:
       address: 0x40007800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB2
         signal: SMBA

--- a/data/chips/STM32G441RB.yaml
+++ b/data/chips/STM32G441RB.yaml
@@ -280,6 +280,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA13
         signal: SCL
@@ -309,6 +310,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF0
         signal: SDA
@@ -335,6 +337,7 @@ cores:
       address: 0x40007800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB2
         signal: SMBA

--- a/data/chips/STM32G441VB.yaml
+++ b/data/chips/STM32G441VB.yaml
@@ -288,6 +288,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA13
         signal: SCL
@@ -317,6 +318,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF0
         signal: SDA
@@ -346,6 +348,7 @@ cores:
       address: 0x40007800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB2
         signal: SMBA

--- a/data/chips/STM32G471CC.yaml
+++ b/data/chips/STM32G471CC.yaml
@@ -271,6 +271,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA13
         signal: SCL
@@ -300,6 +301,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF0
         signal: SDA
@@ -326,6 +328,7 @@ cores:
       address: 0x40007800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB2
         signal: SMBA
@@ -349,6 +352,7 @@ cores:
       address: 0x40008400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PC6
         signal: SCL

--- a/data/chips/STM32G471CE.yaml
+++ b/data/chips/STM32G471CE.yaml
@@ -271,6 +271,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA13
         signal: SCL
@@ -300,6 +301,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF0
         signal: SDA
@@ -326,6 +328,7 @@ cores:
       address: 0x40007800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB2
         signal: SMBA
@@ -349,6 +352,7 @@ cores:
       address: 0x40008400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PC6
         signal: SCL

--- a/data/chips/STM32G471MC.yaml
+++ b/data/chips/STM32G471MC.yaml
@@ -320,6 +320,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA13
         signal: SCL
@@ -349,6 +350,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF0
         signal: SDA
@@ -375,6 +377,7 @@ cores:
       address: 0x40007800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB2
         signal: SMBA
@@ -404,6 +407,7 @@ cores:
       address: 0x40008400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PC6
         signal: SCL

--- a/data/chips/STM32G471ME.yaml
+++ b/data/chips/STM32G471ME.yaml
@@ -324,6 +324,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA15
         signal: SCL
@@ -353,6 +354,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA8
         signal: SDA
@@ -379,6 +381,7 @@ cores:
       address: 0x40007800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB5
         signal: SDA
@@ -408,6 +411,7 @@ cores:
       address: 0x40008400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA13
         signal: SCL

--- a/data/chips/STM32G471QC.yaml
+++ b/data/chips/STM32G471QC.yaml
@@ -331,6 +331,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA13
         signal: SCL
@@ -360,6 +361,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF0
         signal: SDA
@@ -392,6 +394,7 @@ cores:
       address: 0x40007800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF3
         signal: SCL
@@ -436,6 +439,7 @@ cores:
       address: 0x40008400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF13
         signal: SMBA

--- a/data/chips/STM32G471QE.yaml
+++ b/data/chips/STM32G471QE.yaml
@@ -331,6 +331,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA13
         signal: SCL
@@ -360,6 +361,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF0
         signal: SDA
@@ -392,6 +394,7 @@ cores:
       address: 0x40007800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF3
         signal: SCL
@@ -436,6 +439,7 @@ cores:
       address: 0x40008400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF13
         signal: SMBA

--- a/data/chips/STM32G471RC.yaml
+++ b/data/chips/STM32G471RC.yaml
@@ -294,6 +294,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA13
         signal: SCL
@@ -323,6 +324,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF0
         signal: SDA
@@ -349,6 +351,7 @@ cores:
       address: 0x40007800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB2
         signal: SMBA
@@ -378,6 +381,7 @@ cores:
       address: 0x40008400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PC6
         signal: SCL

--- a/data/chips/STM32G471RE.yaml
+++ b/data/chips/STM32G471RE.yaml
@@ -294,6 +294,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA13
         signal: SCL
@@ -323,6 +324,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF0
         signal: SDA
@@ -349,6 +351,7 @@ cores:
       address: 0x40007800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB2
         signal: SMBA
@@ -378,6 +381,7 @@ cores:
       address: 0x40008400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PC6
         signal: SCL

--- a/data/chips/STM32G471VC.yaml
+++ b/data/chips/STM32G471VC.yaml
@@ -332,6 +332,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA13
         signal: SCL
@@ -361,6 +362,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF0
         signal: SDA
@@ -390,6 +392,7 @@ cores:
       address: 0x40007800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB2
         signal: SMBA
@@ -419,6 +422,7 @@ cores:
       address: 0x40008400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PD11
         signal: SMBA

--- a/data/chips/STM32G471VE.yaml
+++ b/data/chips/STM32G471VE.yaml
@@ -332,6 +332,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA13
         signal: SCL
@@ -361,6 +362,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF0
         signal: SDA
@@ -390,6 +392,7 @@ cores:
       address: 0x40007800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB2
         signal: SMBA
@@ -419,6 +422,7 @@ cores:
       address: 0x40008400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PD11
         signal: SMBA

--- a/data/chips/STM32G473CB.yaml
+++ b/data/chips/STM32G473CB.yaml
@@ -365,6 +365,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA13
         signal: SCL
@@ -394,6 +395,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF0
         signal: SDA
@@ -420,6 +422,7 @@ cores:
       address: 0x40007800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB2
         signal: SMBA
@@ -443,6 +446,7 @@ cores:
       address: 0x40008400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PC6
         signal: SCL

--- a/data/chips/STM32G473CC.yaml
+++ b/data/chips/STM32G473CC.yaml
@@ -365,6 +365,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA13
         signal: SCL
@@ -394,6 +395,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF0
         signal: SDA
@@ -420,6 +422,7 @@ cores:
       address: 0x40007800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB2
         signal: SMBA
@@ -443,6 +446,7 @@ cores:
       address: 0x40008400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PC6
         signal: SCL

--- a/data/chips/STM32G473CE.yaml
+++ b/data/chips/STM32G473CE.yaml
@@ -365,6 +365,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA13
         signal: SCL
@@ -394,6 +395,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF0
         signal: SDA
@@ -420,6 +422,7 @@ cores:
       address: 0x40007800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB2
         signal: SMBA
@@ -443,6 +446,7 @@ cores:
       address: 0x40008400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PC6
         signal: SCL

--- a/data/chips/STM32G473MB.yaml
+++ b/data/chips/STM32G473MB.yaml
@@ -454,6 +454,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA13
         signal: SCL
@@ -483,6 +484,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF0
         signal: SDA
@@ -509,6 +511,7 @@ cores:
       address: 0x40007800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB2
         signal: SMBA
@@ -538,6 +541,7 @@ cores:
       address: 0x40008400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PC6
         signal: SCL

--- a/data/chips/STM32G473MC.yaml
+++ b/data/chips/STM32G473MC.yaml
@@ -454,6 +454,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA13
         signal: SCL
@@ -483,6 +484,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF0
         signal: SDA
@@ -509,6 +511,7 @@ cores:
       address: 0x40007800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB2
         signal: SMBA
@@ -538,6 +541,7 @@ cores:
       address: 0x40008400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PC6
         signal: SCL

--- a/data/chips/STM32G473ME.yaml
+++ b/data/chips/STM32G473ME.yaml
@@ -464,6 +464,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA15
         signal: SCL
@@ -493,6 +494,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA8
         signal: SDA
@@ -519,6 +521,7 @@ cores:
       address: 0x40007800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB5
         signal: SDA
@@ -548,6 +551,7 @@ cores:
       address: 0x40008400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA13
         signal: SCL

--- a/data/chips/STM32G473PB.yaml
+++ b/data/chips/STM32G473PB.yaml
@@ -491,6 +491,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB9
         signal: SDA
@@ -520,6 +521,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF6
         signal: SCL
@@ -552,6 +554,7 @@ cores:
       address: 0x40007800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB5
         signal: SDA
@@ -587,6 +590,7 @@ cores:
       address: 0x40008400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA14
         signal: SMBA

--- a/data/chips/STM32G473PC.yaml
+++ b/data/chips/STM32G473PC.yaml
@@ -491,6 +491,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB9
         signal: SDA
@@ -520,6 +521,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF6
         signal: SCL
@@ -552,6 +554,7 @@ cores:
       address: 0x40007800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB5
         signal: SDA
@@ -587,6 +590,7 @@ cores:
       address: 0x40008400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA14
         signal: SMBA

--- a/data/chips/STM32G473PE.yaml
+++ b/data/chips/STM32G473PE.yaml
@@ -491,6 +491,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB9
         signal: SDA
@@ -520,6 +521,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF6
         signal: SCL
@@ -552,6 +554,7 @@ cores:
       address: 0x40007800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB5
         signal: SDA
@@ -587,6 +590,7 @@ cores:
       address: 0x40008400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA14
         signal: SMBA

--- a/data/chips/STM32G473QB.yaml
+++ b/data/chips/STM32G473QB.yaml
@@ -491,6 +491,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA13
         signal: SCL
@@ -520,6 +521,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF0
         signal: SDA
@@ -552,6 +554,7 @@ cores:
       address: 0x40007800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF3
         signal: SCL
@@ -596,6 +599,7 @@ cores:
       address: 0x40008400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF13
         signal: SMBA

--- a/data/chips/STM32G473QC.yaml
+++ b/data/chips/STM32G473QC.yaml
@@ -491,6 +491,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA13
         signal: SCL
@@ -520,6 +521,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF0
         signal: SDA
@@ -552,6 +554,7 @@ cores:
       address: 0x40007800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF3
         signal: SCL
@@ -596,6 +599,7 @@ cores:
       address: 0x40008400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF13
         signal: SMBA

--- a/data/chips/STM32G473QE.yaml
+++ b/data/chips/STM32G473QE.yaml
@@ -491,6 +491,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA13
         signal: SCL
@@ -520,6 +521,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF0
         signal: SDA
@@ -552,6 +554,7 @@ cores:
       address: 0x40007800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF3
         signal: SCL
@@ -596,6 +599,7 @@ cores:
       address: 0x40008400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF13
         signal: SMBA

--- a/data/chips/STM32G473RB.yaml
+++ b/data/chips/STM32G473RB.yaml
@@ -394,6 +394,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA13
         signal: SCL
@@ -423,6 +424,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF0
         signal: SDA
@@ -449,6 +451,7 @@ cores:
       address: 0x40007800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB2
         signal: SMBA
@@ -478,6 +481,7 @@ cores:
       address: 0x40008400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PC6
         signal: SCL

--- a/data/chips/STM32G473RC.yaml
+++ b/data/chips/STM32G473RC.yaml
@@ -394,6 +394,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA13
         signal: SCL
@@ -423,6 +424,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF0
         signal: SDA
@@ -449,6 +451,7 @@ cores:
       address: 0x40007800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB2
         signal: SMBA
@@ -478,6 +481,7 @@ cores:
       address: 0x40008400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PC6
         signal: SCL

--- a/data/chips/STM32G473RE.yaml
+++ b/data/chips/STM32G473RE.yaml
@@ -394,6 +394,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA13
         signal: SCL
@@ -423,6 +424,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF0
         signal: SDA
@@ -449,6 +451,7 @@ cores:
       address: 0x40007800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB2
         signal: SMBA
@@ -478,6 +481,7 @@ cores:
       address: 0x40008400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PC6
         signal: SCL

--- a/data/chips/STM32G473VB.yaml
+++ b/data/chips/STM32G473VB.yaml
@@ -492,6 +492,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA13
         signal: SCL
@@ -521,6 +522,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF0
         signal: SDA
@@ -550,6 +552,7 @@ cores:
       address: 0x40007800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB2
         signal: SMBA
@@ -579,6 +582,7 @@ cores:
       address: 0x40008400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PD11
         signal: SMBA

--- a/data/chips/STM32G473VC.yaml
+++ b/data/chips/STM32G473VC.yaml
@@ -492,6 +492,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA13
         signal: SCL
@@ -521,6 +522,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF0
         signal: SDA
@@ -550,6 +552,7 @@ cores:
       address: 0x40007800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB2
         signal: SMBA
@@ -579,6 +582,7 @@ cores:
       address: 0x40008400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PD11
         signal: SMBA

--- a/data/chips/STM32G473VE.yaml
+++ b/data/chips/STM32G473VE.yaml
@@ -492,6 +492,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA13
         signal: SCL
@@ -521,6 +522,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF0
         signal: SDA
@@ -550,6 +552,7 @@ cores:
       address: 0x40007800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB2
         signal: SMBA
@@ -579,6 +582,7 @@ cores:
       address: 0x40008400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PD11
         signal: SMBA

--- a/data/chips/STM32G474CB.yaml
+++ b/data/chips/STM32G474CB.yaml
@@ -461,6 +461,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA13
         signal: SCL
@@ -490,6 +491,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF0
         signal: SDA
@@ -516,6 +518,7 @@ cores:
       address: 0x40007800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB2
         signal: SMBA
@@ -539,6 +542,7 @@ cores:
       address: 0x40008400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PC6
         signal: SCL

--- a/data/chips/STM32G474CC.yaml
+++ b/data/chips/STM32G474CC.yaml
@@ -461,6 +461,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA13
         signal: SCL
@@ -490,6 +491,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF0
         signal: SDA
@@ -516,6 +518,7 @@ cores:
       address: 0x40007800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB2
         signal: SMBA
@@ -539,6 +542,7 @@ cores:
       address: 0x40008400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PC6
         signal: SCL

--- a/data/chips/STM32G474CE.yaml
+++ b/data/chips/STM32G474CE.yaml
@@ -461,6 +461,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA13
         signal: SCL
@@ -490,6 +491,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF0
         signal: SDA
@@ -516,6 +518,7 @@ cores:
       address: 0x40007800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB2
         signal: SMBA
@@ -539,6 +542,7 @@ cores:
       address: 0x40008400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PC6
         signal: SCL

--- a/data/chips/STM32G474MB.yaml
+++ b/data/chips/STM32G474MB.yaml
@@ -568,6 +568,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA13
         signal: SCL
@@ -597,6 +598,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF0
         signal: SDA
@@ -623,6 +625,7 @@ cores:
       address: 0x40007800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB2
         signal: SMBA
@@ -652,6 +655,7 @@ cores:
       address: 0x40008400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PC6
         signal: SCL

--- a/data/chips/STM32G474MC.yaml
+++ b/data/chips/STM32G474MC.yaml
@@ -568,6 +568,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA13
         signal: SCL
@@ -597,6 +598,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF0
         signal: SDA
@@ -623,6 +625,7 @@ cores:
       address: 0x40007800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB2
         signal: SMBA
@@ -652,6 +655,7 @@ cores:
       address: 0x40008400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PC6
         signal: SCL

--- a/data/chips/STM32G474ME.yaml
+++ b/data/chips/STM32G474ME.yaml
@@ -578,6 +578,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA15
         signal: SCL
@@ -607,6 +608,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA8
         signal: SDA
@@ -633,6 +635,7 @@ cores:
       address: 0x40007800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB5
         signal: SDA
@@ -662,6 +665,7 @@ cores:
       address: 0x40008400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA13
         signal: SCL

--- a/data/chips/STM32G474PB.yaml
+++ b/data/chips/STM32G474PB.yaml
@@ -605,6 +605,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB9
         signal: SDA
@@ -634,6 +635,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF6
         signal: SCL
@@ -666,6 +668,7 @@ cores:
       address: 0x40007800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB5
         signal: SDA
@@ -701,6 +704,7 @@ cores:
       address: 0x40008400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA14
         signal: SMBA

--- a/data/chips/STM32G474PC.yaml
+++ b/data/chips/STM32G474PC.yaml
@@ -605,6 +605,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB9
         signal: SDA
@@ -634,6 +635,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF6
         signal: SCL
@@ -666,6 +668,7 @@ cores:
       address: 0x40007800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB5
         signal: SDA
@@ -701,6 +704,7 @@ cores:
       address: 0x40008400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA14
         signal: SMBA

--- a/data/chips/STM32G474PE.yaml
+++ b/data/chips/STM32G474PE.yaml
@@ -605,6 +605,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB9
         signal: SDA
@@ -634,6 +635,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF6
         signal: SCL
@@ -666,6 +668,7 @@ cores:
       address: 0x40007800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB5
         signal: SDA
@@ -701,6 +704,7 @@ cores:
       address: 0x40008400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA14
         signal: SMBA

--- a/data/chips/STM32G474QB.yaml
+++ b/data/chips/STM32G474QB.yaml
@@ -605,6 +605,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA13
         signal: SCL
@@ -634,6 +635,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF0
         signal: SDA
@@ -666,6 +668,7 @@ cores:
       address: 0x40007800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF3
         signal: SCL
@@ -710,6 +713,7 @@ cores:
       address: 0x40008400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF13
         signal: SMBA

--- a/data/chips/STM32G474QC.yaml
+++ b/data/chips/STM32G474QC.yaml
@@ -605,6 +605,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA13
         signal: SCL
@@ -634,6 +635,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF0
         signal: SDA
@@ -666,6 +668,7 @@ cores:
       address: 0x40007800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF3
         signal: SCL
@@ -710,6 +713,7 @@ cores:
       address: 0x40008400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF13
         signal: SMBA

--- a/data/chips/STM32G474QE.yaml
+++ b/data/chips/STM32G474QE.yaml
@@ -605,6 +605,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA13
         signal: SCL
@@ -634,6 +635,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF0
         signal: SDA
@@ -666,6 +668,7 @@ cores:
       address: 0x40007800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF3
         signal: SCL
@@ -710,6 +713,7 @@ cores:
       address: 0x40008400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF13
         signal: SMBA

--- a/data/chips/STM32G474RB.yaml
+++ b/data/chips/STM32G474RB.yaml
@@ -508,6 +508,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA13
         signal: SCL
@@ -537,6 +538,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF0
         signal: SDA
@@ -563,6 +565,7 @@ cores:
       address: 0x40007800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB2
         signal: SMBA
@@ -592,6 +595,7 @@ cores:
       address: 0x40008400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PC6
         signal: SCL

--- a/data/chips/STM32G474RC.yaml
+++ b/data/chips/STM32G474RC.yaml
@@ -508,6 +508,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA13
         signal: SCL
@@ -537,6 +538,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF0
         signal: SDA
@@ -563,6 +565,7 @@ cores:
       address: 0x40007800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB2
         signal: SMBA
@@ -592,6 +595,7 @@ cores:
       address: 0x40008400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PC6
         signal: SCL

--- a/data/chips/STM32G474RE.yaml
+++ b/data/chips/STM32G474RE.yaml
@@ -508,6 +508,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA13
         signal: SCL
@@ -537,6 +538,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF0
         signal: SDA
@@ -563,6 +565,7 @@ cores:
       address: 0x40007800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB2
         signal: SMBA
@@ -592,6 +595,7 @@ cores:
       address: 0x40008400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PC6
         signal: SCL

--- a/data/chips/STM32G474VB.yaml
+++ b/data/chips/STM32G474VB.yaml
@@ -606,6 +606,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA13
         signal: SCL
@@ -635,6 +636,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF0
         signal: SDA
@@ -664,6 +666,7 @@ cores:
       address: 0x40007800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB2
         signal: SMBA
@@ -693,6 +696,7 @@ cores:
       address: 0x40008400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PD11
         signal: SMBA

--- a/data/chips/STM32G474VC.yaml
+++ b/data/chips/STM32G474VC.yaml
@@ -606,6 +606,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA13
         signal: SCL
@@ -635,6 +636,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF0
         signal: SDA
@@ -664,6 +666,7 @@ cores:
       address: 0x40007800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB2
         signal: SMBA
@@ -693,6 +696,7 @@ cores:
       address: 0x40008400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PD11
         signal: SMBA

--- a/data/chips/STM32G474VE.yaml
+++ b/data/chips/STM32G474VE.yaml
@@ -606,6 +606,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA13
         signal: SCL
@@ -635,6 +636,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF0
         signal: SDA
@@ -664,6 +666,7 @@ cores:
       address: 0x40007800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB2
         signal: SMBA
@@ -693,6 +696,7 @@ cores:
       address: 0x40008400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PD11
         signal: SMBA

--- a/data/chips/STM32G483CE.yaml
+++ b/data/chips/STM32G483CE.yaml
@@ -371,6 +371,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA13
         signal: SCL
@@ -400,6 +401,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF0
         signal: SDA
@@ -426,6 +428,7 @@ cores:
       address: 0x40007800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB2
         signal: SMBA
@@ -449,6 +452,7 @@ cores:
       address: 0x40008400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PC6
         signal: SCL

--- a/data/chips/STM32G483ME.yaml
+++ b/data/chips/STM32G483ME.yaml
@@ -470,6 +470,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA15
         signal: SCL
@@ -499,6 +500,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA8
         signal: SDA
@@ -525,6 +527,7 @@ cores:
       address: 0x40007800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB5
         signal: SDA
@@ -554,6 +557,7 @@ cores:
       address: 0x40008400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA13
         signal: SCL

--- a/data/chips/STM32G483PE.yaml
+++ b/data/chips/STM32G483PE.yaml
@@ -497,6 +497,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB9
         signal: SDA
@@ -526,6 +527,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF6
         signal: SCL
@@ -558,6 +560,7 @@ cores:
       address: 0x40007800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB5
         signal: SDA
@@ -593,6 +596,7 @@ cores:
       address: 0x40008400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA14
         signal: SMBA

--- a/data/chips/STM32G483QE.yaml
+++ b/data/chips/STM32G483QE.yaml
@@ -497,6 +497,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA13
         signal: SCL
@@ -526,6 +527,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF0
         signal: SDA
@@ -558,6 +560,7 @@ cores:
       address: 0x40007800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF3
         signal: SCL
@@ -602,6 +605,7 @@ cores:
       address: 0x40008400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF13
         signal: SMBA

--- a/data/chips/STM32G483RE.yaml
+++ b/data/chips/STM32G483RE.yaml
@@ -400,6 +400,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA13
         signal: SCL
@@ -429,6 +430,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF0
         signal: SDA
@@ -455,6 +457,7 @@ cores:
       address: 0x40007800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB2
         signal: SMBA
@@ -484,6 +487,7 @@ cores:
       address: 0x40008400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PC6
         signal: SCL

--- a/data/chips/STM32G483VE.yaml
+++ b/data/chips/STM32G483VE.yaml
@@ -498,6 +498,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA13
         signal: SCL
@@ -527,6 +528,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF0
         signal: SDA
@@ -556,6 +558,7 @@ cores:
       address: 0x40007800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB2
         signal: SMBA
@@ -585,6 +588,7 @@ cores:
       address: 0x40008400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PD11
         signal: SMBA

--- a/data/chips/STM32G484CE.yaml
+++ b/data/chips/STM32G484CE.yaml
@@ -467,6 +467,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA13
         signal: SCL
@@ -496,6 +497,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF0
         signal: SDA
@@ -522,6 +524,7 @@ cores:
       address: 0x40007800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB2
         signal: SMBA
@@ -545,6 +548,7 @@ cores:
       address: 0x40008400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PC6
         signal: SCL

--- a/data/chips/STM32G484ME.yaml
+++ b/data/chips/STM32G484ME.yaml
@@ -584,6 +584,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA15
         signal: SCL
@@ -613,6 +614,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA8
         signal: SDA
@@ -639,6 +641,7 @@ cores:
       address: 0x40007800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB5
         signal: SDA
@@ -668,6 +671,7 @@ cores:
       address: 0x40008400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA13
         signal: SCL

--- a/data/chips/STM32G484PE.yaml
+++ b/data/chips/STM32G484PE.yaml
@@ -611,6 +611,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB9
         signal: SDA
@@ -640,6 +641,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF6
         signal: SCL
@@ -672,6 +674,7 @@ cores:
       address: 0x40007800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB5
         signal: SDA
@@ -707,6 +710,7 @@ cores:
       address: 0x40008400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA14
         signal: SMBA

--- a/data/chips/STM32G484QE.yaml
+++ b/data/chips/STM32G484QE.yaml
@@ -611,6 +611,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA13
         signal: SCL
@@ -640,6 +641,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF0
         signal: SDA
@@ -672,6 +674,7 @@ cores:
       address: 0x40007800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF3
         signal: SCL
@@ -716,6 +719,7 @@ cores:
       address: 0x40008400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF13
         signal: SMBA

--- a/data/chips/STM32G484RE.yaml
+++ b/data/chips/STM32G484RE.yaml
@@ -514,6 +514,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA13
         signal: SCL
@@ -543,6 +544,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF0
         signal: SDA
@@ -569,6 +571,7 @@ cores:
       address: 0x40007800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB2
         signal: SMBA
@@ -598,6 +601,7 @@ cores:
       address: 0x40008400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PC6
         signal: SCL

--- a/data/chips/STM32G484VE.yaml
+++ b/data/chips/STM32G484VE.yaml
@@ -612,6 +612,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA13
         signal: SCL
@@ -641,6 +642,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF0
         signal: SDA
@@ -670,6 +672,7 @@ cores:
       address: 0x40007800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB2
         signal: SMBA
@@ -699,6 +702,7 @@ cores:
       address: 0x40008400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PD11
         signal: SMBA

--- a/data/chips/STM32G491CC.yaml
+++ b/data/chips/STM32G491CC.yaml
@@ -277,6 +277,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA13
         signal: SCL
@@ -306,6 +307,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF0
         signal: SDA
@@ -332,6 +334,7 @@ cores:
       address: 0x40007800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB2
         signal: SMBA

--- a/data/chips/STM32G491CE.yaml
+++ b/data/chips/STM32G491CE.yaml
@@ -277,6 +277,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA13
         signal: SCL
@@ -306,6 +307,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF0
         signal: SDA
@@ -332,6 +334,7 @@ cores:
       address: 0x40007800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB2
         signal: SMBA

--- a/data/chips/STM32G491KC.yaml
+++ b/data/chips/STM32G491KC.yaml
@@ -230,6 +230,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA13
         signal: SCL
@@ -256,6 +257,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF0
         signal: SDA
@@ -276,6 +278,7 @@ cores:
       address: 0x40007800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA8
         signal: SCL

--- a/data/chips/STM32G491KE.yaml
+++ b/data/chips/STM32G491KE.yaml
@@ -230,6 +230,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA13
         signal: SCL
@@ -256,6 +257,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF0
         signal: SDA
@@ -276,6 +278,7 @@ cores:
       address: 0x40007800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA8
         signal: SCL

--- a/data/chips/STM32G491MC.yaml
+++ b/data/chips/STM32G491MC.yaml
@@ -328,6 +328,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA13
         signal: SCL
@@ -357,6 +358,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF0
         signal: SDA
@@ -383,6 +385,7 @@ cores:
       address: 0x40007800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB2
         signal: SMBA

--- a/data/chips/STM32G491ME.yaml
+++ b/data/chips/STM32G491ME.yaml
@@ -328,6 +328,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA13
         signal: SCL
@@ -357,6 +358,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF0
         signal: SDA
@@ -383,6 +385,7 @@ cores:
       address: 0x40007800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB2
         signal: SMBA

--- a/data/chips/STM32G491RC.yaml
+++ b/data/chips/STM32G491RC.yaml
@@ -302,6 +302,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA13
         signal: SCL
@@ -331,6 +332,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF0
         signal: SDA
@@ -357,6 +359,7 @@ cores:
       address: 0x40007800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB2
         signal: SMBA

--- a/data/chips/STM32G491RE.yaml
+++ b/data/chips/STM32G491RE.yaml
@@ -304,6 +304,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB5
         signal: SMBA
@@ -333,6 +334,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA10
         signal: SMBA
@@ -359,6 +361,7 @@ cores:
       address: 0x40007800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PC11
         signal: SDA

--- a/data/chips/STM32G491VC.yaml
+++ b/data/chips/STM32G491VC.yaml
@@ -334,6 +334,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA13
         signal: SCL
@@ -363,6 +364,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF0
         signal: SDA
@@ -392,6 +394,7 @@ cores:
       address: 0x40007800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB2
         signal: SMBA

--- a/data/chips/STM32G491VE.yaml
+++ b/data/chips/STM32G491VE.yaml
@@ -334,6 +334,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA13
         signal: SCL
@@ -363,6 +364,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF0
         signal: SDA
@@ -392,6 +394,7 @@ cores:
       address: 0x40007800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB2
         signal: SMBA

--- a/data/chips/STM32G4A1CE.yaml
+++ b/data/chips/STM32G4A1CE.yaml
@@ -283,6 +283,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA13
         signal: SCL
@@ -312,6 +313,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF0
         signal: SDA
@@ -338,6 +340,7 @@ cores:
       address: 0x40007800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB2
         signal: SMBA

--- a/data/chips/STM32G4A1KE.yaml
+++ b/data/chips/STM32G4A1KE.yaml
@@ -236,6 +236,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA13
         signal: SCL
@@ -262,6 +263,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF0
         signal: SDA
@@ -282,6 +284,7 @@ cores:
       address: 0x40007800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA8
         signal: SCL

--- a/data/chips/STM32G4A1ME.yaml
+++ b/data/chips/STM32G4A1ME.yaml
@@ -334,6 +334,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA13
         signal: SCL
@@ -363,6 +364,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF0
         signal: SDA
@@ -389,6 +391,7 @@ cores:
       address: 0x40007800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB2
         signal: SMBA

--- a/data/chips/STM32G4A1RE.yaml
+++ b/data/chips/STM32G4A1RE.yaml
@@ -310,6 +310,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB5
         signal: SMBA
@@ -339,6 +340,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA10
         signal: SMBA
@@ -365,6 +367,7 @@ cores:
       address: 0x40007800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PC11
         signal: SDA

--- a/data/chips/STM32G4A1VE.yaml
+++ b/data/chips/STM32G4A1VE.yaml
@@ -340,6 +340,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA13
         signal: SCL
@@ -369,6 +370,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF0
         signal: SDA
@@ -398,6 +400,7 @@ cores:
       address: 0x40007800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB2
         signal: SMBA

--- a/data/chips/STM32GBK1CB.yaml
+++ b/data/chips/STM32GBK1CB.yaml
@@ -263,6 +263,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA13
         signal: SCL
@@ -292,6 +293,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF0
         signal: SDA
@@ -315,6 +317,7 @@ cores:
       address: 0x40007800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB2
         signal: SMBA

--- a/data/chips/STM32L010C6.yaml
+++ b/data/chips/STM32L010C6.yaml
@@ -77,6 +77,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA1
         signal: SMBA

--- a/data/chips/STM32L010F4.yaml
+++ b/data/chips/STM32L010F4.yaml
@@ -72,6 +72,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA1
         signal: SMBA

--- a/data/chips/STM32L010K4.yaml
+++ b/data/chips/STM32L010K4.yaml
@@ -74,6 +74,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA1
         signal: SMBA

--- a/data/chips/STM32L010K8.yaml
+++ b/data/chips/STM32L010K8.yaml
@@ -80,6 +80,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB5
         signal: SMBA

--- a/data/chips/STM32L010R8.yaml
+++ b/data/chips/STM32L010R8.yaml
@@ -92,6 +92,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB5
         signal: SMBA

--- a/data/chips/STM32L010RB.yaml
+++ b/data/chips/STM32L010RB.yaml
@@ -95,6 +95,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA9
         signal: SCL

--- a/data/chips/STM32L011D3.yaml
+++ b/data/chips/STM32L011D3.yaml
@@ -101,6 +101,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA1
         signal: SMBA

--- a/data/chips/STM32L011D4.yaml
+++ b/data/chips/STM32L011D4.yaml
@@ -101,6 +101,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA1
         signal: SMBA

--- a/data/chips/STM32L011E3.yaml
+++ b/data/chips/STM32L011E3.yaml
@@ -133,6 +133,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA13
         signal: SDA

--- a/data/chips/STM32L011E4.yaml
+++ b/data/chips/STM32L011E4.yaml
@@ -133,6 +133,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA13
         signal: SDA

--- a/data/chips/STM32L011F3.yaml
+++ b/data/chips/STM32L011F3.yaml
@@ -120,6 +120,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA1
         signal: SMBA

--- a/data/chips/STM32L011F4.yaml
+++ b/data/chips/STM32L011F4.yaml
@@ -120,6 +120,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA1
         signal: SMBA

--- a/data/chips/STM32L011G3.yaml
+++ b/data/chips/STM32L011G3.yaml
@@ -137,6 +137,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA1
         signal: SMBA

--- a/data/chips/STM32L011G4.yaml
+++ b/data/chips/STM32L011G4.yaml
@@ -137,6 +137,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA1
         signal: SMBA

--- a/data/chips/STM32L011K3.yaml
+++ b/data/chips/STM32L011K3.yaml
@@ -145,6 +145,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA1
         signal: SMBA

--- a/data/chips/STM32L011K4.yaml
+++ b/data/chips/STM32L011K4.yaml
@@ -145,6 +145,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA1
         signal: SMBA

--- a/data/chips/STM32L021D4.yaml
+++ b/data/chips/STM32L021D4.yaml
@@ -109,6 +109,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA1
         signal: SMBA

--- a/data/chips/STM32L021F4.yaml
+++ b/data/chips/STM32L021F4.yaml
@@ -128,6 +128,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA1
         signal: SMBA

--- a/data/chips/STM32L021G4.yaml
+++ b/data/chips/STM32L021G4.yaml
@@ -145,6 +145,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA1
         signal: SMBA

--- a/data/chips/STM32L021K4.yaml
+++ b/data/chips/STM32L021K4.yaml
@@ -153,6 +153,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA1
         signal: SMBA

--- a/data/chips/STM32L031C4.yaml
+++ b/data/chips/STM32L031C4.yaml
@@ -131,6 +131,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA1
         signal: SMBA

--- a/data/chips/STM32L031C6.yaml
+++ b/data/chips/STM32L031C6.yaml
@@ -131,6 +131,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA1
         signal: SMBA

--- a/data/chips/STM32L031E4.yaml
+++ b/data/chips/STM32L031E4.yaml
@@ -119,6 +119,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA14
         signal: SMBA

--- a/data/chips/STM32L031E6.yaml
+++ b/data/chips/STM32L031E6.yaml
@@ -119,6 +119,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA14
         signal: SMBA

--- a/data/chips/STM32L031F4.yaml
+++ b/data/chips/STM32L031F4.yaml
@@ -111,6 +111,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA1
         signal: SMBA

--- a/data/chips/STM32L031F6.yaml
+++ b/data/chips/STM32L031F6.yaml
@@ -111,6 +111,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA1
         signal: SMBA

--- a/data/chips/STM32L031G4.yaml
+++ b/data/chips/STM32L031G4.yaml
@@ -119,6 +119,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA1
         signal: SMBA

--- a/data/chips/STM32L031G6.yaml
+++ b/data/chips/STM32L031G6.yaml
@@ -125,6 +125,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA1
         signal: SMBA

--- a/data/chips/STM32L031K4.yaml
+++ b/data/chips/STM32L031K4.yaml
@@ -131,6 +131,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA1
         signal: SMBA

--- a/data/chips/STM32L031K6.yaml
+++ b/data/chips/STM32L031K6.yaml
@@ -131,6 +131,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA1
         signal: SMBA

--- a/data/chips/STM32L041C4.yaml
+++ b/data/chips/STM32L041C4.yaml
@@ -131,6 +131,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA1
         signal: SMBA

--- a/data/chips/STM32L041C6.yaml
+++ b/data/chips/STM32L041C6.yaml
@@ -139,6 +139,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA1
         signal: SMBA

--- a/data/chips/STM32L041E6.yaml
+++ b/data/chips/STM32L041E6.yaml
@@ -127,6 +127,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA14
         signal: SMBA

--- a/data/chips/STM32L041F6.yaml
+++ b/data/chips/STM32L041F6.yaml
@@ -119,6 +119,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA1
         signal: SMBA

--- a/data/chips/STM32L041G6.yaml
+++ b/data/chips/STM32L041G6.yaml
@@ -133,6 +133,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA1
         signal: SMBA

--- a/data/chips/STM32L041K6.yaml
+++ b/data/chips/STM32L041K6.yaml
@@ -139,6 +139,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA1
         signal: SMBA

--- a/data/chips/STM32L051C6.yaml
+++ b/data/chips/STM32L051C6.yaml
@@ -134,6 +134,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB5
         signal: SMBA
@@ -159,6 +160,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB10
         signal: SCL

--- a/data/chips/STM32L051C8.yaml
+++ b/data/chips/STM32L051C8.yaml
@@ -134,6 +134,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB5
         signal: SMBA
@@ -159,6 +160,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB10
         signal: SCL

--- a/data/chips/STM32L051K6.yaml
+++ b/data/chips/STM32L051K6.yaml
@@ -134,6 +134,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB5
         signal: SMBA

--- a/data/chips/STM32L051K8.yaml
+++ b/data/chips/STM32L051K8.yaml
@@ -134,6 +134,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB5
         signal: SMBA

--- a/data/chips/STM32L051R6.yaml
+++ b/data/chips/STM32L051R6.yaml
@@ -146,6 +146,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB5
         signal: SMBA
@@ -171,6 +172,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB10
         signal: SCL

--- a/data/chips/STM32L051R8.yaml
+++ b/data/chips/STM32L051R8.yaml
@@ -146,6 +146,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB5
         signal: SMBA
@@ -171,6 +172,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB10
         signal: SCL

--- a/data/chips/STM32L051T6.yaml
+++ b/data/chips/STM32L051T6.yaml
@@ -132,6 +132,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB7
         signal: SDA
@@ -154,6 +155,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB11
         signal: SDA

--- a/data/chips/STM32L051T8.yaml
+++ b/data/chips/STM32L051T8.yaml
@@ -132,6 +132,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB7
         signal: SDA
@@ -154,6 +155,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB11
         signal: SDA

--- a/data/chips/STM32L052C6.yaml
+++ b/data/chips/STM32L052C6.yaml
@@ -147,6 +147,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB5
         signal: SMBA
@@ -172,6 +173,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB10
         signal: SCL

--- a/data/chips/STM32L052C8.yaml
+++ b/data/chips/STM32L052C8.yaml
@@ -147,6 +147,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB5
         signal: SMBA
@@ -172,6 +173,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB10
         signal: SCL

--- a/data/chips/STM32L052K6.yaml
+++ b/data/chips/STM32L052K6.yaml
@@ -147,6 +147,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB5
         signal: SMBA

--- a/data/chips/STM32L052K8.yaml
+++ b/data/chips/STM32L052K8.yaml
@@ -147,6 +147,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB5
         signal: SMBA

--- a/data/chips/STM32L052R6.yaml
+++ b/data/chips/STM32L052R6.yaml
@@ -159,6 +159,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB5
         signal: SMBA
@@ -184,6 +185,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB10
         signal: SCL

--- a/data/chips/STM32L052R8.yaml
+++ b/data/chips/STM32L052R8.yaml
@@ -159,6 +159,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB5
         signal: SMBA
@@ -184,6 +185,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB10
         signal: SCL

--- a/data/chips/STM32L052T6.yaml
+++ b/data/chips/STM32L052T6.yaml
@@ -145,6 +145,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB7
         signal: SDA
@@ -167,6 +168,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB11
         signal: SDA

--- a/data/chips/STM32L052T8.yaml
+++ b/data/chips/STM32L052T8.yaml
@@ -147,6 +147,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB7
         signal: SDA
@@ -169,6 +170,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB11
         signal: SDA

--- a/data/chips/STM32L053C6.yaml
+++ b/data/chips/STM32L053C6.yaml
@@ -147,6 +147,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB5
         signal: SMBA
@@ -172,6 +173,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB10
         signal: SCL

--- a/data/chips/STM32L053C8.yaml
+++ b/data/chips/STM32L053C8.yaml
@@ -147,6 +147,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB5
         signal: SMBA
@@ -172,6 +173,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB10
         signal: SCL

--- a/data/chips/STM32L053R6.yaml
+++ b/data/chips/STM32L053R6.yaml
@@ -159,6 +159,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB5
         signal: SMBA
@@ -184,6 +185,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB10
         signal: SCL

--- a/data/chips/STM32L053R8.yaml
+++ b/data/chips/STM32L053R8.yaml
@@ -159,6 +159,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB5
         signal: SMBA
@@ -184,6 +185,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB10
         signal: SCL

--- a/data/chips/STM32L062C8.yaml
+++ b/data/chips/STM32L062C8.yaml
@@ -153,6 +153,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB5
         signal: SMBA
@@ -178,6 +179,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB10
         signal: SCL

--- a/data/chips/STM32L062K8.yaml
+++ b/data/chips/STM32L062K8.yaml
@@ -155,6 +155,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB5
         signal: SMBA

--- a/data/chips/STM32L063C8.yaml
+++ b/data/chips/STM32L063C8.yaml
@@ -155,6 +155,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB5
         signal: SMBA
@@ -180,6 +181,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB10
         signal: SCL

--- a/data/chips/STM32L063R8.yaml
+++ b/data/chips/STM32L063R8.yaml
@@ -165,6 +165,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB5
         signal: SMBA
@@ -190,6 +191,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB10
         signal: SCL

--- a/data/chips/STM32L071C8.yaml
+++ b/data/chips/STM32L071C8.yaml
@@ -137,6 +137,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA9
         signal: SCL
@@ -168,6 +169,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB10
         signal: SCL
@@ -190,6 +192,7 @@ cores:
       address: 0x40007800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB2
         signal: SMBA

--- a/data/chips/STM32L071CB.yaml
+++ b/data/chips/STM32L071CB.yaml
@@ -145,6 +145,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB5
         signal: SMBA
@@ -176,6 +177,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB14
         signal: SDA
@@ -198,6 +200,7 @@ cores:
       address: 0x40007800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB4
         signal: SDA

--- a/data/chips/STM32L071CZ.yaml
+++ b/data/chips/STM32L071CZ.yaml
@@ -145,6 +145,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB5
         signal: SMBA
@@ -176,6 +177,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB14
         signal: SDA
@@ -198,6 +200,7 @@ cores:
       address: 0x40007800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB4
         signal: SDA

--- a/data/chips/STM32L071K8.yaml
+++ b/data/chips/STM32L071K8.yaml
@@ -133,6 +133,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA9
         signal: SCL
@@ -158,6 +159,7 @@ cores:
       address: 0x40007800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA8
         signal: SCL

--- a/data/chips/STM32L071KB.yaml
+++ b/data/chips/STM32L071KB.yaml
@@ -135,6 +135,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA9
         signal: SCL
@@ -160,6 +161,7 @@ cores:
       address: 0x40007800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA8
         signal: SCL

--- a/data/chips/STM32L071KZ.yaml
+++ b/data/chips/STM32L071KZ.yaml
@@ -135,6 +135,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA9
         signal: SCL
@@ -160,6 +161,7 @@ cores:
       address: 0x40007800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA8
         signal: SCL

--- a/data/chips/STM32L071RB.yaml
+++ b/data/chips/STM32L071RB.yaml
@@ -149,6 +149,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA9
         signal: SCL
@@ -180,6 +181,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB10
         signal: SCL
@@ -202,6 +204,7 @@ cores:
       address: 0x40007800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PC0
         signal: SCL

--- a/data/chips/STM32L071RZ.yaml
+++ b/data/chips/STM32L071RZ.yaml
@@ -149,6 +149,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA9
         signal: SCL
@@ -180,6 +181,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB10
         signal: SCL
@@ -202,6 +204,7 @@ cores:
       address: 0x40007800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PC0
         signal: SCL

--- a/data/chips/STM32L071V8.yaml
+++ b/data/chips/STM32L071V8.yaml
@@ -149,6 +149,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA9
         signal: SCL
@@ -180,6 +181,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB10
         signal: SCL
@@ -202,6 +204,7 @@ cores:
       address: 0x40007800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PC0
         signal: SCL

--- a/data/chips/STM32L071VB.yaml
+++ b/data/chips/STM32L071VB.yaml
@@ -149,6 +149,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA9
         signal: SCL
@@ -180,6 +181,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB10
         signal: SCL
@@ -202,6 +204,7 @@ cores:
       address: 0x40007800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PC0
         signal: SCL

--- a/data/chips/STM32L071VZ.yaml
+++ b/data/chips/STM32L071VZ.yaml
@@ -149,6 +149,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA9
         signal: SCL
@@ -180,6 +181,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB10
         signal: SCL
@@ -202,6 +204,7 @@ cores:
       address: 0x40007800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PC0
         signal: SCL

--- a/data/chips/STM32L072CB.yaml
+++ b/data/chips/STM32L072CB.yaml
@@ -162,6 +162,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB5
         signal: SMBA
@@ -193,6 +194,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB14
         signal: SDA
@@ -215,6 +217,7 @@ cores:
       address: 0x40007800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB4
         signal: SDA

--- a/data/chips/STM32L072CZ.yaml
+++ b/data/chips/STM32L072CZ.yaml
@@ -164,6 +164,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB5
         signal: SMBA
@@ -195,6 +196,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB14
         signal: SDA
@@ -217,6 +219,7 @@ cores:
       address: 0x40007800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB4
         signal: SDA

--- a/data/chips/STM32L072KB.yaml
+++ b/data/chips/STM32L072KB.yaml
@@ -152,6 +152,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA9
         signal: SCL
@@ -177,6 +178,7 @@ cores:
       address: 0x40007800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA8
         signal: SCL

--- a/data/chips/STM32L072KZ.yaml
+++ b/data/chips/STM32L072KZ.yaml
@@ -152,6 +152,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA9
         signal: SCL
@@ -177,6 +178,7 @@ cores:
       address: 0x40007800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA8
         signal: SCL

--- a/data/chips/STM32L072RB.yaml
+++ b/data/chips/STM32L072RB.yaml
@@ -168,6 +168,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA9
         signal: SCL
@@ -199,6 +200,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB10
         signal: SCL
@@ -221,6 +223,7 @@ cores:
       address: 0x40007800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PC0
         signal: SCL

--- a/data/chips/STM32L072RZ.yaml
+++ b/data/chips/STM32L072RZ.yaml
@@ -168,6 +168,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA9
         signal: SCL
@@ -199,6 +200,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB10
         signal: SCL
@@ -221,6 +223,7 @@ cores:
       address: 0x40007800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PC0
         signal: SCL

--- a/data/chips/STM32L072V8.yaml
+++ b/data/chips/STM32L072V8.yaml
@@ -166,6 +166,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA9
         signal: SCL
@@ -197,6 +198,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB10
         signal: SCL
@@ -219,6 +221,7 @@ cores:
       address: 0x40007800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PC0
         signal: SCL

--- a/data/chips/STM32L072VB.yaml
+++ b/data/chips/STM32L072VB.yaml
@@ -166,6 +166,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA9
         signal: SCL
@@ -197,6 +198,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB10
         signal: SCL
@@ -219,6 +221,7 @@ cores:
       address: 0x40007800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PC0
         signal: SCL

--- a/data/chips/STM32L072VZ.yaml
+++ b/data/chips/STM32L072VZ.yaml
@@ -166,6 +166,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA9
         signal: SCL
@@ -197,6 +198,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB10
         signal: SCL
@@ -219,6 +221,7 @@ cores:
       address: 0x40007800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PC0
         signal: SCL

--- a/data/chips/STM32L073CB.yaml
+++ b/data/chips/STM32L073CB.yaml
@@ -154,6 +154,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA9
         signal: SCL
@@ -185,6 +186,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB10
         signal: SCL
@@ -207,6 +209,7 @@ cores:
       address: 0x40007800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB2
         signal: SMBA

--- a/data/chips/STM32L073CZ.yaml
+++ b/data/chips/STM32L073CZ.yaml
@@ -162,6 +162,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB5
         signal: SMBA
@@ -193,6 +194,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB14
         signal: SDA
@@ -215,6 +217,7 @@ cores:
       address: 0x40007800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB4
         signal: SDA

--- a/data/chips/STM32L073RB.yaml
+++ b/data/chips/STM32L073RB.yaml
@@ -166,6 +166,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA9
         signal: SCL
@@ -197,6 +198,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB10
         signal: SCL
@@ -219,6 +221,7 @@ cores:
       address: 0x40007800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PC0
         signal: SCL

--- a/data/chips/STM32L073RZ.yaml
+++ b/data/chips/STM32L073RZ.yaml
@@ -166,6 +166,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB9
         signal: SDA
@@ -197,6 +198,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB14
         signal: SDA
@@ -219,6 +221,7 @@ cores:
       address: 0x40007800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB4
         signal: SDA

--- a/data/chips/STM32L073V8.yaml
+++ b/data/chips/STM32L073V8.yaml
@@ -166,6 +166,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA9
         signal: SCL
@@ -197,6 +198,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB10
         signal: SCL
@@ -219,6 +221,7 @@ cores:
       address: 0x40007800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PC0
         signal: SCL

--- a/data/chips/STM32L073VB.yaml
+++ b/data/chips/STM32L073VB.yaml
@@ -166,6 +166,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA9
         signal: SCL
@@ -197,6 +198,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB10
         signal: SCL
@@ -219,6 +221,7 @@ cores:
       address: 0x40007800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PC0
         signal: SCL

--- a/data/chips/STM32L073VZ.yaml
+++ b/data/chips/STM32L073VZ.yaml
@@ -166,6 +166,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA9
         signal: SCL
@@ -197,6 +198,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB10
         signal: SCL
@@ -219,6 +221,7 @@ cores:
       address: 0x40007800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PC0
         signal: SCL

--- a/data/chips/STM32L081CB.yaml
+++ b/data/chips/STM32L081CB.yaml
@@ -143,6 +143,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA9
         signal: SCL
@@ -174,6 +175,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB10
         signal: SCL
@@ -196,6 +198,7 @@ cores:
       address: 0x40007800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB2
         signal: SMBA

--- a/data/chips/STM32L081CZ.yaml
+++ b/data/chips/STM32L081CZ.yaml
@@ -145,6 +145,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA9
         signal: SCL
@@ -176,6 +177,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB10
         signal: SCL
@@ -198,6 +200,7 @@ cores:
       address: 0x40007800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB2
         signal: SMBA

--- a/data/chips/STM32L081KZ.yaml
+++ b/data/chips/STM32L081KZ.yaml
@@ -143,6 +143,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA9
         signal: SCL
@@ -168,6 +169,7 @@ cores:
       address: 0x40007800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA8
         signal: SCL

--- a/data/chips/STM32L082CZ.yaml
+++ b/data/chips/STM32L082CZ.yaml
@@ -168,6 +168,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB5
         signal: SMBA
@@ -199,6 +200,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB14
         signal: SDA
@@ -221,6 +223,7 @@ cores:
       address: 0x40007800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB4
         signal: SDA

--- a/data/chips/STM32L082KB.yaml
+++ b/data/chips/STM32L082KB.yaml
@@ -160,6 +160,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA9
         signal: SCL
@@ -185,6 +186,7 @@ cores:
       address: 0x40007800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA8
         signal: SCL

--- a/data/chips/STM32L082KZ.yaml
+++ b/data/chips/STM32L082KZ.yaml
@@ -160,6 +160,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA9
         signal: SCL
@@ -185,6 +186,7 @@ cores:
       address: 0x40007800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA8
         signal: SCL

--- a/data/chips/STM32L083CB.yaml
+++ b/data/chips/STM32L083CB.yaml
@@ -160,6 +160,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA9
         signal: SCL
@@ -191,6 +192,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB10
         signal: SCL
@@ -213,6 +215,7 @@ cores:
       address: 0x40007800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB2
         signal: SMBA

--- a/data/chips/STM32L083CZ.yaml
+++ b/data/chips/STM32L083CZ.yaml
@@ -162,6 +162,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA9
         signal: SCL
@@ -193,6 +194,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB10
         signal: SCL
@@ -215,6 +217,7 @@ cores:
       address: 0x40007800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB2
         signal: SMBA

--- a/data/chips/STM32L083RB.yaml
+++ b/data/chips/STM32L083RB.yaml
@@ -174,6 +174,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA9
         signal: SCL
@@ -205,6 +206,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB10
         signal: SCL
@@ -227,6 +229,7 @@ cores:
       address: 0x40007800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PC0
         signal: SCL

--- a/data/chips/STM32L083RZ.yaml
+++ b/data/chips/STM32L083RZ.yaml
@@ -174,6 +174,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA9
         signal: SCL
@@ -205,6 +206,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB10
         signal: SCL
@@ -227,6 +229,7 @@ cores:
       address: 0x40007800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PC0
         signal: SCL

--- a/data/chips/STM32L083V8.yaml
+++ b/data/chips/STM32L083V8.yaml
@@ -174,6 +174,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA9
         signal: SCL
@@ -205,6 +206,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB10
         signal: SCL
@@ -227,6 +229,7 @@ cores:
       address: 0x40007800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PC0
         signal: SCL

--- a/data/chips/STM32L083VB.yaml
+++ b/data/chips/STM32L083VB.yaml
@@ -174,6 +174,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA9
         signal: SCL
@@ -205,6 +206,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB10
         signal: SCL
@@ -227,6 +229,7 @@ cores:
       address: 0x40007800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PC0
         signal: SCL

--- a/data/chips/STM32L083VZ.yaml
+++ b/data/chips/STM32L083VZ.yaml
@@ -174,6 +174,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA9
         signal: SCL
@@ -205,6 +206,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB10
         signal: SCL
@@ -227,6 +229,7 @@ cores:
       address: 0x40007800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PC0
         signal: SCL

--- a/data/chips/STM32L412C8.yaml
+++ b/data/chips/STM32L412C8.yaml
@@ -145,6 +145,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA1
         signal: SMBA
@@ -182,6 +183,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB10
         signal: SCL
@@ -207,6 +209,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA7
         signal: SCL

--- a/data/chips/STM32L412CB.yaml
+++ b/data/chips/STM32L412CB.yaml
@@ -149,6 +149,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA1
         signal: SMBA
@@ -183,6 +184,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB10
         signal: SCL
@@ -205,6 +207,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA7
         signal: SCL

--- a/data/chips/STM32L412K8.yaml
+++ b/data/chips/STM32L412K8.yaml
@@ -140,6 +140,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA1
         signal: SMBA
@@ -171,6 +172,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA7
         signal: SCL

--- a/data/chips/STM32L412KB.yaml
+++ b/data/chips/STM32L412KB.yaml
@@ -140,6 +140,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA1
         signal: SMBA
@@ -171,6 +172,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA7
         signal: SCL

--- a/data/chips/STM32L412R8.yaml
+++ b/data/chips/STM32L412R8.yaml
@@ -173,6 +173,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA1
         signal: SMBA
@@ -210,6 +211,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB10
         signal: SCL
@@ -235,6 +237,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PC0
         signal: SCL

--- a/data/chips/STM32L412RB.yaml
+++ b/data/chips/STM32L412RB.yaml
@@ -171,6 +171,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA1
         signal: SMBA
@@ -208,6 +209,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB10
         signal: SCL
@@ -233,6 +235,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PC0
         signal: SCL

--- a/data/chips/STM32L412T8.yaml
+++ b/data/chips/STM32L412T8.yaml
@@ -143,6 +143,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA14
         signal: SMBA
@@ -177,6 +178,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB4
         signal: SDA

--- a/data/chips/STM32L412TB.yaml
+++ b/data/chips/STM32L412TB.yaml
@@ -145,6 +145,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA14
         signal: SMBA
@@ -176,6 +177,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB4
         signal: SDA

--- a/data/chips/STM32L422CB.yaml
+++ b/data/chips/STM32L422CB.yaml
@@ -153,6 +153,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA1
         signal: SMBA
@@ -190,6 +191,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB10
         signal: SCL
@@ -215,6 +217,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA7
         signal: SCL

--- a/data/chips/STM32L422KB.yaml
+++ b/data/chips/STM32L422KB.yaml
@@ -148,6 +148,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA1
         signal: SMBA
@@ -179,6 +180,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA7
         signal: SCL

--- a/data/chips/STM32L422RB.yaml
+++ b/data/chips/STM32L422RB.yaml
@@ -181,6 +181,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA1
         signal: SMBA
@@ -218,6 +219,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB10
         signal: SCL
@@ -243,6 +245,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PC0
         signal: SCL

--- a/data/chips/STM32L422TB.yaml
+++ b/data/chips/STM32L422TB.yaml
@@ -151,6 +151,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA14
         signal: SMBA
@@ -185,6 +186,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB4
         signal: SDA

--- a/data/chips/STM32L431CB.yaml
+++ b/data/chips/STM32L431CB.yaml
@@ -187,6 +187,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA14
         signal: SMBA
@@ -224,6 +225,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB14
         signal: SDA
@@ -249,6 +251,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB4
         signal: SDA

--- a/data/chips/STM32L431CC.yaml
+++ b/data/chips/STM32L431CC.yaml
@@ -187,6 +187,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA14
         signal: SMBA
@@ -224,6 +225,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB14
         signal: SDA
@@ -249,6 +251,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB4
         signal: SDA

--- a/data/chips/STM32L431KB.yaml
+++ b/data/chips/STM32L431KB.yaml
@@ -167,6 +167,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA1
         signal: SMBA
@@ -198,6 +199,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA7
         signal: SCL

--- a/data/chips/STM32L431KC.yaml
+++ b/data/chips/STM32L431KC.yaml
@@ -167,6 +167,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA1
         signal: SMBA
@@ -198,6 +199,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA7
         signal: SCL

--- a/data/chips/STM32L431RB.yaml
+++ b/data/chips/STM32L431RB.yaml
@@ -201,6 +201,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB7
         signal: SDA
@@ -238,6 +239,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB14
         signal: SDA
@@ -263,6 +265,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB4
         signal: SDA

--- a/data/chips/STM32L431RC.yaml
+++ b/data/chips/STM32L431RC.yaml
@@ -201,6 +201,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB7
         signal: SDA
@@ -238,6 +239,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB14
         signal: SDA
@@ -263,6 +265,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB4
         signal: SDA

--- a/data/chips/STM32L431VC.yaml
+++ b/data/chips/STM32L431VC.yaml
@@ -205,6 +205,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA1
         signal: SMBA
@@ -242,6 +243,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB10
         signal: SCL
@@ -267,6 +269,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PC0
         signal: SCL

--- a/data/chips/STM32L432KB.yaml
+++ b/data/chips/STM32L432KB.yaml
@@ -161,6 +161,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA1
         signal: SMBA
@@ -192,6 +193,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA7
         signal: SCL

--- a/data/chips/STM32L432KC.yaml
+++ b/data/chips/STM32L432KC.yaml
@@ -161,6 +161,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA1
         signal: SMBA
@@ -192,6 +193,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA7
         signal: SCL

--- a/data/chips/STM32L433CB.yaml
+++ b/data/chips/STM32L433CB.yaml
@@ -187,6 +187,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA14
         signal: SMBA
@@ -224,6 +225,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB14
         signal: SDA
@@ -249,6 +251,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB4
         signal: SDA

--- a/data/chips/STM32L433CC.yaml
+++ b/data/chips/STM32L433CC.yaml
@@ -187,6 +187,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA14
         signal: SMBA
@@ -224,6 +225,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB14
         signal: SDA
@@ -249,6 +251,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB4
         signal: SDA

--- a/data/chips/STM32L433RB.yaml
+++ b/data/chips/STM32L433RB.yaml
@@ -201,6 +201,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB7
         signal: SDA
@@ -238,6 +239,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB14
         signal: SDA
@@ -263,6 +265,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB4
         signal: SDA

--- a/data/chips/STM32L433RC.yaml
+++ b/data/chips/STM32L433RC.yaml
@@ -199,6 +199,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA1
         signal: SMBA
@@ -236,6 +237,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB10
         signal: SCL
@@ -261,6 +263,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PC0
         signal: SCL

--- a/data/chips/STM32L433VC.yaml
+++ b/data/chips/STM32L433VC.yaml
@@ -205,6 +205,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA1
         signal: SMBA
@@ -242,6 +243,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB10
         signal: SCL
@@ -267,6 +269,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PC0
         signal: SCL

--- a/data/chips/STM32L442KC.yaml
+++ b/data/chips/STM32L442KC.yaml
@@ -169,6 +169,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA1
         signal: SMBA
@@ -200,6 +201,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA7
         signal: SCL

--- a/data/chips/STM32L443CC.yaml
+++ b/data/chips/STM32L443CC.yaml
@@ -195,6 +195,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA14
         signal: SMBA
@@ -232,6 +233,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB14
         signal: SDA
@@ -257,6 +259,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB4
         signal: SDA

--- a/data/chips/STM32L443RC.yaml
+++ b/data/chips/STM32L443RC.yaml
@@ -209,6 +209,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB7
         signal: SDA
@@ -246,6 +247,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB14
         signal: SDA
@@ -271,6 +273,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB4
         signal: SDA

--- a/data/chips/STM32L443VC.yaml
+++ b/data/chips/STM32L443VC.yaml
@@ -213,6 +213,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA1
         signal: SMBA
@@ -250,6 +251,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB10
         signal: SCL
@@ -275,6 +277,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PC0
         signal: SCL

--- a/data/chips/STM32L451CC.yaml
+++ b/data/chips/STM32L451CC.yaml
@@ -191,6 +191,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA1
         signal: SMBA
@@ -228,6 +229,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB10
         signal: SCL
@@ -253,6 +255,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA7
         signal: SCL
@@ -272,6 +275,7 @@ cores:
       address: 0x40008400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB10
         signal: SCL

--- a/data/chips/STM32L451CE.yaml
+++ b/data/chips/STM32L451CE.yaml
@@ -193,6 +193,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA1
         signal: SMBA
@@ -230,6 +231,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB10
         signal: SCL
@@ -255,6 +257,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA7
         signal: SCL
@@ -274,6 +277,7 @@ cores:
       address: 0x40008400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB10
         signal: SCL

--- a/data/chips/STM32L451RC.yaml
+++ b/data/chips/STM32L451RC.yaml
@@ -211,6 +211,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB7
         signal: SDA
@@ -248,6 +249,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB14
         signal: SDA
@@ -273,6 +275,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB4
         signal: SDA
@@ -298,6 +301,7 @@ cores:
       address: 0x40008400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB7
         signal: SDA

--- a/data/chips/STM32L451RE.yaml
+++ b/data/chips/STM32L451RE.yaml
@@ -211,6 +211,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB7
         signal: SDA
@@ -248,6 +249,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB14
         signal: SDA
@@ -273,6 +275,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB4
         signal: SDA
@@ -298,6 +301,7 @@ cores:
       address: 0x40008400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB7
         signal: SDA

--- a/data/chips/STM32L451VC.yaml
+++ b/data/chips/STM32L451VC.yaml
@@ -215,6 +215,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA1
         signal: SMBA
@@ -252,6 +253,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB10
         signal: SCL
@@ -277,6 +279,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PC0
         signal: SCL
@@ -302,6 +305,7 @@ cores:
       address: 0x40008400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PC0
         signal: SCL

--- a/data/chips/STM32L451VE.yaml
+++ b/data/chips/STM32L451VE.yaml
@@ -215,6 +215,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA1
         signal: SMBA
@@ -252,6 +253,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB10
         signal: SCL
@@ -277,6 +279,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PC0
         signal: SCL
@@ -302,6 +305,7 @@ cores:
       address: 0x40008400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PC0
         signal: SCL

--- a/data/chips/STM32L452CC.yaml
+++ b/data/chips/STM32L452CC.yaml
@@ -191,6 +191,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA1
         signal: SMBA
@@ -228,6 +229,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB10
         signal: SCL
@@ -253,6 +255,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA7
         signal: SCL
@@ -272,6 +275,7 @@ cores:
       address: 0x40008400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB10
         signal: SCL

--- a/data/chips/STM32L452CE.yaml
+++ b/data/chips/STM32L452CE.yaml
@@ -193,6 +193,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA1
         signal: SMBA
@@ -230,6 +231,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB10
         signal: SCL
@@ -255,6 +257,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA7
         signal: SCL
@@ -274,6 +277,7 @@ cores:
       address: 0x40008400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB10
         signal: SCL

--- a/data/chips/STM32L452RC.yaml
+++ b/data/chips/STM32L452RC.yaml
@@ -211,6 +211,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB7
         signal: SDA
@@ -248,6 +249,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB14
         signal: SDA
@@ -273,6 +275,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB4
         signal: SDA
@@ -298,6 +301,7 @@ cores:
       address: 0x40008400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB7
         signal: SDA

--- a/data/chips/STM32L452RE.yaml
+++ b/data/chips/STM32L452RE.yaml
@@ -209,6 +209,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA1
         signal: SMBA
@@ -246,6 +247,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB10
         signal: SCL
@@ -271,6 +273,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PC0
         signal: SCL
@@ -296,6 +299,7 @@ cores:
       address: 0x40008400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PC0
         signal: SCL

--- a/data/chips/STM32L452VC.yaml
+++ b/data/chips/STM32L452VC.yaml
@@ -215,6 +215,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA1
         signal: SMBA
@@ -252,6 +253,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB10
         signal: SCL
@@ -277,6 +279,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PC0
         signal: SCL
@@ -302,6 +305,7 @@ cores:
       address: 0x40008400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PC0
         signal: SCL

--- a/data/chips/STM32L452VE.yaml
+++ b/data/chips/STM32L452VE.yaml
@@ -215,6 +215,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA1
         signal: SMBA
@@ -252,6 +253,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB10
         signal: SCL
@@ -277,6 +279,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PC0
         signal: SCL
@@ -302,6 +305,7 @@ cores:
       address: 0x40008400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PC0
         signal: SCL

--- a/data/chips/STM32L462CE.yaml
+++ b/data/chips/STM32L462CE.yaml
@@ -201,6 +201,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA1
         signal: SMBA
@@ -238,6 +239,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB10
         signal: SCL
@@ -263,6 +265,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA7
         signal: SCL
@@ -282,6 +285,7 @@ cores:
       address: 0x40008400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB10
         signal: SCL

--- a/data/chips/STM32L462RE.yaml
+++ b/data/chips/STM32L462RE.yaml
@@ -219,6 +219,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB7
         signal: SDA
@@ -256,6 +257,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB14
         signal: SDA
@@ -281,6 +283,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB4
         signal: SDA
@@ -306,6 +309,7 @@ cores:
       address: 0x40008400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB7
         signal: SDA

--- a/data/chips/STM32L462VE.yaml
+++ b/data/chips/STM32L462VE.yaml
@@ -223,6 +223,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA1
         signal: SMBA
@@ -260,6 +261,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB10
         signal: SCL
@@ -285,6 +287,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PC0
         signal: SCL
@@ -310,6 +313,7 @@ cores:
       address: 0x40008400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PC0
         signal: SCL

--- a/data/chips/STM32L471QE.yaml
+++ b/data/chips/STM32L471QE.yaml
@@ -237,6 +237,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB8
         signal: SCL
@@ -271,6 +272,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF2
         signal: SMBA
@@ -305,6 +307,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PG6
         signal: SMBA

--- a/data/chips/STM32L471QG.yaml
+++ b/data/chips/STM32L471QG.yaml
@@ -237,6 +237,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB8
         signal: SCL
@@ -271,6 +272,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF2
         signal: SMBA
@@ -305,6 +307,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PG6
         signal: SMBA

--- a/data/chips/STM32L471RE.yaml
+++ b/data/chips/STM32L471RE.yaml
@@ -225,6 +225,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB5
         signal: SMBA
@@ -250,6 +251,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB10
         signal: SCL
@@ -275,6 +277,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PC0
         signal: SCL

--- a/data/chips/STM32L471RG.yaml
+++ b/data/chips/STM32L471RG.yaml
@@ -225,6 +225,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB5
         signal: SMBA
@@ -250,6 +251,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB10
         signal: SCL
@@ -275,6 +277,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PC0
         signal: SCL

--- a/data/chips/STM32L471VE.yaml
+++ b/data/chips/STM32L471VE.yaml
@@ -231,6 +231,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB5
         signal: SMBA
@@ -256,6 +257,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB10
         signal: SCL
@@ -281,6 +283,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PC0
         signal: SCL

--- a/data/chips/STM32L471VG.yaml
+++ b/data/chips/STM32L471VG.yaml
@@ -231,6 +231,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB5
         signal: SMBA
@@ -256,6 +257,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB10
         signal: SCL
@@ -281,6 +283,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PC0
         signal: SCL

--- a/data/chips/STM32L471ZE.yaml
+++ b/data/chips/STM32L471ZE.yaml
@@ -249,6 +249,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PG13
         signal: SDA
@@ -283,6 +284,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF0
         signal: SDA
@@ -317,6 +319,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PC0
         signal: SCL

--- a/data/chips/STM32L471ZG.yaml
+++ b/data/chips/STM32L471ZG.yaml
@@ -249,6 +249,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PG13
         signal: SDA
@@ -283,6 +284,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF0
         signal: SDA
@@ -317,6 +319,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PC0
         signal: SCL

--- a/data/chips/STM32L475RC.yaml
+++ b/data/chips/STM32L475RC.yaml
@@ -225,6 +225,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB5
         signal: SMBA
@@ -250,6 +251,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB10
         signal: SCL
@@ -275,6 +277,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PC0
         signal: SCL

--- a/data/chips/STM32L475RE.yaml
+++ b/data/chips/STM32L475RE.yaml
@@ -225,6 +225,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB5
         signal: SMBA
@@ -250,6 +251,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB10
         signal: SCL
@@ -275,6 +277,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PC0
         signal: SCL

--- a/data/chips/STM32L475RG.yaml
+++ b/data/chips/STM32L475RG.yaml
@@ -225,6 +225,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB5
         signal: SMBA
@@ -250,6 +251,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB10
         signal: SCL
@@ -275,6 +277,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PC0
         signal: SCL

--- a/data/chips/STM32L475VC.yaml
+++ b/data/chips/STM32L475VC.yaml
@@ -231,6 +231,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB5
         signal: SMBA
@@ -256,6 +257,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB10
         signal: SCL
@@ -281,6 +283,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PC0
         signal: SCL

--- a/data/chips/STM32L475VE.yaml
+++ b/data/chips/STM32L475VE.yaml
@@ -231,6 +231,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB5
         signal: SMBA
@@ -256,6 +257,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB10
         signal: SCL
@@ -281,6 +283,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PC0
         signal: SCL

--- a/data/chips/STM32L475VG.yaml
+++ b/data/chips/STM32L475VG.yaml
@@ -231,6 +231,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB5
         signal: SMBA
@@ -256,6 +257,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB10
         signal: SCL
@@ -281,6 +283,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PC0
         signal: SCL

--- a/data/chips/STM32L476JE.yaml
+++ b/data/chips/STM32L476JE.yaml
@@ -225,6 +225,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PG14
         signal: SCL
@@ -256,6 +257,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB14
         signal: SDA
@@ -281,6 +283,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PC1
         signal: SDA

--- a/data/chips/STM32L476JG.yaml
+++ b/data/chips/STM32L476JG.yaml
@@ -221,6 +221,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PG14
         signal: SCL
@@ -252,6 +253,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB14
         signal: SDA
@@ -277,6 +279,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PC1
         signal: SDA

--- a/data/chips/STM32L476ME.yaml
+++ b/data/chips/STM32L476ME.yaml
@@ -225,6 +225,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PG14
         signal: SCL
@@ -256,6 +257,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB14
         signal: SDA
@@ -281,6 +283,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PC1
         signal: SDA

--- a/data/chips/STM32L476MG.yaml
+++ b/data/chips/STM32L476MG.yaml
@@ -225,6 +225,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PG14
         signal: SCL
@@ -256,6 +257,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB14
         signal: SDA
@@ -281,6 +283,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PC1
         signal: SDA

--- a/data/chips/STM32L476QE.yaml
+++ b/data/chips/STM32L476QE.yaml
@@ -237,6 +237,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB8
         signal: SCL
@@ -271,6 +272,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF2
         signal: SMBA
@@ -305,6 +307,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PG6
         signal: SMBA

--- a/data/chips/STM32L476QG.yaml
+++ b/data/chips/STM32L476QG.yaml
@@ -237,6 +237,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB8
         signal: SCL
@@ -271,6 +272,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF2
         signal: SMBA
@@ -305,6 +307,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PG6
         signal: SMBA

--- a/data/chips/STM32L476RC.yaml
+++ b/data/chips/STM32L476RC.yaml
@@ -225,6 +225,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB5
         signal: SMBA
@@ -250,6 +251,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB10
         signal: SCL
@@ -275,6 +277,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PC0
         signal: SCL

--- a/data/chips/STM32L476RE.yaml
+++ b/data/chips/STM32L476RE.yaml
@@ -225,6 +225,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB5
         signal: SMBA
@@ -250,6 +251,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB10
         signal: SCL
@@ -275,6 +277,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PC0
         signal: SCL

--- a/data/chips/STM32L476RG.yaml
+++ b/data/chips/STM32L476RG.yaml
@@ -225,6 +225,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB5
         signal: SMBA
@@ -250,6 +251,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB10
         signal: SCL
@@ -275,6 +277,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PC0
         signal: SCL

--- a/data/chips/STM32L476VC.yaml
+++ b/data/chips/STM32L476VC.yaml
@@ -231,6 +231,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB5
         signal: SMBA
@@ -256,6 +257,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB10
         signal: SCL
@@ -281,6 +283,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PC0
         signal: SCL

--- a/data/chips/STM32L476VE.yaml
+++ b/data/chips/STM32L476VE.yaml
@@ -231,6 +231,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB5
         signal: SMBA
@@ -256,6 +257,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB10
         signal: SCL
@@ -281,6 +283,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PC0
         signal: SCL

--- a/data/chips/STM32L476VG.yaml
+++ b/data/chips/STM32L476VG.yaml
@@ -231,6 +231,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB5
         signal: SMBA
@@ -256,6 +257,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB10
         signal: SCL
@@ -281,6 +283,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PC0
         signal: SCL

--- a/data/chips/STM32L476ZE.yaml
+++ b/data/chips/STM32L476ZE.yaml
@@ -247,6 +247,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PG13
         signal: SDA
@@ -281,6 +282,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF0
         signal: SDA
@@ -315,6 +317,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PC0
         signal: SCL

--- a/data/chips/STM32L476ZG.yaml
+++ b/data/chips/STM32L476ZG.yaml
@@ -248,6 +248,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PG13
         signal: SDA
@@ -279,6 +280,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF0
         signal: SDA
@@ -310,6 +312,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PC0
         signal: SCL

--- a/data/chips/STM32L485JC.yaml
+++ b/data/chips/STM32L485JC.yaml
@@ -227,6 +227,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PG14
         signal: SCL
@@ -258,6 +259,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB14
         signal: SDA
@@ -283,6 +285,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PC1
         signal: SDA

--- a/data/chips/STM32L485JE.yaml
+++ b/data/chips/STM32L485JE.yaml
@@ -227,6 +227,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PG14
         signal: SCL
@@ -258,6 +259,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB14
         signal: SDA
@@ -283,6 +285,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PC1
         signal: SDA

--- a/data/chips/STM32L486JG.yaml
+++ b/data/chips/STM32L486JG.yaml
@@ -233,6 +233,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PG14
         signal: SCL
@@ -264,6 +265,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB14
         signal: SDA
@@ -289,6 +291,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PC1
         signal: SDA

--- a/data/chips/STM32L486QG.yaml
+++ b/data/chips/STM32L486QG.yaml
@@ -245,6 +245,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB8
         signal: SCL
@@ -279,6 +280,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF2
         signal: SMBA
@@ -313,6 +315,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PG6
         signal: SMBA

--- a/data/chips/STM32L486RG.yaml
+++ b/data/chips/STM32L486RG.yaml
@@ -233,6 +233,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB5
         signal: SMBA
@@ -258,6 +259,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB10
         signal: SCL
@@ -283,6 +285,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PC0
         signal: SCL

--- a/data/chips/STM32L486VG.yaml
+++ b/data/chips/STM32L486VG.yaml
@@ -239,6 +239,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB5
         signal: SMBA
@@ -264,6 +265,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB10
         signal: SCL
@@ -289,6 +291,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PC0
         signal: SCL

--- a/data/chips/STM32L486ZG.yaml
+++ b/data/chips/STM32L486ZG.yaml
@@ -255,6 +255,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PG13
         signal: SDA
@@ -289,6 +290,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF0
         signal: SDA
@@ -323,6 +325,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PC0
         signal: SCL

--- a/data/chips/STM32L496AE.yaml
+++ b/data/chips/STM32L496AE.yaml
@@ -425,6 +425,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA14
         signal: SMBA
@@ -465,6 +466,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PH6
         signal: SMBA
@@ -508,6 +510,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB4
         signal: SDA
@@ -554,6 +557,7 @@ cores:
       address: 0x40008400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA14
         signal: SMBA

--- a/data/chips/STM32L496AG.yaml
+++ b/data/chips/STM32L496AG.yaml
@@ -421,6 +421,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA14
         signal: SMBA
@@ -458,6 +459,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PH6
         signal: SMBA
@@ -501,6 +503,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB4
         signal: SDA
@@ -547,6 +550,7 @@ cores:
       address: 0x40008400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA14
         signal: SMBA

--- a/data/chips/STM32L496QE.yaml
+++ b/data/chips/STM32L496QE.yaml
@@ -357,6 +357,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB8
         signal: SCL
@@ -397,6 +398,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF2
         signal: SMBA
@@ -431,6 +433,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB4
         signal: SDA
@@ -468,6 +471,7 @@ cores:
       address: 0x40008400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA14
         signal: SMBA

--- a/data/chips/STM32L496QG.yaml
+++ b/data/chips/STM32L496QG.yaml
@@ -356,6 +356,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB8
         signal: SCL
@@ -393,6 +394,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF2
         signal: SMBA
@@ -424,6 +426,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB4
         signal: SDA
@@ -461,6 +464,7 @@ cores:
       address: 0x40008400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA14
         signal: SMBA

--- a/data/chips/STM32L496RE.yaml
+++ b/data/chips/STM32L496RE.yaml
@@ -312,6 +312,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA1
         signal: SMBA
@@ -343,6 +344,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB10
         signal: SCL
@@ -368,6 +370,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PC0
         signal: SCL
@@ -396,6 +399,7 @@ cores:
       address: 0x40008400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PC0
         signal: SCL

--- a/data/chips/STM32L496RG.yaml
+++ b/data/chips/STM32L496RG.yaml
@@ -305,6 +305,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA1
         signal: SMBA
@@ -336,6 +337,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB10
         signal: SCL
@@ -361,6 +363,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PC0
         signal: SCL
@@ -389,6 +392,7 @@ cores:
       address: 0x40008400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PC0
         signal: SCL

--- a/data/chips/STM32L496VE.yaml
+++ b/data/chips/STM32L496VE.yaml
@@ -345,6 +345,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA1
         signal: SMBA
@@ -376,6 +377,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB10
         signal: SCL
@@ -401,6 +403,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PC0
         signal: SCL
@@ -429,6 +432,7 @@ cores:
       address: 0x40008400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PC0
         signal: SCL

--- a/data/chips/STM32L496VG.yaml
+++ b/data/chips/STM32L496VG.yaml
@@ -336,6 +336,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB6
         signal: SCL
@@ -367,6 +368,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB14
         signal: SDA
@@ -392,6 +394,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PC9
         signal: SDA
@@ -420,6 +423,7 @@ cores:
       address: 0x40008400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB6
         signal: SCL

--- a/data/chips/STM32L496WG.yaml
+++ b/data/chips/STM32L496WG.yaml
@@ -327,6 +327,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PG14
         signal: SCL
@@ -361,6 +362,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB14
         signal: SDA
@@ -386,6 +388,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB4
         signal: SDA
@@ -423,6 +426,7 @@ cores:
       address: 0x40008400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB7
         signal: SDA

--- a/data/chips/STM32L496ZE.yaml
+++ b/data/chips/STM32L496ZE.yaml
@@ -370,6 +370,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA1
         signal: SMBA
@@ -410,6 +411,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF0
         signal: SDA
@@ -444,6 +446,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PC0
         signal: SCL
@@ -481,6 +484,7 @@ cores:
       address: 0x40008400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PC0
         signal: SCL

--- a/data/chips/STM32L496ZG.yaml
+++ b/data/chips/STM32L496ZG.yaml
@@ -366,6 +366,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA1
         signal: SMBA
@@ -403,6 +404,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF0
         signal: SDA
@@ -434,6 +436,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PC0
         signal: SCL
@@ -471,6 +474,7 @@ cores:
       address: 0x40008400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PC0
         signal: SCL

--- a/data/chips/STM32L4A6AG.yaml
+++ b/data/chips/STM32L4A6AG.yaml
@@ -435,6 +435,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA14
         signal: SMBA
@@ -472,6 +473,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PH6
         signal: SMBA
@@ -515,6 +517,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB4
         signal: SDA
@@ -561,6 +564,7 @@ cores:
       address: 0x40008400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA14
         signal: SMBA

--- a/data/chips/STM32L4A6QG.yaml
+++ b/data/chips/STM32L4A6QG.yaml
@@ -370,6 +370,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB8
         signal: SCL
@@ -407,6 +408,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF2
         signal: SMBA
@@ -438,6 +440,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB4
         signal: SDA
@@ -475,6 +478,7 @@ cores:
       address: 0x40008400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA14
         signal: SMBA

--- a/data/chips/STM32L4A6RG.yaml
+++ b/data/chips/STM32L4A6RG.yaml
@@ -319,6 +319,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA1
         signal: SMBA
@@ -350,6 +351,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB10
         signal: SCL
@@ -375,6 +377,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PC0
         signal: SCL
@@ -403,6 +406,7 @@ cores:
       address: 0x40008400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PC0
         signal: SCL

--- a/data/chips/STM32L4A6VG.yaml
+++ b/data/chips/STM32L4A6VG.yaml
@@ -350,6 +350,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB6
         signal: SCL
@@ -381,6 +382,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB14
         signal: SDA
@@ -406,6 +408,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PC9
         signal: SDA
@@ -434,6 +437,7 @@ cores:
       address: 0x40008400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB6
         signal: SCL

--- a/data/chips/STM32L4A6ZG.yaml
+++ b/data/chips/STM32L4A6ZG.yaml
@@ -380,6 +380,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA1
         signal: SMBA
@@ -417,6 +418,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF0
         signal: SDA
@@ -448,6 +450,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PC0
         signal: SCL
@@ -485,6 +488,7 @@ cores:
       address: 0x40008400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PC0
         signal: SCL

--- a/data/chips/STM32L4P5AE.yaml
+++ b/data/chips/STM32L4P5AE.yaml
@@ -399,6 +399,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA14
         signal: SMBA
@@ -437,6 +438,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PH6
         signal: SMBA
@@ -478,6 +480,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB4
         signal: SDA
@@ -522,6 +525,7 @@ cores:
       address: 0x40008400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA14
         signal: SMBA

--- a/data/chips/STM32L4P5AG.yaml
+++ b/data/chips/STM32L4P5AG.yaml
@@ -395,6 +395,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA14
         signal: SMBA
@@ -430,6 +431,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PH6
         signal: SMBA
@@ -471,6 +473,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB4
         signal: SDA
@@ -515,6 +518,7 @@ cores:
       address: 0x40008400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA14
         signal: SMBA

--- a/data/chips/STM32L4P5CE.yaml
+++ b/data/chips/STM32L4P5CE.yaml
@@ -202,6 +202,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA1
         signal: SMBA
@@ -231,6 +232,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB10
         signal: SCL
@@ -254,6 +256,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA7
         signal: SCL
@@ -271,6 +274,7 @@ cores:
       address: 0x40008400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB10
         signal: SCL

--- a/data/chips/STM32L4P5CG.yaml
+++ b/data/chips/STM32L4P5CG.yaml
@@ -200,6 +200,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA1
         signal: SMBA
@@ -226,6 +227,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB10
         signal: SCL
@@ -246,6 +248,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA7
         signal: SCL
@@ -263,6 +266,7 @@ cores:
       address: 0x40008400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB10
         signal: SCL

--- a/data/chips/STM32L4P5QE.yaml
+++ b/data/chips/STM32L4P5QE.yaml
@@ -333,6 +333,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB8
         signal: SCL
@@ -371,6 +372,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF2
         signal: SMBA
@@ -403,6 +405,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB4
         signal: SDA
@@ -438,6 +441,7 @@ cores:
       address: 0x40008400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA14
         signal: SMBA

--- a/data/chips/STM32L4P5QG.yaml
+++ b/data/chips/STM32L4P5QG.yaml
@@ -332,6 +332,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB8
         signal: SCL
@@ -367,6 +368,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF2
         signal: SMBA
@@ -396,6 +398,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB4
         signal: SDA
@@ -431,6 +434,7 @@ cores:
       address: 0x40008400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA14
         signal: SMBA

--- a/data/chips/STM32L4P5RE.yaml
+++ b/data/chips/STM32L4P5RE.yaml
@@ -294,6 +294,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA1
         signal: SMBA
@@ -323,6 +324,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB10
         signal: SCL
@@ -346,6 +348,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PC0
         signal: SCL
@@ -372,6 +375,7 @@ cores:
       address: 0x40008400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB10
         signal: SCL

--- a/data/chips/STM32L4P5RG.yaml
+++ b/data/chips/STM32L4P5RG.yaml
@@ -287,6 +287,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA1
         signal: SMBA
@@ -316,6 +317,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB10
         signal: SCL
@@ -339,6 +341,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PC0
         signal: SCL
@@ -365,6 +368,7 @@ cores:
       address: 0x40008400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB10
         signal: SCL

--- a/data/chips/STM32L4P5VE.yaml
+++ b/data/chips/STM32L4P5VE.yaml
@@ -320,6 +320,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB6
         signal: SCL
@@ -349,6 +350,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB14
         signal: SDA
@@ -372,6 +374,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB4
         signal: SDA
@@ -398,6 +401,7 @@ cores:
       address: 0x40008400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB6
         signal: SCL

--- a/data/chips/STM32L4P5VG.yaml
+++ b/data/chips/STM32L4P5VG.yaml
@@ -318,6 +318,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB6
         signal: SCL
@@ -347,6 +348,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB14
         signal: SDA
@@ -370,6 +372,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PC9
         signal: SDA
@@ -396,6 +399,7 @@ cores:
       address: 0x40008400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB6
         signal: SCL

--- a/data/chips/STM32L4P5ZE.yaml
+++ b/data/chips/STM32L4P5ZE.yaml
@@ -336,6 +336,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA1
         signal: SMBA
@@ -374,6 +375,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF0
         signal: SDA
@@ -406,6 +408,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PC0
         signal: SCL
@@ -441,6 +444,7 @@ cores:
       address: 0x40008400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF13
         signal: SMBA

--- a/data/chips/STM32L4P5ZG.yaml
+++ b/data/chips/STM32L4P5ZG.yaml
@@ -332,6 +332,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA1
         signal: SMBA
@@ -367,6 +368,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF0
         signal: SDA
@@ -396,6 +398,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PC0
         signal: SCL
@@ -431,6 +434,7 @@ cores:
       address: 0x40008400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF13
         signal: SMBA

--- a/data/chips/STM32L4Q5AG.yaml
+++ b/data/chips/STM32L4Q5AG.yaml
@@ -401,6 +401,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA14
         signal: SMBA
@@ -436,6 +437,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PH6
         signal: SMBA
@@ -477,6 +479,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB4
         signal: SDA
@@ -521,6 +524,7 @@ cores:
       address: 0x40008400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA14
         signal: SMBA

--- a/data/chips/STM32L4Q5CG.yaml
+++ b/data/chips/STM32L4Q5CG.yaml
@@ -206,6 +206,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA1
         signal: SMBA
@@ -232,6 +233,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB10
         signal: SCL
@@ -252,6 +254,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA7
         signal: SCL
@@ -269,6 +272,7 @@ cores:
       address: 0x40008400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB10
         signal: SCL

--- a/data/chips/STM32L4Q5QG.yaml
+++ b/data/chips/STM32L4Q5QG.yaml
@@ -338,6 +338,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB8
         signal: SCL
@@ -373,6 +374,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF2
         signal: SMBA
@@ -402,6 +404,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB4
         signal: SDA
@@ -437,6 +440,7 @@ cores:
       address: 0x40008400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA14
         signal: SMBA

--- a/data/chips/STM32L4Q5RG.yaml
+++ b/data/chips/STM32L4Q5RG.yaml
@@ -293,6 +293,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA1
         signal: SMBA
@@ -322,6 +323,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB10
         signal: SCL
@@ -345,6 +347,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PC0
         signal: SCL
@@ -371,6 +374,7 @@ cores:
       address: 0x40008400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB10
         signal: SCL

--- a/data/chips/STM32L4Q5VG.yaml
+++ b/data/chips/STM32L4Q5VG.yaml
@@ -324,6 +324,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB6
         signal: SCL
@@ -353,6 +354,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB14
         signal: SDA
@@ -376,6 +378,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PC9
         signal: SDA
@@ -402,6 +405,7 @@ cores:
       address: 0x40008400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB6
         signal: SCL

--- a/data/chips/STM32L4Q5ZG.yaml
+++ b/data/chips/STM32L4Q5ZG.yaml
@@ -338,6 +338,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA1
         signal: SMBA
@@ -373,6 +374,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF0
         signal: SDA
@@ -402,6 +404,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PC0
         signal: SCL
@@ -437,6 +440,7 @@ cores:
       address: 0x40008400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF13
         signal: SMBA

--- a/data/chips/STM32L4R5AG.yaml
+++ b/data/chips/STM32L4R5AG.yaml
@@ -352,6 +352,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA14
         signal: SMBA
@@ -390,6 +391,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PH6
         signal: SMBA
@@ -431,6 +433,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB4
         signal: SDA
@@ -475,6 +478,7 @@ cores:
       address: 0x40008400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA14
         signal: SMBA

--- a/data/chips/STM32L4R5AI.yaml
+++ b/data/chips/STM32L4R5AI.yaml
@@ -352,6 +352,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA14
         signal: SMBA
@@ -390,6 +391,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PH6
         signal: SMBA
@@ -431,6 +433,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB4
         signal: SDA
@@ -475,6 +478,7 @@ cores:
       address: 0x40008400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA14
         signal: SMBA

--- a/data/chips/STM32L4R5QG.yaml
+++ b/data/chips/STM32L4R5QG.yaml
@@ -286,6 +286,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB8
         signal: SCL
@@ -324,6 +325,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF2
         signal: SMBA
@@ -356,6 +358,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB4
         signal: SDA
@@ -391,6 +394,7 @@ cores:
       address: 0x40008400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA14
         signal: SMBA

--- a/data/chips/STM32L4R5QI.yaml
+++ b/data/chips/STM32L4R5QI.yaml
@@ -286,6 +286,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB8
         signal: SCL
@@ -324,6 +325,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF2
         signal: SMBA
@@ -356,6 +358,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB4
         signal: SDA
@@ -391,6 +394,7 @@ cores:
       address: 0x40008400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA14
         signal: SMBA

--- a/data/chips/STM32L4R5VG.yaml
+++ b/data/chips/STM32L4R5VG.yaml
@@ -280,6 +280,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA1
         signal: SMBA
@@ -309,6 +310,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB10
         signal: SCL
@@ -332,6 +334,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PC0
         signal: SCL
@@ -358,6 +361,7 @@ cores:
       address: 0x40008400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB10
         signal: SCL

--- a/data/chips/STM32L4R5VI.yaml
+++ b/data/chips/STM32L4R5VI.yaml
@@ -280,6 +280,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA1
         signal: SMBA
@@ -309,6 +310,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB10
         signal: SCL
@@ -332,6 +334,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PC0
         signal: SCL
@@ -358,6 +361,7 @@ cores:
       address: 0x40008400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB10
         signal: SCL

--- a/data/chips/STM32L4R5ZG.yaml
+++ b/data/chips/STM32L4R5ZG.yaml
@@ -288,6 +288,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA14
         signal: SMBA
@@ -320,6 +321,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF0
         signal: SDA
@@ -352,6 +354,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB4
         signal: SDA
@@ -387,6 +390,7 @@ cores:
       address: 0x40008400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA14
         signal: SMBA

--- a/data/chips/STM32L4R5ZI.yaml
+++ b/data/chips/STM32L4R5ZI.yaml
@@ -287,6 +287,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA1
         signal: SMBA
@@ -322,6 +323,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF0
         signal: SDA
@@ -351,6 +353,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PC0
         signal: SCL
@@ -386,6 +389,7 @@ cores:
       address: 0x40008400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF13
         signal: SMBA

--- a/data/chips/STM32L4R7AI.yaml
+++ b/data/chips/STM32L4R7AI.yaml
@@ -355,6 +355,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA14
         signal: SMBA
@@ -393,6 +394,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PH6
         signal: SMBA
@@ -434,6 +436,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB4
         signal: SDA
@@ -478,6 +481,7 @@ cores:
       address: 0x40008400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA14
         signal: SMBA

--- a/data/chips/STM32L4R7VI.yaml
+++ b/data/chips/STM32L4R7VI.yaml
@@ -283,6 +283,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA1
         signal: SMBA
@@ -312,6 +313,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB10
         signal: SCL
@@ -335,6 +337,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PC0
         signal: SCL
@@ -361,6 +364,7 @@ cores:
       address: 0x40008400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB10
         signal: SCL

--- a/data/chips/STM32L4R7ZI.yaml
+++ b/data/chips/STM32L4R7ZI.yaml
@@ -292,6 +292,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA1
         signal: SMBA
@@ -330,6 +331,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF0
         signal: SDA
@@ -362,6 +364,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PC0
         signal: SCL
@@ -397,6 +400,7 @@ cores:
       address: 0x40008400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF13
         signal: SMBA

--- a/data/chips/STM32L4R9AG.yaml
+++ b/data/chips/STM32L4R9AG.yaml
@@ -342,6 +342,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA14
         signal: SMBA
@@ -377,6 +378,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF2
         signal: SMBA
@@ -415,6 +417,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB4
         signal: SDA
@@ -456,6 +459,7 @@ cores:
       address: 0x40008400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA14
         signal: SMBA

--- a/data/chips/STM32L4R9AI.yaml
+++ b/data/chips/STM32L4R9AI.yaml
@@ -342,6 +342,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA14
         signal: SMBA
@@ -377,6 +378,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF2
         signal: SMBA
@@ -415,6 +417,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB4
         signal: SDA
@@ -456,6 +459,7 @@ cores:
       address: 0x40008400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA14
         signal: SMBA

--- a/data/chips/STM32L4R9VG.yaml
+++ b/data/chips/STM32L4R9VG.yaml
@@ -273,6 +273,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA1
         signal: SMBA
@@ -302,6 +303,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB10
         signal: SCL
@@ -325,6 +327,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PC0
         signal: SCL
@@ -351,6 +354,7 @@ cores:
       address: 0x40008400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB10
         signal: SCL

--- a/data/chips/STM32L4R9VI.yaml
+++ b/data/chips/STM32L4R9VI.yaml
@@ -273,6 +273,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA1
         signal: SMBA
@@ -302,6 +303,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB10
         signal: SCL
@@ -325,6 +327,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PC0
         signal: SCL
@@ -351,6 +354,7 @@ cores:
       address: 0x40008400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB10
         signal: SCL

--- a/data/chips/STM32L4R9ZG.yaml
+++ b/data/chips/STM32L4R9ZG.yaml
@@ -293,6 +293,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA14
         signal: SMBA
@@ -325,6 +326,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF0
         signal: SDA
@@ -357,6 +359,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB4
         signal: SDA
@@ -392,6 +395,7 @@ cores:
       address: 0x40008400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA14
         signal: SMBA

--- a/data/chips/STM32L4R9ZI.yaml
+++ b/data/chips/STM32L4R9ZI.yaml
@@ -292,6 +292,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA14
         signal: SMBA
@@ -321,6 +322,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF0
         signal: SDA
@@ -350,6 +352,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB4
         signal: SDA
@@ -385,6 +388,7 @@ cores:
       address: 0x40008400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA14
         signal: SMBA

--- a/data/chips/STM32L4S5AI.yaml
+++ b/data/chips/STM32L4S5AI.yaml
@@ -363,6 +363,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA14
         signal: SMBA
@@ -401,6 +402,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PH6
         signal: SMBA
@@ -442,6 +444,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB4
         signal: SDA
@@ -486,6 +489,7 @@ cores:
       address: 0x40008400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA14
         signal: SMBA

--- a/data/chips/STM32L4S5QI.yaml
+++ b/data/chips/STM32L4S5QI.yaml
@@ -297,6 +297,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB8
         signal: SCL
@@ -335,6 +336,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF2
         signal: SMBA
@@ -367,6 +369,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB4
         signal: SDA
@@ -402,6 +405,7 @@ cores:
       address: 0x40008400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA14
         signal: SMBA

--- a/data/chips/STM32L4S5VI.yaml
+++ b/data/chips/STM32L4S5VI.yaml
@@ -291,6 +291,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA1
         signal: SMBA
@@ -320,6 +321,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB10
         signal: SCL
@@ -343,6 +345,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PC0
         signal: SCL
@@ -369,6 +372,7 @@ cores:
       address: 0x40008400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB10
         signal: SCL

--- a/data/chips/STM32L4S5ZI.yaml
+++ b/data/chips/STM32L4S5ZI.yaml
@@ -299,6 +299,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA14
         signal: SMBA
@@ -331,6 +332,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF0
         signal: SDA
@@ -363,6 +365,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB4
         signal: SDA
@@ -398,6 +401,7 @@ cores:
       address: 0x40008400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA14
         signal: SMBA

--- a/data/chips/STM32L4S7AI.yaml
+++ b/data/chips/STM32L4S7AI.yaml
@@ -366,6 +366,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA14
         signal: SMBA
@@ -404,6 +405,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PH6
         signal: SMBA
@@ -445,6 +447,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB4
         signal: SDA
@@ -489,6 +492,7 @@ cores:
       address: 0x40008400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA14
         signal: SMBA

--- a/data/chips/STM32L4S7VI.yaml
+++ b/data/chips/STM32L4S7VI.yaml
@@ -294,6 +294,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA1
         signal: SMBA
@@ -323,6 +324,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB10
         signal: SCL
@@ -346,6 +348,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PC0
         signal: SCL
@@ -372,6 +375,7 @@ cores:
       address: 0x40008400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB10
         signal: SCL

--- a/data/chips/STM32L4S7ZI.yaml
+++ b/data/chips/STM32L4S7ZI.yaml
@@ -303,6 +303,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA1
         signal: SMBA
@@ -341,6 +342,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF0
         signal: SDA
@@ -373,6 +375,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PC0
         signal: SCL
@@ -408,6 +411,7 @@ cores:
       address: 0x40008400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF13
         signal: SMBA

--- a/data/chips/STM32L4S9AI.yaml
+++ b/data/chips/STM32L4S9AI.yaml
@@ -353,6 +353,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA14
         signal: SMBA
@@ -388,6 +389,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF2
         signal: SMBA
@@ -426,6 +428,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB4
         signal: SDA
@@ -467,6 +470,7 @@ cores:
       address: 0x40008400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA14
         signal: SMBA

--- a/data/chips/STM32L4S9VI.yaml
+++ b/data/chips/STM32L4S9VI.yaml
@@ -284,6 +284,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA1
         signal: SMBA
@@ -313,6 +314,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB10
         signal: SCL
@@ -336,6 +338,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PC0
         signal: SCL
@@ -362,6 +365,7 @@ cores:
       address: 0x40008400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB10
         signal: SCL

--- a/data/chips/STM32L4S9ZI.yaml
+++ b/data/chips/STM32L4S9ZI.yaml
@@ -304,6 +304,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA14
         signal: SMBA
@@ -336,6 +337,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF0
         signal: SDA
@@ -368,6 +370,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB4
         signal: SDA
@@ -403,6 +406,7 @@ cores:
       address: 0x40008400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA14
         signal: SMBA

--- a/data/chips/STM32L552CC.yaml
+++ b/data/chips/STM32L552CC.yaml
@@ -196,6 +196,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA1
         signal: SMBA
@@ -225,6 +226,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB10
         signal: SCL
@@ -248,6 +250,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA7
         signal: SCL
@@ -265,6 +268,7 @@ cores:
       address: 0x40008400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB10
         signal: SCL

--- a/data/chips/STM32L552CE.yaml
+++ b/data/chips/STM32L552CE.yaml
@@ -194,6 +194,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA1
         signal: SMBA
@@ -220,6 +221,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB10
         signal: SCL
@@ -240,6 +242,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA7
         signal: SCL
@@ -257,6 +260,7 @@ cores:
       address: 0x40008400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB10
         signal: SCL

--- a/data/chips/STM32L552ME.yaml
+++ b/data/chips/STM32L552ME.yaml
@@ -218,6 +218,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PG13
         signal: SDA
@@ -256,6 +257,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB13
         signal: SCL
@@ -279,6 +281,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB4
         signal: SDA
@@ -302,6 +305,7 @@ cores:
       address: 0x40008400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB6
         signal: SCL

--- a/data/chips/STM32L552QC.yaml
+++ b/data/chips/STM32L552QC.yaml
@@ -228,6 +228,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB9
         signal: SDA
@@ -257,6 +258,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF0
         signal: SDA
@@ -289,6 +291,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB4
         signal: SDA
@@ -321,6 +324,7 @@ cores:
       address: 0x40008400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB6
         signal: SCL

--- a/data/chips/STM32L552QE.yaml
+++ b/data/chips/STM32L552QE.yaml
@@ -232,6 +232,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB9
         signal: SDA
@@ -267,6 +268,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF0
         signal: SDA
@@ -299,6 +301,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB4
         signal: SDA
@@ -331,6 +334,7 @@ cores:
       address: 0x40008400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB6
         signal: SCL

--- a/data/chips/STM32L552RC.yaml
+++ b/data/chips/STM32L552RC.yaml
@@ -222,6 +222,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA1
         signal: SMBA
@@ -251,6 +252,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB10
         signal: SCL
@@ -274,6 +276,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PC0
         signal: SCL
@@ -297,6 +300,7 @@ cores:
       address: 0x40008400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB10
         signal: SCL

--- a/data/chips/STM32L552RE.yaml
+++ b/data/chips/STM32L552RE.yaml
@@ -208,6 +208,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA1
         signal: SMBA
@@ -234,6 +235,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB10
         signal: SCL
@@ -251,6 +253,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PC0
         signal: SCL
@@ -274,6 +277,7 @@ cores:
       address: 0x40008400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB10
         signal: SCL

--- a/data/chips/STM32L552VC.yaml
+++ b/data/chips/STM32L552VC.yaml
@@ -216,6 +216,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA1
         signal: SMBA
@@ -245,6 +246,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB10
         signal: SCL
@@ -265,6 +267,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PC0
         signal: SCL
@@ -288,6 +291,7 @@ cores:
       address: 0x40008400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB10
         signal: SCL

--- a/data/chips/STM32L552VE.yaml
+++ b/data/chips/STM32L552VE.yaml
@@ -230,6 +230,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA1
         signal: SMBA
@@ -259,6 +260,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB10
         signal: SCL
@@ -282,6 +284,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PC0
         signal: SCL
@@ -305,6 +308,7 @@ cores:
       address: 0x40008400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB10
         signal: SCL

--- a/data/chips/STM32L552ZC.yaml
+++ b/data/chips/STM32L552ZC.yaml
@@ -216,6 +216,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA1
         signal: SMBA
@@ -254,6 +255,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF0
         signal: SDA
@@ -283,6 +285,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PC0
         signal: SCL
@@ -315,6 +318,7 @@ cores:
       address: 0x40008400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF13
         signal: SMBA

--- a/data/chips/STM32L552ZE.yaml
+++ b/data/chips/STM32L552ZE.yaml
@@ -230,6 +230,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA1
         signal: SMBA
@@ -268,6 +269,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF0
         signal: SDA
@@ -300,6 +302,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PC0
         signal: SCL
@@ -332,6 +335,7 @@ cores:
       address: 0x40008400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF13
         signal: SMBA

--- a/data/chips/STM32L562CE.yaml
+++ b/data/chips/STM32L562CE.yaml
@@ -200,6 +200,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA1
         signal: SMBA
@@ -226,6 +227,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB10
         signal: SCL
@@ -246,6 +248,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA7
         signal: SCL
@@ -263,6 +266,7 @@ cores:
       address: 0x40008400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB10
         signal: SCL

--- a/data/chips/STM32L562ME.yaml
+++ b/data/chips/STM32L562ME.yaml
@@ -224,6 +224,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PG13
         signal: SDA
@@ -262,6 +263,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB13
         signal: SCL
@@ -285,6 +287,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB4
         signal: SDA
@@ -308,6 +311,7 @@ cores:
       address: 0x40008400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB6
         signal: SCL

--- a/data/chips/STM32L562QE.yaml
+++ b/data/chips/STM32L562QE.yaml
@@ -238,6 +238,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB9
         signal: SDA
@@ -267,6 +268,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF0
         signal: SDA
@@ -299,6 +301,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB4
         signal: SDA
@@ -331,6 +334,7 @@ cores:
       address: 0x40008400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB6
         signal: SCL

--- a/data/chips/STM32L562RE.yaml
+++ b/data/chips/STM32L562RE.yaml
@@ -214,6 +214,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA1
         signal: SMBA
@@ -240,6 +241,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB10
         signal: SCL
@@ -257,6 +259,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PC0
         signal: SCL
@@ -280,6 +283,7 @@ cores:
       address: 0x40008400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB10
         signal: SCL

--- a/data/chips/STM32L562VE.yaml
+++ b/data/chips/STM32L562VE.yaml
@@ -224,6 +224,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA1
         signal: SMBA
@@ -253,6 +254,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB10
         signal: SCL
@@ -273,6 +275,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PC0
         signal: SCL
@@ -296,6 +299,7 @@ cores:
       address: 0x40008400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB10
         signal: SCL

--- a/data/chips/STM32L562ZE.yaml
+++ b/data/chips/STM32L562ZE.yaml
@@ -224,6 +224,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA1
         signal: SMBA
@@ -262,6 +263,7 @@ cores:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF0
         signal: SDA
@@ -291,6 +293,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PC0
         signal: SCL
@@ -323,6 +326,7 @@ cores:
       address: 0x40008400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PF13
         signal: SMBA

--- a/data/chips/STM32WB10CC.yaml
+++ b/data/chips/STM32WB10CC.yaml
@@ -86,6 +86,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB8
         signal: SCL

--- a/data/chips/STM32WB15CC.yaml
+++ b/data/chips/STM32WB15CC.yaml
@@ -112,6 +112,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB5
         signal: SMBA

--- a/data/chips/STM32WB30CE.yaml
+++ b/data/chips/STM32WB30CE.yaml
@@ -91,6 +91,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB8
         signal: SCL

--- a/data/chips/STM32WB35CC.yaml
+++ b/data/chips/STM32WB35CC.yaml
@@ -151,6 +151,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB8
         signal: SCL
@@ -186,6 +187,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA7
         signal: SCL

--- a/data/chips/STM32WB35CE.yaml
+++ b/data/chips/STM32WB35CE.yaml
@@ -151,6 +151,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB8
         signal: SCL
@@ -186,6 +187,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA7
         signal: SCL

--- a/data/chips/STM32WB50CG.yaml
+++ b/data/chips/STM32WB50CG.yaml
@@ -91,6 +91,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB8
         signal: SCL

--- a/data/chips/STM32WB55CC.yaml
+++ b/data/chips/STM32WB55CC.yaml
@@ -157,6 +157,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB8
         signal: SCL
@@ -192,6 +193,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA7
         signal: SCL

--- a/data/chips/STM32WB55CE.yaml
+++ b/data/chips/STM32WB55CE.yaml
@@ -157,6 +157,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB8
         signal: SCL
@@ -192,6 +193,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA7
         signal: SCL

--- a/data/chips/STM32WB55CG.yaml
+++ b/data/chips/STM32WB55CG.yaml
@@ -157,6 +157,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB8
         signal: SCL
@@ -192,6 +193,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA7
         signal: SCL

--- a/data/chips/STM32WB55RC.yaml
+++ b/data/chips/STM32WB55RC.yaml
@@ -179,6 +179,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB8
         signal: SCL
@@ -214,6 +215,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PC0
         signal: SCL

--- a/data/chips/STM32WB55RE.yaml
+++ b/data/chips/STM32WB55RE.yaml
@@ -179,6 +179,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB8
         signal: SCL
@@ -214,6 +215,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PC0
         signal: SCL

--- a/data/chips/STM32WB55RG.yaml
+++ b/data/chips/STM32WB55RG.yaml
@@ -179,6 +179,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB8
         signal: SCL
@@ -214,6 +215,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PC0
         signal: SCL

--- a/data/chips/STM32WB55VC.yaml
+++ b/data/chips/STM32WB55VC.yaml
@@ -181,6 +181,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA14
         signal: SMBA
@@ -216,6 +217,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB13
         signal: SCL

--- a/data/chips/STM32WB55VE.yaml
+++ b/data/chips/STM32WB55VE.yaml
@@ -181,6 +181,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA14
         signal: SMBA
@@ -216,6 +217,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB13
         signal: SCL

--- a/data/chips/STM32WB55VG.yaml
+++ b/data/chips/STM32WB55VG.yaml
@@ -181,6 +181,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA14
         signal: SMBA
@@ -216,6 +217,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB13
         signal: SCL

--- a/data/chips/STM32WB55VY.yaml
+++ b/data/chips/STM32WB55VY.yaml
@@ -179,6 +179,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA14
         signal: SMBA
@@ -214,6 +215,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB13
         signal: SCL

--- a/data/chips/STM32WB5MMG.yaml
+++ b/data/chips/STM32WB5MMG.yaml
@@ -173,6 +173,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA1
         signal: SMBA
@@ -208,6 +209,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PC1
         signal: SDA

--- a/data/chips/STM32WL54CC.yaml
+++ b/data/chips/STM32WL54CC.yaml
@@ -143,6 +143,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins: &id008
       - pin: PB5
         signal: SMBA
@@ -174,6 +175,7 @@ cores:
     I2C2:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
+      block: i2c_v2/I2C
       pins: &id010
       - pin: PA6
         signal: SMBA
@@ -197,6 +199,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins: &id012
       - pin: PB4
         signal: SDA
@@ -808,17 +811,20 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins: *id008
       dma_requests: *id009
     I2C2:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
+      block: i2c_v2/I2C
       pins: *id010
       dma_requests: *id011
     I2C3:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins: *id012
       dma_requests: *id013
     IPCC:

--- a/data/chips/STM32WL54JC.yaml
+++ b/data/chips/STM32WL54JC.yaml
@@ -157,6 +157,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins: &id008
       - pin: PA14
         signal: SMBA
@@ -191,6 +192,7 @@ cores:
     I2C2:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
+      block: i2c_v2/I2C
       pins: &id010
       - pin: PA12
         signal: SCL
@@ -217,6 +219,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins: &id012
       - pin: PB4
         signal: SDA
@@ -936,17 +939,20 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins: *id008
       dma_requests: *id009
     I2C2:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
+      block: i2c_v2/I2C
       pins: *id010
       dma_requests: *id011
     I2C3:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins: *id012
       dma_requests: *id013
     IPCC:

--- a/data/chips/STM32WL55CC.yaml
+++ b/data/chips/STM32WL55CC.yaml
@@ -143,6 +143,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins: &id008
       - pin: PB5
         signal: SMBA
@@ -174,6 +175,7 @@ cores:
     I2C2:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
+      block: i2c_v2/I2C
       pins: &id010
       - pin: PA6
         signal: SMBA
@@ -197,6 +199,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins: &id012
       - pin: PB4
         signal: SDA
@@ -808,17 +811,20 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins: *id008
       dma_requests: *id009
     I2C2:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
+      block: i2c_v2/I2C
       pins: *id010
       dma_requests: *id011
     I2C3:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins: *id012
       dma_requests: *id013
     IPCC:

--- a/data/chips/STM32WL55JC.yaml
+++ b/data/chips/STM32WL55JC.yaml
@@ -157,6 +157,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins: &id008
       - pin: PA14
         signal: SMBA
@@ -191,6 +192,7 @@ cores:
     I2C2:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
+      block: i2c_v2/I2C
       pins: &id010
       - pin: PA12
         signal: SCL
@@ -217,6 +219,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins: &id012
       - pin: PB4
         signal: SDA
@@ -936,17 +939,20 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins: *id008
       dma_requests: *id009
     I2C2:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
+      block: i2c_v2/I2C
       pins: *id010
       dma_requests: *id011
     I2C3:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins: *id012
       dma_requests: *id013
     IPCC:

--- a/data/chips/STM32WL55UC.yaml
+++ b/data/chips/STM32WL55UC.yaml
@@ -128,6 +128,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins: &id008
       - pin: PA14
         signal: SMBA
@@ -147,6 +148,7 @@ cores:
     I2C2:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
+      block: i2c_v2/I2C
       pins: &id010
       - pin: PA15
         signal: SDA
@@ -170,6 +172,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins: &id012
       - pin: PB4
         signal: SDA
@@ -711,17 +714,20 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins: *id008
       dma_requests: *id009
     I2C2:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
+      block: i2c_v2/I2C
       pins: *id010
       dma_requests: *id011
     I2C3:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins: *id012
       dma_requests: *id013
     IPCC:

--- a/data/chips/STM32WLE4C8.yaml
+++ b/data/chips/STM32WLE4C8.yaml
@@ -137,6 +137,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB5
         signal: SMBA
@@ -168,6 +169,7 @@ cores:
     I2C2:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
+      block: i2c_v2/I2C
       pins:
       - pin: PA6
         signal: SMBA
@@ -191,6 +193,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB4
         signal: SDA

--- a/data/chips/STM32WLE4CB.yaml
+++ b/data/chips/STM32WLE4CB.yaml
@@ -137,6 +137,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB5
         signal: SMBA
@@ -168,6 +169,7 @@ cores:
     I2C2:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
+      block: i2c_v2/I2C
       pins:
       - pin: PA6
         signal: SMBA
@@ -191,6 +193,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB4
         signal: SDA

--- a/data/chips/STM32WLE4CC.yaml
+++ b/data/chips/STM32WLE4CC.yaml
@@ -143,6 +143,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB5
         signal: SMBA
@@ -174,6 +175,7 @@ cores:
     I2C2:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
+      block: i2c_v2/I2C
       pins:
       - pin: PA6
         signal: SMBA
@@ -197,6 +199,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB4
         signal: SDA

--- a/data/chips/STM32WLE4J8.yaml
+++ b/data/chips/STM32WLE4J8.yaml
@@ -151,6 +151,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA14
         signal: SMBA
@@ -185,6 +186,7 @@ cores:
     I2C2:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
+      block: i2c_v2/I2C
       pins:
       - pin: PA12
         signal: SCL
@@ -211,6 +213,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB4
         signal: SDA

--- a/data/chips/STM32WLE4JB.yaml
+++ b/data/chips/STM32WLE4JB.yaml
@@ -151,6 +151,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA14
         signal: SMBA
@@ -185,6 +186,7 @@ cores:
     I2C2:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
+      block: i2c_v2/I2C
       pins:
       - pin: PA12
         signal: SCL
@@ -211,6 +213,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB4
         signal: SDA

--- a/data/chips/STM32WLE4JC.yaml
+++ b/data/chips/STM32WLE4JC.yaml
@@ -157,6 +157,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA14
         signal: SMBA
@@ -191,6 +192,7 @@ cores:
     I2C2:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
+      block: i2c_v2/I2C
       pins:
       - pin: PA12
         signal: SCL
@@ -217,6 +219,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB4
         signal: SDA

--- a/data/chips/STM32WLE5C8.yaml
+++ b/data/chips/STM32WLE5C8.yaml
@@ -143,6 +143,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB5
         signal: SMBA
@@ -174,6 +175,7 @@ cores:
     I2C2:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
+      block: i2c_v2/I2C
       pins:
       - pin: PA6
         signal: SMBA
@@ -197,6 +199,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB4
         signal: SDA

--- a/data/chips/STM32WLE5CB.yaml
+++ b/data/chips/STM32WLE5CB.yaml
@@ -143,6 +143,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB5
         signal: SMBA
@@ -174,6 +175,7 @@ cores:
     I2C2:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
+      block: i2c_v2/I2C
       pins:
       - pin: PA6
         signal: SMBA
@@ -197,6 +199,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB4
         signal: SDA

--- a/data/chips/STM32WLE5CC.yaml
+++ b/data/chips/STM32WLE5CC.yaml
@@ -143,6 +143,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB5
         signal: SMBA
@@ -174,6 +175,7 @@ cores:
     I2C2:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
+      block: i2c_v2/I2C
       pins:
       - pin: PA6
         signal: SMBA
@@ -197,6 +199,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB4
         signal: SDA

--- a/data/chips/STM32WLE5J8.yaml
+++ b/data/chips/STM32WLE5J8.yaml
@@ -157,6 +157,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA14
         signal: SMBA
@@ -191,6 +192,7 @@ cores:
     I2C2:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
+      block: i2c_v2/I2C
       pins:
       - pin: PA12
         signal: SCL
@@ -217,6 +219,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB4
         signal: SDA

--- a/data/chips/STM32WLE5JB.yaml
+++ b/data/chips/STM32WLE5JB.yaml
@@ -157,6 +157,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA14
         signal: SMBA
@@ -191,6 +192,7 @@ cores:
     I2C2:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
+      block: i2c_v2/I2C
       pins:
       - pin: PA12
         signal: SCL
@@ -217,6 +219,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB4
         signal: SDA

--- a/data/chips/STM32WLE5JC.yaml
+++ b/data/chips/STM32WLE5JC.yaml
@@ -157,6 +157,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA14
         signal: SMBA
@@ -191,6 +192,7 @@ cores:
     I2C2:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
+      block: i2c_v2/I2C
       pins:
       - pin: PA12
         signal: SCL
@@ -217,6 +219,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB4
         signal: SDA

--- a/data/chips/STM32WLE5U8.yaml
+++ b/data/chips/STM32WLE5U8.yaml
@@ -128,6 +128,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA14
         signal: SMBA
@@ -147,6 +148,7 @@ cores:
     I2C2:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
+      block: i2c_v2/I2C
       pins:
       - pin: PA15
         signal: SDA
@@ -170,6 +172,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB4
         signal: SDA

--- a/data/chips/STM32WLE5UB.yaml
+++ b/data/chips/STM32WLE5UB.yaml
@@ -128,6 +128,7 @@ cores:
       address: 0x40005400
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PA14
         signal: SMBA
@@ -147,6 +148,7 @@ cores:
     I2C2:
       address: 0x40005800
       kind: I2C:i2c2_v1_1
+      block: i2c_v2/I2C
       pins:
       - pin: PA15
         signal: SDA
@@ -170,6 +172,7 @@ cores:
       address: 0x40005c00
       kind: I2C:i2c2_v1_1
       clock: APB1
+      block: i2c_v2/I2C
       pins:
       - pin: PB4
         signal: SDA

--- a/parse.py
+++ b/parse.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import xmltodict
 import yaml
 try:
@@ -305,6 +307,7 @@ perimap = [
     ('.*:SPI:spi2s2_v1_1', 'spi_v3/SPI'),
     ('.*:SPI:spi2s2_v1_0', 'spi_v3/SPI'),
     ('.*:I2C:i2c1_v1_5', 'i2c_v1/I2C'),
+    ('.*:I2C:i2c2_v1_1', 'i2c_v2/I2C'),
     ('.*:I2C:i2c2_v1_1F7', 'i2c_v2/I2C'),
     ('.*:DAC:dacif_v2_0', 'dac_v2/DAC'),
     ('.*:DAC:dacif_v3_0', 'dac_v2/DAC'),


### PR DESCRIPTION
I think I did the right thing. However, I have no real understanding of what I really did :grin: 

I also checked the `data/registery/i2c_v2.yaml` file with the PDF `dm00151940-stm32l41xxx42xxx43xxx44xxx45xxx46xxx-advanced-armbased-32bit-mcus-stmicroelectronics.pdf` … and it looks like the relative I2C registers and the absolute (for I2C1 and I2C3) match.