### PR TITLE
Add wl55 radio spi

### DIFF
--- a/data/chips/STM32G030C6.yaml
+++ b/data/chips/STM32G030C6.yaml
@@ -256,6 +256,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB
+      block: spi_v2/SPI
       pins:
       - pin: PA1
         signal: SCK
@@ -309,6 +310,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB
+      block: spi_v2/SPI
       pins:
       - pin: PA0
         signal: SCK

--- a/data/chips/STM32G030C8.yaml
+++ b/data/chips/STM32G030C8.yaml
@@ -256,6 +256,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB
+      block: spi_v2/SPI
       pins:
       - pin: PA1
         signal: SCK
@@ -309,6 +310,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB
+      block: spi_v2/SPI
       pins:
       - pin: PA0
         signal: SCK

--- a/data/chips/STM32G030F6.yaml
+++ b/data/chips/STM32G030F6.yaml
@@ -224,6 +224,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB
+      block: spi_v2/SPI
       pins:
       - pin: PA1
         signal: SCK
@@ -277,6 +278,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB
+      block: spi_v2/SPI
       pins:
       - pin: PB7
         signal: MOSI

--- a/data/chips/STM32G030J6.yaml
+++ b/data/chips/STM32G030J6.yaml
@@ -196,6 +196,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB
+      block: spi_v2/SPI
       pins:
       - pin: PA1
         signal: SCK
@@ -231,6 +232,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB
+      block: spi_v2/SPI
       pins:
       - pin: PB7
         signal: MOSI

--- a/data/chips/STM32G030K6.yaml
+++ b/data/chips/STM32G030K6.yaml
@@ -233,6 +233,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB
+      block: spi_v2/SPI
       pins:
       - pin: PA1
         signal: SCK
@@ -286,6 +287,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB
+      block: spi_v2/SPI
       pins:
       - pin: PB9
         signal: NSS

--- a/data/chips/STM32G030K8.yaml
+++ b/data/chips/STM32G030K8.yaml
@@ -233,6 +233,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB
+      block: spi_v2/SPI
       pins:
       - pin: PA1
         signal: SCK
@@ -286,6 +287,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB
+      block: spi_v2/SPI
       pins:
       - pin: PB9
         signal: NSS

--- a/data/chips/STM32G031C4.yaml
+++ b/data/chips/STM32G031C4.yaml
@@ -351,6 +351,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB
+      block: spi_v2/SPI
       pins:
       - pin: PA1
         signal: SCK
@@ -404,6 +405,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB
+      block: spi_v2/SPI
       pins:
       - pin: PA0
         signal: SCK

--- a/data/chips/STM32G031C6.yaml
+++ b/data/chips/STM32G031C6.yaml
@@ -351,6 +351,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB
+      block: spi_v2/SPI
       pins:
       - pin: PA1
         signal: SCK
@@ -404,6 +405,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB
+      block: spi_v2/SPI
       pins:
       - pin: PA0
         signal: SCK

--- a/data/chips/STM32G031C8.yaml
+++ b/data/chips/STM32G031C8.yaml
@@ -351,6 +351,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB
+      block: spi_v2/SPI
       pins:
       - pin: PA1
         signal: SCK
@@ -404,6 +405,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB
+      block: spi_v2/SPI
       pins:
       - pin: PA0
         signal: SCK

--- a/data/chips/STM32G031F4.yaml
+++ b/data/chips/STM32G031F4.yaml
@@ -300,6 +300,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB
+      block: spi_v2/SPI
       pins:
       - pin: PA1
         signal: SCK
@@ -353,6 +354,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB
+      block: spi_v2/SPI
       pins:
       - pin: PB7
         signal: MOSI

--- a/data/chips/STM32G031F6.yaml
+++ b/data/chips/STM32G031F6.yaml
@@ -300,6 +300,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB
+      block: spi_v2/SPI
       pins:
       - pin: PA1
         signal: SCK
@@ -353,6 +354,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB
+      block: spi_v2/SPI
       pins:
       - pin: PB7
         signal: MOSI

--- a/data/chips/STM32G031F8.yaml
+++ b/data/chips/STM32G031F8.yaml
@@ -300,6 +300,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB
+      block: spi_v2/SPI
       pins:
       - pin: PA1
         signal: SCK
@@ -353,6 +354,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB
+      block: spi_v2/SPI
       pins:
       - pin: PB7
         signal: MOSI

--- a/data/chips/STM32G031G4.yaml
+++ b/data/chips/STM32G031G4.yaml
@@ -292,6 +292,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB
+      block: spi_v2/SPI
       pins:
       - pin: PA1
         signal: SCK
@@ -345,6 +346,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB
+      block: spi_v2/SPI
       pins:
       - pin: PA0
         signal: SCK

--- a/data/chips/STM32G031G6.yaml
+++ b/data/chips/STM32G031G6.yaml
@@ -292,6 +292,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB
+      block: spi_v2/SPI
       pins:
       - pin: PA1
         signal: SCK
@@ -345,6 +346,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB
+      block: spi_v2/SPI
       pins:
       - pin: PA0
         signal: SCK

--- a/data/chips/STM32G031G8.yaml
+++ b/data/chips/STM32G031G8.yaml
@@ -292,6 +292,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB
+      block: spi_v2/SPI
       pins:
       - pin: PA1
         signal: SCK
@@ -345,6 +346,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB
+      block: spi_v2/SPI
       pins:
       - pin: PA0
         signal: SCK

--- a/data/chips/STM32G031J4.yaml
+++ b/data/chips/STM32G031J4.yaml
@@ -257,6 +257,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB
+      block: spi_v2/SPI
       pins:
       - pin: PA1
         signal: SCK
@@ -292,6 +293,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB
+      block: spi_v2/SPI
       pins:
       - pin: PB7
         signal: MOSI

--- a/data/chips/STM32G031J6.yaml
+++ b/data/chips/STM32G031J6.yaml
@@ -257,6 +257,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB
+      block: spi_v2/SPI
       pins:
       - pin: PA1
         signal: SCK
@@ -292,6 +293,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB
+      block: spi_v2/SPI
       pins:
       - pin: PB7
         signal: MOSI

--- a/data/chips/STM32G031K4.yaml
+++ b/data/chips/STM32G031K4.yaml
@@ -311,6 +311,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB
+      block: spi_v2/SPI
       pins:
       - pin: PA1
         signal: SCK
@@ -364,6 +365,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB
+      block: spi_v2/SPI
       pins:
       - pin: PB9
         signal: NSS

--- a/data/chips/STM32G031K6.yaml
+++ b/data/chips/STM32G031K6.yaml
@@ -311,6 +311,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB
+      block: spi_v2/SPI
       pins:
       - pin: PA1
         signal: SCK
@@ -364,6 +365,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB
+      block: spi_v2/SPI
       pins:
       - pin: PB9
         signal: NSS

--- a/data/chips/STM32G031K8.yaml
+++ b/data/chips/STM32G031K8.yaml
@@ -311,6 +311,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB
+      block: spi_v2/SPI
       pins:
       - pin: PA1
         signal: SCK
@@ -364,6 +365,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB
+      block: spi_v2/SPI
       pins:
       - pin: PB9
         signal: NSS

--- a/data/chips/STM32G031Y8.yaml
+++ b/data/chips/STM32G031Y8.yaml
@@ -300,6 +300,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB
+      block: spi_v2/SPI
       pins:
       - pin: PA15
         signal: NSS
@@ -353,6 +354,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB
+      block: spi_v2/SPI
       pins:
       - pin: PB7
         signal: MOSI

--- a/data/chips/STM32G041C6.yaml
+++ b/data/chips/STM32G041C6.yaml
@@ -368,6 +368,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB
+      block: spi_v2/SPI
       pins:
       - pin: PA1
         signal: SCK
@@ -421,6 +422,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB
+      block: spi_v2/SPI
       pins:
       - pin: PA0
         signal: SCK

--- a/data/chips/STM32G041C8.yaml
+++ b/data/chips/STM32G041C8.yaml
@@ -368,6 +368,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB
+      block: spi_v2/SPI
       pins:
       - pin: PA1
         signal: SCK
@@ -421,6 +422,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB
+      block: spi_v2/SPI
       pins:
       - pin: PA0
         signal: SCK

--- a/data/chips/STM32G041F6.yaml
+++ b/data/chips/STM32G041F6.yaml
@@ -317,6 +317,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB
+      block: spi_v2/SPI
       pins:
       - pin: PA1
         signal: SCK
@@ -370,6 +371,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB
+      block: spi_v2/SPI
       pins:
       - pin: PB7
         signal: MOSI

--- a/data/chips/STM32G041F8.yaml
+++ b/data/chips/STM32G041F8.yaml
@@ -317,6 +317,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB
+      block: spi_v2/SPI
       pins:
       - pin: PA1
         signal: SCK
@@ -370,6 +371,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB
+      block: spi_v2/SPI
       pins:
       - pin: PB7
         signal: MOSI

--- a/data/chips/STM32G041G6.yaml
+++ b/data/chips/STM32G041G6.yaml
@@ -309,6 +309,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB
+      block: spi_v2/SPI
       pins:
       - pin: PA1
         signal: SCK
@@ -362,6 +363,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB
+      block: spi_v2/SPI
       pins:
       - pin: PA0
         signal: SCK

--- a/data/chips/STM32G041G8.yaml
+++ b/data/chips/STM32G041G8.yaml
@@ -309,6 +309,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB
+      block: spi_v2/SPI
       pins:
       - pin: PA1
         signal: SCK
@@ -362,6 +363,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB
+      block: spi_v2/SPI
       pins:
       - pin: PA0
         signal: SCK

--- a/data/chips/STM32G041J6.yaml
+++ b/data/chips/STM32G041J6.yaml
@@ -274,6 +274,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB
+      block: spi_v2/SPI
       pins:
       - pin: PA1
         signal: SCK
@@ -309,6 +310,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB
+      block: spi_v2/SPI
       pins:
       - pin: PB7
         signal: MOSI

--- a/data/chips/STM32G041K6.yaml
+++ b/data/chips/STM32G041K6.yaml
@@ -328,6 +328,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB
+      block: spi_v2/SPI
       pins:
       - pin: PA1
         signal: SCK
@@ -381,6 +382,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB
+      block: spi_v2/SPI
       pins:
       - pin: PB9
         signal: NSS

--- a/data/chips/STM32G041K8.yaml
+++ b/data/chips/STM32G041K8.yaml
@@ -328,6 +328,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB
+      block: spi_v2/SPI
       pins:
       - pin: PA1
         signal: SCK
@@ -381,6 +382,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB
+      block: spi_v2/SPI
       pins:
       - pin: PB9
         signal: NSS

--- a/data/chips/STM32G041Y8.yaml
+++ b/data/chips/STM32G041Y8.yaml
@@ -317,6 +317,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB
+      block: spi_v2/SPI
       pins:
       - pin: PA15
         signal: NSS
@@ -370,6 +371,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB
+      block: spi_v2/SPI
       pins:
       - pin: PB7
         signal: MOSI

--- a/data/chips/STM32G050C6.yaml
+++ b/data/chips/STM32G050C6.yaml
@@ -249,6 +249,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB
+      block: spi_v2/SPI
       pins:
       - pin: PA1
         signal: SCK
@@ -302,6 +303,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB
+      block: spi_v2/SPI
       pins:
       - pin: PA0
         signal: SCK

--- a/data/chips/STM32G050C8.yaml
+++ b/data/chips/STM32G050C8.yaml
@@ -249,6 +249,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB
+      block: spi_v2/SPI
       pins:
       - pin: PA1
         signal: SCK
@@ -302,6 +303,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB
+      block: spi_v2/SPI
       pins:
       - pin: PA0
         signal: SCK

--- a/data/chips/STM32G050F6.yaml
+++ b/data/chips/STM32G050F6.yaml
@@ -213,6 +213,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB
+      block: spi_v2/SPI
       pins:
       - pin: PA1
         signal: SCK
@@ -266,6 +267,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB
+      block: spi_v2/SPI
       pins:
       - pin: PB7
         signal: MOSI

--- a/data/chips/STM32G050K6.yaml
+++ b/data/chips/STM32G050K6.yaml
@@ -222,6 +222,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB
+      block: spi_v2/SPI
       pins:
       - pin: PA1
         signal: SCK
@@ -275,6 +276,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB
+      block: spi_v2/SPI
       pins:
       - pin: PB9
         signal: NSS

--- a/data/chips/STM32G050K8.yaml
+++ b/data/chips/STM32G050K8.yaml
@@ -222,6 +222,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB
+      block: spi_v2/SPI
       pins:
       - pin: PA1
         signal: SCK
@@ -275,6 +276,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB
+      block: spi_v2/SPI
       pins:
       - pin: PB9
         signal: NSS

--- a/data/chips/STM32G051C6.yaml
+++ b/data/chips/STM32G051C6.yaml
@@ -423,6 +423,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB
+      block: spi_v2/SPI
       pins:
       - pin: PA1
         signal: SCK
@@ -476,6 +477,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB
+      block: spi_v2/SPI
       pins:
       - pin: PA0
         signal: SCK

--- a/data/chips/STM32G051C8.yaml
+++ b/data/chips/STM32G051C8.yaml
@@ -423,6 +423,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB
+      block: spi_v2/SPI
       pins:
       - pin: PA1
         signal: SCK
@@ -476,6 +477,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB
+      block: spi_v2/SPI
       pins:
       - pin: PA0
         signal: SCK

--- a/data/chips/STM32G051F6.yaml
+++ b/data/chips/STM32G051F6.yaml
@@ -364,6 +364,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB
+      block: spi_v2/SPI
       pins:
       - pin: PA1
         signal: SCK
@@ -417,6 +418,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB
+      block: spi_v2/SPI
       pins:
       - pin: PB7
         signal: MOSI

--- a/data/chips/STM32G051F8.yaml
+++ b/data/chips/STM32G051F8.yaml
@@ -366,6 +366,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB
+      block: spi_v2/SPI
       pins:
       - pin: PA12
         signal: MOSI
@@ -419,6 +420,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB
+      block: spi_v2/SPI
       pins:
       - pin: PA10
         signal: MOSI

--- a/data/chips/STM32G051G6.yaml
+++ b/data/chips/STM32G051G6.yaml
@@ -354,6 +354,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB
+      block: spi_v2/SPI
       pins:
       - pin: PA1
         signal: SCK
@@ -407,6 +408,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB
+      block: spi_v2/SPI
       pins:
       - pin: PA0
         signal: SCK

--- a/data/chips/STM32G051G8.yaml
+++ b/data/chips/STM32G051G8.yaml
@@ -354,6 +354,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB
+      block: spi_v2/SPI
       pins:
       - pin: PA1
         signal: SCK
@@ -407,6 +408,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB
+      block: spi_v2/SPI
       pins:
       - pin: PA0
         signal: SCK

--- a/data/chips/STM32G051K6.yaml
+++ b/data/chips/STM32G051K6.yaml
@@ -375,6 +375,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB
+      block: spi_v2/SPI
       pins:
       - pin: PA1
         signal: SCK
@@ -428,6 +429,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB
+      block: spi_v2/SPI
       pins:
       - pin: PB9
         signal: NSS

--- a/data/chips/STM32G051K8.yaml
+++ b/data/chips/STM32G051K8.yaml
@@ -375,6 +375,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB
+      block: spi_v2/SPI
       pins:
       - pin: PA1
         signal: SCK
@@ -428,6 +429,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB
+      block: spi_v2/SPI
       pins:
       - pin: PB9
         signal: NSS

--- a/data/chips/STM32G061C6.yaml
+++ b/data/chips/STM32G061C6.yaml
@@ -440,6 +440,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB
+      block: spi_v2/SPI
       pins:
       - pin: PA1
         signal: SCK
@@ -493,6 +494,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB
+      block: spi_v2/SPI
       pins:
       - pin: PA0
         signal: SCK

--- a/data/chips/STM32G061C8.yaml
+++ b/data/chips/STM32G061C8.yaml
@@ -440,6 +440,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB
+      block: spi_v2/SPI
       pins:
       - pin: PA1
         signal: SCK
@@ -493,6 +494,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB
+      block: spi_v2/SPI
       pins:
       - pin: PA0
         signal: SCK

--- a/data/chips/STM32G061F6.yaml
+++ b/data/chips/STM32G061F6.yaml
@@ -381,6 +381,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB
+      block: spi_v2/SPI
       pins:
       - pin: PA1
         signal: SCK
@@ -434,6 +435,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB
+      block: spi_v2/SPI
       pins:
       - pin: PB7
         signal: MOSI

--- a/data/chips/STM32G061F8.yaml
+++ b/data/chips/STM32G061F8.yaml
@@ -383,6 +383,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB
+      block: spi_v2/SPI
       pins:
       - pin: PA12
         signal: MOSI
