### PR TITLE
add UART:sci2_v2_1 to parser

### DIFF
--- a/data/chips/STM32F302RB.yaml
+++ b/data/chips/STM32F302RB.yaml
@@ -1004,6 +1004,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PC10
         signal: TX
@@ -1022,6 +1023,7 @@ cores:
       address: 0x40005000
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PC12
         signal: TX

--- a/data/chips/STM32F302RC.yaml
+++ b/data/chips/STM32F302RC.yaml
@@ -1004,6 +1004,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PC10
         signal: TX
@@ -1022,6 +1023,7 @@ cores:
       address: 0x40005000
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PC12
         signal: TX

--- a/data/chips/STM32F302RD.yaml
+++ b/data/chips/STM32F302RD.yaml
@@ -1062,6 +1062,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PC10
         signal: TX
@@ -1080,6 +1081,7 @@ cores:
       address: 0x40005000
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PC12
         signal: TX

--- a/data/chips/STM32F302RE.yaml
+++ b/data/chips/STM32F302RE.yaml
@@ -1065,6 +1065,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PC10
         signal: TX
@@ -1083,6 +1084,7 @@ cores:
       address: 0x40005000
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PC12
         signal: TX

--- a/data/chips/STM32F302VB.yaml
+++ b/data/chips/STM32F302VB.yaml
@@ -1151,6 +1151,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PC10
         signal: TX
@@ -1169,6 +1170,7 @@ cores:
       address: 0x40005000
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PC12
         signal: TX

--- a/data/chips/STM32F302VC.yaml
+++ b/data/chips/STM32F302VC.yaml
@@ -1127,6 +1127,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PC11
         signal: RX
@@ -1145,6 +1146,7 @@ cores:
       address: 0x40005000
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PC12
         signal: TX

--- a/data/chips/STM32F302VD.yaml
+++ b/data/chips/STM32F302VD.yaml
@@ -1246,6 +1246,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PC10
         signal: TX
@@ -1264,6 +1265,7 @@ cores:
       address: 0x40005000
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PC12
         signal: TX

--- a/data/chips/STM32F302VE.yaml
+++ b/data/chips/STM32F302VE.yaml
@@ -1249,6 +1249,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PC10
         signal: TX
@@ -1267,6 +1268,7 @@ cores:
       address: 0x40005000
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PC12
         signal: TX

--- a/data/chips/STM32F302ZD.yaml
+++ b/data/chips/STM32F302ZD.yaml
@@ -1249,6 +1249,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PC10
         signal: TX
@@ -1267,6 +1268,7 @@ cores:
       address: 0x40005000
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PC12
         signal: TX

--- a/data/chips/STM32F302ZE.yaml
+++ b/data/chips/STM32F302ZE.yaml
@@ -1252,6 +1252,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PC10
         signal: TX
@@ -1270,6 +1271,7 @@ cores:
       address: 0x40005000
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PC12
         signal: TX

--- a/data/chips/STM32F303RB.yaml
+++ b/data/chips/STM32F303RB.yaml
@@ -1263,6 +1263,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PC10
         signal: TX
@@ -1281,6 +1282,7 @@ cores:
       address: 0x40005000
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PC12
         signal: TX

--- a/data/chips/STM32F303RC.yaml
+++ b/data/chips/STM32F303RC.yaml
@@ -1263,6 +1263,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PC10
         signal: TX
@@ -1281,6 +1282,7 @@ cores:
       address: 0x40005000
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PC12
         signal: TX

--- a/data/chips/STM32F303RD.yaml
+++ b/data/chips/STM32F303RD.yaml
@@ -1321,6 +1321,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PC10
         signal: TX
@@ -1339,6 +1340,7 @@ cores:
       address: 0x40005000
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PC12
         signal: TX

--- a/data/chips/STM32F303RE.yaml
+++ b/data/chips/STM32F303RE.yaml
@@ -1324,6 +1324,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PC10
         signal: TX
@@ -1342,6 +1343,7 @@ cores:
       address: 0x40005000
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PC12
         signal: TX

--- a/data/chips/STM32F303VB.yaml
+++ b/data/chips/STM32F303VB.yaml
@@ -1476,6 +1476,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PC10
         signal: TX
@@ -1494,6 +1495,7 @@ cores:
       address: 0x40005000
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PC12
         signal: TX

--- a/data/chips/STM32F303VC.yaml
+++ b/data/chips/STM32F303VC.yaml
@@ -1436,6 +1436,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PC11
         signal: RX
@@ -1454,6 +1455,7 @@ cores:
       address: 0x40005000
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PC12
         signal: TX

--- a/data/chips/STM32F303VD.yaml
+++ b/data/chips/STM32F303VD.yaml
@@ -1622,6 +1622,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PC10
         signal: TX
@@ -1640,6 +1641,7 @@ cores:
       address: 0x40005000
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PC12
         signal: TX

--- a/data/chips/STM32F303VE.yaml
+++ b/data/chips/STM32F303VE.yaml
@@ -1584,6 +1584,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PC11
         signal: RX
@@ -1602,6 +1603,7 @@ cores:
       address: 0x40005000
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PC12
         signal: TX

--- a/data/chips/STM32F303ZD.yaml
+++ b/data/chips/STM32F303ZD.yaml
@@ -1679,6 +1679,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PC10
         signal: TX
@@ -1697,6 +1698,7 @@ cores:
       address: 0x40005000
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PC12
         signal: TX

--- a/data/chips/STM32F303ZE.yaml
+++ b/data/chips/STM32F303ZE.yaml
@@ -1682,6 +1682,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PC10
         signal: TX
@@ -1700,6 +1701,7 @@ cores:
       address: 0x40005000
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PC12
         signal: TX

--- a/data/chips/STM32F358RC.yaml
+++ b/data/chips/STM32F358RC.yaml
@@ -1252,6 +1252,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PC10
         signal: TX
@@ -1270,6 +1271,7 @@ cores:
       address: 0x40005000
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PC12
         signal: TX

--- a/data/chips/STM32F358VC.yaml
+++ b/data/chips/STM32F358VC.yaml
@@ -1465,6 +1465,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PC10
         signal: TX
@@ -1483,6 +1484,7 @@ cores:
       address: 0x40005000
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PC12
         signal: TX

--- a/data/chips/STM32F398VE.yaml
+++ b/data/chips/STM32F398VE.yaml
@@ -1612,6 +1612,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PC10
         signal: TX
@@ -1630,6 +1631,7 @@ cores:
       address: 0x40005000
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PC12
         signal: TX

--- a/data/chips/STM32F412VE.yaml
+++ b/data/chips/STM32F412VE.yaml
@@ -235,14 +235,6 @@ cores:
       address: 0x40021000
       block: gpio_v2/GPIO
       clock: AHB1
-    GPIOF:
-      address: 0x40021400
-      block: gpio_v2/GPIO
-      clock: AHB1
-    GPIOG:
-      address: 0x40021800
-      block: gpio_v2/GPIO
-      clock: AHB1
     GPIOH:
       address: 0x40021c00
       block: gpio_v2/GPIO

--- a/data/chips/STM32F412VG.yaml
+++ b/data/chips/STM32F412VG.yaml
@@ -235,14 +235,6 @@ cores:
       address: 0x40021000
       block: gpio_v2/GPIO
       clock: AHB1
-    GPIOF:
-      address: 0x40021400
-      block: gpio_v2/GPIO
-      clock: AHB1
-    GPIOG:
-      address: 0x40021800
-      block: gpio_v2/GPIO
-      clock: AHB1
     GPIOH:
       address: 0x40021c00
       block: gpio_v2/GPIO

--- a/data/chips/STM32F722IC.yaml
+++ b/data/chips/STM32F722IC.yaml
@@ -1633,6 +1633,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PI9
         signal: RX
@@ -1677,6 +1678,7 @@ cores:
       address: 0x40005000
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PC8
         signal: DE
@@ -1705,6 +1707,7 @@ cores:
     UART7:
       address: 0x40007800
       kind: UART:sci2_v2_1
+      block: usart_v2/USART
       pins:
       - pin: PF6
         signal: RX
@@ -1748,6 +1751,7 @@ cores:
     UART8:
       address: 0x40007c00
       kind: UART:sci2_v2_1
+      block: usart_v2/USART
       pins:
       - pin: PD14
         signal: CTS

--- a/data/chips/STM32F722IE.yaml
+++ b/data/chips/STM32F722IE.yaml
@@ -1633,6 +1633,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PI9
         signal: RX
@@ -1677,6 +1678,7 @@ cores:
       address: 0x40005000
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PC8
         signal: DE
@@ -1705,6 +1707,7 @@ cores:
     UART7:
       address: 0x40007800
       kind: UART:sci2_v2_1
+      block: usart_v2/USART
       pins:
       - pin: PF6
         signal: RX
@@ -1748,6 +1751,7 @@ cores:
     UART8:
       address: 0x40007c00
       kind: UART:sci2_v2_1
+      block: usart_v2/USART
       pins:
       - pin: PD14
         signal: CTS

--- a/data/chips/STM32F722RC.yaml
+++ b/data/chips/STM32F722RC.yaml
@@ -1125,6 +1125,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PA0
         signal: TX
@@ -1160,6 +1161,7 @@ cores:
       address: 0x40005000
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PC8
         signal: DE

--- a/data/chips/STM32F722RE.yaml
+++ b/data/chips/STM32F722RE.yaml
@@ -1125,6 +1125,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PA0
         signal: TX
@@ -1160,6 +1161,7 @@ cores:
       address: 0x40005000
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PC8
         signal: DE

--- a/data/chips/STM32F722VC.yaml
+++ b/data/chips/STM32F722VC.yaml
@@ -1374,6 +1374,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PA0
         signal: TX
@@ -1409,6 +1410,7 @@ cores:
       address: 0x40005000
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PC8
         signal: DE