@@ -436,6 +437,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB
+      block: spi_v2/SPI
       pins:
       - pin: PA10
         signal: MOSI

--- a/data/chips/STM32G061G6.yaml
+++ b/data/chips/STM32G061G6.yaml
@@ -371,6 +371,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB
+      block: spi_v2/SPI
       pins:
       - pin: PA1
         signal: SCK
@@ -424,6 +425,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB
+      block: spi_v2/SPI
       pins:
       - pin: PA0
         signal: SCK

--- a/data/chips/STM32G061G8.yaml
+++ b/data/chips/STM32G061G8.yaml
@@ -371,6 +371,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB
+      block: spi_v2/SPI
       pins:
       - pin: PA1
         signal: SCK
@@ -424,6 +425,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB
+      block: spi_v2/SPI
       pins:
       - pin: PA0
         signal: SCK

--- a/data/chips/STM32G061K6.yaml
+++ b/data/chips/STM32G061K6.yaml
@@ -392,6 +392,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB
+      block: spi_v2/SPI
       pins:
       - pin: PA1
         signal: SCK
@@ -445,6 +446,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB
+      block: spi_v2/SPI
       pins:
       - pin: PB9
         signal: NSS

--- a/data/chips/STM32G061K8.yaml
+++ b/data/chips/STM32G061K8.yaml
@@ -392,6 +392,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB
+      block: spi_v2/SPI
       pins:
       - pin: PA1
         signal: SCK
@@ -445,6 +446,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB
+      block: spi_v2/SPI
       pins:
       - pin: PB9
         signal: NSS

--- a/data/chips/STM32G0B0CE.yaml
+++ b/data/chips/STM32G0B0CE.yaml
@@ -322,6 +322,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB
+      block: spi_v2/SPI
       pins:
       - pin: PA1
         signal: SCK
@@ -375,6 +376,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB
+      block: spi_v2/SPI
       pins:
       - pin: PA0
         signal: SCK
@@ -453,6 +455,7 @@ cores:
     SPI3:
       address: 0x40003c00
       kind: SPI:spi2s1_v3_5
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS

--- a/data/chips/STM32G0B0KE.yaml
+++ b/data/chips/STM32G0B0KE.yaml
@@ -292,6 +292,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB
+      block: spi_v2/SPI
       pins:
       - pin: PA1
         signal: SCK
@@ -345,6 +346,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB
+      block: spi_v2/SPI
       pins:
       - pin: PB9
         signal: NSS
@@ -396,6 +398,7 @@ cores:
     SPI3:
       address: 0x40003c00
       kind: SPI:spi2s1_v3_5
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS

--- a/data/chips/STM32G0B0RE.yaml
+++ b/data/chips/STM32G0B0RE.yaml
@@ -332,6 +332,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB
+      block: spi_v2/SPI
       pins:
       - pin: PA1
         signal: SCK
@@ -397,6 +398,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB
+      block: spi_v2/SPI
       pins:
       - pin: PC2
         signal: MISO
@@ -484,6 +486,7 @@ cores:
     SPI3:
       address: 0x40003c00
       kind: SPI:spi2s1_v3_5
+      block: spi_v2/SPI
       pins:
       - pin: PC11
         signal: MISO

--- a/data/chips/STM32G0B0VE.yaml
+++ b/data/chips/STM32G0B0VE.yaml
@@ -340,6 +340,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB
+      block: spi_v2/SPI
       pins:
       - pin: PA1
         signal: SCK
@@ -417,6 +418,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB
+      block: spi_v2/SPI
       pins:
       - pin: PB9
         signal: NSS
@@ -504,6 +506,7 @@ cores:
     SPI3:
       address: 0x40003c00
       kind: SPI:spi2s1_v3_5
+      block: spi_v2/SPI
       pins:
       - pin: PC10
         signal: SCK

--- a/data/chips/STM32G0B1CB.yaml
+++ b/data/chips/STM32G0B1CB.yaml
@@ -606,6 +606,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB
+      block: spi_v2/SPI
       pins:
       - pin: PA1
         signal: SCK
@@ -659,6 +660,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB
+      block: spi_v2/SPI
       pins:
       - pin: PA0
         signal: SCK
@@ -737,6 +739,7 @@ cores:
     SPI3:
       address: 0x40003c00
       kind: SPI:spi2s1_v3_5
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS

--- a/data/chips/STM32G0B1CC.yaml
+++ b/data/chips/STM32G0B1CC.yaml
@@ -606,6 +606,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB
+      block: spi_v2/SPI
       pins:
       - pin: PA1
         signal: SCK
@@ -659,6 +660,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB
+      block: spi_v2/SPI
       pins:
       - pin: PA0
         signal: SCK
@@ -737,6 +739,7 @@ cores:
     SPI3:
       address: 0x40003c00
       kind: SPI:spi2s1_v3_5
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS

--- a/data/chips/STM32G0B1CE.yaml
+++ b/data/chips/STM32G0B1CE.yaml
@@ -606,6 +606,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB
+      block: spi_v2/SPI
       pins:
       - pin: PA1
         signal: SCK
@@ -659,6 +660,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB
+      block: spi_v2/SPI
       pins:
       - pin: PA0
         signal: SCK
@@ -737,6 +739,7 @@ cores:
     SPI3:
       address: 0x40003c00
       kind: SPI:spi2s1_v3_5
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS

--- a/data/chips/STM32G0B1KB.yaml
+++ b/data/chips/STM32G0B1KB.yaml
@@ -505,6 +505,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB
+      block: spi_v2/SPI
       pins:
       - pin: PA1
         signal: SCK
@@ -546,6 +547,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB
+      block: spi_v2/SPI
       pins:
       - pin: PB9
         signal: NSS
@@ -606,6 +608,7 @@ cores:
     SPI3:
       address: 0x40003c00
       kind: SPI:spi2s1_v3_5
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS

--- a/data/chips/STM32G0B1KC.yaml
+++ b/data/chips/STM32G0B1KC.yaml
@@ -505,6 +505,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB
+      block: spi_v2/SPI
       pins:
       - pin: PA1
         signal: SCK
@@ -546,6 +547,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB
+      block: spi_v2/SPI
       pins:
       - pin: PB9
         signal: NSS
@@ -606,6 +608,7 @@ cores:
     SPI3:
       address: 0x40003c00
       kind: SPI:spi2s1_v3_5
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS

--- a/data/chips/STM32G0B1KE.yaml
+++ b/data/chips/STM32G0B1KE.yaml
@@ -505,6 +505,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB
+      block: spi_v2/SPI
       pins:
       - pin: PA1
         signal: SCK
@@ -546,6 +547,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB
+      block: spi_v2/SPI
       pins:
       - pin: PB9
         signal: NSS
@@ -606,6 +608,7 @@ cores:
     SPI3:
       address: 0x40003c00
       kind: SPI:spi2s1_v3_5
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS

--- a/data/chips/STM32G0B1MB.yaml
+++ b/data/chips/STM32G0B1MB.yaml
@@ -730,6 +730,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB
+      block: spi_v2/SPI
       pins:
       - pin: PA1
         signal: SCK
@@ -795,6 +796,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB
+      block: spi_v2/SPI
       pins:
       - pin: PB9
         signal: NSS
@@ -882,6 +884,7 @@ cores:
     SPI3:
       address: 0x40003c00
       kind: SPI:spi2s1_v3_5
+      block: spi_v2/SPI
       pins:
       - pin: PC10
         signal: SCK

--- a/data/chips/STM32G0B1MC.yaml
+++ b/data/chips/STM32G0B1MC.yaml
@@ -730,6 +730,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB
+      block: spi_v2/SPI
       pins:
       - pin: PA1
         signal: SCK
@@ -795,6 +796,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB
+      block: spi_v2/SPI
       pins:
       - pin: PB9
         signal: NSS
@@ -882,6 +884,7 @@ cores:
     SPI3:
       address: 0x40003c00
       kind: SPI:spi2s1_v3_5
+      block: spi_v2/SPI
       pins:
       - pin: PC10
         signal: SCK

--- a/data/chips/STM32G0B1ME.yaml
+++ b/data/chips/STM32G0B1ME.yaml
@@ -730,6 +730,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB
+      block: spi_v2/SPI
       pins:
       - pin: PA1
         signal: SCK
@@ -795,6 +796,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB
+      block: spi_v2/SPI
       pins:
       - pin: PB9
         signal: NSS
@@ -882,6 +884,7 @@ cores:
     SPI3:
       address: 0x40003c00
       kind: SPI:spi2s1_v3_5
+      block: spi_v2/SPI
       pins:
       - pin: PC10
         signal: SCK

--- a/data/chips/STM32G0B1NE.yaml
+++ b/data/chips/STM32G0B1NE.yaml
@@ -612,6 +612,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB
+      block: spi_v2/SPI
       pins:
       - pin: PA15
         signal: NSS
@@ -665,6 +666,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB
+      block: spi_v2/SPI
       pins:
       - pin: PD0
         signal: NSS
@@ -743,6 +745,7 @@ cores:
     SPI3:
       address: 0x40003c00
       kind: SPI:spi2s1_v3_5
+      block: spi_v2/SPI
       pins:
       - pin: PA15
         signal: NSS

--- a/data/chips/STM32G0B1RB.yaml
+++ b/data/chips/STM32G0B1RB.yaml
@@ -691,6 +691,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB
+      block: spi_v2/SPI
       pins:
       - pin: PA1
         signal: SCK
@@ -750,6 +751,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB
+      block: spi_v2/SPI
       pins:
       - pin: PC2
         signal: MISO
@@ -837,6 +839,7 @@ cores:
     SPI3:
       address: 0x40003c00
       kind: SPI:spi2s1_v3_5
+      block: spi_v2/SPI
       pins:
       - pin: PC11
         signal: MISO

--- a/data/chips/STM32G0B1RC.yaml
+++ b/data/chips/STM32G0B1RC.yaml
@@ -691,6 +691,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB
+      block: spi_v2/SPI
       pins:
       - pin: PA1
         signal: SCK
@@ -750,6 +751,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB
+      block: spi_v2/SPI
       pins:
       - pin: PC2
         signal: MISO
@@ -837,6 +839,7 @@ cores:
     SPI3:
       address: 0x40003c00
       kind: SPI:spi2s1_v3_5
+      block: spi_v2/SPI
       pins:
       - pin: PC11
         signal: MISO

--- a/data/chips/STM32G0B1RE.yaml
+++ b/data/chips/STM32G0B1RE.yaml
@@ -691,6 +691,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB
+      block: spi_v2/SPI
       pins:
       - pin: PA1
         signal: SCK
@@ -750,6 +751,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB
+      block: spi_v2/SPI
       pins:
       - pin: PC2
         signal: MISO
@@ -837,6 +839,7 @@ cores:
     SPI3:
       address: 0x40003c00
       kind: SPI:spi2s1_v3_5
+      block: spi_v2/SPI
       pins:
       - pin: PC11
         signal: MISO

--- a/data/chips/STM32G0B1VB.yaml
+++ b/data/chips/STM32G0B1VB.yaml
@@ -752,6 +752,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB
+      block: spi_v2/SPI
       pins:
       - pin: PA1
         signal: SCK
@@ -829,6 +830,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB
+      block: spi_v2/SPI
       pins:
       - pin: PB9
         signal: NSS
@@ -916,6 +918,7 @@ cores:
     SPI3:
       address: 0x40003c00
       kind: SPI:spi2s1_v3_5
+      block: spi_v2/SPI
       pins:
       - pin: PC10
         signal: SCK

--- a/data/chips/STM32G0B1VC.yaml
+++ b/data/chips/STM32G0B1VC.yaml
@@ -752,6 +752,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB
+      block: spi_v2/SPI
       pins:
       - pin: PA1
         signal: SCK
@@ -829,6 +830,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB
+      block: spi_v2/SPI
       pins:
       - pin: PB9
         signal: NSS
@@ -916,6 +918,7 @@ cores:
     SPI3:
       address: 0x40003c00
       kind: SPI:spi2s1_v3_5
+      block: spi_v2/SPI
       pins:
       - pin: PC10
         signal: SCK

--- a/data/chips/STM32G0B1VE.yaml
+++ b/data/chips/STM32G0B1VE.yaml
@@ -752,6 +752,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB
+      block: spi_v2/SPI
       pins:
       - pin: PA1
         signal: SCK
@@ -829,6 +830,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB
+      block: spi_v2/SPI
       pins:
       - pin: PB9
         signal: NSS
@@ -916,6 +918,7 @@ cores:
     SPI3:
       address: 0x40003c00
       kind: SPI:spi2s1_v3_5
+      block: spi_v2/SPI
       pins:
       - pin: PC10
         signal: SCK

--- a/data/chips/STM32G0C1CC.yaml
+++ b/data/chips/STM32G0C1CC.yaml
@@ -623,6 +623,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB
+      block: spi_v2/SPI
       pins:
       - pin: PA1
         signal: SCK
@@ -676,6 +677,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB
+      block: spi_v2/SPI
       pins:
       - pin: PA0
         signal: SCK
@@ -754,6 +756,7 @@ cores:
     SPI3:
       address: 0x40003c00
       kind: SPI:spi2s1_v3_5
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS

--- a/data/chips/STM32G0C1CE.yaml
+++ b/data/chips/STM32G0C1CE.yaml
@@ -623,6 +623,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB
+      block: spi_v2/SPI
       pins:
       - pin: PA1
         signal: SCK
@@ -676,6 +677,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB
+      block: spi_v2/SPI
       pins:
       - pin: PA0
         signal: SCK
@@ -754,6 +756,7 @@ cores:
     SPI3:
       address: 0x40003c00
       kind: SPI:spi2s1_v3_5
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS

--- a/data/chips/STM32G0C1KC.yaml
+++ b/data/chips/STM32G0C1KC.yaml
@@ -522,6 +522,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB
+      block: spi_v2/SPI
       pins:
       - pin: PA1
         signal: SCK
@@ -563,6 +564,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB
+      block: spi_v2/SPI
       pins:
       - pin: PB9
         signal: NSS
@@ -623,6 +625,7 @@ cores:
     SPI3:
       address: 0x40003c00
       kind: SPI:spi2s1_v3_5
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS

--- a/data/chips/STM32G0C1KE.yaml
+++ b/data/chips/STM32G0C1KE.yaml
@@ -522,6 +522,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB
+      block: spi_v2/SPI
       pins:
       - pin: PA1
         signal: SCK
@@ -563,6 +564,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB
+      block: spi_v2/SPI
       pins:
       - pin: PB9
         signal: NSS
@@ -623,6 +625,7 @@ cores:
     SPI3:
       address: 0x40003c00
       kind: SPI:spi2s1_v3_5
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS

--- a/data/chips/STM32G0C1MC.yaml
+++ b/data/chips/STM32G0C1MC.yaml
@@ -747,6 +747,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB
+      block: spi_v2/SPI
       pins:
       - pin: PA1
         signal: SCK
@@ -812,6 +813,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB
+      block: spi_v2/SPI
       pins:
       - pin: PB9
         signal: NSS
@@ -899,6 +901,7 @@ cores:
     SPI3:
       address: 0x40003c00
       kind: SPI:spi2s1_v3_5
+      block: spi_v2/SPI
       pins:
       - pin: PC10
         signal: SCK

--- a/data/chips/STM32G0C1ME.yaml
+++ b/data/chips/STM32G0C1ME.yaml
@@ -747,6 +747,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB
+      block: spi_v2/SPI
       pins:
       - pin: PA1
         signal: SCK
@@ -812,6 +813,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB
+      block: spi_v2/SPI
       pins:
       - pin: PB9
         signal: NSS
@@ -899,6 +901,7 @@ cores:
     SPI3:
       address: 0x40003c00
       kind: SPI:spi2s1_v3_5
+      block: spi_v2/SPI
       pins:
       - pin: PC10
         signal: SCK

--- a/data/chips/STM32G0C1NE.yaml
+++ b/data/chips/STM32G0C1NE.yaml
@@ -629,6 +629,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB
+      block: spi_v2/SPI
       pins:
       - pin: PA15
         signal: NSS
@@ -682,6 +683,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB
+      block: spi_v2/SPI
       pins:
       - pin: PD0
         signal: NSS
@@ -760,6 +762,7 @@ cores:
     SPI3:
       address: 0x40003c00
       kind: SPI:spi2s1_v3_5
+      block: spi_v2/SPI
       pins:
       - pin: PA15
         signal: NSS

--- a/data/chips/STM32G0C1RC.yaml
+++ b/data/chips/STM32G0C1RC.yaml
@@ -708,6 +708,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB
+      block: spi_v2/SPI
       pins:
       - pin: PA1
         signal: SCK
@@ -767,6 +768,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB
+      block: spi_v2/SPI
       pins:
       - pin: PC2
         signal: MISO
@@ -854,6 +856,7 @@ cores:
     SPI3:
       address: 0x40003c00
       kind: SPI:spi2s1_v3_5
+      block: spi_v2/SPI
       pins:
       - pin: PC11
         signal: MISO

--- a/data/chips/STM32G0C1RE.yaml
+++ b/data/chips/STM32G0C1RE.yaml
@@ -708,6 +708,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB
+      block: spi_v2/SPI
       pins:
       - pin: PA1
         signal: SCK
@@ -767,6 +768,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB
+      block: spi_v2/SPI
       pins:
       - pin: PC2
         signal: MISO
@@ -854,6 +856,7 @@ cores:
     SPI3:
       address: 0x40003c00
       kind: SPI:spi2s1_v3_5
+      block: spi_v2/SPI
       pins:
       - pin: PC11
         signal: MISO

--- a/data/chips/STM32G0C1VC.yaml
+++ b/data/chips/STM32G0C1VC.yaml
@@ -769,6 +769,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB
+      block: spi_v2/SPI
       pins:
       - pin: PA1
         signal: SCK
@@ -846,6 +847,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB
+      block: spi_v2/SPI
       pins:
       - pin: PB9
         signal: NSS
@@ -933,6 +935,7 @@ cores:
     SPI3:
       address: 0x40003c00
       kind: SPI:spi2s1_v3_5
+      block: spi_v2/SPI
       pins:
       - pin: PC10
         signal: SCK

--- a/data/chips/STM32G0C1VE.yaml
+++ b/data/chips/STM32G0C1VE.yaml
@@ -769,6 +769,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB
+      block: spi_v2/SPI
       pins:
       - pin: PA1
         signal: SCK
@@ -846,6 +847,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB
+      block: spi_v2/SPI
       pins:
       - pin: PB9
         signal: NSS
@@ -933,6 +935,7 @@ cores:
     SPI3:
       address: 0x40003c00
       kind: SPI:spi2s1_v3_5
+      block: spi_v2/SPI
       pins:
       - pin: PC10
         signal: SCK

--- a/data/chips/STM32G431C6.yaml
+++ b/data/chips/STM32G431C6.yaml
@@ -689,6 +689,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -727,6 +728,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PF0
         signal: NSS
@@ -765,6 +767,7 @@ cores:
       address: 0x40003c00
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS

--- a/data/chips/STM32G431C8.yaml
+++ b/data/chips/STM32G431C8.yaml
@@ -689,6 +689,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -727,6 +728,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PF0
         signal: NSS
@@ -765,6 +767,7 @@ cores:
       address: 0x40003c00
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS

--- a/data/chips/STM32G431CB.yaml
+++ b/data/chips/STM32G431CB.yaml
@@ -691,6 +691,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins:
       - pin: PA15
         signal: NSS
@@ -729,6 +730,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PA11
         signal: MOSI
@@ -767,6 +769,7 @@ cores:
       address: 0x40003c00
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PA15
         signal: NSS

--- a/data/chips/STM32G431K6.yaml
+++ b/data/chips/STM32G431K6.yaml
@@ -568,6 +568,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -606,6 +607,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PF0
         signal: NSS
@@ -632,6 +634,7 @@ cores:
       address: 0x40003c00
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS

--- a/data/chips/STM32G431K8.yaml
+++ b/data/chips/STM32G431K8.yaml
@@ -568,6 +568,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -606,6 +607,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PF0
         signal: NSS
@@ -632,6 +634,7 @@ cores:
       address: 0x40003c00
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS

--- a/data/chips/STM32G431KB.yaml
+++ b/data/chips/STM32G431KB.yaml
@@ -568,6 +568,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -606,6 +607,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PF0
         signal: NSS
@@ -632,6 +634,7 @@ cores:
       address: 0x40003c00
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS

--- a/data/chips/STM32G431M6.yaml
+++ b/data/chips/STM32G431M6.yaml
@@ -782,6 +782,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -820,6 +821,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PF0
         signal: NSS
@@ -858,6 +860,7 @@ cores:
       address: 0x40003c00
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS

--- a/data/chips/STM32G431M8.yaml
+++ b/data/chips/STM32G431M8.yaml
@@ -782,6 +782,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -820,6 +821,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PF0
         signal: NSS
@@ -858,6 +860,7 @@ cores:
       address: 0x40003c00
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS

--- a/data/chips/STM32G431MB.yaml
+++ b/data/chips/STM32G431MB.yaml
@@ -782,6 +782,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -820,6 +821,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PF0
         signal: NSS
@@ -858,6 +860,7 @@ cores:
       address: 0x40003c00
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS

--- a/data/chips/STM32G431R6.yaml
+++ b/data/chips/STM32G431R6.yaml
@@ -762,6 +762,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -800,6 +801,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PF0
         signal: NSS
@@ -838,6 +840,7 @@ cores:
       address: 0x40003c00
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS

--- a/data/chips/STM32G431R8.yaml
+++ b/data/chips/STM32G431R8.yaml
@@ -762,6 +762,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -800,6 +801,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PF0
         signal: NSS
@@ -838,6 +840,7 @@ cores:
       address: 0x40003c00
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS

--- a/data/chips/STM32G431RB.yaml
+++ b/data/chips/STM32G431RB.yaml
@@ -762,6 +762,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -800,6 +801,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PF0
         signal: NSS
@@ -838,6 +840,7 @@ cores:
       address: 0x40003c00
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS

--- a/data/chips/STM32G431V6.yaml
+++ b/data/chips/STM32G431V6.yaml
@@ -830,6 +830,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -868,6 +869,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PF9
         signal: SCK
@@ -915,6 +917,7 @@ cores:
       address: 0x40003c00
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS

--- a/data/chips/STM32G431V8.yaml
+++ b/data/chips/STM32G431V8.yaml
@@ -830,6 +830,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -868,6 +869,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PF9
         signal: SCK
@@ -915,6 +917,7 @@ cores:
       address: 0x40003c00
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS

--- a/data/chips/STM32G431VB.yaml
+++ b/data/chips/STM32G431VB.yaml
@@ -830,6 +830,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -868,6 +869,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PF9
         signal: SCK
@@ -915,6 +917,7 @@ cores:
       address: 0x40003c00
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS

--- a/data/chips/STM32G441CB.yaml
+++ b/data/chips/STM32G441CB.yaml
@@ -703,6 +703,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins:
       - pin: PA15
         signal: NSS
@@ -741,6 +742,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PA11
         signal: MOSI
@@ -779,6 +781,7 @@ cores:
       address: 0x40003c00
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PA15
         signal: NSS

--- a/data/chips/STM32G441KB.yaml
+++ b/data/chips/STM32G441KB.yaml
@@ -580,6 +580,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -618,6 +619,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PF0
         signal: NSS
@@ -644,6 +646,7 @@ cores:
       address: 0x40003c00
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS

--- a/data/chips/STM32G441MB.yaml
+++ b/data/chips/STM32G441MB.yaml
@@ -794,6 +794,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -832,6 +833,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PF0
         signal: NSS
@@ -870,6 +872,7 @@ cores:
       address: 0x40003c00
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS

--- a/data/chips/STM32G441RB.yaml
+++ b/data/chips/STM32G441RB.yaml
@@ -774,6 +774,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -812,6 +813,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PF0
         signal: NSS
@@ -850,6 +852,7 @@ cores:
       address: 0x40003c00
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS

--- a/data/chips/STM32G441VB.yaml
+++ b/data/chips/STM32G441VB.yaml
@@ -842,6 +842,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -880,6 +881,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PF9
         signal: SCK
@@ -927,6 +929,7 @@ cores:
       address: 0x40003c00
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS

--- a/data/chips/STM32G471CC.yaml
+++ b/data/chips/STM32G471CC.yaml
@@ -746,6 +746,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -784,6 +785,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PF0
         signal: NSS
@@ -822,6 +824,7 @@ cores:
       address: 0x40003c00
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS

--- a/data/chips/STM32G471CE.yaml
+++ b/data/chips/STM32G471CE.yaml
@@ -746,6 +746,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -784,6 +785,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PF0
         signal: NSS
@@ -822,6 +824,7 @@ cores:
       address: 0x40003c00
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS

--- a/data/chips/STM32G471MC.yaml
+++ b/data/chips/STM32G471MC.yaml
@@ -858,6 +858,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -896,6 +897,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PF0
         signal: NSS
@@ -934,6 +936,7 @@ cores:
       address: 0x40003c00
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -972,6 +975,7 @@ cores:
       address: 0x40013c00
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins:
       - pin: PE11
         signal: NSS

--- a/data/chips/STM32G471ME.yaml
+++ b/data/chips/STM32G471ME.yaml
@@ -865,6 +865,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins:
       - pin: PA15
         signal: NSS
@@ -903,6 +904,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PA11
         signal: MOSI
@@ -941,6 +943,7 @@ cores:
       address: 0x40003c00
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PA15
         signal: NSS
@@ -979,6 +982,7 @@ cores:
       address: 0x40013c00
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins:
       - pin: PE12
         signal: SCK

--- a/data/chips/STM32G471QC.yaml
+++ b/data/chips/STM32G471QC.yaml
@@ -983,6 +983,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -1033,6 +1034,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PF9
         signal: SCK
@@ -1080,6 +1082,7 @@ cores:
       address: 0x40003c00
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -1121,6 +1124,7 @@ cores:
       address: 0x40013c00
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins:
       - pin: PE2
         signal: SCK

--- a/data/chips/STM32G471QE.yaml
+++ b/data/chips/STM32G471QE.yaml
@@ -983,6 +983,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -1033,6 +1034,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PF9
         signal: SCK
@@ -1080,6 +1082,7 @@ cores:
       address: 0x40003c00
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -1121,6 +1124,7 @@ cores:
       address: 0x40013c00
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins:
       - pin: PE2
         signal: SCK

--- a/data/chips/STM32G471RC.yaml
+++ b/data/chips/STM32G471RC.yaml
@@ -820,6 +820,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -858,6 +859,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PF0
         signal: NSS
@@ -896,6 +898,7 @@ cores:
       address: 0x40003c00
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS

--- a/data/chips/STM32G471RE.yaml
+++ b/data/chips/STM32G471RE.yaml
@@ -820,6 +820,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -858,6 +859,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PF0
         signal: NSS
@@ -896,6 +898,7 @@ cores:
       address: 0x40003c00
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS

--- a/data/chips/STM32G471VC.yaml
+++ b/data/chips/STM32G471VC.yaml
@@ -921,6 +921,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -959,6 +960,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PF9
         signal: SCK
@@ -1006,6 +1008,7 @@ cores:
       address: 0x40003c00
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -1044,6 +1047,7 @@ cores:
       address: 0x40013c00
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins:
       - pin: PE2
         signal: SCK

--- a/data/chips/STM32G471VE.yaml
+++ b/data/chips/STM32G471VE.yaml
@@ -921,6 +921,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -959,6 +960,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PF9
         signal: SCK
@@ -1006,6 +1008,7 @@ cores:
       address: 0x40003c00
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -1044,6 +1047,7 @@ cores:
       address: 0x40013c00
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins:
       - pin: PE2
         signal: SCK

--- a/data/chips/STM32G473CB.yaml
+++ b/data/chips/STM32G473CB.yaml
@@ -934,6 +934,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -972,6 +973,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PF0
         signal: NSS
@@ -1010,6 +1012,7 @@ cores:
       address: 0x40003c00
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS

--- a/data/chips/STM32G473CC.yaml
+++ b/data/chips/STM32G473CC.yaml
@@ -934,6 +934,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -972,6 +973,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PF0
         signal: NSS
@@ -1010,6 +1012,7 @@ cores:
       address: 0x40003c00
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS

--- a/data/chips/STM32G473CE.yaml
+++ b/data/chips/STM32G473CE.yaml
@@ -934,6 +934,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -972,6 +973,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PF0
         signal: NSS
@@ -1010,6 +1012,7 @@ cores:
       address: 0x40003c00
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS

--- a/data/chips/STM32G473MB.yaml
+++ b/data/chips/STM32G473MB.yaml
@@ -1100,6 +1100,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -1138,6 +1139,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PF0
         signal: NSS
@@ -1176,6 +1178,7 @@ cores:
       address: 0x40003c00
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -1214,6 +1217,7 @@ cores:
       address: 0x40013c00
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins:
       - pin: PE11
         signal: NSS

--- a/data/chips/STM32G473MC.yaml
+++ b/data/chips/STM32G473MC.yaml
@@ -1100,6 +1100,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -1138,6 +1139,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PF0
         signal: NSS
@@ -1176,6 +1178,7 @@ cores:
       address: 0x40003c00
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -1214,6 +1217,7 @@ cores:
       address: 0x40013c00
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins:
       - pin: PE11
         signal: NSS

--- a/data/chips/STM32G473ME.yaml
+++ b/data/chips/STM32G473ME.yaml
@@ -1117,6 +1117,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins:
       - pin: PA15
         signal: NSS
@@ -1155,6 +1156,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PA11
         signal: MOSI
@@ -1193,6 +1195,7 @@ cores:
       address: 0x40003c00
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PA15
         signal: NSS
@@ -1231,6 +1234,7 @@ cores:
       address: 0x40013c00
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins:
       - pin: PE12
         signal: SCK

--- a/data/chips/STM32G473PB.yaml
+++ b/data/chips/STM32G473PB.yaml
@@ -1229,6 +1229,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins:
       - pin: PB3
         signal: SCK
@@ -1276,6 +1277,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PA10
         signal: MISO
@@ -1323,6 +1325,7 @@ cores:
       address: 0x40003c00
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PB3
         signal: SCK
@@ -1361,6 +1364,7 @@ cores:
       address: 0x40013c00
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins:
       - pin: PE4
         signal: NSS

--- a/data/chips/STM32G473PC.yaml
+++ b/data/chips/STM32G473PC.yaml
@@ -1229,6 +1229,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins:
       - pin: PB3
         signal: SCK
@@ -1276,6 +1277,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PA10
         signal: MISO
@@ -1323,6 +1325,7 @@ cores:
       address: 0x40003c00
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PB3
         signal: SCK
@@ -1361,6 +1364,7 @@ cores:
       address: 0x40013c00
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins:
       - pin: PE4
         signal: NSS

--- a/data/chips/STM32G473PE.yaml
+++ b/data/chips/STM32G473PE.yaml
@@ -1229,6 +1229,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins:
       - pin: PB3
         signal: SCK
@@ -1276,6 +1277,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PA10
         signal: MISO
@@ -1323,6 +1325,7 @@ cores:
       address: 0x40003c00
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PB3
         signal: SCK
@@ -1361,6 +1364,7 @@ cores:
       address: 0x40013c00
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins:
       - pin: PE4
         signal: NSS

--- a/data/chips/STM32G473QB.yaml
+++ b/data/chips/STM32G473QB.yaml
@@ -1259,6 +1259,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -1309,6 +1310,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PF9
         signal: SCK
@@ -1356,6 +1358,7 @@ cores:
       address: 0x40003c00
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -1397,6 +1400,7 @@ cores:
       address: 0x40013c00
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins:
       - pin: PE2
         signal: SCK

--- a/data/chips/STM32G473QC.yaml
+++ b/data/chips/STM32G473QC.yaml
@@ -1259,6 +1259,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -1309,6 +1310,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PF9
         signal: SCK
@@ -1356,6 +1358,7 @@ cores:
       address: 0x40003c00
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -1397,6 +1400,7 @@ cores:
       address: 0x40013c00
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins:
       - pin: PE2
         signal: SCK

--- a/data/chips/STM32G473QE.yaml
+++ b/data/chips/STM32G473QE.yaml
@@ -1259,6 +1259,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -1309,6 +1310,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PF9
         signal: SCK
@@ -1356,6 +1358,7 @@ cores:
       address: 0x40003c00
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -1397,6 +1400,7 @@ cores:
       address: 0x40013c00
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins:
       - pin: PE2
         signal: SCK

--- a/data/chips/STM32G473RB.yaml
+++ b/data/chips/STM32G473RB.yaml
@@ -1018,6 +1018,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -1056,6 +1057,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PF0
         signal: NSS
@@ -1094,6 +1096,7 @@ cores:
       address: 0x40003c00
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS

--- a/data/chips/STM32G473RC.yaml
+++ b/data/chips/STM32G473RC.yaml
@@ -1018,6 +1018,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -1056,6 +1057,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PF0
         signal: NSS
@@ -1094,6 +1096,7 @@ cores:
       address: 0x40003c00
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS

--- a/data/chips/STM32G473RE.yaml
+++ b/data/chips/STM32G473RE.yaml
@@ -1018,6 +1018,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -1056,6 +1057,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PF0
         signal: NSS
@@ -1094,6 +1096,7 @@ cores:
       address: 0x40003c00
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS

--- a/data/chips/STM32G473VB.yaml
+++ b/data/chips/STM32G473VB.yaml
@@ -1197,6 +1197,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -1235,6 +1236,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PF9
         signal: SCK
@@ -1282,6 +1284,7 @@ cores:
       address: 0x40003c00
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -1320,6 +1323,7 @@ cores:
       address: 0x40013c00
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins:
       - pin: PE2
         signal: SCK

--- a/data/chips/STM32G473VC.yaml
+++ b/data/chips/STM32G473VC.yaml
@@ -1197,6 +1197,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -1235,6 +1236,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PF9
         signal: SCK
@@ -1282,6 +1284,7 @@ cores:
       address: 0x40003c00
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -1320,6 +1323,7 @@ cores:
       address: 0x40013c00
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins:
       - pin: PE2
         signal: SCK

--- a/data/chips/STM32G473VE.yaml
+++ b/data/chips/STM32G473VE.yaml
@@ -1197,6 +1197,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -1235,6 +1236,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PF9
         signal: SCK
@@ -1282,6 +1284,7 @@ cores:
       address: 0x40003c00
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -1320,6 +1323,7 @@ cores:
       address: 0x40013c00
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins:
       - pin: PE2
         signal: SCK

--- a/data/chips/STM32G474CB.yaml
+++ b/data/chips/STM32G474CB.yaml
@@ -1052,6 +1052,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -1090,6 +1091,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PF0
         signal: NSS
@@ -1128,6 +1130,7 @@ cores:
       address: 0x40003c00
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS

--- a/data/chips/STM32G474CC.yaml
+++ b/data/chips/STM32G474CC.yaml
@@ -1052,6 +1052,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -1090,6 +1091,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PF0
         signal: NSS
@@ -1128,6 +1130,7 @@ cores:
       address: 0x40003c00
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS

--- a/data/chips/STM32G474CE.yaml
+++ b/data/chips/STM32G474CE.yaml
@@ -1052,6 +1052,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -1090,6 +1091,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PF0
         signal: NSS
@@ -1128,6 +1130,7 @@ cores:
       address: 0x40003c00
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS

--- a/data/chips/STM32G474MB.yaml
+++ b/data/chips/STM32G474MB.yaml
@@ -1236,6 +1236,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -1274,6 +1275,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PF0
         signal: NSS
@@ -1312,6 +1314,7 @@ cores:
       address: 0x40003c00
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -1350,6 +1353,7 @@ cores:
       address: 0x40013c00
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins:
       - pin: PE11
         signal: NSS

--- a/data/chips/STM32G474MC.yaml
+++ b/data/chips/STM32G474MC.yaml
@@ -1236,6 +1236,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -1274,6 +1275,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PF0
         signal: NSS
@@ -1312,6 +1314,7 @@ cores:
       address: 0x40003c00
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -1350,6 +1353,7 @@ cores:
       address: 0x40013c00
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins:
       - pin: PE11
         signal: NSS

--- a/data/chips/STM32G474ME.yaml
+++ b/data/chips/STM32G474ME.yaml
@@ -1253,6 +1253,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins:
       - pin: PA15
         signal: NSS
@@ -1291,6 +1292,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PA11
         signal: MOSI
@@ -1329,6 +1331,7 @@ cores:
       address: 0x40003c00
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PA15
         signal: NSS
@@ -1367,6 +1370,7 @@ cores:
       address: 0x40013c00
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins:
       - pin: PE12
         signal: SCK

--- a/data/chips/STM32G474PB.yaml
+++ b/data/chips/STM32G474PB.yaml
@@ -1365,6 +1365,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins:
       - pin: PB3
         signal: SCK
@@ -1412,6 +1413,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PA10
         signal: MISO
@@ -1459,6 +1461,7 @@ cores:
       address: 0x40003c00
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PB3
         signal: SCK
@@ -1497,6 +1500,7 @@ cores:
       address: 0x40013c00
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins:
       - pin: PE4
         signal: NSS

--- a/data/chips/STM32G474PC.yaml
+++ b/data/chips/STM32G474PC.yaml
@@ -1365,6 +1365,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins:
       - pin: PB3
         signal: SCK
@@ -1412,6 +1413,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PA10
         signal: MISO
@@ -1459,6 +1461,7 @@ cores:
       address: 0x40003c00
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PB3
         signal: SCK
@@ -1497,6 +1500,7 @@ cores:
       address: 0x40013c00
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins:
       - pin: PE4
         signal: NSS

--- a/data/chips/STM32G474PE.yaml
+++ b/data/chips/STM32G474PE.yaml
@@ -1365,6 +1365,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins:
       - pin: PB3
         signal: SCK
@@ -1412,6 +1413,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PA10
         signal: MISO
@@ -1459,6 +1461,7 @@ cores:
       address: 0x40003c00
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PB3
         signal: SCK
@@ -1497,6 +1500,7 @@ cores:
       address: 0x40013c00
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins:
       - pin: PE4
         signal: NSS

--- a/data/chips/STM32G474QB.yaml
+++ b/data/chips/STM32G474QB.yaml
@@ -1395,6 +1395,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -1445,6 +1446,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PF9
         signal: SCK
@@ -1492,6 +1494,7 @@ cores:
       address: 0x40003c00
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -1533,6 +1536,7 @@ cores:
       address: 0x40013c00
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins:
       - pin: PE2
         signal: SCK

--- a/data/chips/STM32G474QC.yaml
+++ b/data/chips/STM32G474QC.yaml
@@ -1395,6 +1395,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -1445,6 +1446,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PF9
         signal: SCK
@@ -1492,6 +1494,7 @@ cores:
       address: 0x40003c00
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -1533,6 +1536,7 @@ cores:
       address: 0x40013c00
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins:
       - pin: PE2
         signal: SCK

--- a/data/chips/STM32G474QE.yaml
+++ b/data/chips/STM32G474QE.yaml
@@ -1395,6 +1395,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -1445,6 +1446,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PF9
         signal: SCK
@@ -1492,6 +1494,7 @@ cores:
       address: 0x40003c00
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -1533,6 +1536,7 @@ cores:
       address: 0x40013c00
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins:
       - pin: PE2
         signal: SCK

--- a/data/chips/STM32G474RB.yaml
+++ b/data/chips/STM32G474RB.yaml
@@ -1154,6 +1154,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -1192,6 +1193,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PF0
         signal: NSS
@@ -1230,6 +1232,7 @@ cores:
       address: 0x40003c00
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS

--- a/data/chips/STM32G474RC.yaml
+++ b/data/chips/STM32G474RC.yaml
@@ -1154,6 +1154,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -1192,6 +1193,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PF0
         signal: NSS
@@ -1230,6 +1232,7 @@ cores:
       address: 0x40003c00
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS

--- a/data/chips/STM32G474RE.yaml
+++ b/data/chips/STM32G474RE.yaml
@@ -1154,6 +1154,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -1192,6 +1193,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PF0
         signal: NSS
@@ -1230,6 +1232,7 @@ cores:
       address: 0x40003c00
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS

--- a/data/chips/STM32G474VB.yaml
+++ b/data/chips/STM32G474VB.yaml
@@ -1333,6 +1333,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -1371,6 +1372,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PF9
         signal: SCK
@@ -1418,6 +1420,7 @@ cores:
       address: 0x40003c00
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -1456,6 +1459,7 @@ cores:
       address: 0x40013c00
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins:
       - pin: PE2
         signal: SCK

--- a/data/chips/STM32G474VC.yaml
+++ b/data/chips/STM32G474VC.yaml
@@ -1333,6 +1333,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -1371,6 +1372,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PF9
         signal: SCK
@@ -1418,6 +1420,7 @@ cores:
       address: 0x40003c00
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -1456,6 +1459,7 @@ cores:
       address: 0x40013c00
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins:
       - pin: PE2
         signal: SCK

--- a/data/chips/STM32G474VE.yaml
+++ b/data/chips/STM32G474VE.yaml
@@ -1333,6 +1333,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -1371,6 +1372,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PF9
         signal: SCK
@@ -1418,6 +1420,7 @@ cores:
       address: 0x40003c00
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -1456,6 +1459,7 @@ cores:
       address: 0x40013c00
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins:
       - pin: PE2
         signal: SCK

--- a/data/chips/STM32G483CE.yaml
+++ b/data/chips/STM32G483CE.yaml
@@ -946,6 +946,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -984,6 +985,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PF0
         signal: NSS
@@ -1022,6 +1024,7 @@ cores:
       address: 0x40003c00
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS

--- a/data/chips/STM32G483ME.yaml
+++ b/data/chips/STM32G483ME.yaml
@@ -1129,6 +1129,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins:
       - pin: PA15
         signal: NSS
@@ -1167,6 +1168,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PA11
         signal: MOSI
@@ -1205,6 +1207,7 @@ cores:
       address: 0x40003c00
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PA15
         signal: NSS
@@ -1243,6 +1246,7 @@ cores:
       address: 0x40013c00
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins:
       - pin: PE12
         signal: SCK

--- a/data/chips/STM32G483PE.yaml
+++ b/data/chips/STM32G483PE.yaml
@@ -1241,6 +1241,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins:
       - pin: PB3
         signal: SCK
@@ -1288,6 +1289,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PA10
         signal: MISO
@@ -1335,6 +1337,7 @@ cores:
       address: 0x40003c00
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PB3
         signal: SCK
@@ -1373,6 +1376,7 @@ cores:
       address: 0x40013c00
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins:
       - pin: PE4
         signal: NSS

--- a/data/chips/STM32G483QE.yaml
+++ b/data/chips/STM32G483QE.yaml
@@ -1271,6 +1271,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -1321,6 +1322,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PF9
         signal: SCK
@@ -1368,6 +1370,7 @@ cores:
       address: 0x40003c00
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -1409,6 +1412,7 @@ cores:
       address: 0x40013c00
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins:
       - pin: PE2
         signal: SCK

--- a/data/chips/STM32G483RE.yaml
+++ b/data/chips/STM32G483RE.yaml
@@ -1030,6 +1030,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -1068,6 +1069,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PF0
         signal: NSS
@@ -1106,6 +1108,7 @@ cores:
       address: 0x40003c00
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS

--- a/data/chips/STM32G483VE.yaml
+++ b/data/chips/STM32G483VE.yaml
@@ -1209,6 +1209,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -1247,6 +1248,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PF9
         signal: SCK
@@ -1294,6 +1296,7 @@ cores:
       address: 0x40003c00
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -1332,6 +1335,7 @@ cores:
       address: 0x40013c00
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins:
       - pin: PE2
         signal: SCK

--- a/data/chips/STM32G484CE.yaml
+++ b/data/chips/STM32G484CE.yaml
@@ -1064,6 +1064,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -1102,6 +1103,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PF0
         signal: NSS
@@ -1140,6 +1142,7 @@ cores:
       address: 0x40003c00
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS

--- a/data/chips/STM32G484ME.yaml
+++ b/data/chips/STM32G484ME.yaml
@@ -1265,6 +1265,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins:
       - pin: PA15
         signal: NSS
@@ -1303,6 +1304,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PA11
         signal: MOSI
@@ -1341,6 +1343,7 @@ cores:
       address: 0x40003c00
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PA15
         signal: NSS
@@ -1379,6 +1382,7 @@ cores:
       address: 0x40013c00
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins:
       - pin: PE12
         signal: SCK

--- a/data/chips/STM32G484PE.yaml
+++ b/data/chips/STM32G484PE.yaml
@@ -1377,6 +1377,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins:
       - pin: PB3
         signal: SCK
@@ -1424,6 +1425,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PA10
         signal: MISO
@@ -1471,6 +1473,7 @@ cores:
       address: 0x40003c00
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PB3
         signal: SCK
@@ -1509,6 +1512,7 @@ cores:
       address: 0x40013c00
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins:
       - pin: PE4
         signal: NSS

--- a/data/chips/STM32G484QE.yaml
+++ b/data/chips/STM32G484QE.yaml
@@ -1407,6 +1407,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -1457,6 +1458,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PF9
         signal: SCK
@@ -1504,6 +1506,7 @@ cores:
       address: 0x40003c00
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -1545,6 +1548,7 @@ cores:
       address: 0x40013c00
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins:
       - pin: PE2
         signal: SCK

--- a/data/chips/STM32G484RE.yaml
+++ b/data/chips/STM32G484RE.yaml
@@ -1166,6 +1166,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -1204,6 +1205,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PF0
         signal: NSS
@@ -1242,6 +1244,7 @@ cores:
       address: 0x40003c00
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS

--- a/data/chips/STM32G484VE.yaml
+++ b/data/chips/STM32G484VE.yaml
@@ -1345,6 +1345,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -1383,6 +1384,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PF9
         signal: SCK
@@ -1430,6 +1432,7 @@ cores:
       address: 0x40003c00
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -1468,6 +1471,7 @@ cores:
       address: 0x40013c00
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins:
       - pin: PE2
         signal: SCK

--- a/data/chips/STM32G491CC.yaml
+++ b/data/chips/STM32G491CC.yaml
@@ -752,6 +752,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -790,6 +791,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PF0
         signal: NSS
@@ -828,6 +830,7 @@ cores:
       address: 0x40003c00
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS

--- a/data/chips/STM32G491CE.yaml
+++ b/data/chips/STM32G491CE.yaml
@@ -752,6 +752,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -790,6 +791,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PF0
         signal: NSS
@@ -828,6 +830,7 @@ cores:
       address: 0x40003c00
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS

--- a/data/chips/STM32G491KC.yaml
+++ b/data/chips/STM32G491KC.yaml
@@ -603,6 +603,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -641,6 +642,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PF0
         signal: NSS
@@ -667,6 +669,7 @@ cores:
       address: 0x40003c00
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS

--- a/data/chips/STM32G491KE.yaml
+++ b/data/chips/STM32G491KE.yaml
@@ -603,6 +603,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -641,6 +642,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PF0
         signal: NSS
@@ -667,6 +669,7 @@ cores:
       address: 0x40003c00
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS

--- a/data/chips/STM32G491MC.yaml
+++ b/data/chips/STM32G491MC.yaml
@@ -867,6 +867,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -905,6 +906,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PF0
         signal: NSS
@@ -943,6 +945,7 @@ cores:
       address: 0x40003c00
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS

--- a/data/chips/STM32G491ME.yaml
+++ b/data/chips/STM32G491ME.yaml
@@ -867,6 +867,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -905,6 +906,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PF0
         signal: NSS
@@ -943,6 +945,7 @@ cores:
       address: 0x40003c00
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS

--- a/data/chips/STM32G491RC.yaml
+++ b/data/chips/STM32G491RC.yaml
@@ -825,6 +825,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -863,6 +864,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PF0
         signal: NSS
@@ -901,6 +903,7 @@ cores:
       address: 0x40003c00
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS

--- a/data/chips/STM32G491RE.yaml
+++ b/data/chips/STM32G491RE.yaml
@@ -827,6 +827,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins:
       - pin: PB5
         signal: MOSI
@@ -865,6 +866,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PA11
         signal: MOSI
@@ -903,6 +905,7 @@ cores:
       address: 0x40003c00
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PC11
         signal: MISO

--- a/data/chips/STM32G491VC.yaml
+++ b/data/chips/STM32G491VC.yaml
@@ -921,6 +921,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -959,6 +960,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PF9
         signal: SCK
@@ -1006,6 +1008,7 @@ cores:
       address: 0x40003c00
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS

--- a/data/chips/STM32G491VE.yaml
+++ b/data/chips/STM32G491VE.yaml
@@ -921,6 +921,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -959,6 +960,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PF9
         signal: SCK
@@ -1006,6 +1008,7 @@ cores:
       address: 0x40003c00
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS

--- a/data/chips/STM32G4A1CE.yaml
+++ b/data/chips/STM32G4A1CE.yaml
@@ -761,6 +761,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -799,6 +800,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PF0
         signal: NSS
@@ -837,6 +839,7 @@ cores:
       address: 0x40003c00
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS

--- a/data/chips/STM32G4A1KE.yaml
+++ b/data/chips/STM32G4A1KE.yaml
@@ -612,6 +612,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -650,6 +651,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PF0
         signal: NSS
@@ -676,6 +678,7 @@ cores:
       address: 0x40003c00
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS

--- a/data/chips/STM32G4A1ME.yaml
+++ b/data/chips/STM32G4A1ME.yaml
@@ -876,6 +876,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -914,6 +915,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PF0
         signal: NSS