@@ -1437,6 +1439,7 @@ cores:
     UART7:
       address: 0x40007800
       kind: UART:sci2_v2_1
+      block: usart_v2/USART
       pins:
       - pin: PE7
         signal: RX
@@ -1465,6 +1468,7 @@ cores:
     UART8:
       address: 0x40007c00
       kind: UART:sci2_v2_1
+      block: usart_v2/USART
       pins:
       - pin: PD14
         signal: CTS

--- a/data/chips/STM32F722VE.yaml
+++ b/data/chips/STM32F722VE.yaml
@@ -1374,6 +1374,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PA0
         signal: TX
@@ -1409,6 +1410,7 @@ cores:
       address: 0x40005000
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PC8
         signal: DE
@@ -1437,6 +1439,7 @@ cores:
     UART7:
       address: 0x40007800
       kind: UART:sci2_v2_1
+      block: usart_v2/USART
       pins:
       - pin: PE7
         signal: RX
@@ -1465,6 +1468,7 @@ cores:
     UART8:
       address: 0x40007c00
       kind: UART:sci2_v2_1
+      block: usart_v2/USART
       pins:
       - pin: PD14
         signal: CTS

--- a/data/chips/STM32F722ZC.yaml
+++ b/data/chips/STM32F722ZC.yaml
@@ -1504,6 +1504,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PA0
         signal: TX
@@ -1539,6 +1540,7 @@ cores:
       address: 0x40005000
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PC8
         signal: DE
@@ -1567,6 +1569,7 @@ cores:
     UART7:
       address: 0x40007800
       kind: UART:sci2_v2_1
+      block: usart_v2/USART
       pins:
       - pin: PF6
         signal: RX
@@ -1610,6 +1613,7 @@ cores:
     UART8:
       address: 0x40007c00
       kind: UART:sci2_v2_1
+      block: usart_v2/USART
       pins:
       - pin: PD14
         signal: CTS

--- a/data/chips/STM32F722ZE.yaml
+++ b/data/chips/STM32F722ZE.yaml
@@ -1504,6 +1504,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PA0
         signal: TX
@@ -1539,6 +1540,7 @@ cores:
       address: 0x40005000
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PC8
         signal: DE
@@ -1567,6 +1569,7 @@ cores:
     UART7:
       address: 0x40007800
       kind: UART:sci2_v2_1
+      block: usart_v2/USART
       pins:
       - pin: PF6
         signal: RX
@@ -1610,6 +1613,7 @@ cores:
     UART8:
       address: 0x40007c00
       kind: UART:sci2_v2_1
+      block: usart_v2/USART
       pins:
       - pin: PD14
         signal: CTS

--- a/data/chips/STM32F723IC.yaml
+++ b/data/chips/STM32F723IC.yaml
@@ -1600,6 +1600,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PI9
         signal: RX
@@ -1644,6 +1645,7 @@ cores:
       address: 0x40005000
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PC8
         signal: DE
@@ -1672,6 +1674,7 @@ cores:
     UART7:
       address: 0x40007800
       kind: UART:sci2_v2_1
+      block: usart_v2/USART
       pins:
       - pin: PF6
         signal: RX
@@ -1715,6 +1718,7 @@ cores:
     UART8:
       address: 0x40007c00
       kind: UART:sci2_v2_1
+      block: usart_v2/USART
       pins:
       - pin: PD14
         signal: CTS

--- a/data/chips/STM32F723IE.yaml
+++ b/data/chips/STM32F723IE.yaml
@@ -1600,6 +1600,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PI9
         signal: RX
@@ -1644,6 +1645,7 @@ cores:
       address: 0x40005000
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PC8
         signal: DE
@@ -1672,6 +1674,7 @@ cores:
     UART7:
       address: 0x40007800
       kind: UART:sci2_v2_1
+      block: usart_v2/USART
       pins:
       - pin: PF6
         signal: RX
@@ -1715,6 +1718,7 @@ cores:
     UART8:
       address: 0x40007c00
       kind: UART:sci2_v2_1
+      block: usart_v2/USART
       pins:
       - pin: PD14
         signal: CTS

--- a/data/chips/STM32F723VC.yaml
+++ b/data/chips/STM32F723VC.yaml
@@ -1286,6 +1286,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PC10
         signal: TX
@@ -1321,6 +1322,7 @@ cores:
       address: 0x40005000
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PC9
         signal: CTS
@@ -1349,6 +1351,7 @@ cores:
     UART7:
       address: 0x40007800
       kind: UART:sci2_v2_1
+      block: usart_v2/USART
       pins:
       - pin: PE10
         signal: CTS
@@ -1377,6 +1380,7 @@ cores:
     UART8:
       address: 0x40007c00
       kind: UART:sci2_v2_1
+      block: usart_v2/USART
       pins:
       - pin: PE1
         signal: TX

--- a/data/chips/STM32F723VE.yaml
+++ b/data/chips/STM32F723VE.yaml
@@ -1286,6 +1286,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PC10
         signal: TX
@@ -1321,6 +1322,7 @@ cores:
       address: 0x40005000
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PC9
         signal: CTS
@@ -1349,6 +1351,7 @@ cores:
     UART7:
       address: 0x40007800
       kind: UART:sci2_v2_1
+      block: usart_v2/USART
       pins:
       - pin: PE10
         signal: CTS
@@ -1377,6 +1380,7 @@ cores:
     UART8:
       address: 0x40007c00
       kind: UART:sci2_v2_1
+      block: usart_v2/USART
       pins:
       - pin: PE1
         signal: TX

--- a/data/chips/STM32F723ZC.yaml
+++ b/data/chips/STM32F723ZC.yaml
@@ -1463,6 +1463,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PA0
         signal: TX
@@ -1498,6 +1499,7 @@ cores:
       address: 0x40005000
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PC8
         signal: DE
@@ -1526,6 +1528,7 @@ cores:
     UART7:
       address: 0x40007800
       kind: UART:sci2_v2_1
+      block: usart_v2/USART
       pins:
       - pin: PF6
         signal: RX
@@ -1569,6 +1572,7 @@ cores:
     UART8:
       address: 0x40007c00
       kind: UART:sci2_v2_1
+      block: usart_v2/USART
       pins:
       - pin: PD14
         signal: CTS

--- a/data/chips/STM32F723ZE.yaml
+++ b/data/chips/STM32F723ZE.yaml
@@ -1463,6 +1463,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PA0
         signal: TX
@@ -1498,6 +1499,7 @@ cores:
       address: 0x40005000
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PC8
         signal: DE
@@ -1526,6 +1528,7 @@ cores:
     UART7:
       address: 0x40007800
       kind: UART:sci2_v2_1
+      block: usart_v2/USART
       pins:
       - pin: PF6
         signal: RX
@@ -1569,6 +1572,7 @@ cores:
     UART8:
       address: 0x40007c00
       kind: UART:sci2_v2_1
+      block: usart_v2/USART
       pins:
       - pin: PD14
         signal: CTS

--- a/data/chips/STM32F730I8.yaml
+++ b/data/chips/STM32F730I8.yaml
@@ -1610,6 +1610,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PA15
         signal: DE
@@ -1654,6 +1655,7 @@ cores:
       address: 0x40005000
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PC12
         signal: TX
@@ -1682,6 +1684,7 @@ cores:
     UART7:
       address: 0x40007800
       kind: UART:sci2_v2_1
+      block: usart_v2/USART
       pins:
       - pin: PF7
         signal: TX
@@ -1725,6 +1728,7 @@ cores:
     UART8:
       address: 0x40007c00
       kind: UART:sci2_v2_1
+      block: usart_v2/USART
       pins:
       - pin: PE1
         signal: TX

--- a/data/chips/STM32F730R8.yaml
+++ b/data/chips/STM32F730R8.yaml
@@ -1137,6 +1137,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PA0
         signal: TX
@@ -1172,6 +1173,7 @@ cores:
       address: 0x40005000
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PC8
         signal: DE

--- a/data/chips/STM32F730V8.yaml
+++ b/data/chips/STM32F730V8.yaml
@@ -1386,6 +1386,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PA0
         signal: TX
@@ -1421,6 +1422,7 @@ cores:
       address: 0x40005000
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PC8
         signal: DE
@@ -1449,6 +1451,7 @@ cores:
     UART7:
       address: 0x40007800
       kind: UART:sci2_v2_1
+      block: usart_v2/USART
       pins:
       - pin: PE7
         signal: RX
@@ -1477,6 +1480,7 @@ cores:
     UART8:
       address: 0x40007c00
       kind: UART:sci2_v2_1
+      block: usart_v2/USART
       pins:
       - pin: PD14
         signal: CTS

--- a/data/chips/STM32F730Z8.yaml
+++ b/data/chips/STM32F730Z8.yaml
@@ -1473,6 +1473,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PA0
         signal: TX
@@ -1508,6 +1509,7 @@ cores:
       address: 0x40005000
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PC8
         signal: DE
@@ -1536,6 +1538,7 @@ cores:
     UART7:
       address: 0x40007800
       kind: UART:sci2_v2_1
+      block: usart_v2/USART
       pins:
       - pin: PF6
         signal: RX
@@ -1579,6 +1582,7 @@ cores:
     UART8:
       address: 0x40007c00
       kind: UART:sci2_v2_1
+      block: usart_v2/USART
       pins:
       - pin: PD14
         signal: CTS

--- a/data/chips/STM32F732IE.yaml
+++ b/data/chips/STM32F732IE.yaml
@@ -1645,6 +1645,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PI9
         signal: RX
@@ -1689,6 +1690,7 @@ cores:
       address: 0x40005000
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PC8
         signal: DE
@@ -1717,6 +1719,7 @@ cores:
     UART7:
       address: 0x40007800
       kind: UART:sci2_v2_1
+      block: usart_v2/USART
       pins:
       - pin: PF6
         signal: RX
@@ -1760,6 +1763,7 @@ cores:
     UART8:
       address: 0x40007c00
       kind: UART:sci2_v2_1
+      block: usart_v2/USART
       pins:
       - pin: PD14
         signal: CTS

--- a/data/chips/STM32F732RE.yaml
+++ b/data/chips/STM32F732RE.yaml
@@ -1137,6 +1137,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PA0
         signal: TX
@@ -1172,6 +1173,7 @@ cores:
       address: 0x40005000
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PC8
         signal: DE

--- a/data/chips/STM32F732VE.yaml
+++ b/data/chips/STM32F732VE.yaml
@@ -1386,6 +1386,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PA0
         signal: TX
@@ -1421,6 +1422,7 @@ cores:
       address: 0x40005000
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PC8
         signal: DE
@@ -1449,6 +1451,7 @@ cores:
     UART7:
       address: 0x40007800
       kind: UART:sci2_v2_1
+      block: usart_v2/USART
       pins:
       - pin: PE7
         signal: RX
@@ -1477,6 +1480,7 @@ cores:
     UART8:
       address: 0x40007c00
       kind: UART:sci2_v2_1
+      block: usart_v2/USART
       pins:
       - pin: PD14
         signal: CTS

--- a/data/chips/STM32F732ZE.yaml
+++ b/data/chips/STM32F732ZE.yaml
@@ -1516,6 +1516,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PA0
         signal: TX
@@ -1551,6 +1552,7 @@ cores:
       address: 0x40005000
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PC8
         signal: DE
@@ -1579,6 +1581,7 @@ cores:
     UART7:
       address: 0x40007800
       kind: UART:sci2_v2_1
+      block: usart_v2/USART
       pins:
       - pin: PF6
         signal: RX
@@ -1622,6 +1625,7 @@ cores:
     UART8:
       address: 0x40007c00
       kind: UART:sci2_v2_1
+      block: usart_v2/USART
       pins:
       - pin: PD14
         signal: CTS

--- a/data/chips/STM32F733IE.yaml
+++ b/data/chips/STM32F733IE.yaml
@@ -1612,6 +1612,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PI9
         signal: RX
@@ -1656,6 +1657,7 @@ cores:
       address: 0x40005000
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PC8
         signal: DE
@@ -1684,6 +1686,7 @@ cores:
     UART7:
       address: 0x40007800
       kind: UART:sci2_v2_1
+      block: usart_v2/USART
       pins:
       - pin: PF6
         signal: RX
@@ -1727,6 +1730,7 @@ cores:
     UART8:
       address: 0x40007c00
       kind: UART:sci2_v2_1
+      block: usart_v2/USART
       pins:
       - pin: PD14
         signal: CTS

--- a/data/chips/STM32F733VE.yaml
+++ b/data/chips/STM32F733VE.yaml
@@ -1298,6 +1298,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PC10
         signal: TX
@@ -1333,6 +1334,7 @@ cores:
       address: 0x40005000
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PC9
         signal: CTS
@@ -1361,6 +1363,7 @@ cores:
     UART7:
       address: 0x40007800
       kind: UART:sci2_v2_1
+      block: usart_v2/USART
       pins:
       - pin: PE10
         signal: CTS
@@ -1389,6 +1392,7 @@ cores:
     UART8:
       address: 0x40007c00
       kind: UART:sci2_v2_1
+      block: usart_v2/USART
       pins:
       - pin: PE1
         signal: TX

--- a/data/chips/STM32F733ZE.yaml
+++ b/data/chips/STM32F733ZE.yaml
@@ -1475,6 +1475,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PA0
         signal: TX
@@ -1510,6 +1511,7 @@ cores:
       address: 0x40005000
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PC8
         signal: DE
@@ -1538,6 +1540,7 @@ cores:
     UART7:
       address: 0x40007800
       kind: UART:sci2_v2_1
+      block: usart_v2/USART
       pins:
       - pin: PF6
         signal: RX
@@ -1581,6 +1584,7 @@ cores:
     UART8:
       address: 0x40007c00
       kind: UART:sci2_v2_1
+      block: usart_v2/USART
       pins:
       - pin: PD14
         signal: CTS

--- a/data/chips/STM32F745IE.yaml
+++ b/data/chips/STM32F745IE.yaml
@@ -1968,6 +1968,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PA0/WKUP
         signal: TX
@@ -2002,6 +2003,7 @@ cores:
       address: 0x40005000
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PC8
         signal: DE
@@ -2030,6 +2032,7 @@ cores:
     UART7:
       address: 0x40007800
       kind: UART:sci2_v2_1
+      block: usart_v2/USART
       pins:
       - pin: PF6
         signal: RX
@@ -2073,6 +2076,7 @@ cores:
     UART8:
       address: 0x40007c00
       kind: UART:sci2_v2_1
+      block: usart_v2/USART
       pins:
       - pin: PD14
         signal: CTS

--- a/data/chips/STM32F745IG.yaml
+++ b/data/chips/STM32F745IG.yaml
@@ -1968,6 +1968,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PA0/WKUP
         signal: TX
@@ -2002,6 +2003,7 @@ cores:
       address: 0x40005000
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PC8
         signal: DE
@@ -2030,6 +2032,7 @@ cores:
     UART7:
       address: 0x40007800
       kind: UART:sci2_v2_1
+      block: usart_v2/USART
       pins:
       - pin: PF6
         signal: RX
@@ -2073,6 +2076,7 @@ cores:
     UART8:
       address: 0x40007c00
       kind: UART:sci2_v2_1
+      block: usart_v2/USART
       pins:
       - pin: PD14
         signal: CTS

--- a/data/chips/STM32F745VE.yaml
+++ b/data/chips/STM32F745VE.yaml
@@ -1566,6 +1566,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PA0/WKUP
         signal: TX
@@ -1600,6 +1601,7 @@ cores:
       address: 0x40005000
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PC8
         signal: DE
@@ -1628,6 +1630,7 @@ cores:
     UART7:
       address: 0x40007800
       kind: UART:sci2_v2_1
+      block: usart_v2/USART
       pins:
       - pin: PE7
         signal: RX
@@ -1656,6 +1659,7 @@ cores:
     UART8:
       address: 0x40007c00
       kind: UART:sci2_v2_1
+      block: usart_v2/USART
       pins:
       - pin: PD14
         signal: CTS

--- a/data/chips/STM32F745VG.yaml
+++ b/data/chips/STM32F745VG.yaml
@@ -1566,6 +1566,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PA0/WKUP
         signal: TX
@@ -1600,6 +1601,7 @@ cores:
       address: 0x40005000
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PC8
         signal: DE
@@ -1628,6 +1630,7 @@ cores:
     UART7:
       address: 0x40007800
       kind: UART:sci2_v2_1
+      block: usart_v2/USART
       pins:
       - pin: PE7
         signal: RX
@@ -1656,6 +1659,7 @@ cores:
     UART8:
       address: 0x40007c00
       kind: UART:sci2_v2_1
+      block: usart_v2/USART
       pins:
       - pin: PD14
         signal: CTS

--- a/data/chips/STM32F745ZE.yaml
+++ b/data/chips/STM32F745ZE.yaml
@@ -1767,6 +1767,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PA0/WKUP
         signal: TX
@@ -1801,6 +1802,7 @@ cores:
       address: 0x40005000
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PC8
         signal: DE
@@ -1829,6 +1831,7 @@ cores:
     UART7:
       address: 0x40007800
       kind: UART:sci2_v2_1
+      block: usart_v2/USART
       pins:
       - pin: PF6
         signal: RX
@@ -1872,6 +1875,7 @@ cores:
     UART8:
       address: 0x40007c00
       kind: UART:sci2_v2_1
+      block: usart_v2/USART
       pins:
       - pin: PD14
         signal: CTS

--- a/data/chips/STM32F745ZG.yaml
+++ b/data/chips/STM32F745ZG.yaml
@@ -1767,6 +1767,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PA0/WKUP
         signal: TX
@@ -1801,6 +1802,7 @@ cores:
       address: 0x40005000
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PC8
         signal: DE
@@ -1829,6 +1831,7 @@ cores:
     UART7:
       address: 0x40007800
       kind: UART:sci2_v2_1
+      block: usart_v2/USART
       pins:
       - pin: PF6
         signal: RX
@@ -1872,6 +1875,7 @@ cores:
     UART8:
       address: 0x40007c00
       kind: UART:sci2_v2_1
+      block: usart_v2/USART
       pins:
       - pin: PD14
         signal: CTS

--- a/data/chips/STM32F746BE.yaml
+++ b/data/chips/STM32F746BE.yaml
@@ -2233,6 +2233,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PA0/WKUP
         signal: TX
@@ -2267,6 +2268,7 @@ cores:
       address: 0x40005000
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PC8
         signal: DE
@@ -2295,6 +2297,7 @@ cores:
     UART7:
       address: 0x40007800
       kind: UART:sci2_v2_1
+      block: usart_v2/USART
       pins:
       - pin: PF6
         signal: RX
@@ -2338,6 +2341,7 @@ cores:
     UART8:
       address: 0x40007c00
       kind: UART:sci2_v2_1
+      block: usart_v2/USART
       pins:
       - pin: PD14
         signal: CTS

--- a/data/chips/STM32F746BG.yaml
+++ b/data/chips/STM32F746BG.yaml
@@ -2233,6 +2233,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PA0/WKUP
         signal: TX
@@ -2267,6 +2268,7 @@ cores:
       address: 0x40005000
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PC8
         signal: DE
@@ -2295,6 +2297,7 @@ cores:
     UART7:
       address: 0x40007800
       kind: UART:sci2_v2_1
+      block: usart_v2/USART
       pins:
       - pin: PF6
         signal: RX