@@ -952,6 +954,7 @@ cores:
       address: 0x40003c00
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS

--- a/data/chips/STM32G4A1RE.yaml
+++ b/data/chips/STM32G4A1RE.yaml
@@ -836,6 +836,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins:
       - pin: PB5
         signal: MOSI
@@ -874,6 +875,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PA11
         signal: MOSI
@@ -912,6 +914,7 @@ cores:
       address: 0x40003c00
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PC11
         signal: MISO

--- a/data/chips/STM32G4A1VE.yaml
+++ b/data/chips/STM32G4A1VE.yaml
@@ -930,6 +930,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -968,6 +969,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PF9
         signal: SCK
@@ -1015,6 +1017,7 @@ cores:
       address: 0x40003c00
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS

--- a/data/chips/STM32GBK1CB.yaml
+++ b/data/chips/STM32GBK1CB.yaml
@@ -724,6 +724,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -762,6 +763,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PF0
         signal: NSS
@@ -800,6 +802,7 @@ cores:
       address: 0x40003c00
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS

--- a/data/chips/STM32L552CC.yaml
+++ b/data/chips/STM32L552CC.yaml
@@ -709,6 +709,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins:
       - pin: PA1
         signal: SCK
@@ -759,6 +760,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PB10
         signal: SCK
@@ -794,6 +796,7 @@ cores:
       address: 0x40003c00
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS

--- a/data/chips/STM32L552CE.yaml
+++ b/data/chips/STM32L552CE.yaml
@@ -686,6 +686,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins:
       - pin: PA1
         signal: SCK
@@ -736,6 +737,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PB10
         signal: SCK
@@ -768,6 +770,7 @@ cores:
       address: 0x40003c00
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS

--- a/data/chips/STM32L552ME.yaml
+++ b/data/chips/STM32L552ME.yaml
@@ -907,6 +907,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins:
       - pin: PB5
         signal: MOSI
@@ -957,6 +958,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PB9
         signal: NSS
@@ -1001,6 +1003,7 @@ cores:
       address: 0x40003c00
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PC10
         signal: SCK

--- a/data/chips/STM32L552QC.yaml
+++ b/data/chips/STM32L552QC.yaml
@@ -1093,6 +1093,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins:
       - pin: PA15
         signal: NSS
@@ -1167,6 +1168,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PB9
         signal: NSS
@@ -1226,6 +1228,7 @@ cores:
       address: 0x40003c00
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PG12
         signal: NSS

--- a/data/chips/STM32L552QE.yaml
+++ b/data/chips/STM32L552QE.yaml
@@ -1103,6 +1103,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins:
       - pin: PA15
         signal: NSS
@@ -1177,6 +1178,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PB9
         signal: NSS
@@ -1236,6 +1238,7 @@ cores:
       address: 0x40003c00
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PG12
         signal: NSS

--- a/data/chips/STM32L552RC.yaml
+++ b/data/chips/STM32L552RC.yaml
@@ -880,6 +880,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins:
       - pin: PA1
         signal: SCK
@@ -930,6 +931,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PC1
         signal: MOSI
@@ -974,6 +976,7 @@ cores:
       address: 0x40003c00
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS

--- a/data/chips/STM32L552RE.yaml
+++ b/data/chips/STM32L552RE.yaml
@@ -816,6 +816,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins:
       - pin: PA1
         signal: SCK
@@ -866,6 +867,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PC1
         signal: MOSI
@@ -904,6 +906,7 @@ cores:
       address: 0x40003c00
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS

--- a/data/chips/STM32L552VC.yaml
+++ b/data/chips/STM32L552VC.yaml
@@ -964,6 +964,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins:
       - pin: PA1
         signal: SCK
@@ -1026,6 +1027,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PC1
         signal: MOSI
@@ -1082,6 +1084,7 @@ cores:
       address: 0x40003c00
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS

--- a/data/chips/STM32L552VE.yaml
+++ b/data/chips/STM32L552VE.yaml
@@ -1001,6 +1001,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins:
       - pin: PA1
         signal: SCK
@@ -1063,6 +1064,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PC1
         signal: MOSI
@@ -1122,6 +1124,7 @@ cores:
       address: 0x40003c00
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS

--- a/data/chips/STM32L552ZC.yaml
+++ b/data/chips/STM32L552ZC.yaml
@@ -1096,6 +1096,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins:
       - pin: PA1
         signal: SCK
@@ -1170,6 +1171,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PC1
         signal: MOSI
@@ -1226,6 +1228,7 @@ cores:
       address: 0x40003c00
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS

--- a/data/chips/STM32L552ZE.yaml
+++ b/data/chips/STM32L552ZE.yaml
@@ -1142,6 +1142,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins:
       - pin: PA1
         signal: SCK
@@ -1216,6 +1217,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PC1
         signal: MOSI
@@ -1275,6 +1277,7 @@ cores:
       address: 0x40003c00
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS

--- a/data/chips/STM32L562CE.yaml
+++ b/data/chips/STM32L562CE.yaml
@@ -708,6 +708,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins:
       - pin: PA1
         signal: SCK
@@ -758,6 +759,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PB10
         signal: SCK
@@ -790,6 +792,7 @@ cores:
       address: 0x40003c00
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS

--- a/data/chips/STM32L562ME.yaml
+++ b/data/chips/STM32L562ME.yaml
@@ -929,6 +929,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins:
       - pin: PB5
         signal: MOSI
@@ -979,6 +980,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PB9
         signal: NSS
@@ -1023,6 +1025,7 @@ cores:
       address: 0x40003c00
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PC10
         signal: SCK

--- a/data/chips/STM32L562QE.yaml
+++ b/data/chips/STM32L562QE.yaml
@@ -1119,6 +1119,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins:
       - pin: PA15
         signal: NSS
@@ -1193,6 +1194,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PB9
         signal: NSS
@@ -1252,6 +1254,7 @@ cores:
       address: 0x40003c00
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PG12
         signal: NSS

--- a/data/chips/STM32L562RE.yaml
+++ b/data/chips/STM32L562RE.yaml
@@ -838,6 +838,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins:
       - pin: PA1
         signal: SCK
@@ -888,6 +889,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PC1
         signal: MOSI
@@ -926,6 +928,7 @@ cores:
       address: 0x40003c00
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS

--- a/data/chips/STM32L562VE.yaml
+++ b/data/chips/STM32L562VE.yaml
@@ -988,6 +988,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins:
       - pin: PA1
         signal: SCK
@@ -1050,6 +1051,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PC1
         signal: MOSI
@@ -1106,6 +1108,7 @@ cores:
       address: 0x40003c00
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS

--- a/data/chips/STM32L562ZE.yaml
+++ b/data/chips/STM32L562ZE.yaml
@@ -1120,6 +1120,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins:
       - pin: PA1
         signal: SCK
@@ -1194,6 +1195,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PC1
         signal: MOSI
@@ -1250,6 +1252,7 @@ cores:
       address: 0x40003c00
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS

--- a/data/chips/STM32WB10CC.yaml
+++ b/data/chips/STM32WB10CC.yaml
@@ -264,6 +264,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins:
       - pin: PA1
         signal: SCK

--- a/data/chips/STM32WB15CC.yaml
+++ b/data/chips/STM32WB15CC.yaml
@@ -320,6 +320,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins:
       - pin: PA11
         signal: MISO

--- a/data/chips/STM32WB30CE.yaml
+++ b/data/chips/STM32WB30CE.yaml
@@ -280,6 +280,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins:
       - pin: PA1
         signal: SCK

--- a/data/chips/STM32WB35CC.yaml
+++ b/data/chips/STM32WB35CC.yaml
@@ -497,6 +497,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins:
       - pin: PA1
         signal: SCK

--- a/data/chips/STM32WB35CE.yaml
+++ b/data/chips/STM32WB35CE.yaml
@@ -497,6 +497,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins:
       - pin: PA1
         signal: SCK

--- a/data/chips/STM32WB55RC.yaml
+++ b/data/chips/STM32WB55RC.yaml
@@ -843,6 +843,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PB9
         signal: NSS

--- a/data/chips/STM32WB55RE.yaml
+++ b/data/chips/STM32WB55RE.yaml
@@ -843,6 +843,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PB9
         signal: NSS

--- a/data/chips/STM32WB55RG.yaml
+++ b/data/chips/STM32WB55RG.yaml
@@ -843,6 +843,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PB9
         signal: NSS

--- a/data/chips/STM32WB55VC.yaml
+++ b/data/chips/STM32WB55VC.yaml
@@ -941,6 +941,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PB13
         signal: SCK

--- a/data/chips/STM32WB55VE.yaml
+++ b/data/chips/STM32WB55VE.yaml
@@ -941,6 +941,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PB13
         signal: SCK

--- a/data/chips/STM32WB55VG.yaml
+++ b/data/chips/STM32WB55VG.yaml
@@ -941,6 +941,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PB13
         signal: SCK

--- a/data/chips/STM32WB55VY.yaml
+++ b/data/chips/STM32WB55VY.yaml
@@ -939,6 +939,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PB13
         signal: SCK

--- a/data/chips/STM32WB5MMG.yaml
+++ b/data/chips/STM32WB5MMG.yaml
@@ -903,6 +903,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PC3
         signal: MOSI

--- a/data/chips/STM32WL54CC.yaml
+++ b/data/chips/STM32WL54CC.yaml
@@ -477,6 +477,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins: &id027
       - pin: PB3
         signal: SCK
@@ -529,6 +530,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins: &id030
       - pin: PA5
         signal: MISO
@@ -559,6 +561,20 @@ cores:
         - &id032
           dmamux: DMAMUX1
           request: 10
+    SUBGHZSPI:
+      address: 0x58010000
+      kind: SUBGHZ:STM32WLxx_v1_0
+      block: spi_v2/SPI
+      clock: APB3
+      dma_channels:
+        RX:
+        - &id033
+          dmamux: DMAMUX1
+          request: 41
+        TX:
+        - &id034
+          dmamux: DMAMUX1
+          request: 42
     SYSCFG:
       address: 0x40010000
       kind: SYS:STM32WL5xx_sys_v1_0
@@ -568,7 +584,7 @@ cores:
       address: 0x40012c00
       kind: TIM1_8WL5:gptimer2_v3_x
       block: timer_v1/TIM_GP16
-      pins: &id033
+      pins: &id035
       - pin: PB7
         signal: BKIN
         af: 3
@@ -610,38 +626,38 @@ cores:
       clock: APB2
       dma_channels:
         CH1:
-        - &id034
+        - &id036
           dmamux: DMAMUX1
           request: 23
         CH2:
-        - &id035
+        - &id037
           dmamux: DMAMUX1
           request: 24
         CH3:
-        - &id036
+        - &id038
           dmamux: DMAMUX1
           request: 25
         CH4:
-        - &id037
+        - &id039
           dmamux: DMAMUX1
           request: 26
         COM:
-        - &id038
+        - &id040
           dmamux: DMAMUX1
           request: 29
         TRIG:
-        - &id039
+        - &id041
           dmamux: DMAMUX1
           request: 28
         UP:
-        - &id040
+        - &id042
           dmamux: DMAMUX1
           request: 27
     TIM16:
       address: 0x40014400
       kind: TIM1_8WL5:gptimer2_v3_x
       block: timer_v1/TIM_GP16
-      pins: &id041
+      pins: &id043
       - pin: PB5
         signal: BKIN
         af: 14
@@ -662,18 +678,18 @@ cores:
       clock: APB2
       dma_channels:
         CH1:
-        - &id042
+        - &id044
           dmamux: DMAMUX1
           request: 35
         UP:
-        - &id043
+        - &id045
           dmamux: DMAMUX1
           request: 36
     TIM17:
       address: 0x40014800
       kind: TIM1_8WL5:gptimer2_v3_x
       block: timer_v1/TIM_GP16
-      pins: &id044
+      pins: &id046
       - pin: PB4
         signal: BKIN
         af: 14
@@ -694,18 +710,18 @@ cores:
       clock: APB2
       dma_channels:
         CH1:
-        - &id045
+        - &id047
           dmamux: DMAMUX1
           request: 37
         UP:
-        - &id046
+        - &id048
           dmamux: DMAMUX1
           request: 38
     TIM2:
       address: 0x40000000
       kind: TIM1_8WL5:gptimer2_v3_x
       block: timer_v1/TIM_GP16
-      pins: &id047
+      pins: &id049
       - pin: PB3
         signal: CH2
         af: 1
@@ -743,23 +759,23 @@ cores:
         UP: TIM2
       dma_channels:
         CH1:
-        - &id048
+        - &id050
           dmamux: DMAMUX1
           request: 30
         CH2:
-        - &id049
+        - &id051
           dmamux: DMAMUX1
           request: 31
         CH3:
-        - &id050
+        - &id052
           dmamux: DMAMUX1
           request: 32
         CH4:
-        - &id051
+        - &id053
           dmamux: DMAMUX1
           request: 33
         UP:
-        - &id052
+        - &id054
           dmamux: DMAMUX1
           request: 34
     USART1:
@@ -767,7 +783,7 @@ cores:
       kind: USART:sci3_v2_1
       clock: APB2
       block: usart_v2/USART
-      pins: &id053
+      pins: &id055
       - pin: PB3
         signal: DE
         af: 7
@@ -814,18 +830,18 @@ cores:
         GLOBAL: USART1
       dma_channels:
         RX:
-        - &id054
+        - &id056
           dmamux: DMAMUX1
           request: 17
         TX:
-        - &id055
+        - &id057
           dmamux: DMAMUX1
           request: 18
     USART2:
       address: 0x40004400
       kind: USART:sci3_v2_1
       block: usart_v2/USART
-      pins: &id056
+      pins: &id058
       - pin: PA0
         signal: CTS
         af: 7
@@ -851,11 +867,11 @@ cores:
         GLOBAL: USART2
       dma_channels:
         RX:
-        - &id057
+        - &id059
           dmamux: DMAMUX1
           request: 19
         TX:
-        - &id058
+        - &id060
           dmamux: DMAMUX1
           request: 20
     VREFBUF:
@@ -1192,6 +1208,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins: *id027
       interrupts:
         GLOBAL: SPI1
@@ -1204,6 +1221,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins: *id030
       interrupts:
         GLOBAL: SPI2
@@ -1212,6 +1230,16 @@ cores:
         - *id031
         TX:
         - *id032
+    SUBGHZSPI:
+      address: 0x58010000
+      kind: SUBGHZ:STM32WLxx_v1_0
+      block: spi_v2/SPI
+      clock: APB3
+      dma_channels:
+        RX:
+        - *id033
+        TX:
+        - *id034
     SYSCFG:
       address: 0x40010000
       kind: SYS:STM32WL5xx_sys_v1_0
@@ -1221,29 +1249,29 @@ cores:
       address: 0x40012c00
       kind: TIM1_8WL5:gptimer2_v3_x
       block: timer_v1/TIM_GP16
-      pins: *id033
+      pins: *id035
       interrupts: {}
       clock: APB2
       dma_channels:
         CH1:
-        - *id034
-        CH2:
-        - *id035
-        CH3:
         - *id036
-        CH4:
+        CH2:
         - *id037
-        COM:
+        CH3:
         - *id038
-        TRIG:
+        CH4:
         - *id039
-        UP:
+        COM:
         - *id040
+        TRIG:
+        - *id041
+        UP:
+        - *id042
     TIM16:
       address: 0x40014400
       kind: TIM1_8WL5:gptimer2_v3_x
       block: timer_v1/TIM_GP16
-      pins: *id041
+      pins: *id043
       interrupts:
         BRK: TIM16
         COM: TIM16
@@ -1252,14 +1280,14 @@ cores:
       clock: APB2
       dma_channels:
         CH1:
-        - *id042
+        - *id044
         UP:
-        - *id043
+        - *id045
     TIM17:
       address: 0x40014800
       kind: TIM1_8WL5:gptimer2_v3_x
       block: timer_v1/TIM_GP16
-      pins: *id044
+      pins: *id046
       interrupts:
         BRK: TIM17
         COM: TIM17
@@ -1268,14 +1296,14 @@ cores:
       clock: APB2
       dma_channels:
         CH1:
-        - *id045
+        - *id047
         UP:
-        - *id046
+        - *id048
     TIM2:
       address: 0x40000000
       kind: TIM1_8WL5:gptimer2_v3_x
       block: timer_v1/TIM_GP16
-      pins: *id047
+      pins: *id049
       interrupts:
         BRK: TIM2
         COM: TIM2
@@ -1283,40 +1311,40 @@ cores:
         UP: TIM2
       dma_channels:
         CH1:
-        - *id048
-        CH2:
-        - *id049
-        CH3:
         - *id050