@@ -2338,6 +2341,7 @@ cores:
     UART8:
       address: 0x40007c00
       kind: UART:sci2_v2_1
+      block: usart_v2/USART
       pins:
       - pin: PD14
         signal: CTS

--- a/data/chips/STM32F746IE.yaml
+++ b/data/chips/STM32F746IE.yaml
@@ -2151,6 +2151,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PA0/WKUP
         signal: TX
@@ -2185,6 +2186,7 @@ cores:
       address: 0x40005000
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PC8
         signal: DE
@@ -2213,6 +2215,7 @@ cores:
     UART7:
       address: 0x40007800
       kind: UART:sci2_v2_1
+      block: usart_v2/USART
       pins:
       - pin: PF6
         signal: RX
@@ -2256,6 +2259,7 @@ cores:
     UART8:
       address: 0x40007c00
       kind: UART:sci2_v2_1
+      block: usart_v2/USART
       pins:
       - pin: PD14
         signal: CTS

--- a/data/chips/STM32F746IG.yaml
+++ b/data/chips/STM32F746IG.yaml
@@ -2151,6 +2151,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PA0/WKUP
         signal: TX
@@ -2185,6 +2186,7 @@ cores:
       address: 0x40005000
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PC8
         signal: DE
@@ -2213,6 +2215,7 @@ cores:
     UART7:
       address: 0x40007800
       kind: UART:sci2_v2_1
+      block: usart_v2/USART
       pins:
       - pin: PF6
         signal: RX
@@ -2256,6 +2259,7 @@ cores:
     UART8:
       address: 0x40007c00
       kind: UART:sci2_v2_1
+      block: usart_v2/USART
       pins:
       - pin: PD14
         signal: CTS

--- a/data/chips/STM32F746NE.yaml
+++ b/data/chips/STM32F746NE.yaml
@@ -2233,6 +2233,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PA15
         signal: DE
@@ -2267,6 +2268,7 @@ cores:
       address: 0x40005000
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PC12
         signal: TX
@@ -2295,6 +2297,7 @@ cores:
     UART7:
       address: 0x40007800
       kind: UART:sci2_v2_1
+      block: usart_v2/USART
       pins:
       - pin: PF7
         signal: TX
@@ -2338,6 +2341,7 @@ cores:
     UART8:
       address: 0x40007c00
       kind: UART:sci2_v2_1
+      block: usart_v2/USART
       pins:
       - pin: PE1
         signal: TX

--- a/data/chips/STM32F746NG.yaml
+++ b/data/chips/STM32F746NG.yaml
@@ -2233,6 +2233,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PA15
         signal: DE
@@ -2267,6 +2268,7 @@ cores:
       address: 0x40005000
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PC12
         signal: TX
@@ -2295,6 +2297,7 @@ cores:
     UART7:
       address: 0x40007800
       kind: UART:sci2_v2_1
+      block: usart_v2/USART
       pins:
       - pin: PF7
         signal: TX
@@ -2338,6 +2341,7 @@ cores:
     UART8:
       address: 0x40007c00
       kind: UART:sci2_v2_1
+      block: usart_v2/USART
       pins:
       - pin: PE1
         signal: TX

--- a/data/chips/STM32F746VE.yaml
+++ b/data/chips/STM32F746VE.yaml
@@ -1662,6 +1662,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PA0/WKUP
         signal: TX
@@ -1696,6 +1697,7 @@ cores:
       address: 0x40005000
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PC8
         signal: DE
@@ -1724,6 +1726,7 @@ cores:
     UART7:
       address: 0x40007800
       kind: UART:sci2_v2_1
+      block: usart_v2/USART
       pins:
       - pin: PE7
         signal: RX
@@ -1752,6 +1755,7 @@ cores:
     UART8:
       address: 0x40007c00
       kind: UART:sci2_v2_1
+      block: usart_v2/USART
       pins:
       - pin: PD14
         signal: CTS

--- a/data/chips/STM32F746VG.yaml
+++ b/data/chips/STM32F746VG.yaml
@@ -1662,6 +1662,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PA0/WKUP
         signal: TX
@@ -1696,6 +1697,7 @@ cores:
       address: 0x40005000
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PC8
         signal: DE
@@ -1724,6 +1726,7 @@ cores:
     UART7:
       address: 0x40007800
       kind: UART:sci2_v2_1
+      block: usart_v2/USART
       pins:
       - pin: PE7
         signal: RX
@@ -1752,6 +1755,7 @@ cores:
     UART8:
       address: 0x40007c00
       kind: UART:sci2_v2_1
+      block: usart_v2/USART
       pins:
       - pin: PD14
         signal: CTS

--- a/data/chips/STM32F746ZE.yaml
+++ b/data/chips/STM32F746ZE.yaml
@@ -1895,6 +1895,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PA0/WKUP
         signal: TX
@@ -1929,6 +1930,7 @@ cores:
       address: 0x40005000
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PC8
         signal: DE
@@ -1957,6 +1959,7 @@ cores:
     UART7:
       address: 0x40007800
       kind: UART:sci2_v2_1
+      block: usart_v2/USART
       pins:
       - pin: PF6
         signal: RX
@@ -2000,6 +2003,7 @@ cores:
     UART8:
       address: 0x40007c00
       kind: UART:sci2_v2_1
+      block: usart_v2/USART
       pins:
       - pin: PD14
         signal: CTS

--- a/data/chips/STM32F746ZG.yaml
+++ b/data/chips/STM32F746ZG.yaml
@@ -1895,6 +1895,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PA0/WKUP
         signal: TX
@@ -1929,6 +1930,7 @@ cores:
       address: 0x40005000
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PC8
         signal: DE
@@ -1957,6 +1959,7 @@ cores:
     UART7:
       address: 0x40007800
       kind: UART:sci2_v2_1
+      block: usart_v2/USART
       pins:
       - pin: PF6
         signal: RX
@@ -2000,6 +2003,7 @@ cores:
     UART8:
       address: 0x40007c00
       kind: UART:sci2_v2_1
+      block: usart_v2/USART
       pins:
       - pin: PD14
         signal: CTS

--- a/data/chips/STM32F750N8.yaml
+++ b/data/chips/STM32F750N8.yaml
@@ -2254,6 +2254,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PA15
         signal: DE
@@ -2288,6 +2289,7 @@ cores:
       address: 0x40005000
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PC12
         signal: TX
@@ -2316,6 +2318,7 @@ cores:
     UART7:
       address: 0x40007800
       kind: UART:sci2_v2_1
+      block: usart_v2/USART
       pins:
       - pin: PF7
         signal: TX
@@ -2359,6 +2362,7 @@ cores:
     UART8:
       address: 0x40007c00
       kind: UART:sci2_v2_1
+      block: usart_v2/USART
       pins:
       - pin: PE1
         signal: TX

--- a/data/chips/STM32F750V8.yaml
+++ b/data/chips/STM32F750V8.yaml
@@ -1681,6 +1681,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PA0/WKUP
         signal: TX
@@ -1715,6 +1716,7 @@ cores:
       address: 0x40005000
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PC8
         signal: DE
@@ -1743,6 +1745,7 @@ cores:
     UART7:
       address: 0x40007800
       kind: UART:sci2_v2_1
+      block: usart_v2/USART
       pins:
       - pin: PE7
         signal: RX
@@ -1771,6 +1774,7 @@ cores:
     UART8:
       address: 0x40007c00
       kind: UART:sci2_v2_1
+      block: usart_v2/USART
       pins:
       - pin: PD14
         signal: CTS

--- a/data/chips/STM32F750Z8.yaml
+++ b/data/chips/STM32F750Z8.yaml
@@ -1914,6 +1914,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PA0/WKUP
         signal: TX
@@ -1948,6 +1949,7 @@ cores:
       address: 0x40005000
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PC8
         signal: DE
@@ -1976,6 +1978,7 @@ cores:
     UART7:
       address: 0x40007800
       kind: UART:sci2_v2_1
+      block: usart_v2/USART
       pins:
       - pin: PF6
         signal: RX
@@ -2019,6 +2022,7 @@ cores:
     UART8:
       address: 0x40007c00
       kind: UART:sci2_v2_1
+      block: usart_v2/USART
       pins:
       - pin: PD14
         signal: CTS

--- a/data/chips/STM32F756BG.yaml
+++ b/data/chips/STM32F756BG.yaml
@@ -2254,6 +2254,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PA0/WKUP
         signal: TX
@@ -2288,6 +2289,7 @@ cores:
       address: 0x40005000
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PC8
         signal: DE
@@ -2316,6 +2318,7 @@ cores:
     UART7:
       address: 0x40007800
       kind: UART:sci2_v2_1
+      block: usart_v2/USART
       pins:
       - pin: PF6
         signal: RX
@@ -2359,6 +2362,7 @@ cores:
     UART8:
       address: 0x40007c00
       kind: UART:sci2_v2_1
+      block: usart_v2/USART
       pins:
       - pin: PD14
         signal: CTS

--- a/data/chips/STM32F756IG.yaml
+++ b/data/chips/STM32F756IG.yaml
@@ -2172,6 +2172,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PA0/WKUP
         signal: TX
@@ -2206,6 +2207,7 @@ cores:
       address: 0x40005000
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PC8
         signal: DE
@@ -2234,6 +2236,7 @@ cores:
     UART7:
       address: 0x40007800
       kind: UART:sci2_v2_1
+      block: usart_v2/USART
       pins:
       - pin: PF6
         signal: RX
@@ -2277,6 +2280,7 @@ cores:
     UART8:
       address: 0x40007c00
       kind: UART:sci2_v2_1
+      block: usart_v2/USART
       pins:
       - pin: PD14
         signal: CTS

--- a/data/chips/STM32F756NG.yaml
+++ b/data/chips/STM32F756NG.yaml
@@ -2254,6 +2254,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PA15
         signal: DE