-        CH4:
+        CH2:
         - *id051
-        UP:
+        CH3:
         - *id052
+        CH4:
+        - *id053
+        UP:
+        - *id054
     USART1:
       address: 0x40013800
       kind: USART:sci3_v2_1
       clock: APB2
       block: usart_v2/USART
-      pins: *id053
+      pins: *id055
       interrupts:
         GLOBAL: USART1
       dma_channels:
         RX:
-        - *id054
+        - *id056
         TX:
-        - *id055
+        - *id057
     USART2:
       address: 0x40004400
       kind: USART:sci3_v2_1
       block: usart_v2/USART
-      pins: *id056
+      pins: *id058
       interrupts:
         GLOBAL: USART2
       dma_channels:
         RX:
-        - *id057
+        - *id059
         TX:
-        - *id058
+        - *id060
     VREFBUF:
       address: 0x40010030
       kind: VREFBUF:STM32WL_vrefbuf_v1_0

--- a/data/chips/STM32WL54JC.yaml
+++ b/data/chips/STM32WL54JC.yaml
@@ -557,6 +557,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins: &id027
       - pin: PA12
         signal: MOSI
@@ -609,6 +610,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins: &id030
       - pin: PB15
         signal: MOSI
@@ -663,6 +665,20 @@ cores:
         - &id032
           dmamux: DMAMUX1
           request: 10
+    SUBGHZSPI:
+      address: 0x58010000
+      kind: SUBGHZ:STM32WLxx_v1_0
+      block: spi_v2/SPI
+      clock: APB3
+      dma_channels:
+        RX:
+        - &id033
+          dmamux: DMAMUX1
+          request: 41
+        TX:
+        - &id034
+          dmamux: DMAMUX1
+          request: 42
     SYSCFG:
       address: 0x40010000
       kind: SYS:STM32WL5xx_sys_v1_0
@@ -672,7 +688,7 @@ cores:
       address: 0x40012c00
       kind: TIM1_8WL5:gptimer2_v3_x
       block: timer_v1/TIM_GP16
-      pins: &id033
+      pins: &id035
       - pin: PA12
         signal: ETR
         af: 1
@@ -726,38 +742,38 @@ cores:
       clock: APB2
       dma_channels:
         CH1:
-        - &id034
+        - &id036
           dmamux: DMAMUX1
           request: 23
         CH2:
-        - &id035
+        - &id037
           dmamux: DMAMUX1
           request: 24
         CH3:
-        - &id036
+        - &id038
           dmamux: DMAMUX1
           request: 25
         CH4:
-        - &id037
+        - &id039
           dmamux: DMAMUX1
           request: 26
         COM:
-        - &id038
+        - &id040
           dmamux: DMAMUX1
           request: 29
         TRIG:
-        - &id039
+        - &id041
           dmamux: DMAMUX1
           request: 28
         UP:
-        - &id040
+        - &id042
           dmamux: DMAMUX1
           request: 27
     TIM16:
       address: 0x40014400
       kind: TIM1_8WL5:gptimer2_v3_x
       block: timer_v1/TIM_GP16
-      pins: &id041
+      pins: &id043
       - pin: PB5
         signal: BKIN
         af: 14
@@ -778,18 +794,18 @@ cores:
       clock: APB2
       dma_channels:
         CH1:
-        - &id042
+        - &id044
           dmamux: DMAMUX1
           request: 35
         UP:
-        - &id043
+        - &id045
           dmamux: DMAMUX1
           request: 36
     TIM17:
       address: 0x40014800
       kind: TIM1_8WL5:gptimer2_v3_x
       block: timer_v1/TIM_GP16
-      pins: &id044
+      pins: &id046
       - pin: PB4
         signal: BKIN
         af: 14
@@ -813,18 +829,18 @@ cores:
       clock: APB2
       dma_channels:
         CH1:
-        - &id045
+        - &id047
           dmamux: DMAMUX1
           request: 37
         UP:
-        - &id046
+        - &id048
           dmamux: DMAMUX1
           request: 38
     TIM2:
       address: 0x40000000
       kind: TIM1_8WL5:gptimer2_v3_x
       block: timer_v1/TIM_GP16
-      pins: &id047
+      pins: &id049
       - pin: PA15
         signal: CH1
         af: 1
@@ -868,23 +884,23 @@ cores:
         UP: TIM2
       dma_channels:
         CH1:
-        - &id048
+        - &id050
           dmamux: DMAMUX1
           request: 30
         CH2:
-        - &id049
+        - &id051
           dmamux: DMAMUX1
           request: 31
         CH3:
-        - &id050
+        - &id052
           dmamux: DMAMUX1
           request: 32
         CH4:
-        - &id051
+        - &id053
           dmamux: DMAMUX1
           request: 33
         UP:
-        - &id052
+        - &id054
           dmamux: DMAMUX1
           request: 34
     USART1:
@@ -892,7 +908,7 @@ cores:
       kind: USART:sci3_v2_1
       clock: APB2
       block: usart_v2/USART
-      pins: &id053
+      pins: &id055
       - pin: PA12
         signal: DE
         af: 7
@@ -939,18 +955,18 @@ cores:
         GLOBAL: USART1
       dma_channels:
         RX:
-        - &id054
+        - &id056
           dmamux: DMAMUX1
           request: 17
         TX:
-        - &id055
+        - &id057
           dmamux: DMAMUX1
           request: 18
     USART2:
       address: 0x40004400
       kind: USART:sci3_v2_1
       block: usart_v2/USART
-      pins: &id056
+      pins: &id058
       - pin: PA0
         signal: CTS
         af: 7
@@ -976,17 +992,17 @@ cores:
         GLOBAL: USART2
       dma_channels:
         RX:
-        - &id057
+        - &id059
           dmamux: DMAMUX1
           request: 19
         TX:
-        - &id058
+        - &id060
           dmamux: DMAMUX1
           request: 20
     VREFBUF:
       address: 0x40010030
       kind: VREFBUF:STM32WL_vrefbuf_v1_0
-      pins: &id059
+      pins: &id061
       - pin: VREF+
         signal: OUT
     WWDG:
@@ -1320,6 +1336,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins: *id027
       interrupts:
         GLOBAL: SPI1
@@ -1332,6 +1349,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins: *id030
       interrupts:
         GLOBAL: SPI2
@@ -1340,6 +1358,16 @@ cores:
         - *id031
         TX:
         - *id032
+    SUBGHZSPI:
+      address: 0x58010000
+      kind: SUBGHZ:STM32WLxx_v1_0
+      block: spi_v2/SPI
+      clock: APB3
+      dma_channels:
+        RX:
+        - *id033
+        TX:
+        - *id034
     SYSCFG:
       address: 0x40010000
       kind: SYS:STM32WL5xx_sys_v1_0
@@ -1349,29 +1377,29 @@ cores:
       address: 0x40012c00
       kind: TIM1_8WL5:gptimer2_v3_x
       block: timer_v1/TIM_GP16
-      pins: *id033
+      pins: *id035
       interrupts: {}
       clock: APB2
       dma_channels:
         CH1:
-        - *id034
-        CH2:
-        - *id035
-        CH3:
         - *id036
-        CH4:
+        CH2:
         - *id037
-        COM:
+        CH3:
         - *id038
-        TRIG:
+        CH4:
         - *id039
-        UP:
+        COM:
         - *id040
+        TRIG:
+        - *id041
+        UP:
+        - *id042
     TIM16:
       address: 0x40014400
       kind: TIM1_8WL5:gptimer2_v3_x
       block: timer_v1/TIM_GP16
-      pins: *id041
+      pins: *id043
       interrupts:
         BRK: TIM16
         COM: TIM16
@@ -1380,14 +1408,14 @@ cores:
       clock: APB2
       dma_channels:
         CH1:
-        - *id042
+        - *id044
         UP:
-        - *id043
+        - *id045
     TIM17:
       address: 0x40014800
       kind: TIM1_8WL5:gptimer2_v3_x
       block: timer_v1/TIM_GP16
-      pins: *id044
+      pins: *id046
       interrupts:
         BRK: TIM17
         COM: TIM17
@@ -1396,14 +1424,14 @@ cores:
       clock: APB2
       dma_channels:
         CH1:
-        - *id045
+        - *id047
         UP:
-        - *id046
+        - *id048
     TIM2:
       address: 0x40000000
       kind: TIM1_8WL5:gptimer2_v3_x
       block: timer_v1/TIM_GP16
-      pins: *id047
+      pins: *id049
       interrupts:
         BRK: TIM2
         COM: TIM2
@@ -1411,44 +1439,44 @@ cores:
         UP: TIM2
       dma_channels:
         CH1:
-        - *id048
-        CH2:
-        - *id049
-        CH3:
         - *id050
-        CH4:
+        CH2:
         - *id051
-        UP:
+        CH3:
         - *id052
+        CH4:
+        - *id053
+        UP:
+        - *id054
     USART1:
       address: 0x40013800
       kind: USART:sci3_v2_1
       clock: APB2
       block: usart_v2/USART
-      pins: *id053
+      pins: *id055
       interrupts:
         GLOBAL: USART1
       dma_channels:
         RX:
-        - *id054
+        - *id056
         TX:
-        - *id055
+        - *id057
     USART2:
       address: 0x40004400
       kind: USART:sci3_v2_1
       block: usart_v2/USART
-      pins: *id056
+      pins: *id058
       interrupts:
         GLOBAL: USART2
       dma_channels:
         RX:
-        - *id057
+        - *id059
         TX:
-        - *id058
+        - *id060
     VREFBUF:
       address: 0x40010030
       kind: VREFBUF:STM32WL_vrefbuf_v1_0
-      pins: *id059
+      pins: *id061
     WWDG:
       address: 0x40002c00
       kind: WWDG:wwdg1_v2_0

--- a/data/chips/STM32WL55CC.yaml
+++ b/data/chips/STM32WL55CC.yaml
@@ -477,6 +477,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins: &id027
       - pin: PB3
         signal: SCK
@@ -529,6 +530,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins: &id030
       - pin: PA5
         signal: MISO
@@ -559,6 +561,20 @@ cores:
         - &id032
           dmamux: DMAMUX1
           request: 10
+    SUBGHZSPI:
+      address: 0x58010000
+      kind: SUBGHZ:STM32WLxx_v1_0
+      block: spi_v2/SPI
+      clock: APB3
+      dma_channels:
+        RX:
+        - &id033
+          dmamux: DMAMUX1
+          request: 41
+        TX:
+        - &id034
+          dmamux: DMAMUX1
+          request: 42
     SYSCFG:
       address: 0x40010000
       kind: SYS:STM32WL5xx_sys_v1_0
@@ -568,7 +584,7 @@ cores:
       address: 0x40012c00
       kind: TIM1_8WL5:gptimer2_v3_x
       block: timer_v1/TIM_GP16
-      pins: &id033
+      pins: &id035
       - pin: PB7
         signal: BKIN
         af: 3
@@ -610,38 +626,38 @@ cores:
       clock: APB2
       dma_channels:
         CH1:
-        - &id034
+        - &id036
           dmamux: DMAMUX1
           request: 23
         CH2:
-        - &id035
+        - &id037
           dmamux: DMAMUX1
           request: 24
         CH3:
-        - &id036
+        - &id038
           dmamux: DMAMUX1
           request: 25
         CH4:
-        - &id037
+        - &id039
           dmamux: DMAMUX1
           request: 26
         COM:
-        - &id038
+        - &id040
           dmamux: DMAMUX1
           request: 29
         TRIG:
-        - &id039
+        - &id041
           dmamux: DMAMUX1
           request: 28
         UP:
-        - &id040
+        - &id042
           dmamux: DMAMUX1
           request: 27
     TIM16:
       address: 0x40014400
       kind: TIM1_8WL5:gptimer2_v3_x
       block: timer_v1/TIM_GP16
-      pins: &id041
+      pins: &id043
       - pin: PB5
         signal: BKIN
         af: 14
@@ -662,18 +678,18 @@ cores:
       clock: APB2
       dma_channels:
         CH1:
-        - &id042
+        - &id044
           dmamux: DMAMUX1
           request: 35
         UP:
-        - &id043
+        - &id045
           dmamux: DMAMUX1
           request: 36
     TIM17:
       address: 0x40014800
       kind: TIM1_8WL5:gptimer2_v3_x
       block: timer_v1/TIM_GP16
-      pins: &id044
+      pins: &id046
       - pin: PB4
         signal: BKIN
         af: 14
@@ -694,18 +710,18 @@ cores:
       clock: APB2
       dma_channels:
         CH1:
-        - &id045
+        - &id047
           dmamux: DMAMUX1
           request: 37
         UP:
-        - &id046
+        - &id048
           dmamux: DMAMUX1
           request: 38
     TIM2:
       address: 0x40000000
       kind: TIM1_8WL5:gptimer2_v3_x
       block: timer_v1/TIM_GP16
-      pins: &id047
+      pins: &id049
       - pin: PB3
         signal: CH2
         af: 1
@@ -743,23 +759,23 @@ cores:
         UP: TIM2
       dma_channels:
         CH1:
-        - &id048
+        - &id050
           dmamux: DMAMUX1
           request: 30
         CH2:
-        - &id049
+        - &id051
           dmamux: DMAMUX1
           request: 31
         CH3:
-        - &id050
+        - &id052
           dmamux: DMAMUX1
           request: 32
         CH4:
-        - &id051
+        - &id053
           dmamux: DMAMUX1
           request: 33
         UP:
-        - &id052
+        - &id054
           dmamux: DMAMUX1
           request: 34
     USART1:
@@ -767,7 +783,7 @@ cores:
       kind: USART:sci3_v2_1
       clock: APB2
       block: usart_v2/USART
-      pins: &id053
+      pins: &id055
       - pin: PB3
         signal: DE
         af: 7
@@ -814,18 +830,18 @@ cores:
         GLOBAL: USART1
       dma_channels:
         RX:
-        - &id054
+        - &id056
           dmamux: DMAMUX1
           request: 17
         TX:
-        - &id055
+        - &id057
           dmamux: DMAMUX1
           request: 18
     USART2:
       address: 0x40004400
       kind: USART:sci3_v2_1
       block: usart_v2/USART
-      pins: &id056
+      pins: &id058
       - pin: PA0
         signal: CTS
         af: 7
@@ -851,11 +867,11 @@ cores:
         GLOBAL: USART2
       dma_channels:
         RX:
-        - &id057
+        - &id059
           dmamux: DMAMUX1
           request: 19
         TX:
-        - &id058
+        - &id060
           dmamux: DMAMUX1
           request: 20
     VREFBUF:
@@ -1192,6 +1208,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins: *id027
       interrupts:
         GLOBAL: SPI1
@@ -1204,6 +1221,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins: *id030
       interrupts:
         GLOBAL: SPI2
@@ -1212,6 +1230,16 @@ cores:
         - *id031
         TX:
         - *id032
+    SUBGHZSPI:
+      address: 0x58010000
+      kind: SUBGHZ:STM32WLxx_v1_0
+      block: spi_v2/SPI
+      clock: APB3
+      dma_channels:
+        RX:
+        - *id033
+        TX:
+        - *id034
     SYSCFG:
       address: 0x40010000
       kind: SYS:STM32WL5xx_sys_v1_0
@@ -1221,29 +1249,29 @@ cores:
       address: 0x40012c00
       kind: TIM1_8WL5:gptimer2_v3_x
       block: timer_v1/TIM_GP16
-      pins: *id033
+      pins: *id035
       interrupts: {}
       clock: APB2
       dma_channels:
         CH1:
-        - *id034
-        CH2:
-        - *id035
-        CH3:
         - *id036
-        CH4:
+        CH2:
         - *id037
-        COM:
+        CH3:
         - *id038
-        TRIG:
+        CH4:
         - *id039
-        UP:
+        COM:
         - *id040
+        TRIG:
+        - *id041
+        UP:
+        - *id042
     TIM16:
       address: 0x40014400
       kind: TIM1_8WL5:gptimer2_v3_x
       block: timer_v1/TIM_GP16
-      pins: *id041
+      pins: *id043
       interrupts:
         BRK: TIM16
         COM: TIM16
@@ -1252,14 +1280,14 @@ cores:
       clock: APB2
       dma_channels:
         CH1:
-        - *id042
+        - *id044
         UP:
-        - *id043
+        - *id045
     TIM17:
       address: 0x40014800
       kind: TIM1_8WL5:gptimer2_v3_x
       block: timer_v1/TIM_GP16
-      pins: *id044
+      pins: *id046
       interrupts:
         BRK: TIM17
         COM: TIM17
@@ -1268,14 +1296,14 @@ cores:
       clock: APB2
       dma_channels:
         CH1:
-        - *id045
+        - *id047
         UP:
-        - *id046
+        - *id048
     TIM2:
       address: 0x40000000
       kind: TIM1_8WL5:gptimer2_v3_x
       block: timer_v1/TIM_GP16
-      pins: *id047
+      pins: *id049
       interrupts:
         BRK: TIM2
         COM: TIM2
@@ -1283,40 +1311,40 @@ cores:
         UP: TIM2
       dma_channels:
         CH1:
-        - *id048
-        CH2:
-        - *id049
-        CH3:
         - *id050
-        CH4:
+        CH2:
         - *id051
-        UP:
+        CH3:
         - *id052
+        CH4:
+        - *id053
+        UP:
+        - *id054
     USART1:
       address: 0x40013800
       kind: USART:sci3_v2_1
       clock: APB2
       block: usart_v2/USART
-      pins: *id053
+      pins: *id055
       interrupts:
         GLOBAL: USART1
       dma_channels:
         RX:
-        - *id054
+        - *id056
         TX:
-        - *id055
+        - *id057
     USART2:
       address: 0x40004400
       kind: USART:sci3_v2_1
       block: usart_v2/USART
-      pins: *id056
+      pins: *id058
       interrupts:
         GLOBAL: USART2
       dma_channels:
         RX:
-        - *id057
+        - *id059
         TX:
-        - *id058
+        - *id060
     VREFBUF:
       address: 0x40010030
       kind: VREFBUF:STM32WL_vrefbuf_v1_0

--- a/data/chips/STM32WL55JC.yaml
+++ b/data/chips/STM32WL55JC.yaml
@@ -557,6 +557,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins: &id027
       - pin: PA12
         signal: MOSI
@@ -609,6 +610,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins: &id030
       - pin: PB15
         signal: MOSI
@@ -663,6 +665,20 @@ cores:
         - &id032
           dmamux: DMAMUX1
           request: 10
+    SUBGHZSPI:
+      address: 0x58010000
+      kind: SUBGHZ:STM32WLxx_v1_0
+      block: spi_v2/SPI
+      clock: APB3
+      dma_channels:
+        RX:
+        - &id033
+          dmamux: DMAMUX1
+          request: 41
+        TX:
+        - &id034
+          dmamux: DMAMUX1
+          request: 42
     SYSCFG:
       address: 0x40010000
       kind: SYS:STM32WL5xx_sys_v1_0
@@ -672,7 +688,7 @@ cores:
       address: 0x40012c00
       kind: TIM1_8WL5:gptimer2_v3_x
       block: timer_v1/TIM_GP16
-      pins: &id033
+      pins: &id035
       - pin: PA12
         signal: ETR
         af: 1
@@ -726,38 +742,38 @@ cores:
       clock: APB2
       dma_channels:
         CH1:
-        - &id034
+        - &id036
           dmamux: DMAMUX1
           request: 23
         CH2:
-        - &id035
+        - &id037
           dmamux: DMAMUX1
           request: 24
         CH3:
-        - &id036
+        - &id038
           dmamux: DMAMUX1
           request: 25
         CH4:
-        - &id037
+        - &id039
           dmamux: DMAMUX1
           request: 26
         COM:
-        - &id038
+        - &id040
           dmamux: DMAMUX1
           request: 29
         TRIG:
-        - &id039
+        - &id041
           dmamux: DMAMUX1
           request: 28
         UP:
-        - &id040
+        - &id042
           dmamux: DMAMUX1
           request: 27
     TIM16:
       address: 0x40014400
       kind: TIM1_8WL5:gptimer2_v3_x
       block: timer_v1/TIM_GP16
-      pins: &id041
+      pins: &id043
       - pin: PB5
         signal: BKIN
         af: 14
@@ -778,18 +794,18 @@ cores:
       clock: APB2
       dma_channels:
         CH1:
-        - &id042
+        - &id044
           dmamux: DMAMUX1
           request: 35
         UP:
-        - &id043
+        - &id045
           dmamux: DMAMUX1
           request: 36
     TIM17:
       address: 0x40014800
       kind: TIM1_8WL5:gptimer2_v3_x
       block: timer_v1/TIM_GP16
-      pins: &id044
+      pins: &id046
       - pin: PB4
         signal: BKIN
         af: 14
@@ -813,18 +829,18 @@ cores:
       clock: APB2
       dma_channels:
         CH1:
-        - &id045
+        - &id047
           dmamux: DMAMUX1
           request: 37
         UP:
-        - &id046
+        - &id048
           dmamux: DMAMUX1
           request: 38
     TIM2:
       address: 0x40000000
       kind: TIM1_8WL5:gptimer2_v3_x
       block: timer_v1/TIM_GP16
-      pins: &id047
+      pins: &id049
       - pin: PA15
         signal: CH1
         af: 1
@@ -868,23 +884,23 @@ cores:
         UP: TIM2
       dma_channels:
         CH1:
-        - &id048
+        - &id050
           dmamux: DMAMUX1
           request: 30
         CH2:
-        - &id049
+        - &id051
           dmamux: DMAMUX1
           request: 31
         CH3:
-        - &id050
+        - &id052
           dmamux: DMAMUX1
           request: 32
         CH4:
-        - &id051
+        - &id053
           dmamux: DMAMUX1
           request: 33
         UP:
-        - &id052
+        - &id054
           dmamux: DMAMUX1
           request: 34
     USART1:
@@ -892,7 +908,7 @@ cores:
       kind: USART:sci3_v2_1
       clock: APB2
       block: usart_v2/USART
-      pins: &id053
+      pins: &id055
       - pin: PA12
         signal: DE
         af: 7
@@ -939,18 +955,18 @@ cores:
         GLOBAL: USART1
       dma_channels:
         RX:
-        - &id054
+        - &id056
           dmamux: DMAMUX1
           request: 17
         TX:
-        - &id055
+        - &id057
           dmamux: DMAMUX1
           request: 18
     USART2:
       address: 0x40004400
       kind: USART:sci3_v2_1
       block: usart_v2/USART
-      pins: &id056
+      pins: &id058
       - pin: PA0
         signal: CTS
         af: 7
@@ -976,17 +992,17 @@ cores:
         GLOBAL: USART2
       dma_channels:
         RX:
-        - &id057
+        - &id059
           dmamux: DMAMUX1
           request: 19
         TX:
-        - &id058
+        - &id060
           dmamux: DMAMUX1
           request: 20
     VREFBUF:
       address: 0x40010030
       kind: VREFBUF:STM32WL_vrefbuf_v1_0
-      pins: &id059
+      pins: &id061
       - pin: VREF+
         signal: OUT
     WWDG:
@@ -1320,6 +1336,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins: *id027
       interrupts:
         GLOBAL: SPI1
@@ -1332,6 +1349,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins: *id030
       interrupts:
         GLOBAL: SPI2
@@ -1340,6 +1358,16 @@ cores:
         - *id031
         TX:
         - *id032
+    SUBGHZSPI:
+      address: 0x58010000
+      kind: SUBGHZ:STM32WLxx_v1_0
+      block: spi_v2/SPI
+      clock: APB3
+      dma_channels:
+        RX:
+        - *id033
+        TX:
+        - *id034
     SYSCFG:
       address: 0x40010000
       kind: SYS:STM32WL5xx_sys_v1_0
@@ -1349,29 +1377,29 @@ cores:
       address: 0x40012c00
       kind: TIM1_8WL5:gptimer2_v3_x
       block: timer_v1/TIM_GP16
-      pins: *id033
+      pins: *id035
       interrupts: {}
       clock: APB2
       dma_channels:
         CH1:
-        - *id034
-        CH2:
-        - *id035
-        CH3:
         - *id036
-        CH4:
+        CH2:
         - *id037
-        COM:
+        CH3:
         - *id038
-        TRIG:
+        CH4:
         - *id039
-        UP:
+        COM:
         - *id040
+        TRIG:
+        - *id041
+        UP:
+        - *id042
     TIM16:
       address: 0x40014400
       kind: TIM1_8WL5:gptimer2_v3_x
       block: timer_v1/TIM_GP16
-      pins: *id041
+      pins: *id043
       interrupts:
         BRK: TIM16
         COM: TIM16
@@ -1380,14 +1408,14 @@ cores:
       clock: APB2
       dma_channels:
         CH1:
-        - *id042
+        - *id044
         UP:
-        - *id043
+        - *id045
     TIM17:
       address: 0x40014800
       kind: TIM1_8WL5:gptimer2_v3_x
       block: timer_v1/TIM_GP16
-      pins: *id044
+      pins: *id046
       interrupts:
         BRK: TIM17
         COM: TIM17
@@ -1396,14 +1424,14 @@ cores:
       clock: APB2
       dma_channels:
         CH1:
-        - *id045
+        - *id047
         UP:
-        - *id046
+        - *id048
     TIM2:
       address: 0x40000000
       kind: TIM1_8WL5:gptimer2_v3_x
       block: timer_v1/TIM_GP16
-      pins: *id047
+      pins: *id049
       interrupts:
         BRK: TIM2
         COM: TIM2
@@ -1411,44 +1439,44 @@ cores:
         UP: TIM2
       dma_channels:
         CH1:
-        - *id048
-        CH2:
-        - *id049
-        CH3:
         - *id050
-        CH4:
+        CH2:
         - *id051
-        UP:
+        CH3:
         - *id052
+        CH4:
+        - *id053
+        UP:
+        - *id054
     USART1:
       address: 0x40013800
       kind: USART:sci3_v2_1
       clock: APB2
       block: usart_v2/USART
-      pins: *id053
+      pins: *id055
       interrupts:
         GLOBAL: USART1
       dma_channels:
         RX:
-        - *id054
+        - *id056
         TX:
-        - *id055
+        - *id057
     USART2:
       address: 0x40004400
       kind: USART:sci3_v2_1
       block: usart_v2/USART
-      pins: *id056
+      pins: *id058
       interrupts:
         GLOBAL: USART2
       dma_channels:
         RX:
-        - *id057
+        - *id059
         TX:
-        - *id058
+        - *id060
     VREFBUF:
       address: 0x40010030
       kind: VREFBUF:STM32WL_vrefbuf_v1_0
-      pins: *id059
+      pins: *id061
     WWDG:
       address: 0x40002c00
       kind: WWDG:wwdg1_v2_0

--- a/data/chips/STM32WL55UC.yaml
+++ b/data/chips/STM32WL55UC.yaml
@@ -417,6 +417,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins: &id027
       - pin: PA15
         signal: NSS
@@ -463,6 +464,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins: &id030
       - pin: PA10
         signal: MOSI
@@ -490,6 +492,20 @@ cores:
         - &id032
           dmamux: DMAMUX1
           request: 10
+    SUBGHZSPI:
+      address: 0x58010000
+      kind: SUBGHZ:STM32WLxx_v1_0
+      block: spi_v2/SPI
+      clock: APB3
+      dma_channels:
+        RX:
+        - &id033
+          dmamux: DMAMUX1
+          request: 41
+        TX:
+        - &id034
+          dmamux: DMAMUX1
+          request: 42
     SYSCFG:
       address: 0x40010000
       kind: SYS:STM32WL5xx_sys_v1_0
@@ -499,7 +515,7 @@ cores:
       address: 0x40012c00
       kind: TIM1_8WL5:gptimer2_v3_x
       block: timer_v1/TIM_GP16
-      pins: &id033
+      pins: &id035
       - pin: PA10
         signal: CH3
         af: 1
@@ -532,38 +548,38 @@ cores:
       clock: APB2
       dma_channels:
         CH1:
-        - &id034
+        - &id036
           dmamux: DMAMUX1
           request: 23
         CH2:
-        - &id035
+        - &id037
           dmamux: DMAMUX1
           request: 24
         CH3:
-        - &id036
+        - &id038
           dmamux: DMAMUX1
           request: 25
         CH4:
-        - &id037
+        - &id039
           dmamux: DMAMUX1
           request: 26
         COM:
-        - &id038
+        - &id040
           dmamux: DMAMUX1
           request: 29
         TRIG:
-        - &id039
+        - &id041
           dmamux: DMAMUX1
           request: 28
         UP:
-        - &id040
+        - &id042
           dmamux: DMAMUX1
           request: 27
     TIM16:
       address: 0x40014400
       kind: TIM1_8WL5:gptimer2_v3_x
       block: timer_v1/TIM_GP16
-      pins: &id041
+      pins: &id043
       - pin: PA6
         signal: CH1
         af: 14
@@ -575,18 +591,18 @@ cores:
       clock: APB2
       dma_channels:
         CH1:
-        - &id042
+        - &id044
           dmamux: DMAMUX1
           request: 35
         UP:
-        - &id043
+        - &id045
           dmamux: DMAMUX1
           request: 36
     TIM17:
       address: 0x40014800
       kind: TIM1_8WL5:gptimer2_v3_x
       block: timer_v1/TIM_GP16
-      pins: &id044
+      pins: &id046
       - pin: PA10
         signal: BKIN
         af: 14
@@ -604,18 +620,18 @@ cores:
       clock: APB2
       dma_channels:
         CH1:
-        - &id045
+        - &id047
           dmamux: DMAMUX1
           request: 37
         UP:
-        - &id046
+        - &id048
           dmamux: DMAMUX1
           request: 38
     TIM2:
       address: 0x40000000
       kind: TIM1_8WL5:gptimer2_v3_x
       block: timer_v1/TIM_GP16
-      pins: &id047
+      pins: &id049
       - pin: PA15
         signal: CH1
         af: 1
@@ -653,23 +669,23 @@ cores:
         UP: TIM2
       dma_channels:
         CH1:
-        - &id048
+        - &id050
           dmamux: DMAMUX1
           request: 30
         CH2:
-        - &id049
+        - &id051
           dmamux: DMAMUX1
           request: 31
         CH3:
-        - &id050
+        - &id052
           dmamux: DMAMUX1
           request: 32
         CH4:
-        - &id051
+        - &id053
           dmamux: DMAMUX1
           request: 33
         UP:
-        - &id052
+        - &id054
           dmamux: DMAMUX1
           request: 34
     USART1:
@@ -677,7 +693,7 @@ cores:
       kind: USART:sci3_v2_1
       clock: APB2
       block: usart_v2/USART
-      pins: &id053
+      pins: &id055
       - pin: PA10
         signal: RX
         af: 7
@@ -715,18 +731,18 @@ cores:
         GLOBAL: USART1
       dma_channels:
         RX:
-        - &id054
+        - &id056
           dmamux: DMAMUX1
           request: 17
         TX:
-        - &id055
+        - &id057
           dmamux: DMAMUX1
           request: 18
     USART2:
       address: 0x40004400
       kind: USART:sci3_v2_1
       block: usart_v2/USART
-      pins: &id056
+      pins: &id058
       - pin: PA3
         signal: RX
         af: 7
@@ -752,11 +768,11 @@ cores:
         GLOBAL: USART2
       dma_channels:
         RX:
-        - &id057
+        - &id059
           dmamux: DMAMUX1
           request: 19
         TX:
-        - &id058
+        - &id060
           dmamux: DMAMUX1
           request: 20
     VREFBUF:
@@ -1093,6 +1109,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins: *id027
       interrupts:
         GLOBAL: SPI1
@@ -1105,6 +1122,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins: *id030
       interrupts:
         GLOBAL: SPI2
@@ -1113,6 +1131,16 @@ cores:
         - *id031
         TX:
         - *id032
+    SUBGHZSPI:
+      address: 0x58010000
+      kind: SUBGHZ:STM32WLxx_v1_0
+      block: spi_v2/SPI
+      clock: APB3
+      dma_channels:
+        RX:
+        - *id033
+        TX:
+        - *id034
     SYSCFG:
       address: 0x40010000
       kind: SYS:STM32WL5xx_sys_v1_0
@@ -1122,29 +1150,29 @@ cores:
       address: 0x40012c00
       kind: TIM1_8WL5:gptimer2_v3_x
       block: timer_v1/TIM_GP16
-      pins: *id033
+      pins: *id035
       interrupts: {}
       clock: APB2
       dma_channels:
         CH1:
-        - *id034
-        CH2:
-        - *id035
-        CH3:
         - *id036
-        CH4:
+        CH2:
         - *id037
-        COM:
+        CH3:
         - *id038
-        TRIG:
+        CH4:
         - *id039
-        UP:
+        COM:
         - *id040
+        TRIG:
+        - *id041
+        UP:
+        - *id042
     TIM16:
       address: 0x40014400
       kind: TIM1_8WL5:gptimer2_v3_x
       block: timer_v1/TIM_GP16
-      pins: *id041
+      pins: *id043
       interrupts:
         BRK: TIM16
         COM: TIM16
@@ -1153,14 +1181,14 @@ cores:
       clock: APB2
       dma_channels:
         CH1:
-        - *id042
+        - *id044
         UP:
-        - *id043
+        - *id045
     TIM17:
       address: 0x40014800
       kind: TIM1_8WL5:gptimer2_v3_x
       block: timer_v1/TIM_GP16
-      pins: *id044
+      pins: *id046
       interrupts:
         BRK: TIM17
         COM: TIM17
@@ -1169,14 +1197,14 @@ cores:
       clock: APB2
       dma_channels:
         CH1:
-        - *id045
+        - *id047
         UP:
-        - *id046
+        - *id048
     TIM2:
       address: 0x40000000
       kind: TIM1_8WL5:gptimer2_v3_x
       block: timer_v1/TIM_GP16
-      pins: *id047
+      pins: *id049
       interrupts:
         BRK: TIM2
         COM: TIM2
@@ -1184,40 +1212,40 @@ cores:
         UP: TIM2
       dma_channels:
         CH1:
-        - *id048
-        CH2:
-        - *id049
-        CH3:
         - *id050
-        CH4:
+        CH2:
         - *id051
-        UP:
+        CH3:
         - *id052
+        CH4:
+        - *id053
+        UP:
+        - *id054
     USART1:
       address: 0x40013800
       kind: USART:sci3_v2_1
       clock: APB2
       block: usart_v2/USART
-      pins: *id053
+      pins: *id055
       interrupts:
         GLOBAL: USART1
       dma_channels:
         RX:
-        - *id054
+        - *id056
         TX:
-        - *id055
+        - *id057
     USART2:
       address: 0x40004400
       kind: USART:sci3_v2_1
       block: usart_v2/USART
-      pins: *id056
+      pins: *id058
       interrupts:
         GLOBAL: USART2
       dma_channels:
         RX:
-        - *id057
+        - *id059
         TX:
-        - *id058
+        - *id060
     VREFBUF:
       address: 0x40010030
       kind: VREFBUF:STM32WL_vrefbuf_v1_0

--- a/data/chips/STM32WLE4C8.yaml
+++ b/data/chips/STM32WLE4C8.yaml
@@ -451,6 +451,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins:
       - pin: PB3
         signal: SCK
@@ -501,6 +502,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PA5
         signal: MISO
@@ -529,6 +531,18 @@ cores:
         TX:
         - dmamux: DMAMUX1
           request: 10
+    SUBGHZSPI:
+      address: 0x58010000
+      kind: SUBGHZ:STM32WLxx_v1_0
+      block: spi_v2/SPI
+      clock: APB3
+      dma_channels:
+        RX:
+        - dmamux: DMAMUX1
+          request: 41
+        TX:
+        - dmamux: DMAMUX1
+          request: 42
     SYSCFG:
       address: 0x40010000
       kind: SYS:STM32WL5xx_sys_v1_0

--- a/data/chips/STM32WLE4CB.yaml
+++ b/data/chips/STM32WLE4CB.yaml
@@ -451,6 +451,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins:
       - pin: PB3
         signal: SCK
@@ -501,6 +502,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PA5
         signal: MISO
@@ -529,6 +531,18 @@ cores:
         TX:
         - dmamux: DMAMUX1
           request: 10
+    SUBGHZSPI:
+      address: 0x58010000
+      kind: SUBGHZ:STM32WLxx_v1_0
+      block: spi_v2/SPI
+      clock: APB3
+      dma_channels:
+        RX:
+        - dmamux: DMAMUX1
+          request: 41
+        TX:
+        - dmamux: DMAMUX1
+          request: 42
     SYSCFG:
       address: 0x40010000
       kind: SYS:STM32WL5xx_sys_v1_0

--- a/data/chips/STM32WLE4CC.yaml
+++ b/data/chips/STM32WLE4CC.yaml
@@ -459,6 +459,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins:
       - pin: PB3
         signal: SCK
@@ -509,6 +510,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PA5
         signal: MISO
@@ -537,6 +539,18 @@ cores:
         TX:
         - dmamux: DMAMUX1
           request: 10
+    SUBGHZSPI:
+      address: 0x58010000
+      kind: SUBGHZ:STM32WLxx_v1_0
+      block: spi_v2/SPI
+      clock: APB3
+      dma_channels:
+        RX:
+        - dmamux: DMAMUX1
+          request: 41
+        TX:
+        - dmamux: DMAMUX1
+          request: 42
     SYSCFG:
       address: 0x40010000
       kind: SYS:STM32WL5xx_sys_v1_0

--- a/data/chips/STM32WLE4J8.yaml
+++ b/data/chips/STM32WLE4J8.yaml
@@ -531,6 +531,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins:
       - pin: PA12
         signal: MOSI
@@ -581,6 +582,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PB15
         signal: MOSI
@@ -633,6 +635,18 @@ cores:
         TX:
         - dmamux: DMAMUX1
           request: 10
+    SUBGHZSPI:
+      address: 0x58010000
+      kind: SUBGHZ:STM32WLxx_v1_0
+      block: spi_v2/SPI
+      clock: APB3
+      dma_channels:
+        RX:
+        - dmamux: DMAMUX1
+          request: 41
+        TX:
+        - dmamux: DMAMUX1
+          request: 42
     SYSCFG:
       address: 0x40010000
       kind: SYS:STM32WL5xx_sys_v1_0

--- a/data/chips/STM32WLE4JB.yaml
+++ b/data/chips/STM32WLE4JB.yaml
@@ -531,6 +531,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins:
       - pin: PA12
         signal: MOSI
@@ -581,6 +582,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PB15
         signal: MOSI
@@ -633,6 +635,18 @@ cores:
         TX:
         - dmamux: DMAMUX1
           request: 10
+    SUBGHZSPI:
+      address: 0x58010000
+      kind: SUBGHZ:STM32WLxx_v1_0
+      block: spi_v2/SPI
+      clock: APB3
+      dma_channels:
+        RX:
+        - dmamux: DMAMUX1
+          request: 41
+        TX:
+        - dmamux: DMAMUX1
+          request: 42
     SYSCFG:
       address: 0x40010000
       kind: SYS:STM32WL5xx_sys_v1_0

--- a/data/chips/STM32WLE4JC.yaml
+++ b/data/chips/STM32WLE4JC.yaml
@@ -539,6 +539,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins:
       - pin: PA12
         signal: MOSI
@@ -589,6 +590,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PB15
         signal: MOSI
@@ -641,6 +643,18 @@ cores:
         TX:
         - dmamux: DMAMUX1
           request: 10
+    SUBGHZSPI:
+      address: 0x58010000
+      kind: SUBGHZ:STM32WLxx_v1_0
+      block: spi_v2/SPI
+      clock: APB3
+      dma_channels:
+        RX:
+        - dmamux: DMAMUX1
+          request: 41
+        TX:
+        - dmamux: DMAMUX1
+          request: 42
     SYSCFG:
       address: 0x40010000
       kind: SYS:STM32WL5xx_sys_v1_0

--- a/data/chips/STM32WLE5C8.yaml
+++ b/data/chips/STM32WLE5C8.yaml
@@ -459,6 +459,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins:
       - pin: PB3
         signal: SCK
@@ -509,6 +510,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PA5
         signal: MISO
@@ -537,6 +539,18 @@ cores:
         TX:
         - dmamux: DMAMUX1
           request: 10
+    SUBGHZSPI:
+      address: 0x58010000
+      kind: SUBGHZ:STM32WLxx_v1_0
+      block: spi_v2/SPI
+      clock: APB3
+      dma_channels:
+        RX:
+        - dmamux: DMAMUX1
+          request: 41
+        TX:
+        - dmamux: DMAMUX1
+          request: 42
     SYSCFG:
       address: 0x40010000
       kind: SYS:STM32WL5xx_sys_v1_0

--- a/data/chips/STM32WLE5CB.yaml
+++ b/data/chips/STM32WLE5CB.yaml
@@ -459,6 +459,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins:
       - pin: PB3
         signal: SCK
@@ -509,6 +510,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PA5
         signal: MISO
@@ -537,6 +539,18 @@ cores:
         TX:
         - dmamux: DMAMUX1
           request: 10
+    SUBGHZSPI:
+      address: 0x58010000
+      kind: SUBGHZ:STM32WLxx_v1_0
+      block: spi_v2/SPI
+      clock: APB3
+      dma_channels:
+        RX:
+        - dmamux: DMAMUX1
+          request: 41
+        TX:
+        - dmamux: DMAMUX1
+          request: 42
     SYSCFG:
       address: 0x40010000
       kind: SYS:STM32WL5xx_sys_v1_0

--- a/data/chips/STM32WLE5CC.yaml
+++ b/data/chips/STM32WLE5CC.yaml
@@ -459,6 +459,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins:
       - pin: PB3
         signal: SCK
@@ -509,6 +510,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PA5
         signal: MISO
@@ -537,6 +539,18 @@ cores:
         TX:
         - dmamux: DMAMUX1
           request: 10
+    SUBGHZSPI:
+      address: 0x58010000
+      kind: SUBGHZ:STM32WLxx_v1_0
+      block: spi_v2/SPI
+      clock: APB3
+      dma_channels:
+        RX:
+        - dmamux: DMAMUX1
+          request: 41
+        TX:
+        - dmamux: DMAMUX1
+          request: 42
     SYSCFG:
       address: 0x40010000
       kind: SYS:STM32WL5xx_sys_v1_0

--- a/data/chips/STM32WLE5J8.yaml
+++ b/data/chips/STM32WLE5J8.yaml
@@ -539,6 +539,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins:
       - pin: PA12
         signal: MOSI
@@ -589,6 +590,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PB15
         signal: MOSI
@@ -641,6 +643,18 @@ cores:
         TX:
         - dmamux: DMAMUX1
           request: 10
+    SUBGHZSPI:
+      address: 0x58010000
+      kind: SUBGHZ:STM32WLxx_v1_0
+      block: spi_v2/SPI
+      clock: APB3
+      dma_channels:
+        RX:
+        - dmamux: DMAMUX1
+          request: 41
+        TX:
+        - dmamux: DMAMUX1
+          request: 42
     SYSCFG:
       address: 0x40010000
       kind: SYS:STM32WL5xx_sys_v1_0

--- a/data/chips/STM32WLE5JB.yaml
+++ b/data/chips/STM32WLE5JB.yaml
@@ -539,6 +539,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins:
       - pin: PA12
         signal: MOSI
@@ -589,6 +590,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PB15
         signal: MOSI
@@ -641,6 +643,18 @@ cores:
         TX:
         - dmamux: DMAMUX1
           request: 10
+    SUBGHZSPI:
+      address: 0x58010000
+      kind: SUBGHZ:STM32WLxx_v1_0
+      block: spi_v2/SPI
+      clock: APB3
+      dma_channels:
+        RX:
+        - dmamux: DMAMUX1
+          request: 41
+        TX:
+        - dmamux: DMAMUX1
+          request: 42
     SYSCFG:
       address: 0x40010000
       kind: SYS:STM32WL5xx_sys_v1_0

--- a/data/chips/STM32WLE5JC.yaml
+++ b/data/chips/STM32WLE5JC.yaml
@@ -539,6 +539,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins:
       - pin: PA12
         signal: MOSI
@@ -589,6 +590,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PB15
         signal: MOSI
@@ -641,6 +643,18 @@ cores:
         TX:
         - dmamux: DMAMUX1
           request: 10
+    SUBGHZSPI:
+      address: 0x58010000
+      kind: SUBGHZ:STM32WLxx_v1_0
+      block: spi_v2/SPI
+      clock: APB3
+      dma_channels:
+        RX:
+        - dmamux: DMAMUX1
+          request: 41
+        TX:
+        - dmamux: DMAMUX1
+          request: 42
     SYSCFG:
       address: 0x40010000
       kind: SYS:STM32WL5xx_sys_v1_0

--- a/data/chips/STM32WLE5U8.yaml
+++ b/data/chips/STM32WLE5U8.yaml
@@ -399,6 +399,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins:
       - pin: PA15
         signal: NSS
@@ -443,6 +444,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PA10
         signal: MOSI
@@ -468,6 +470,18 @@ cores:
         TX:
         - dmamux: DMAMUX1
           request: 10
+    SUBGHZSPI:
+      address: 0x58010000
+      kind: SUBGHZ:STM32WLxx_v1_0
+      block: spi_v2/SPI
+      clock: APB3
+      dma_channels:
+        RX:
+        - dmamux: DMAMUX1
+          request: 41
+        TX:
+        - dmamux: DMAMUX1
+          request: 42
     SYSCFG:
       address: 0x40010000
       kind: SYS:STM32WL5xx_sys_v1_0

--- a/data/chips/STM32WLE5UB.yaml
+++ b/data/chips/STM32WLE5UB.yaml
@@ -399,6 +399,7 @@ cores:
       address: 0x40013000
       kind: SPI:spi2s1_v3_5
       clock: APB2
+      block: spi_v2/SPI
       pins:
       - pin: PA15
         signal: NSS
@@ -443,6 +444,7 @@ cores:
       address: 0x40003800
       kind: SPI:spi2s1_v3_5
       clock: APB1
+      block: spi_v2/SPI
       pins:
       - pin: PA10
         signal: MOSI
@@ -468,6 +470,18 @@ cores:
         TX:
         - dmamux: DMAMUX1
           request: 10
+    SUBGHZSPI:
+      address: 0x58010000
+      kind: SUBGHZ:STM32WLxx_v1_0
+      block: spi_v2/SPI
+      clock: APB3
+      dma_channels:
+        RX:
+        - dmamux: DMAMUX1
+          request: 41
+        TX:
+        - dmamux: DMAMUX1
+          request: 42
     SYSCFG:
       address: 0x40010000
       kind: SYS:STM32WL5xx_sys_v1_0

--- a/extract.sh
+++ b/extract.sh
@@ -6,7 +6,7 @@ board=$1
 peri=$2
 mkdir -p regs/$peri
 
-cargo build --release --manifest-path ../../svd2rust/Cargo.toml 
+cargo build --release --manifest-path ../../svd4rust/Cargo.toml 
 
 transform="transform.yaml"
 
@@ -28,7 +28,7 @@ for f in `ls $query`; do
     f=${f#"stm32"}
     f=${f%".svd"}
     echo -n processing $f ...
-    RUST_LOG=info ../../svd2rust/target/release/svd4rust extract-peripheral --svd sources/svd/stm32$f.svd --transform $transform --peripheral $peri > regs/$peri/$f.yaml 2> regs/$peri/$f.yaml.out
+    RUST_LOG=info ../../svd4rust/target/release/svd4rust extract-peripheral --svd sources/svd/stm32$f.svd --transform $transform --peripheral $peri > regs/$peri/$f.yaml 2> regs/$peri/$f.yaml.out
     if [ $? -ne 0 ]; then 
         mv regs/$peri/$f.yaml.out regs/$peri/$f.err
         rm regs/$peri/$f.yaml

--- a/parse.py
+++ b/parse.py
@@ -330,6 +330,7 @@ perimap = [
     ('.*:SPI:spi2s1_v2_2', 'spi_v1/SPI'),
     ('.*:SPI:spi2s1_v3_3', 'spi_v2/SPI'),
     ('.*:SPI:spi2s1_v3_5', 'spi_v2/SPI'),
+    ('.*:SUBGHZSPI:.*', 'spi_v2/SPI'),
     ('.*:SPI:spi2s1_v3_1', 'spi_v2/SPI'),
     ('.*:SPI:spi2s2_v1_1', 'spi_v3/SPI'),
     ('.*:SPI:spi2s2_v1_0', 'spi_v3/SPI'),
@@ -657,6 +658,8 @@ def parse_chips():
 
                 if pname == 'SYS':
                     pname = 'SYSCFG'
+                if pname == 'SUBGHZ':
+                    pname = 'SUBGHZSPI'
                 if pname in FAKE_PERIPHERALS:
                     continue
                 if pname.startswith('ADC'):

--- a/parse.py
+++ b/parse.py
@@ -329,6 +329,7 @@ perimap = [
     ('.*:RNG:rng1_v3_1', 'rng_v1/RNG'),
     ('.*:SPI:spi2s1_v2_2', 'spi_v1/SPI'),
     ('.*:SPI:spi2s1_v3_3', 'spi_v2/SPI'),
+    ('.*:SPI:spi2s1_v3_5', 'spi_v2/SPI'),
     ('.*:SPI:spi2s1_v3_1', 'spi_v2/SPI'),
     ('.*:SPI:spi2s2_v1_1', 'spi_v3/SPI'),
     ('.*:SPI:spi2s2_v1_0', 'spi_v3/SPI'),


### PR DESCRIPTION
This adds the peripheral block for SPI2s1 v3_5 and also adds a mapping for the SUBGHZSPI peripheral on the WL5x devices which is using the same register block.