@@ -2288,6 +2289,7 @@ cores:
       address: 0x40005000
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PC12
         signal: TX
@@ -2316,6 +2318,7 @@ cores:
     UART7:
       address: 0x40007800
       kind: UART:sci2_v2_1
+      block: usart_v2/USART
       pins:
       - pin: PF7
         signal: TX
@@ -2359,6 +2362,7 @@ cores:
     UART8:
       address: 0x40007c00
       kind: UART:sci2_v2_1
+      block: usart_v2/USART
       pins:
       - pin: PE1
         signal: TX

--- a/data/chips/STM32F756VG.yaml
+++ b/data/chips/STM32F756VG.yaml
@@ -1683,6 +1683,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PA0/WKUP
         signal: TX
@@ -1717,6 +1718,7 @@ cores:
       address: 0x40005000
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PC8
         signal: DE
@@ -1745,6 +1747,7 @@ cores:
     UART7:
       address: 0x40007800
       kind: UART:sci2_v2_1
+      block: usart_v2/USART
       pins:
       - pin: PE7
         signal: RX
@@ -1773,6 +1776,7 @@ cores:
     UART8:
       address: 0x40007c00
       kind: UART:sci2_v2_1
+      block: usart_v2/USART
       pins:
       - pin: PD14
         signal: CTS

--- a/data/chips/STM32F756ZG.yaml
+++ b/data/chips/STM32F756ZG.yaml
@@ -1916,6 +1916,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PC10
         signal: TX
@@ -1950,6 +1951,7 @@ cores:
       address: 0x40005000
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PD2
         signal: RX
@@ -1978,6 +1980,7 @@ cores:
     UART7:
       address: 0x40007800
       kind: UART:sci2_v2_1
+      block: usart_v2/USART
       pins:
       - pin: PF7
         signal: TX
@@ -2021,6 +2024,7 @@ cores:
     UART8:
       address: 0x40007c00
       kind: UART:sci2_v2_1
+      block: usart_v2/USART
       pins:
       - pin: PE1
         signal: TX

--- a/data/chips/STM32F765BG.yaml
+++ b/data/chips/STM32F765BG.yaml
@@ -2143,6 +2143,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PI9
         signal: RX
@@ -2207,6 +2208,7 @@ cores:
       address: 0x40005000
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PB12
         signal: RX
@@ -2254,6 +2256,7 @@ cores:
       address: 0x40007800
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PF6
         signal: RX
@@ -2310,6 +2313,7 @@ cores:
       address: 0x40007c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PD14
         signal: CTS

--- a/data/chips/STM32F765BI.yaml
+++ b/data/chips/STM32F765BI.yaml
@@ -2143,6 +2143,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PI9
         signal: RX
@@ -2207,6 +2208,7 @@ cores:
       address: 0x40005000
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PB12
         signal: RX
@@ -2254,6 +2256,7 @@ cores:
       address: 0x40007800
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PF6
         signal: RX
@@ -2310,6 +2313,7 @@ cores:
       address: 0x40007c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PD14
         signal: CTS

--- a/data/chips/STM32F765IG.yaml
+++ b/data/chips/STM32F765IG.yaml
@@ -2145,6 +2145,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PI9
         signal: RX
@@ -2209,6 +2210,7 @@ cores:
       address: 0x40005000
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PB12
         signal: RX
@@ -2256,6 +2258,7 @@ cores:
       address: 0x40007800
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PF6
         signal: RX
@@ -2312,6 +2315,7 @@ cores:
       address: 0x40007c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PD14
         signal: CTS

--- a/data/chips/STM32F765II.yaml
+++ b/data/chips/STM32F765II.yaml
@@ -2145,6 +2145,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PI9
         signal: RX
@@ -2209,6 +2210,7 @@ cores:
       address: 0x40005000
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PB12
         signal: RX
@@ -2256,6 +2258,7 @@ cores:
       address: 0x40007800
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PF6
         signal: RX
@@ -2312,6 +2315,7 @@ cores:
       address: 0x40007c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PD14
         signal: CTS

--- a/data/chips/STM32F765NG.yaml
+++ b/data/chips/STM32F765NG.yaml
@@ -2143,6 +2143,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PA15
         signal: DE
@@ -2207,6 +2208,7 @@ cores:
       address: 0x40005000
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PB8
         signal: RX
@@ -2254,6 +2256,7 @@ cores:
       address: 0x40007800
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PB4
         signal: TX
@@ -2310,6 +2313,7 @@ cores:
       address: 0x40007c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PE1
         signal: TX

--- a/data/chips/STM32F765NI.yaml
+++ b/data/chips/STM32F765NI.yaml
@@ -2143,6 +2143,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PA15
         signal: DE
@@ -2207,6 +2208,7 @@ cores:
       address: 0x40005000
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PB8
         signal: RX
@@ -2254,6 +2256,7 @@ cores:
       address: 0x40007800
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PB4
         signal: TX
@@ -2310,6 +2313,7 @@ cores:
       address: 0x40007c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PE1
         signal: TX

--- a/data/chips/STM32F765VG.yaml
+++ b/data/chips/STM32F765VG.yaml
@@ -1727,6 +1727,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PA0/WKUP
         signal: TX
@@ -1782,6 +1783,7 @@ cores:
       address: 0x40005000
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PB12
         signal: RX
@@ -1829,6 +1831,7 @@ cores:
       address: 0x40007800
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PE7
         signal: RX
@@ -1870,6 +1873,7 @@ cores:
       address: 0x40007c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PD14
         signal: CTS

--- a/data/chips/STM32F765VI.yaml
+++ b/data/chips/STM32F765VI.yaml
@@ -1727,6 +1727,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PA0/WKUP
         signal: TX
@@ -1782,6 +1783,7 @@ cores:
       address: 0x40005000
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PB12
         signal: RX
@@ -1829,6 +1831,7 @@ cores:
       address: 0x40007800
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PE7
         signal: RX
@@ -1870,6 +1873,7 @@ cores:
       address: 0x40007c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PD14
         signal: CTS

--- a/data/chips/STM32F765ZG.yaml
+++ b/data/chips/STM32F765ZG.yaml
@@ -1941,6 +1941,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PA0/WKUP
         signal: TX
@@ -1996,6 +1997,7 @@ cores:
       address: 0x40005000
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PB12
         signal: RX
@@ -2043,6 +2045,7 @@ cores:
       address: 0x40007800
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PF6
         signal: RX
@@ -2099,6 +2102,7 @@ cores:
       address: 0x40007c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PD14
         signal: CTS

--- a/data/chips/STM32F765ZI.yaml
+++ b/data/chips/STM32F765ZI.yaml
@@ -1941,6 +1941,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PA0/WKUP
         signal: TX
@@ -1996,6 +1997,7 @@ cores:
       address: 0x40005000
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PB12
         signal: RX
@@ -2043,6 +2045,7 @@ cores:
       address: 0x40007800
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PF6
         signal: RX
@@ -2099,6 +2102,7 @@ cores:
       address: 0x40007c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PD14
         signal: CTS

--- a/data/chips/STM32F767BG.yaml
+++ b/data/chips/STM32F767BG.yaml
@@ -2480,6 +2480,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PI9
         signal: RX
@@ -2544,6 +2545,7 @@ cores:
       address: 0x40005000
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PB12
         signal: RX
@@ -2591,6 +2593,7 @@ cores:
       address: 0x40007800
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PF6
         signal: RX
@@ -2647,6 +2650,7 @@ cores:
       address: 0x40007c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PD14
         signal: CTS

--- a/data/chips/STM32F767BI.yaml
+++ b/data/chips/STM32F767BI.yaml
@@ -2480,6 +2480,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PI9
         signal: RX
@@ -2544,6 +2545,7 @@ cores:
       address: 0x40005000
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PB12
         signal: RX
@@ -2591,6 +2593,7 @@ cores:
       address: 0x40007800
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PF6
         signal: RX
@@ -2647,6 +2650,7 @@ cores:
       address: 0x40007c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PD14
         signal: CTS

--- a/data/chips/STM32F767IG.yaml
+++ b/data/chips/STM32F767IG.yaml
@@ -2386,6 +2386,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PI9
         signal: RX
@@ -2450,6 +2451,7 @@ cores:
       address: 0x40005000
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PB12
         signal: RX
@@ -2497,6 +2499,7 @@ cores:
       address: 0x40007800
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PF6
         signal: RX
@@ -2553,6 +2556,7 @@ cores:
       address: 0x40007c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PD14
         signal: CTS

--- a/data/chips/STM32F767II.yaml
+++ b/data/chips/STM32F767II.yaml
@@ -2386,6 +2386,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PI9
         signal: RX
@@ -2450,6 +2451,7 @@ cores:
       address: 0x40005000
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PB12
         signal: RX
@@ -2497,6 +2499,7 @@ cores:
       address: 0x40007800
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PF6
         signal: RX
@@ -2553,6 +2556,7 @@ cores:
       address: 0x40007c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PD14
         signal: CTS

--- a/data/chips/STM32F767NG.yaml
+++ b/data/chips/STM32F767NG.yaml
@@ -2480,6 +2480,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PA15
         signal: DE
@@ -2544,6 +2545,7 @@ cores:
       address: 0x40005000
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PB8
         signal: RX
@@ -2591,6 +2593,7 @@ cores:
       address: 0x40007800
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PB4
         signal: TX
@@ -2647,6 +2650,7 @@ cores:
       address: 0x40007c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PE1
         signal: TX

--- a/data/chips/STM32F767NI.yaml
+++ b/data/chips/STM32F767NI.yaml
@@ -2480,6 +2480,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PA15
         signal: DE
@@ -2544,6 +2545,7 @@ cores:
       address: 0x40005000
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PB8
         signal: RX
@@ -2591,6 +2593,7 @@ cores:
       address: 0x40007800
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PB4
         signal: TX
@@ -2647,6 +2650,7 @@ cores:
       address: 0x40007c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PE1
         signal: TX

--- a/data/chips/STM32F767VG.yaml
+++ b/data/chips/STM32F767VG.yaml
@@ -1869,6 +1869,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PA0/WKUP
         signal: TX
@@ -1924,6 +1925,7 @@ cores:
       address: 0x40005000
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PB12
         signal: RX
@@ -1971,6 +1973,7 @@ cores:
       address: 0x40007800
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PE7
         signal: RX
@@ -2012,6 +2015,7 @@ cores:
       address: 0x40007c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PD14
         signal: CTS

--- a/data/chips/STM32F767VI.yaml
+++ b/data/chips/STM32F767VI.yaml
@@ -1869,6 +1869,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PA0/WKUP
         signal: TX
@@ -1924,6 +1925,7 @@ cores:
       address: 0x40005000
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PB12
         signal: RX
@@ -1971,6 +1973,7 @@ cores:
       address: 0x40007800
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PE7
         signal: RX
@@ -2012,6 +2015,7 @@ cores:
       address: 0x40007c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PD14
         signal: CTS

--- a/data/chips/STM32F767ZG.yaml
+++ b/data/chips/STM32F767ZG.yaml
@@ -2116,6 +2116,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PA0/WKUP
         signal: TX
@@ -2171,6 +2172,7 @@ cores:
       address: 0x40005000
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PB12
         signal: RX
@@ -2218,6 +2220,7 @@ cores:
       address: 0x40007800
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PF6
         signal: RX
@@ -2274,6 +2277,7 @@ cores:
       address: 0x40007c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PD14
         signal: CTS

--- a/data/chips/STM32F767ZI.yaml
+++ b/data/chips/STM32F767ZI.yaml
@@ -2116,6 +2116,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PA0/WKUP
         signal: TX
@@ -2171,6 +2172,7 @@ cores:
       address: 0x40005000
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PB12
         signal: RX
@@ -2218,6 +2220,7 @@ cores:
       address: 0x40007800
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PF6
         signal: RX
@@ -2274,6 +2277,7 @@ cores:
       address: 0x40007c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PD14
         signal: CTS

--- a/data/chips/STM32F768AI.yaml
+++ b/data/chips/STM32F768AI.yaml
@@ -2130,6 +2130,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PD0
         signal: RX
@@ -2194,6 +2195,7 @@ cores:
       address: 0x40005000
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PB5
         signal: RX
@@ -2241,6 +2243,7 @@ cores:
       address: 0x40007800
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PB4
         signal: TX
@@ -2282,6 +2285,7 @@ cores:
       address: 0x40007c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PE1
         signal: TX

--- a/data/chips/STM32F769AG.yaml
+++ b/data/chips/STM32F769AG.yaml
@@ -2130,6 +2130,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PD0
         signal: RX
@@ -2194,6 +2195,7 @@ cores:
       address: 0x40005000
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PB5
         signal: RX
@@ -2241,6 +2243,7 @@ cores:
       address: 0x40007800
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PB4
         signal: TX
@@ -2282,6 +2285,7 @@ cores:
       address: 0x40007c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PE1
         signal: TX

--- a/data/chips/STM32F769AI.yaml
+++ b/data/chips/STM32F769AI.yaml
@@ -2138,6 +2138,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PD0
         signal: RX
@@ -2202,6 +2203,7 @@ cores:
       address: 0x40005000
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PB5
         signal: RX
@@ -2249,6 +2251,7 @@ cores:
       address: 0x40007800
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PB4
         signal: TX
@@ -2290,6 +2293,7 @@ cores:
       address: 0x40007c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PE1
         signal: TX

--- a/data/chips/STM32F769BG.yaml
+++ b/data/chips/STM32F769BG.yaml
@@ -2453,6 +2453,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PI9
         signal: RX
@@ -2517,6 +2518,7 @@ cores:
       address: 0x40005000
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PB12
         signal: RX
@@ -2564,6 +2566,7 @@ cores:
       address: 0x40007800
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PF6
         signal: RX
@@ -2620,6 +2623,7 @@ cores:
       address: 0x40007c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PD14
         signal: CTS

--- a/data/chips/STM32F769BI.yaml
+++ b/data/chips/STM32F769BI.yaml
@@ -2453,6 +2453,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PI9
         signal: RX
@@ -2517,6 +2518,7 @@ cores:
       address: 0x40005000
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PB12
         signal: RX
@@ -2564,6 +2566,7 @@ cores:
       address: 0x40007800
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PF6
         signal: RX
@@ -2620,6 +2623,7 @@ cores:
       address: 0x40007c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PD14
         signal: CTS

--- a/data/chips/STM32F769IG.yaml
+++ b/data/chips/STM32F769IG.yaml
@@ -2285,6 +2285,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PI9
         signal: RX
@@ -2343,6 +2344,7 @@ cores:
       address: 0x40005000
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PB12
         signal: RX
@@ -2390,6 +2392,7 @@ cores:
       address: 0x40007800
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PF6
         signal: RX
@@ -2446,6 +2449,7 @@ cores:
       address: 0x40007c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PD14
         signal: CTS

--- a/data/chips/STM32F769II.yaml
+++ b/data/chips/STM32F769II.yaml
@@ -2285,6 +2285,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PI9
         signal: RX
@@ -2343,6 +2344,7 @@ cores:
       address: 0x40005000
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PB12
         signal: RX
@@ -2390,6 +2392,7 @@ cores:
       address: 0x40007800
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PF6
         signal: RX
@@ -2446,6 +2449,7 @@ cores:
       address: 0x40007c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PD14
         signal: CTS

--- a/data/chips/STM32F769NG.yaml
+++ b/data/chips/STM32F769NG.yaml
@@ -2453,6 +2453,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PA15
         signal: DE
@@ -2517,6 +2518,7 @@ cores:
       address: 0x40005000
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PB8
         signal: RX
@@ -2564,6 +2566,7 @@ cores:
       address: 0x40007800
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PB4
         signal: TX
@@ -2620,6 +2623,7 @@ cores:
       address: 0x40007c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PE1
         signal: TX

--- a/data/chips/STM32F769NI.yaml
+++ b/data/chips/STM32F769NI.yaml
@@ -2453,6 +2453,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PA15
         signal: DE
@@ -2517,6 +2518,7 @@ cores:
       address: 0x40005000
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PB8
         signal: RX
@@ -2564,6 +2566,7 @@ cores:
       address: 0x40007800
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PB4
         signal: TX
@@ -2620,6 +2623,7 @@ cores:
       address: 0x40007c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PE1
         signal: TX

--- a/data/chips/STM32F777BI.yaml
+++ b/data/chips/STM32F777BI.yaml
@@ -2501,6 +2501,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PI9
         signal: RX
@@ -2565,6 +2566,7 @@ cores:
       address: 0x40005000
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PB12
         signal: RX
@@ -2612,6 +2614,7 @@ cores:
       address: 0x40007800
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PF6
         signal: RX
@@ -2668,6 +2671,7 @@ cores:
       address: 0x40007c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PD14
         signal: CTS

--- a/data/chips/STM32F777II.yaml
+++ b/data/chips/STM32F777II.yaml
@@ -2407,6 +2407,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PI9
         signal: RX
@@ -2471,6 +2472,7 @@ cores:
       address: 0x40005000
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PB12
         signal: RX
@@ -2518,6 +2520,7 @@ cores:
       address: 0x40007800
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PF6
         signal: RX
@@ -2574,6 +2577,7 @@ cores:
       address: 0x40007c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PD14
         signal: CTS

--- a/data/chips/STM32F777NI.yaml
+++ b/data/chips/STM32F777NI.yaml
@@ -2501,6 +2501,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PA15
         signal: DE
@@ -2565,6 +2566,7 @@ cores:
       address: 0x40005000
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PB8
         signal: RX
@@ -2612,6 +2614,7 @@ cores:
       address: 0x40007800
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PB4
         signal: TX
@@ -2668,6 +2671,7 @@ cores:
       address: 0x40007c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PE1
         signal: TX

--- a/data/chips/STM32F777VI.yaml
+++ b/data/chips/STM32F777VI.yaml
@@ -1890,6 +1890,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PA0/WKUP
         signal: TX
@@ -1945,6 +1946,7 @@ cores:
       address: 0x40005000
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PB12
         signal: RX
@@ -1992,6 +1994,7 @@ cores:
       address: 0x40007800
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PE7
         signal: RX
@@ -2033,6 +2036,7 @@ cores:
       address: 0x40007c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PD14
         signal: CTS

--- a/data/chips/STM32F777ZI.yaml
+++ b/data/chips/STM32F777ZI.yaml
@@ -2137,6 +2137,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PA0/WKUP
         signal: TX
@@ -2192,6 +2193,7 @@ cores:
       address: 0x40005000
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PB12
         signal: RX
@@ -2239,6 +2241,7 @@ cores:
       address: 0x40007800
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PF6
         signal: RX
@@ -2295,6 +2298,7 @@ cores:
       address: 0x40007c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PD14
         signal: CTS

--- a/data/chips/STM32F778AI.yaml
+++ b/data/chips/STM32F778AI.yaml
@@ -2159,6 +2159,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PD0
         signal: RX
@@ -2223,6 +2224,7 @@ cores:
       address: 0x40005000
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PB5
         signal: RX
@@ -2270,6 +2272,7 @@ cores:
       address: 0x40007800
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PB4
         signal: TX
@@ -2311,6 +2314,7 @@ cores:
       address: 0x40007c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PE1
         signal: TX

--- a/data/chips/STM32F779AI.yaml
+++ b/data/chips/STM32F779AI.yaml
@@ -2159,6 +2159,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PD0
         signal: RX
@@ -2223,6 +2224,7 @@ cores:
       address: 0x40005000
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PB5
         signal: RX
@@ -2270,6 +2272,7 @@ cores:
       address: 0x40007800
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PB4
         signal: TX
@@ -2311,6 +2314,7 @@ cores:
       address: 0x40007c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PE1
         signal: TX

--- a/data/chips/STM32F779BI.yaml
+++ b/data/chips/STM32F779BI.yaml
@@ -2474,6 +2474,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PI9
         signal: RX
@@ -2538,6 +2539,7 @@ cores:
       address: 0x40005000
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PB12
         signal: RX
@@ -2585,6 +2587,7 @@ cores:
       address: 0x40007800
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PF6
         signal: RX
@@ -2641,6 +2644,7 @@ cores:
       address: 0x40007c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PD14
         signal: CTS

--- a/data/chips/STM32F779II.yaml
+++ b/data/chips/STM32F779II.yaml
@@ -2306,6 +2306,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PI9
         signal: RX
@@ -2364,6 +2365,7 @@ cores:
       address: 0x40005000
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PB12
         signal: RX
@@ -2411,6 +2413,7 @@ cores:
       address: 0x40007800
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PF6
         signal: RX
@@ -2467,6 +2470,7 @@ cores:
       address: 0x40007c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PD14
         signal: CTS

--- a/data/chips/STM32F779NI.yaml
+++ b/data/chips/STM32F779NI.yaml
@@ -2474,6 +2474,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PA15
         signal: DE
@@ -2538,6 +2539,7 @@ cores:
       address: 0x40005000
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PB8
         signal: RX
@@ -2585,6 +2587,7 @@ cores:
       address: 0x40007800
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PB4
         signal: TX
@@ -2641,6 +2644,7 @@ cores:
       address: 0x40007c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PE1
         signal: TX

--- a/data/chips/STM32L451CC.yaml
+++ b/data/chips/STM32L451CC.yaml
@@ -1076,6 +1076,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PA0
         signal: TX

--- a/data/chips/STM32L451CE.yaml
+++ b/data/chips/STM32L451CE.yaml
@@ -1078,6 +1078,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PA0
         signal: TX

--- a/data/chips/STM32L451RC.yaml
+++ b/data/chips/STM32L451RC.yaml
@@ -1245,6 +1245,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PA15
         signal: DE

--- a/data/chips/STM32L451RE.yaml
+++ b/data/chips/STM32L451RE.yaml
@@ -1245,6 +1245,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PA15
         signal: DE

--- a/data/chips/STM32L451VC.yaml
+++ b/data/chips/STM32L451VC.yaml
@@ -1446,6 +1446,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PA0
         signal: TX

--- a/data/chips/STM32L451VE.yaml
+++ b/data/chips/STM32L451VE.yaml
@@ -1446,6 +1446,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PA0
         signal: TX

--- a/data/chips/STM32L452CC.yaml
+++ b/data/chips/STM32L452CC.yaml
@@ -1076,6 +1076,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PA0
         signal: TX

--- a/data/chips/STM32L452CE.yaml
+++ b/data/chips/STM32L452CE.yaml
@@ -1078,6 +1078,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PA0
         signal: TX

--- a/data/chips/STM32L452RC.yaml
+++ b/data/chips/STM32L452RC.yaml
@@ -1245,6 +1245,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PA15
         signal: DE

--- a/data/chips/STM32L452RE.yaml
+++ b/data/chips/STM32L452RE.yaml
@@ -1237,6 +1237,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PA0
         signal: TX

--- a/data/chips/STM32L452VC.yaml
+++ b/data/chips/STM32L452VC.yaml
@@ -1446,6 +1446,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PA0
         signal: TX

--- a/data/chips/STM32L452VE.yaml
+++ b/data/chips/STM32L452VE.yaml
@@ -1446,6 +1446,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PA0
         signal: TX

--- a/data/chips/STM32L462CE.yaml
+++ b/data/chips/STM32L462CE.yaml
@@ -1095,6 +1095,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PA0
         signal: TX

--- a/data/chips/STM32L462RE.yaml
+++ b/data/chips/STM32L462RE.yaml
@@ -1262,6 +1262,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PA15
         signal: DE

--- a/data/chips/STM32L462VE.yaml
+++ b/data/chips/STM32L462VE.yaml
@@ -1463,6 +1463,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PA0
         signal: TX

--- a/data/chips/STM32L471QE.yaml
+++ b/data/chips/STM32L471QE.yaml
@@ -1789,6 +1789,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PA15
         signal: DE
@@ -1824,6 +1825,7 @@ cores:
       address: 0x40005000
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PB4
         signal: DE

--- a/data/chips/STM32L471QG.yaml
+++ b/data/chips/STM32L471QG.yaml
@@ -1789,6 +1789,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PA15
         signal: DE
@@ -1824,6 +1825,7 @@ cores:
       address: 0x40005000
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PB4
         signal: DE

--- a/data/chips/STM32L471RE.yaml
+++ b/data/chips/STM32L471RE.yaml
@@ -1447,6 +1447,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PA0
         signal: TX
@@ -1482,6 +1483,7 @@ cores:
       address: 0x40005000
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PC12
         signal: TX

--- a/data/chips/STM32L471RG.yaml
+++ b/data/chips/STM32L471RG.yaml
@@ -1447,6 +1447,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PA0
         signal: TX
@@ -1482,6 +1483,7 @@ cores:
       address: 0x40005000
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PC12
         signal: TX

--- a/data/chips/STM32L471VE.yaml
+++ b/data/chips/STM32L471VE.yaml
@@ -1656,6 +1656,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PA0
         signal: TX
@@ -1691,6 +1692,7 @@ cores:
       address: 0x40005000
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PC12
         signal: TX

--- a/data/chips/STM32L471VG.yaml
+++ b/data/chips/STM32L471VG.yaml
@@ -1656,6 +1656,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PA0
         signal: TX
@@ -1691,6 +1692,7 @@ cores:
       address: 0x40005000
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PC12
         signal: TX

--- a/data/chips/STM32L471ZE.yaml
+++ b/data/chips/STM32L471ZE.yaml
@@ -1830,6 +1830,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PA0
         signal: TX
@@ -1865,6 +1866,7 @@ cores:
       address: 0x40005000
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PC12
         signal: TX

--- a/data/chips/STM32L471ZG.yaml
+++ b/data/chips/STM32L471ZG.yaml
@@ -1830,6 +1830,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PA0
         signal: TX
@@ -1865,6 +1866,7 @@ cores:
       address: 0x40005000
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PC12
         signal: TX

--- a/data/chips/STM32L475RC.yaml
+++ b/data/chips/STM32L475RC.yaml
@@ -1447,6 +1447,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PA0
         signal: TX
@@ -1482,6 +1483,7 @@ cores:
       address: 0x40005000
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PC12
         signal: TX

--- a/data/chips/STM32L475RE.yaml
+++ b/data/chips/STM32L475RE.yaml
@@ -1447,6 +1447,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PA0
         signal: TX
@@ -1482,6 +1483,7 @@ cores:
       address: 0x40005000
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PC12
         signal: TX

--- a/data/chips/STM32L475RG.yaml
+++ b/data/chips/STM32L475RG.yaml
@@ -1447,6 +1447,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PA0
         signal: TX
@@ -1482,6 +1483,7 @@ cores:
       address: 0x40005000
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PC12
         signal: TX

--- a/data/chips/STM32L475VC.yaml
+++ b/data/chips/STM32L475VC.yaml
@@ -1656,6 +1656,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PA0
         signal: TX
@@ -1691,6 +1692,7 @@ cores:
       address: 0x40005000
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PC12
         signal: TX

--- a/data/chips/STM32L475VE.yaml
+++ b/data/chips/STM32L475VE.yaml
@@ -1656,6 +1656,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PA0
         signal: TX
@@ -1691,6 +1692,7 @@ cores:
       address: 0x40005000
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PC12
         signal: TX

--- a/data/chips/STM32L475VG.yaml
+++ b/data/chips/STM32L475VG.yaml
@@ -1656,6 +1656,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PA0
         signal: TX
@@ -1691,6 +1692,7 @@ cores:
       address: 0x40005000
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PC12
         signal: TX

--- a/data/chips/STM32L476JE.yaml
+++ b/data/chips/STM32L476JE.yaml
@@ -1637,6 +1637,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PA15
         signal: DE
@@ -1672,6 +1673,7 @@ cores:
       address: 0x40005000
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PD2
         signal: RX

--- a/data/chips/STM32L476JG.yaml
+++ b/data/chips/STM32L476JG.yaml
@@ -1618,6 +1618,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PC10
         signal: TX
@@ -1653,6 +1654,7 @@ cores:
       address: 0x40005000
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PD2
         signal: RX

--- a/data/chips/STM32L476ME.yaml
+++ b/data/chips/STM32L476ME.yaml
@@ -1664,6 +1664,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PA15
         signal: DE
@@ -1699,6 +1700,7 @@ cores:
       address: 0x40005000
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PD2
         signal: RX

--- a/data/chips/STM32L476MG.yaml
+++ b/data/chips/STM32L476MG.yaml
@@ -1664,6 +1664,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PA15
         signal: DE
@@ -1699,6 +1700,7 @@ cores:
       address: 0x40005000
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PD2
         signal: RX

--- a/data/chips/STM32L476QE.yaml
+++ b/data/chips/STM32L476QE.yaml
@@ -1967,6 +1967,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PA15
         signal: DE
@@ -2002,6 +2003,7 @@ cores:
       address: 0x40005000
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PB4
         signal: DE

--- a/data/chips/STM32L476QG.yaml
+++ b/data/chips/STM32L476QG.yaml
@@ -1967,6 +1967,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PA15
         signal: DE
@@ -2002,6 +2003,7 @@ cores:
       address: 0x40005000
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PB4
         signal: DE

--- a/data/chips/STM32L476RC.yaml
+++ b/data/chips/STM32L476RC.yaml
@@ -1589,6 +1589,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PA0
         signal: TX
@@ -1624,6 +1625,7 @@ cores:
       address: 0x40005000
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PC12
         signal: TX

--- a/data/chips/STM32L476RE.yaml
+++ b/data/chips/STM32L476RE.yaml
@@ -1589,6 +1589,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PA0
         signal: TX
@@ -1624,6 +1625,7 @@ cores:
       address: 0x40005000
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PC12
         signal: TX

--- a/data/chips/STM32L476RG.yaml
+++ b/data/chips/STM32L476RG.yaml
@@ -1589,6 +1589,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PA0
         signal: TX
@@ -1624,6 +1625,7 @@ cores:
       address: 0x40005000
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PC12
         signal: TX

--- a/data/chips/STM32L476VC.yaml
+++ b/data/chips/STM32L476VC.yaml
@@ -1834,6 +1834,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PA0
         signal: TX
@@ -1869,6 +1870,7 @@ cores:
       address: 0x40005000
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PC12
         signal: TX

--- a/data/chips/STM32L476VE.yaml
+++ b/data/chips/STM32L476VE.yaml
@@ -1834,6 +1834,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PA0
         signal: TX
@@ -1869,6 +1870,7 @@ cores:
       address: 0x40005000
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PC12
         signal: TX

--- a/data/chips/STM32L476VG.yaml
+++ b/data/chips/STM32L476VG.yaml
@@ -1834,6 +1834,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PA0
         signal: TX
@@ -1869,6 +1870,7 @@ cores:
       address: 0x40005000
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PC12
         signal: TX

--- a/data/chips/STM32L476ZE.yaml
+++ b/data/chips/STM32L476ZE.yaml
@@ -2006,6 +2006,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PA0
         signal: TX
@@ -2041,6 +2042,7 @@ cores:
       address: 0x40005000
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PC12
         signal: TX

--- a/data/chips/STM32L476ZG.yaml
+++ b/data/chips/STM32L476ZG.yaml
@@ -1986,6 +1986,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PA0
         signal: TX
@@ -2021,6 +2022,7 @@ cores:
       address: 0x40005000
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PC12
         signal: TX

--- a/data/chips/STM32L485JC.yaml
+++ b/data/chips/STM32L485JC.yaml
@@ -1501,6 +1501,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PA15
         signal: DE
@@ -1536,6 +1537,7 @@ cores:
       address: 0x40005000
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PD2
         signal: RX

--- a/data/chips/STM32L485JE.yaml
+++ b/data/chips/STM32L485JE.yaml
@@ -1501,6 +1501,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PA15
         signal: DE
@@ -1536,6 +1537,7 @@ cores:
       address: 0x40005000
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PD2
         signal: RX

--- a/data/chips/STM32L486JG.yaml
+++ b/data/chips/STM32L486JG.yaml
@@ -1654,6 +1654,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PA15
         signal: DE
@@ -1689,6 +1690,7 @@ cores:
       address: 0x40005000
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PD2
         signal: RX

--- a/data/chips/STM32L486QG.yaml
+++ b/data/chips/STM32L486QG.yaml
@@ -1984,6 +1984,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PA15
         signal: DE
@@ -2019,6 +2020,7 @@ cores:
       address: 0x40005000
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PB4
         signal: DE

--- a/data/chips/STM32L486RG.yaml
+++ b/data/chips/STM32L486RG.yaml
@@ -1606,6 +1606,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PA0
         signal: TX
@@ -1641,6 +1642,7 @@ cores:
       address: 0x40005000
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PC12
         signal: TX

--- a/data/chips/STM32L486VG.yaml
+++ b/data/chips/STM32L486VG.yaml
@@ -1851,6 +1851,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PA0
         signal: TX
@@ -1886,6 +1887,7 @@ cores:
       address: 0x40005000
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PC12
         signal: TX

--- a/data/chips/STM32L486ZG.yaml
+++ b/data/chips/STM32L486ZG.yaml
@@ -2023,6 +2023,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PA0
         signal: TX
@@ -2058,6 +2059,7 @@ cores:
       address: 0x40005000
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PC12
         signal: TX

--- a/data/chips/STM32L496AE.yaml
+++ b/data/chips/STM32L496AE.yaml
@@ -2433,6 +2433,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PA15
         signal: DE
@@ -2468,6 +2469,7 @@ cores:
       address: 0x40005000
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PB4
         signal: DE

--- a/data/chips/STM32L496AG.yaml
+++ b/data/chips/STM32L496AG.yaml
@@ -2420,6 +2420,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PA15
         signal: DE
@@ -2455,6 +2456,7 @@ cores:
       address: 0x40005000
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PB4
         signal: DE

--- a/data/chips/STM32L496QE.yaml
+++ b/data/chips/STM32L496QE.yaml
@@ -2287,6 +2287,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PA15
         signal: DE
@@ -2322,6 +2323,7 @@ cores:
       address: 0x40005000
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PB4
         signal: DE

--- a/data/chips/STM32L496QG.yaml
+++ b/data/chips/STM32L496QG.yaml
@@ -2265,6 +2265,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PA15
         signal: DE
@@ -2300,6 +2301,7 @@ cores:
       address: 0x40005000
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PB4
         signal: DE

--- a/data/chips/STM32L496RE.yaml
+++ b/data/chips/STM32L496RE.yaml
@@ -1838,6 +1838,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PA0
         signal: TX
@@ -1873,6 +1874,7 @@ cores:
       address: 0x40005000
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PC12
         signal: TX

--- a/data/chips/STM32L496RG.yaml
+++ b/data/chips/STM32L496RG.yaml
@@ -1813,6 +1813,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PA0
         signal: TX
@@ -1848,6 +1849,7 @@ cores:
       address: 0x40005000
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PC12
         signal: TX

--- a/data/chips/STM32L496VE.yaml
+++ b/data/chips/STM32L496VE.yaml
@@ -2140,6 +2140,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PA0
         signal: TX
@@ -2175,6 +2176,7 @@ cores:
       address: 0x40005000
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PC12
         signal: TX

--- a/data/chips/STM32L496VG.yaml
+++ b/data/chips/STM32L496VG.yaml
@@ -2095,6 +2095,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PA15
         signal: DE
@@ -2130,6 +2131,7 @@ cores:
       address: 0x40005000
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PC12
         signal: TX

--- a/data/chips/STM32L496WG.yaml
+++ b/data/chips/STM32L496WG.yaml
@@ -2109,6 +2109,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PC11
         signal: RX
@@ -2144,6 +2145,7 @@ cores:
       address: 0x40005000
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PD2
         signal: RX

--- a/data/chips/STM32L496ZE.yaml
+++ b/data/chips/STM32L496ZE.yaml
@@ -2348,6 +2348,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PA0
         signal: TX
@@ -2383,6 +2384,7 @@ cores:
       address: 0x40005000
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PC12
         signal: TX

--- a/data/chips/STM32L496ZG.yaml
+++ b/data/chips/STM32L496ZG.yaml
@@ -2320,6 +2320,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PA0
         signal: TX
@@ -2355,6 +2356,7 @@ cores:
       address: 0x40005000
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PC12
         signal: TX

--- a/data/chips/STM32L4A6AG.yaml
+++ b/data/chips/STM32L4A6AG.yaml
@@ -2446,6 +2446,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PA15
         signal: DE
@@ -2481,6 +2482,7 @@ cores:
       address: 0x40005000
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PB4
         signal: DE

--- a/data/chips/STM32L4A6QG.yaml
+++ b/data/chips/STM32L4A6QG.yaml
@@ -2291,6 +2291,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PA15
         signal: DE
@@ -2326,6 +2327,7 @@ cores:
       address: 0x40005000
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PB4
         signal: DE

--- a/data/chips/STM32L4A6RG.yaml
+++ b/data/chips/STM32L4A6RG.yaml
@@ -1836,6 +1836,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PA0
         signal: TX
@@ -1871,6 +1872,7 @@ cores:
       address: 0x40005000
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PC12
         signal: TX

--- a/data/chips/STM32L4A6VG.yaml
+++ b/data/chips/STM32L4A6VG.yaml
@@ -2121,6 +2121,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PA15
         signal: DE
@@ -2156,6 +2157,7 @@ cores:
       address: 0x40005000
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PC12
         signal: TX

--- a/data/chips/STM32L4A6ZG.yaml
+++ b/data/chips/STM32L4A6ZG.yaml
@@ -2346,6 +2346,7 @@ cores:
       address: 0x40004c00
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PA0
         signal: TX
@@ -2381,6 +2382,7 @@ cores:
       address: 0x40005000
       kind: UART:sci2_v2_1
       clock: APB1
+      block: usart_v2/USART
       pins:
       - pin: PC12
         signal: TX

--- a/parse.py
+++ b/parse.py
@@ -317,6 +317,7 @@ perimap = [
     ('.*:USART:sci3_v1_2', 'usart_v2/USART'),
     ('.*:USART:sci3_v2_0', 'usart_v2/USART'),
     ('.*:USART:sci3_v2_1', 'usart_v2/USART'),
+    ('.*:UART:sci2_v2_1', 'usart_v2/USART'),
     ('.*:UART:sci2_v3_0', 'usart_v2/USART'),
     ('.*:UART:sci2_v3_1', 'usart_v2/USART'),
     ('.*:RNG:rng1_v1_1', 'rng_v1/RNG'),


### PR DESCRIPTION
Needed this to get the rest of the UARTs working on the STM32L476.

Is there a way to know which version a peripheral is from its "kind", other than guessing?