### PR TITLE
Fix ADC register layout on STM32G0

### DIFF
--- a/data/chips/STM32F030C6.yaml
+++ b/data/chips/STM32F030C6.yaml
@@ -87,18 +87,23 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F030C8.yaml
+++ b/data/chips/STM32F030C8.yaml
@@ -87,18 +87,23 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F030CC.yaml
+++ b/data/chips/STM32F030CC.yaml
@@ -89,18 +89,23 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F030F4.yaml
+++ b/data/chips/STM32F030F4.yaml
@@ -85,18 +85,23 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F030K6.yaml
+++ b/data/chips/STM32F030K6.yaml
@@ -87,18 +87,23 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F030R8.yaml
+++ b/data/chips/STM32F030R8.yaml
@@ -99,18 +99,23 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F030RC.yaml
+++ b/data/chips/STM32F030RC.yaml
@@ -101,18 +101,23 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F031C4.yaml
+++ b/data/chips/STM32F031C4.yaml
@@ -87,15 +87,19 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F031C6.yaml
+++ b/data/chips/STM32F031C6.yaml
@@ -87,15 +87,19 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F031E6.yaml
+++ b/data/chips/STM32F031E6.yaml
@@ -87,15 +87,19 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F031F4.yaml
+++ b/data/chips/STM32F031F4.yaml
@@ -85,15 +85,19 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F031F6.yaml
+++ b/data/chips/STM32F031F6.yaml
@@ -85,15 +85,19 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F031G4.yaml
+++ b/data/chips/STM32F031G4.yaml
@@ -87,15 +87,19 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F031G6.yaml
+++ b/data/chips/STM32F031G6.yaml
@@ -87,15 +87,19 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F031K4.yaml
+++ b/data/chips/STM32F031K4.yaml
@@ -87,15 +87,19 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F031K6.yaml
+++ b/data/chips/STM32F031K6.yaml
@@ -89,15 +89,19 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F038C6.yaml
+++ b/data/chips/STM32F038C6.yaml
@@ -87,15 +87,19 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F038E6.yaml
+++ b/data/chips/STM32F038E6.yaml
@@ -87,15 +87,19 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F038F6.yaml
+++ b/data/chips/STM32F038F6.yaml
@@ -83,15 +83,19 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F038G6.yaml
+++ b/data/chips/STM32F038G6.yaml
@@ -85,15 +85,19 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F038K6.yaml
+++ b/data/chips/STM32F038K6.yaml
@@ -87,15 +87,19 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F042C4.yaml
+++ b/data/chips/STM32F042C4.yaml
@@ -116,15 +116,19 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F042C6.yaml
+++ b/data/chips/STM32F042C6.yaml
@@ -116,15 +116,19 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F042F4.yaml
+++ b/data/chips/STM32F042F4.yaml
@@ -109,15 +109,19 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F042F6.yaml
+++ b/data/chips/STM32F042F6.yaml
@@ -109,15 +109,19 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F042G4.yaml
+++ b/data/chips/STM32F042G4.yaml
@@ -111,15 +111,19 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F042G6.yaml
+++ b/data/chips/STM32F042G6.yaml
@@ -111,15 +111,19 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F042K4.yaml
+++ b/data/chips/STM32F042K4.yaml
@@ -113,15 +113,19 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F042K6.yaml
+++ b/data/chips/STM32F042K6.yaml
@@ -113,15 +113,19 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F042T6.yaml
+++ b/data/chips/STM32F042T6.yaml
@@ -111,15 +111,19 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F048C6.yaml
+++ b/data/chips/STM32F048C6.yaml
@@ -91,15 +91,19 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F048G6.yaml
+++ b/data/chips/STM32F048G6.yaml
@@ -89,15 +89,19 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F048T6.yaml
+++ b/data/chips/STM32F048T6.yaml
@@ -91,15 +91,19 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F051C4.yaml
+++ b/data/chips/STM32F051C4.yaml
@@ -154,18 +154,23 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F051C6.yaml
+++ b/data/chips/STM32F051C6.yaml
@@ -154,18 +154,23 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F051C8.yaml
+++ b/data/chips/STM32F051C8.yaml
@@ -154,18 +154,23 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F051K4.yaml
+++ b/data/chips/STM32F051K4.yaml
@@ -154,18 +154,23 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F051K6.yaml
+++ b/data/chips/STM32F051K6.yaml
@@ -154,18 +154,23 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F051K8.yaml
+++ b/data/chips/STM32F051K8.yaml
@@ -154,18 +154,23 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F051R4.yaml
+++ b/data/chips/STM32F051R4.yaml
@@ -164,18 +164,23 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F051R6.yaml
+++ b/data/chips/STM32F051R6.yaml
@@ -164,18 +164,23 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F051R8.yaml
+++ b/data/chips/STM32F051R8.yaml
@@ -166,18 +166,23 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F051T8.yaml
+++ b/data/chips/STM32F051T8.yaml
@@ -152,18 +152,23 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F058C8.yaml
+++ b/data/chips/STM32F058C8.yaml
@@ -152,18 +152,23 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F058R8.yaml
+++ b/data/chips/STM32F058R8.yaml
@@ -166,18 +166,23 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F058T8.yaml
+++ b/data/chips/STM32F058T8.yaml
@@ -152,18 +152,23 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F070C6.yaml
+++ b/data/chips/STM32F070C6.yaml
@@ -87,18 +87,23 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F070CB.yaml
+++ b/data/chips/STM32F070CB.yaml
@@ -87,18 +87,23 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F070F6.yaml
+++ b/data/chips/STM32F070F6.yaml
@@ -85,18 +85,23 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F070RB.yaml
+++ b/data/chips/STM32F070RB.yaml
@@ -99,18 +99,23 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F071C8.yaml
+++ b/data/chips/STM32F071C8.yaml
@@ -154,21 +154,27 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x48001000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F071CB.yaml
+++ b/data/chips/STM32F071CB.yaml
@@ -156,21 +156,27 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x48001000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F071RB.yaml
+++ b/data/chips/STM32F071RB.yaml
@@ -164,21 +164,27 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x48001000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F071V8.yaml
+++ b/data/chips/STM32F071V8.yaml
@@ -166,21 +166,27 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x48001000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F071VB.yaml
+++ b/data/chips/STM32F071VB.yaml
@@ -166,21 +166,27 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x48001000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F072C8.yaml
+++ b/data/chips/STM32F072C8.yaml
@@ -177,21 +177,27 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x48001000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F072CB.yaml
+++ b/data/chips/STM32F072CB.yaml
@@ -179,21 +179,27 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x48001000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F072R8.yaml
+++ b/data/chips/STM32F072R8.yaml
@@ -187,21 +187,27 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x48001000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F072RB.yaml
+++ b/data/chips/STM32F072RB.yaml
@@ -191,21 +191,27 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x48001000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F072V8.yaml
+++ b/data/chips/STM32F072V8.yaml
@@ -195,21 +195,27 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x48001000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F072VB.yaml
+++ b/data/chips/STM32F072VB.yaml
@@ -195,21 +195,27 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x48001000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F078CB.yaml
+++ b/data/chips/STM32F078CB.yaml
@@ -156,21 +156,27 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x48001000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F078RB.yaml
+++ b/data/chips/STM32F078RB.yaml
@@ -166,21 +166,27 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x48001000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F078VB.yaml
+++ b/data/chips/STM32F078VB.yaml
@@ -166,21 +166,27 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x48001000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F091CB.yaml
+++ b/data/chips/STM32F091CB.yaml
@@ -189,21 +189,27 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x48001000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F091CC.yaml
+++ b/data/chips/STM32F091CC.yaml
@@ -189,21 +189,27 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x48001000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F091RB.yaml
+++ b/data/chips/STM32F091RB.yaml
@@ -199,21 +199,27 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x48001000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F091RC.yaml
+++ b/data/chips/STM32F091RC.yaml
@@ -203,21 +203,27 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x48001000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F091VB.yaml
+++ b/data/chips/STM32F091VB.yaml
@@ -205,21 +205,27 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x48001000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F091VC.yaml
+++ b/data/chips/STM32F091VC.yaml
@@ -207,21 +207,27 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x48001000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F098CC.yaml
+++ b/data/chips/STM32F098CC.yaml
@@ -189,21 +189,27 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x48001000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F098RC.yaml
+++ b/data/chips/STM32F098RC.yaml
@@ -203,21 +203,27 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x48001000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F098VC.yaml
+++ b/data/chips/STM32F098VC.yaml
@@ -207,21 +207,27 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x48001000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F100C4.yaml
+++ b/data/chips/STM32F100C4.yaml
@@ -104,18 +104,23 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOE:
       address: 0x40011800
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F100C6.yaml
+++ b/data/chips/STM32F100C6.yaml
@@ -104,18 +104,23 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOE:
       address: 0x40011800
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F100C8.yaml
+++ b/data/chips/STM32F100C8.yaml
@@ -104,18 +104,23 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOE:
       address: 0x40011800
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F100CB.yaml
+++ b/data/chips/STM32F100CB.yaml
@@ -104,18 +104,23 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOE:
       address: 0x40011800
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F100R4.yaml
+++ b/data/chips/STM32F100R4.yaml
@@ -118,18 +118,23 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOE:
       address: 0x40011800
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F100R6.yaml
+++ b/data/chips/STM32F100R6.yaml
@@ -118,18 +118,23 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOE:
       address: 0x40011800
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F100R8.yaml
+++ b/data/chips/STM32F100R8.yaml
@@ -118,18 +118,23 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOE:
       address: 0x40011800
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F100RB.yaml
+++ b/data/chips/STM32F100RB.yaml
@@ -118,18 +118,23 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOE:
       address: 0x40011800
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F100RC.yaml
+++ b/data/chips/STM32F100RC.yaml
@@ -128,24 +128,31 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOE:
       address: 0x40011800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOF:
       address: 0x40011c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOG:
       address: 0x40012000
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F100RD.yaml
+++ b/data/chips/STM32F100RD.yaml
@@ -128,24 +128,31 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOE:
       address: 0x40011800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOF:
       address: 0x40011c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOG:
       address: 0x40012000
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F100RE.yaml
+++ b/data/chips/STM32F100RE.yaml
@@ -128,24 +128,31 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOE:
       address: 0x40011800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOF:
       address: 0x40011c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOG:
       address: 0x40012000
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F100V8.yaml
+++ b/data/chips/STM32F100V8.yaml
@@ -116,18 +116,23 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOE:
       address: 0x40011800
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F100VB.yaml
+++ b/data/chips/STM32F100VB.yaml
@@ -116,18 +116,23 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOE:
       address: 0x40011800
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F100VC.yaml
+++ b/data/chips/STM32F100VC.yaml
@@ -128,24 +128,31 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOE:
       address: 0x40011800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOF:
       address: 0x40011c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOG:
       address: 0x40012000
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F100VD.yaml
+++ b/data/chips/STM32F100VD.yaml
@@ -128,24 +128,31 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOE:
       address: 0x40011800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOF:
       address: 0x40011c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOG:
       address: 0x40012000
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F100VE.yaml
+++ b/data/chips/STM32F100VE.yaml
@@ -128,24 +128,31 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOE:
       address: 0x40011800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOF:
       address: 0x40011c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOG:
       address: 0x40012000
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F100ZC.yaml
+++ b/data/chips/STM32F100ZC.yaml
@@ -128,24 +128,31 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOE:
       address: 0x40011800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOF:
       address: 0x40011c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOG:
       address: 0x40012000
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F100ZD.yaml
+++ b/data/chips/STM32F100ZD.yaml
@@ -128,24 +128,31 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOE:
       address: 0x40011800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOF:
       address: 0x40011c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOG:
       address: 0x40012000
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F100ZE.yaml
+++ b/data/chips/STM32F100ZE.yaml
@@ -128,24 +128,31 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOE:
       address: 0x40011800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOF:
       address: 0x40011c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOG:
       address: 0x40012000
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F101C4.yaml
+++ b/data/chips/STM32F101C4.yaml
@@ -88,15 +88,19 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F101C6.yaml
+++ b/data/chips/STM32F101C6.yaml
@@ -88,15 +88,19 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F101C8.yaml
+++ b/data/chips/STM32F101C8.yaml
@@ -90,18 +90,23 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOE:
       address: 0x40011800
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F101CB.yaml
+++ b/data/chips/STM32F101CB.yaml
@@ -90,18 +90,23 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOE:
       address: 0x40011800
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F101R4.yaml
+++ b/data/chips/STM32F101R4.yaml
@@ -100,15 +100,19 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F101R6.yaml
+++ b/data/chips/STM32F101R6.yaml
@@ -100,15 +100,19 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F101R8.yaml
+++ b/data/chips/STM32F101R8.yaml
@@ -100,18 +100,23 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOE:
       address: 0x40011800
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F101RB.yaml
+++ b/data/chips/STM32F101RB.yaml
@@ -100,18 +100,23 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOE:
       address: 0x40011800
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F101RC.yaml
+++ b/data/chips/STM32F101RC.yaml
@@ -123,24 +123,31 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOE:
       address: 0x40011800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOF:
       address: 0x40011c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOG:
       address: 0x40012000
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F101RD.yaml
+++ b/data/chips/STM32F101RD.yaml
@@ -123,24 +123,31 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOE:
       address: 0x40011800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOF:
       address: 0x40011c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOG:
       address: 0x40012000
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F101RE.yaml
+++ b/data/chips/STM32F101RE.yaml
@@ -123,24 +123,31 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOE:
       address: 0x40011800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOF:
       address: 0x40011c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOG:
       address: 0x40012000
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F101RF.yaml
+++ b/data/chips/STM32F101RF.yaml
@@ -123,24 +123,31 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOE:
       address: 0x40011800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOF:
       address: 0x40011c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOG:
       address: 0x40012000
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F101RG.yaml
+++ b/data/chips/STM32F101RG.yaml
@@ -123,24 +123,31 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOE:
       address: 0x40011800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOF:
       address: 0x40011c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOG:
       address: 0x40012000
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F101T4.yaml
+++ b/data/chips/STM32F101T4.yaml
@@ -88,15 +88,19 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F101T6.yaml
+++ b/data/chips/STM32F101T6.yaml
@@ -88,15 +88,19 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F101T8.yaml
+++ b/data/chips/STM32F101T8.yaml
@@ -88,18 +88,23 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOE:
       address: 0x40011800
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F101TB.yaml
+++ b/data/chips/STM32F101TB.yaml
@@ -88,18 +88,23 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOE:
       address: 0x40011800
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F101V8.yaml
+++ b/data/chips/STM32F101V8.yaml
@@ -100,18 +100,23 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOE:
       address: 0x40011800
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F101VB.yaml
+++ b/data/chips/STM32F101VB.yaml
@@ -100,18 +100,23 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOE:
       address: 0x40011800
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F101VC.yaml
+++ b/data/chips/STM32F101VC.yaml
@@ -123,24 +123,31 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOE:
       address: 0x40011800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOF:
       address: 0x40011c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOG:
       address: 0x40012000
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F101VD.yaml
+++ b/data/chips/STM32F101VD.yaml
@@ -123,24 +123,31 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOE:
       address: 0x40011800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOF:
       address: 0x40011c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOG:
       address: 0x40012000
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F101VE.yaml
+++ b/data/chips/STM32F101VE.yaml
@@ -123,24 +123,31 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOE:
       address: 0x40011800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOF:
       address: 0x40011c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOG:
       address: 0x40012000
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F101VF.yaml
+++ b/data/chips/STM32F101VF.yaml
@@ -123,24 +123,31 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOE:
       address: 0x40011800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOF:
       address: 0x40011c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOG:
       address: 0x40012000
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F101VG.yaml
+++ b/data/chips/STM32F101VG.yaml
@@ -123,24 +123,31 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOE:
       address: 0x40011800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOF:
       address: 0x40011c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOG:
       address: 0x40012000
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F101ZC.yaml
+++ b/data/chips/STM32F101ZC.yaml
@@ -123,24 +123,31 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOE:
       address: 0x40011800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOF:
       address: 0x40011c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOG:
       address: 0x40012000
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F101ZD.yaml
+++ b/data/chips/STM32F101ZD.yaml
@@ -123,24 +123,31 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOE:
       address: 0x40011800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOF:
       address: 0x40011c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOG:
       address: 0x40012000
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F101ZE.yaml
+++ b/data/chips/STM32F101ZE.yaml
@@ -123,24 +123,31 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOE:
       address: 0x40011800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOF:
       address: 0x40011c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOG:
       address: 0x40012000
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F101ZF.yaml
+++ b/data/chips/STM32F101ZF.yaml
@@ -123,24 +123,31 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOE:
       address: 0x40011800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOF:
       address: 0x40011c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOG:
       address: 0x40012000
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F101ZG.yaml
+++ b/data/chips/STM32F101ZG.yaml
@@ -123,24 +123,31 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOE:
       address: 0x40011800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOF:
       address: 0x40011c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOG:
       address: 0x40012000
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F102C4.yaml
+++ b/data/chips/STM32F102C4.yaml
@@ -88,15 +88,19 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F102C6.yaml
+++ b/data/chips/STM32F102C6.yaml
@@ -88,15 +88,19 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F102C8.yaml
+++ b/data/chips/STM32F102C8.yaml
@@ -88,15 +88,19 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F102CB.yaml
+++ b/data/chips/STM32F102CB.yaml
@@ -88,15 +88,19 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F102R4.yaml
+++ b/data/chips/STM32F102R4.yaml
@@ -100,15 +100,19 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F102R6.yaml
+++ b/data/chips/STM32F102R6.yaml
@@ -100,15 +100,19 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F102R8.yaml
+++ b/data/chips/STM32F102R8.yaml
@@ -100,15 +100,19 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F102RB.yaml
+++ b/data/chips/STM32F102RB.yaml
@@ -100,15 +100,19 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F103C4.yaml
+++ b/data/chips/STM32F103C4.yaml
@@ -114,15 +114,19 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F103C6.yaml
+++ b/data/chips/STM32F103C6.yaml
@@ -116,15 +116,19 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F103C8.yaml
+++ b/data/chips/STM32F103C8.yaml
@@ -114,18 +114,23 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOE:
       address: 0x40011800
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F103CB.yaml
+++ b/data/chips/STM32F103CB.yaml
@@ -116,18 +116,23 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOE:
       address: 0x40011800
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F103R4.yaml
+++ b/data/chips/STM32F103R4.yaml
@@ -140,15 +140,19 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F103R6.yaml
+++ b/data/chips/STM32F103R6.yaml
@@ -140,15 +140,19 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F103R8.yaml
+++ b/data/chips/STM32F103R8.yaml
@@ -140,18 +140,23 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOE:
       address: 0x40011800
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F103RB.yaml
+++ b/data/chips/STM32F103RB.yaml
@@ -140,18 +140,23 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOE:
       address: 0x40011800
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F103RC.yaml
+++ b/data/chips/STM32F103RC.yaml
@@ -183,24 +183,31 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOE:
       address: 0x40011800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOF:
       address: 0x40011c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOG:
       address: 0x40012000
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F103RD.yaml
+++ b/data/chips/STM32F103RD.yaml
@@ -183,24 +183,31 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOE:
       address: 0x40011800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOF:
       address: 0x40011c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOG:
       address: 0x40012000
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F103RE.yaml
+++ b/data/chips/STM32F103RE.yaml
@@ -183,24 +183,31 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOE:
       address: 0x40011800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOF:
       address: 0x40011c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOG:
       address: 0x40012000
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F103RF.yaml
+++ b/data/chips/STM32F103RF.yaml
@@ -187,24 +187,31 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOE:
       address: 0x40011800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOF:
       address: 0x40011c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOG:
       address: 0x40012000
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F103RG.yaml
+++ b/data/chips/STM32F103RG.yaml
@@ -187,24 +187,31 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOE:
       address: 0x40011800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOF:
       address: 0x40011c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOG:
       address: 0x40012000
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F103T4.yaml
+++ b/data/chips/STM32F103T4.yaml
@@ -114,15 +114,19 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F103T6.yaml
+++ b/data/chips/STM32F103T6.yaml
@@ -114,15 +114,19 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F103T8.yaml
+++ b/data/chips/STM32F103T8.yaml
@@ -114,18 +114,23 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOE:
       address: 0x40011800
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F103TB.yaml
+++ b/data/chips/STM32F103TB.yaml
@@ -114,18 +114,23 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOE:
       address: 0x40011800
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F103V8.yaml
+++ b/data/chips/STM32F103V8.yaml
@@ -140,18 +140,23 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOE:
       address: 0x40011800
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F103VB.yaml
+++ b/data/chips/STM32F103VB.yaml
@@ -142,18 +142,23 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOE:
       address: 0x40011800
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F103VC.yaml
+++ b/data/chips/STM32F103VC.yaml
@@ -189,24 +189,31 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOE:
       address: 0x40011800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOF:
       address: 0x40011c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOG:
       address: 0x40012000
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F103VD.yaml
+++ b/data/chips/STM32F103VD.yaml
@@ -189,24 +189,31 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOE:
       address: 0x40011800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOF:
       address: 0x40011c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOG:
       address: 0x40012000
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F103VE.yaml
+++ b/data/chips/STM32F103VE.yaml
@@ -189,24 +189,31 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOE:
       address: 0x40011800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOF:
       address: 0x40011c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOG:
       address: 0x40012000
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F103VF.yaml
+++ b/data/chips/STM32F103VF.yaml
@@ -187,24 +187,31 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOE:
       address: 0x40011800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOF:
       address: 0x40011c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOG:
       address: 0x40012000
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F103VG.yaml
+++ b/data/chips/STM32F103VG.yaml
@@ -187,24 +187,31 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOE:
       address: 0x40011800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOF:
       address: 0x40011c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOG:
       address: 0x40012000
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F103ZC.yaml
+++ b/data/chips/STM32F103ZC.yaml
@@ -199,24 +199,31 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOE:
       address: 0x40011800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOF:
       address: 0x40011c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOG:
       address: 0x40012000
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F103ZD.yaml
+++ b/data/chips/STM32F103ZD.yaml
@@ -199,24 +199,31 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOE:
       address: 0x40011800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOF:
       address: 0x40011c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOG:
       address: 0x40012000
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F103ZE.yaml
+++ b/data/chips/STM32F103ZE.yaml
@@ -199,24 +199,31 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOE:
       address: 0x40011800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOF:
       address: 0x40011c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOG:
       address: 0x40012000
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F103ZF.yaml
+++ b/data/chips/STM32F103ZF.yaml
@@ -199,24 +199,31 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOE:
       address: 0x40011800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOF:
       address: 0x40011c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOG:
       address: 0x40012000
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F103ZG.yaml
+++ b/data/chips/STM32F103ZG.yaml
@@ -199,24 +199,31 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOE:
       address: 0x40011800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOF:
       address: 0x40011c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOG:
       address: 0x40012000
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F105R8.yaml
+++ b/data/chips/STM32F105R8.yaml
@@ -200,18 +200,23 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOE:
       address: 0x40011800
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F105RB.yaml
+++ b/data/chips/STM32F105RB.yaml
@@ -200,18 +200,23 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOE:
       address: 0x40011800
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F105RC.yaml
+++ b/data/chips/STM32F105RC.yaml
@@ -200,18 +200,23 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOE:
       address: 0x40011800
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F105V8.yaml
+++ b/data/chips/STM32F105V8.yaml
@@ -206,18 +206,23 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOE:
       address: 0x40011800
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F105VB.yaml
+++ b/data/chips/STM32F105VB.yaml
@@ -206,18 +206,23 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOE:
       address: 0x40011800
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F105VC.yaml
+++ b/data/chips/STM32F105VC.yaml
@@ -204,18 +204,23 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOE:
       address: 0x40011800
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F107RB.yaml
+++ b/data/chips/STM32F107RB.yaml
@@ -246,18 +246,23 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOE:
       address: 0x40011800
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F107RC.yaml
+++ b/data/chips/STM32F107RC.yaml
@@ -246,18 +246,23 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOE:
       address: 0x40011800
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F107VB.yaml
+++ b/data/chips/STM32F107VB.yaml
@@ -262,18 +262,23 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOE:
       address: 0x40011800
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F107VC.yaml
+++ b/data/chips/STM32F107VC.yaml
@@ -264,18 +264,23 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOE:
       address: 0x40011800
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F301C6.yaml
+++ b/data/chips/STM32F301C6.yaml
@@ -150,18 +150,23 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F301C8.yaml
+++ b/data/chips/STM32F301C8.yaml
@@ -152,18 +152,23 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F301K6.yaml
+++ b/data/chips/STM32F301K6.yaml
@@ -123,18 +123,23 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F301K8.yaml
+++ b/data/chips/STM32F301K8.yaml
@@ -123,18 +123,23 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F301R6.yaml
+++ b/data/chips/STM32F301R6.yaml
@@ -161,18 +161,23 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F301R8.yaml
+++ b/data/chips/STM32F301R8.yaml
@@ -161,18 +161,23 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F302C6.yaml
+++ b/data/chips/STM32F302C6.yaml
@@ -173,18 +173,23 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F302C8.yaml
+++ b/data/chips/STM32F302C8.yaml
@@ -175,18 +175,23 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F302CB.yaml
+++ b/data/chips/STM32F302CB.yaml
@@ -227,21 +227,26 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x48001000
       block: gpio_v2/GPIO
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F302CC.yaml
+++ b/data/chips/STM32F302CC.yaml
@@ -227,21 +227,26 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x48001000
       block: gpio_v2/GPIO
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F302K6.yaml
+++ b/data/chips/STM32F302K6.yaml
@@ -138,18 +138,23 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F302K8.yaml
+++ b/data/chips/STM32F302K8.yaml
@@ -138,18 +138,23 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F302R6.yaml
+++ b/data/chips/STM32F302R6.yaml
@@ -184,18 +184,23 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F302R8.yaml
+++ b/data/chips/STM32F302R8.yaml
@@ -184,18 +184,23 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F302RB.yaml
+++ b/data/chips/STM32F302RB.yaml
@@ -255,21 +255,26 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x48001000
       block: gpio_v2/GPIO
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F302RC.yaml
+++ b/data/chips/STM32F302RC.yaml
@@ -255,21 +255,26 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x48001000
       block: gpio_v2/GPIO
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F302RD.yaml
+++ b/data/chips/STM32F302RD.yaml
@@ -248,21 +248,26 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x48001000
       block: gpio_v2/GPIO
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOG:
       address: 0x48001800
       block: gpio_v2/GPIO

--- a/data/chips/STM32F302RE.yaml
+++ b/data/chips/STM32F302RE.yaml
@@ -251,21 +251,26 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x48001000
       block: gpio_v2/GPIO
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOG:
       address: 0x48001800
       block: gpio_v2/GPIO

--- a/data/chips/STM32F302VB.yaml
+++ b/data/chips/STM32F302VB.yaml
@@ -273,21 +273,26 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x48001000
       block: gpio_v2/GPIO
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F302VC.yaml
+++ b/data/chips/STM32F302VC.yaml
@@ -270,21 +270,26 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x48001000
       block: gpio_v2/GPIO
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F302VD.yaml
+++ b/data/chips/STM32F302VD.yaml
@@ -264,21 +264,26 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x48001000
       block: gpio_v2/GPIO
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOG:
       address: 0x48001800
       block: gpio_v2/GPIO

--- a/data/chips/STM32F302VE.yaml
+++ b/data/chips/STM32F302VE.yaml
@@ -267,21 +267,26 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x48001000
       block: gpio_v2/GPIO
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOG:
       address: 0x48001800
       block: gpio_v2/GPIO

--- a/data/chips/STM32F302ZD.yaml
+++ b/data/chips/STM32F302ZD.yaml
@@ -267,21 +267,26 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x48001000
       block: gpio_v2/GPIO
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOG:
       address: 0x48001800
       block: gpio_v2/GPIO

--- a/data/chips/STM32F302ZE.yaml
+++ b/data/chips/STM32F302ZE.yaml
@@ -270,21 +270,26 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x48001000
       block: gpio_v2/GPIO
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOG:
       address: 0x48001800
       block: gpio_v2/GPIO

--- a/data/chips/STM32F303C6.yaml
+++ b/data/chips/STM32F303C6.yaml
@@ -206,18 +206,23 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F303C8.yaml
+++ b/data/chips/STM32F303C8.yaml
@@ -216,18 +216,23 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F303CB.yaml
+++ b/data/chips/STM32F303CB.yaml
@@ -302,21 +302,26 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x48001000
       block: gpio_v2/GPIO
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F303CC.yaml
+++ b/data/chips/STM32F303CC.yaml
@@ -302,21 +302,26 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x48001000
       block: gpio_v2/GPIO
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F303K6.yaml
+++ b/data/chips/STM32F303K6.yaml
@@ -167,18 +167,23 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F303K8.yaml
+++ b/data/chips/STM32F303K8.yaml
@@ -167,18 +167,23 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F303R6.yaml
+++ b/data/chips/STM32F303R6.yaml
@@ -229,18 +229,23 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F303R8.yaml
+++ b/data/chips/STM32F303R8.yaml
@@ -229,18 +229,23 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F303RB.yaml
+++ b/data/chips/STM32F303RB.yaml
@@ -343,21 +343,26 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x48001000
       block: gpio_v2/GPIO
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F303RC.yaml
+++ b/data/chips/STM32F303RC.yaml
@@ -343,21 +343,26 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x48001000
       block: gpio_v2/GPIO
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F303RD.yaml
+++ b/data/chips/STM32F303RD.yaml
@@ -336,21 +336,26 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x48001000
       block: gpio_v2/GPIO
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOG:
       address: 0x48001800
       block: gpio_v2/GPIO

--- a/data/chips/STM32F303RE.yaml
+++ b/data/chips/STM32F303RE.yaml
@@ -339,21 +339,26 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x48001000
       block: gpio_v2/GPIO
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOG:
       address: 0x48001800
       block: gpio_v2/GPIO

--- a/data/chips/STM32F303VB.yaml
+++ b/data/chips/STM32F303VB.yaml
@@ -413,21 +413,26 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x48001000
       block: gpio_v2/GPIO
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F303VC.yaml
+++ b/data/chips/STM32F303VC.yaml
@@ -398,21 +398,26 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x48001000
       block: gpio_v2/GPIO
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F303VD.yaml
+++ b/data/chips/STM32F303VD.yaml
@@ -400,21 +400,26 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x48001000
       block: gpio_v2/GPIO
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOG:
       address: 0x48001800
       block: gpio_v2/GPIO

--- a/data/chips/STM32F303VE.yaml
+++ b/data/chips/STM32F303VE.yaml
@@ -393,21 +393,26 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x48001000
       block: gpio_v2/GPIO
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOG:
       address: 0x48001800
       block: gpio_v2/GPIO

--- a/data/chips/STM32F303ZD.yaml
+++ b/data/chips/STM32F303ZD.yaml
@@ -403,21 +403,26 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x48001000
       block: gpio_v2/GPIO
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOG:
       address: 0x48001800
       block: gpio_v2/GPIO

--- a/data/chips/STM32F303ZE.yaml
+++ b/data/chips/STM32F303ZE.yaml
@@ -406,21 +406,26 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x48001000
       block: gpio_v2/GPIO
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOG:
       address: 0x48001800
       block: gpio_v2/GPIO

--- a/data/chips/STM32F318C8.yaml
+++ b/data/chips/STM32F318C8.yaml
@@ -150,18 +150,23 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F318K8.yaml
+++ b/data/chips/STM32F318K8.yaml
@@ -121,18 +121,23 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F328C8.yaml
+++ b/data/chips/STM32F328C8.yaml
@@ -202,18 +202,23 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F334C4.yaml
+++ b/data/chips/STM32F334C4.yaml
@@ -206,18 +206,23 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     HRTIM1:
       address: 0x40017400
       kind: HRTIM:hrtim_v1_0

--- a/data/chips/STM32F334C6.yaml
+++ b/data/chips/STM32F334C6.yaml
@@ -206,18 +206,23 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     HRTIM1:
       address: 0x40017400
       kind: HRTIM:hrtim_v1_0

--- a/data/chips/STM32F334C8.yaml
+++ b/data/chips/STM32F334C8.yaml
@@ -216,18 +216,23 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     HRTIM1:
       address: 0x40017400
       kind: HRTIM:hrtim_v1_0

--- a/data/chips/STM32F334K4.yaml
+++ b/data/chips/STM32F334K4.yaml
@@ -167,18 +167,23 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     HRTIM1:
       address: 0x40017400
       kind: HRTIM:hrtim_v1_0

--- a/data/chips/STM32F334K6.yaml
+++ b/data/chips/STM32F334K6.yaml
@@ -167,18 +167,23 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     HRTIM1:
       address: 0x40017400
       kind: HRTIM:hrtim_v1_0

--- a/data/chips/STM32F334K8.yaml
+++ b/data/chips/STM32F334K8.yaml
@@ -167,18 +167,23 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     HRTIM1:
       address: 0x40017400
       kind: HRTIM:hrtim_v1_0

--- a/data/chips/STM32F334R6.yaml
+++ b/data/chips/STM32F334R6.yaml
@@ -229,18 +229,23 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     HRTIM1:
       address: 0x40017400
       kind: HRTIM:hrtim_v1_0

--- a/data/chips/STM32F334R8.yaml
+++ b/data/chips/STM32F334R8.yaml
@@ -229,18 +229,23 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     HRTIM1:
       address: 0x40017400
       kind: HRTIM:hrtim_v1_0

--- a/data/chips/STM32F358CC.yaml
+++ b/data/chips/STM32F358CC.yaml
@@ -296,21 +296,26 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x48001000
       block: gpio_v2/GPIO
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F358RC.yaml
+++ b/data/chips/STM32F358RC.yaml
@@ -337,21 +337,26 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x48001000
       block: gpio_v2/GPIO
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F358VC.yaml
+++ b/data/chips/STM32F358VC.yaml
@@ -407,21 +407,26 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x48001000
       block: gpio_v2/GPIO
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F373C8.yaml
+++ b/data/chips/STM32F373C8.yaml
@@ -188,21 +188,26 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x48001000
       block: gpio_v2/GPIO
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F373CB.yaml
+++ b/data/chips/STM32F373CB.yaml
@@ -188,21 +188,26 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x48001000
       block: gpio_v2/GPIO
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F373CC.yaml
+++ b/data/chips/STM32F373CC.yaml
@@ -188,21 +188,26 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x48001000
       block: gpio_v2/GPIO
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F373R8.yaml
+++ b/data/chips/STM32F373R8.yaml
@@ -205,21 +205,26 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x48001000
       block: gpio_v2/GPIO
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F373RB.yaml
+++ b/data/chips/STM32F373RB.yaml
@@ -205,21 +205,26 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x48001000
       block: gpio_v2/GPIO
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F373RC.yaml
+++ b/data/chips/STM32F373RC.yaml
@@ -205,21 +205,26 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x48001000
       block: gpio_v2/GPIO
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F373V8.yaml
+++ b/data/chips/STM32F373V8.yaml
@@ -213,21 +213,26 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x48001000
       block: gpio_v2/GPIO
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F373VB.yaml
+++ b/data/chips/STM32F373VB.yaml
@@ -213,21 +213,26 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x48001000
       block: gpio_v2/GPIO
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F373VC.yaml
+++ b/data/chips/STM32F373VC.yaml
@@ -213,21 +213,26 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x48001000
       block: gpio_v2/GPIO
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F378CC.yaml
+++ b/data/chips/STM32F378CC.yaml
@@ -188,21 +188,26 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x48001000
       block: gpio_v2/GPIO
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F378RC.yaml
+++ b/data/chips/STM32F378RC.yaml
@@ -207,21 +207,26 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x48001000
       block: gpio_v2/GPIO
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F378VC.yaml
+++ b/data/chips/STM32F378VC.yaml
@@ -213,21 +213,26 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x48001000
       block: gpio_v2/GPIO
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F398VE.yaml
+++ b/data/chips/STM32F398VE.yaml
@@ -395,21 +395,26 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x48001000
       block: gpio_v2/GPIO
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOG:
       address: 0x48001800
       block: gpio_v2/GPIO

--- a/data/chips/STM32G030C6.yaml
+++ b/data/chips/STM32G030C6.yaml
@@ -32,7 +32,7 @@ cores:
     ADC1:
       address: 0x40012400
       kind: ADC:aditf4_v3_0
-      block: adc_v3/ADC
+      block: adc_g0/ADC
       pins:
       - pin: PA0
         signal: IN0

--- a/data/chips/STM32G030C6.yaml
+++ b/data/chips/STM32G030C6.yaml
@@ -195,6 +195,7 @@ cores:
     PWR:
       address: 0x40007000
       kind: PWR:STM32G0_pwr_v1_0
+      block: pwr_g0/PWR
     RCC:
       address: 0x40021000
       kind: RCC:STM32G0_64_rcc_v1_0

--- a/data/chips/STM32G030C8.yaml
+++ b/data/chips/STM32G030C8.yaml
@@ -32,7 +32,7 @@ cores:
     ADC1:
       address: 0x40012400
       kind: ADC:aditf4_v3_0
-      block: adc_v3/ADC
+      block: adc_g0/ADC
       pins:
       - pin: PA0
         signal: IN0

--- a/data/chips/STM32G030C8.yaml
+++ b/data/chips/STM32G030C8.yaml
@@ -195,6 +195,7 @@ cores:
     PWR:
       address: 0x40007000
       kind: PWR:STM32G0_pwr_v1_0
+      block: pwr_g0/PWR
     RCC:
       address: 0x40021000
       kind: RCC:STM32G0_64_rcc_v1_0

--- a/data/chips/STM32G030F6.yaml
+++ b/data/chips/STM32G030F6.yaml
@@ -183,6 +183,7 @@ cores:
     PWR:
       address: 0x40007000
       kind: PWR:STM32G0_pwr_v1_0
+      block: pwr_g0/PWR
     RCC:
       address: 0x40021000
       kind: RCC:STM32G0_64_rcc_v1_0

--- a/data/chips/STM32G030F6.yaml
+++ b/data/chips/STM32G030F6.yaml
@@ -32,7 +32,7 @@ cores:
     ADC1:
       address: 0x40012400
       kind: ADC:aditf4_v3_0
-      block: adc_v3/ADC
+      block: adc_g0/ADC
       pins:
       - pin: PB7
         signal: IN11

--- a/data/chips/STM32G030J6.yaml
+++ b/data/chips/STM32G030J6.yaml
@@ -171,6 +171,7 @@ cores:
     PWR:
       address: 0x40007000
       kind: PWR:STM32G0_pwr_v1_0
+      block: pwr_g0/PWR
     RCC:
       address: 0x40021000
       kind: RCC:STM32G0_64_rcc_v1_0

--- a/data/chips/STM32G030J6.yaml
+++ b/data/chips/STM32G030J6.yaml
@@ -32,7 +32,7 @@ cores:
     ADC1:
       address: 0x40012400
       kind: ADC:aditf4_v3_0
-      block: adc_v3/ADC
+      block: adc_g0/ADC
       pins:
       - pin: PB7
         signal: IN11

--- a/data/chips/STM32G030K6.yaml
+++ b/data/chips/STM32G030K6.yaml
@@ -32,7 +32,7 @@ cores:
     ADC1:
       address: 0x40012400
       kind: ADC:aditf4_v3_0
-      block: adc_v3/ADC
+      block: adc_g0/ADC
       pins:
       - pin: PA0
         signal: IN0

--- a/data/chips/STM32G030K6.yaml
+++ b/data/chips/STM32G030K6.yaml
@@ -183,6 +183,7 @@ cores:
     PWR:
       address: 0x40007000
       kind: PWR:STM32G0_pwr_v1_0
+      block: pwr_g0/PWR
     RCC:
       address: 0x40021000
       kind: RCC:STM32G0_64_rcc_v1_0

--- a/data/chips/STM32G030K8.yaml
+++ b/data/chips/STM32G030K8.yaml
@@ -32,7 +32,7 @@ cores:
     ADC1:
       address: 0x40012400
       kind: ADC:aditf4_v3_0
-      block: adc_v3/ADC
+      block: adc_g0/ADC
       pins:
       - pin: PA0
         signal: IN0

--- a/data/chips/STM32G030K8.yaml
+++ b/data/chips/STM32G030K8.yaml
@@ -183,6 +183,7 @@ cores:
     PWR:
       address: 0x40007000
       kind: PWR:STM32G0_pwr_v1_0
+      block: pwr_g0/PWR
     RCC:
       address: 0x40021000
       kind: RCC:STM32G0_64_rcc_v1_0

--- a/data/chips/STM32G031C4.yaml
+++ b/data/chips/STM32G031C4.yaml
@@ -34,7 +34,7 @@ cores:
     ADC1:
       address: 0x40012400
       kind: ADC:aditf4_v3_0
-      block: adc_v3/ADC
+      block: adc_g0/ADC
       pins:
       - pin: PA0
         signal: IN0

--- a/data/chips/STM32G031C4.yaml
+++ b/data/chips/STM32G031C4.yaml
@@ -287,6 +287,7 @@ cores:
     PWR:
       address: 0x40007000
       kind: PWR:STM32G0_pwr_v1_0
+      block: pwr_g0/PWR
     RCC:
       address: 0x40021000
       kind: RCC:STM32G0_64_rcc_v1_0

--- a/data/chips/STM32G031C6.yaml
+++ b/data/chips/STM32G031C6.yaml
@@ -34,7 +34,7 @@ cores:
     ADC1:
       address: 0x40012400
       kind: ADC:aditf4_v3_0
-      block: adc_v3/ADC
+      block: adc_g0/ADC
       pins:
       - pin: PA0
         signal: IN0

--- a/data/chips/STM32G031C6.yaml
+++ b/data/chips/STM32G031C6.yaml
@@ -287,6 +287,7 @@ cores:
     PWR:
       address: 0x40007000
       kind: PWR:STM32G0_pwr_v1_0
+      block: pwr_g0/PWR
     RCC:
       address: 0x40021000
       kind: RCC:STM32G0_64_rcc_v1_0

--- a/data/chips/STM32G031C8.yaml
+++ b/data/chips/STM32G031C8.yaml
@@ -34,7 +34,7 @@ cores:
     ADC1:
       address: 0x40012400
       kind: ADC:aditf4_v3_0
-      block: adc_v3/ADC
+      block: adc_g0/ADC
       pins:
       - pin: PA0
         signal: IN0

--- a/data/chips/STM32G031C8.yaml
+++ b/data/chips/STM32G031C8.yaml
@@ -287,6 +287,7 @@ cores:
     PWR:
       address: 0x40007000
       kind: PWR:STM32G0_pwr_v1_0
+      block: pwr_g0/PWR
     RCC:
       address: 0x40021000
       kind: RCC:STM32G0_64_rcc_v1_0

--- a/data/chips/STM32G031F4.yaml
+++ b/data/chips/STM32G031F4.yaml
@@ -32,7 +32,7 @@ cores:
     ADC1:
       address: 0x40012400
       kind: ADC:aditf4_v3_0
-      block: adc_v3/ADC
+      block: adc_g0/ADC
       pins:
       - pin: PB7
         signal: IN11

--- a/data/chips/STM32G031F4.yaml
+++ b/data/chips/STM32G031F4.yaml
@@ -256,6 +256,7 @@ cores:
     PWR:
       address: 0x40007000
       kind: PWR:STM32G0_pwr_v1_0
+      block: pwr_g0/PWR
     RCC:
       address: 0x40021000
       kind: RCC:STM32G0_64_rcc_v1_0

--- a/data/chips/STM32G031F6.yaml
+++ b/data/chips/STM32G031F6.yaml
@@ -32,7 +32,7 @@ cores:
     ADC1:
       address: 0x40012400
       kind: ADC:aditf4_v3_0
-      block: adc_v3/ADC
+      block: adc_g0/ADC
       pins:
       - pin: PB7
         signal: IN11

--- a/data/chips/STM32G031F6.yaml
+++ b/data/chips/STM32G031F6.yaml
@@ -256,6 +256,7 @@ cores:
     PWR:
       address: 0x40007000
       kind: PWR:STM32G0_pwr_v1_0
+      block: pwr_g0/PWR
     RCC:
       address: 0x40021000
       kind: RCC:STM32G0_64_rcc_v1_0

--- a/data/chips/STM32G031F8.yaml
+++ b/data/chips/STM32G031F8.yaml
@@ -32,7 +32,7 @@ cores:
     ADC1:
       address: 0x40012400
       kind: ADC:aditf4_v3_0
-      block: adc_v3/ADC
+      block: adc_g0/ADC
       pins:
       - pin: PB7
         signal: IN11

--- a/data/chips/STM32G031F8.yaml
+++ b/data/chips/STM32G031F8.yaml
@@ -256,6 +256,7 @@ cores:
     PWR:
       address: 0x40007000
       kind: PWR:STM32G0_pwr_v1_0
+      block: pwr_g0/PWR
     RCC:
       address: 0x40021000
       kind: RCC:STM32G0_64_rcc_v1_0

--- a/data/chips/STM32G031G4.yaml
+++ b/data/chips/STM32G031G4.yaml
@@ -32,7 +32,7 @@ cores:
     ADC1:
       address: 0x40012400
       kind: ADC:aditf4_v3_0
-      block: adc_v3/ADC
+      block: adc_g0/ADC
       pins:
       - pin: PA0
         signal: IN0

--- a/data/chips/STM32G031G4.yaml
+++ b/data/chips/STM32G031G4.yaml
@@ -248,6 +248,7 @@ cores:
     PWR:
       address: 0x40007000
       kind: PWR:STM32G0_pwr_v1_0
+      block: pwr_g0/PWR
     RCC:
       address: 0x40021000
       kind: RCC:STM32G0_64_rcc_v1_0

--- a/data/chips/STM32G031G6.yaml
+++ b/data/chips/STM32G031G6.yaml
@@ -32,7 +32,7 @@ cores:
     ADC1:
       address: 0x40012400
       kind: ADC:aditf4_v3_0
-      block: adc_v3/ADC
+      block: adc_g0/ADC
       pins:
       - pin: PA0
         signal: IN0

--- a/data/chips/STM32G031G6.yaml
+++ b/data/chips/STM32G031G6.yaml
@@ -248,6 +248,7 @@ cores:
     PWR:
       address: 0x40007000
       kind: PWR:STM32G0_pwr_v1_0
+      block: pwr_g0/PWR
     RCC:
       address: 0x40021000
       kind: RCC:STM32G0_64_rcc_v1_0

--- a/data/chips/STM32G031G8.yaml
+++ b/data/chips/STM32G031G8.yaml
@@ -32,7 +32,7 @@ cores:
     ADC1:
       address: 0x40012400
       kind: ADC:aditf4_v3_0
-      block: adc_v3/ADC
+      block: adc_g0/ADC
       pins:
       - pin: PA0
         signal: IN0

--- a/data/chips/STM32G031G8.yaml
+++ b/data/chips/STM32G031G8.yaml
@@ -248,6 +248,7 @@ cores:
     PWR:
       address: 0x40007000
       kind: PWR:STM32G0_pwr_v1_0
+      block: pwr_g0/PWR
     RCC:
       address: 0x40021000
       kind: RCC:STM32G0_64_rcc_v1_0

--- a/data/chips/STM32G031J4.yaml
+++ b/data/chips/STM32G031J4.yaml
@@ -229,6 +229,7 @@ cores:
     PWR:
       address: 0x40007000
       kind: PWR:STM32G0_pwr_v1_0
+      block: pwr_g0/PWR
     RCC:
       address: 0x40021000
       kind: RCC:STM32G0_64_rcc_v1_0

--- a/data/chips/STM32G031J4.yaml
+++ b/data/chips/STM32G031J4.yaml
@@ -32,7 +32,7 @@ cores:
     ADC1:
       address: 0x40012400
       kind: ADC:aditf4_v3_0
-      block: adc_v3/ADC
+      block: adc_g0/ADC
       pins:
       - pin: PB7
         signal: IN11

--- a/data/chips/STM32G031J6.yaml
+++ b/data/chips/STM32G031J6.yaml
@@ -229,6 +229,7 @@ cores:
     PWR:
       address: 0x40007000
       kind: PWR:STM32G0_pwr_v1_0
+      block: pwr_g0/PWR
     RCC:
       address: 0x40021000
       kind: RCC:STM32G0_64_rcc_v1_0

--- a/data/chips/STM32G031J6.yaml
+++ b/data/chips/STM32G031J6.yaml
@@ -32,7 +32,7 @@ cores:
     ADC1:
       address: 0x40012400
       kind: ADC:aditf4_v3_0
-      block: adc_v3/ADC
+      block: adc_g0/ADC
       pins:
       - pin: PB7
         signal: IN11

--- a/data/chips/STM32G031K4.yaml
+++ b/data/chips/STM32G031K4.yaml
@@ -34,7 +34,7 @@ cores:
     ADC1:
       address: 0x40012400
       kind: ADC:aditf4_v3_0
-      block: adc_v3/ADC
+      block: adc_g0/ADC
       pins:
       - pin: PA0
         signal: IN0

--- a/data/chips/STM32G031K4.yaml
+++ b/data/chips/STM32G031K4.yaml
@@ -258,6 +258,7 @@ cores:
     PWR:
       address: 0x40007000
       kind: PWR:STM32G0_pwr_v1_0
+      block: pwr_g0/PWR
     RCC:
       address: 0x40021000
       kind: RCC:STM32G0_64_rcc_v1_0

--- a/data/chips/STM32G031K6.yaml
+++ b/data/chips/STM32G031K6.yaml
@@ -34,7 +34,7 @@ cores:
     ADC1:
       address: 0x40012400
       kind: ADC:aditf4_v3_0
-      block: adc_v3/ADC
+      block: adc_g0/ADC
       pins:
       - pin: PA0
         signal: IN0

--- a/data/chips/STM32G031K6.yaml
+++ b/data/chips/STM32G031K6.yaml
@@ -258,6 +258,7 @@ cores:
     PWR:
       address: 0x40007000
       kind: PWR:STM32G0_pwr_v1_0
+      block: pwr_g0/PWR
     RCC:
       address: 0x40021000
       kind: RCC:STM32G0_64_rcc_v1_0

--- a/data/chips/STM32G031K8.yaml
+++ b/data/chips/STM32G031K8.yaml
@@ -34,7 +34,7 @@ cores:
     ADC1:
       address: 0x40012400
       kind: ADC:aditf4_v3_0
-      block: adc_v3/ADC
+      block: adc_g0/ADC
       pins:
       - pin: PA0
         signal: IN0

--- a/data/chips/STM32G031K8.yaml
+++ b/data/chips/STM32G031K8.yaml
@@ -258,6 +258,7 @@ cores:
     PWR:
       address: 0x40007000
       kind: PWR:STM32G0_pwr_v1_0
+      block: pwr_g0/PWR
     RCC:
       address: 0x40021000
       kind: RCC:STM32G0_64_rcc_v1_0

--- a/data/chips/STM32G031Y8.yaml
+++ b/data/chips/STM32G031Y8.yaml
@@ -32,7 +32,7 @@ cores:
     ADC1:
       address: 0x40012400
       kind: ADC:aditf4_v3_0
-      block: adc_v3/ADC
+      block: adc_g0/ADC
       pins:
       - pin: PA13
         signal: IN17

--- a/data/chips/STM32G031Y8.yaml
+++ b/data/chips/STM32G031Y8.yaml
@@ -256,6 +256,7 @@ cores:
     PWR:
       address: 0x40007000
       kind: PWR:STM32G0_pwr_v1_0
+      block: pwr_g0/PWR
     RCC:
       address: 0x40021000
       kind: RCC:STM32G0_64_rcc_v1_0

--- a/data/chips/STM32G041C6.yaml
+++ b/data/chips/STM32G041C6.yaml
@@ -34,7 +34,7 @@ cores:
     ADC1:
       address: 0x40012400
       kind: ADC:aditf4_v3_0
-      block: adc_v3/ADC
+      block: adc_g0/ADC
       pins:
       - pin: PA0
         signal: IN0

--- a/data/chips/STM32G041C6.yaml
+++ b/data/chips/STM32G041C6.yaml
@@ -299,6 +299,7 @@ cores:
     PWR:
       address: 0x40007000
       kind: PWR:STM32G0_pwr_v1_0
+      block: pwr_g0/PWR
     RCC:
       address: 0x40021000
       kind: RCC:STM32G0_64_rcc_v1_0

--- a/data/chips/STM32G041C8.yaml
+++ b/data/chips/STM32G041C8.yaml
@@ -34,7 +34,7 @@ cores:
     ADC1:
       address: 0x40012400
       kind: ADC:aditf4_v3_0
-      block: adc_v3/ADC
+      block: adc_g0/ADC
       pins:
       - pin: PA0
         signal: IN0

--- a/data/chips/STM32G041C8.yaml
+++ b/data/chips/STM32G041C8.yaml
@@ -299,6 +299,7 @@ cores:
     PWR:
       address: 0x40007000
       kind: PWR:STM32G0_pwr_v1_0
+      block: pwr_g0/PWR
     RCC:
       address: 0x40021000
       kind: RCC:STM32G0_64_rcc_v1_0

--- a/data/chips/STM32G041F6.yaml
+++ b/data/chips/STM32G041F6.yaml
@@ -268,6 +268,7 @@ cores:
     PWR:
       address: 0x40007000
       kind: PWR:STM32G0_pwr_v1_0
+      block: pwr_g0/PWR
     RCC:
       address: 0x40021000
       kind: RCC:STM32G0_64_rcc_v1_0

--- a/data/chips/STM32G041F6.yaml
+++ b/data/chips/STM32G041F6.yaml
@@ -32,7 +32,7 @@ cores:
     ADC1:
       address: 0x40012400
       kind: ADC:aditf4_v3_0
-      block: adc_v3/ADC
+      block: adc_g0/ADC
       pins:
       - pin: PB7
         signal: IN11

--- a/data/chips/STM32G041F8.yaml
+++ b/data/chips/STM32G041F8.yaml
@@ -268,6 +268,7 @@ cores:
     PWR:
       address: 0x40007000
       kind: PWR:STM32G0_pwr_v1_0
+      block: pwr_g0/PWR
     RCC:
       address: 0x40021000
       kind: RCC:STM32G0_64_rcc_v1_0

--- a/data/chips/STM32G041F8.yaml
+++ b/data/chips/STM32G041F8.yaml
@@ -32,7 +32,7 @@ cores:
     ADC1:
       address: 0x40012400
       kind: ADC:aditf4_v3_0
-      block: adc_v3/ADC
+      block: adc_g0/ADC
       pins:
       - pin: PB7
         signal: IN11

--- a/data/chips/STM32G041G6.yaml
+++ b/data/chips/STM32G041G6.yaml
@@ -32,7 +32,7 @@ cores:
     ADC1:
       address: 0x40012400
       kind: ADC:aditf4_v3_0
-      block: adc_v3/ADC
+      block: adc_g0/ADC
       pins:
       - pin: PA0
         signal: IN0

--- a/data/chips/STM32G041G6.yaml
+++ b/data/chips/STM32G041G6.yaml
@@ -260,6 +260,7 @@ cores:
     PWR:
       address: 0x40007000
       kind: PWR:STM32G0_pwr_v1_0
+      block: pwr_g0/PWR
     RCC:
       address: 0x40021000
       kind: RCC:STM32G0_64_rcc_v1_0

--- a/data/chips/STM32G041G8.yaml
+++ b/data/chips/STM32G041G8.yaml
@@ -32,7 +32,7 @@ cores:
     ADC1:
       address: 0x40012400
       kind: ADC:aditf4_v3_0
-      block: adc_v3/ADC
+      block: adc_g0/ADC
       pins:
       - pin: PA0
         signal: IN0

--- a/data/chips/STM32G041G8.yaml
+++ b/data/chips/STM32G041G8.yaml
@@ -260,6 +260,7 @@ cores:
     PWR:
       address: 0x40007000
       kind: PWR:STM32G0_pwr_v1_0
+      block: pwr_g0/PWR
     RCC:
       address: 0x40021000
       kind: RCC:STM32G0_64_rcc_v1_0

--- a/data/chips/STM32G041J6.yaml
+++ b/data/chips/STM32G041J6.yaml
@@ -241,6 +241,7 @@ cores:
     PWR:
       address: 0x40007000
       kind: PWR:STM32G0_pwr_v1_0
+      block: pwr_g0/PWR
     RCC:
       address: 0x40021000
       kind: RCC:STM32G0_64_rcc_v1_0

--- a/data/chips/STM32G041J6.yaml
+++ b/data/chips/STM32G041J6.yaml
@@ -32,7 +32,7 @@ cores:
     ADC1:
       address: 0x40012400
       kind: ADC:aditf4_v3_0
-      block: adc_v3/ADC
+      block: adc_g0/ADC
       pins:
       - pin: PB7
         signal: IN11

--- a/data/chips/STM32G041K6.yaml
+++ b/data/chips/STM32G041K6.yaml
@@ -34,7 +34,7 @@ cores:
     ADC1:
       address: 0x40012400
       kind: ADC:aditf4_v3_0
-      block: adc_v3/ADC
+      block: adc_g0/ADC
       pins:
       - pin: PA0
         signal: IN0

--- a/data/chips/STM32G041K6.yaml
+++ b/data/chips/STM32G041K6.yaml
@@ -270,6 +270,7 @@ cores:
     PWR:
       address: 0x40007000
       kind: PWR:STM32G0_pwr_v1_0
+      block: pwr_g0/PWR
     RCC:
       address: 0x40021000
       kind: RCC:STM32G0_64_rcc_v1_0

--- a/data/chips/STM32G041K8.yaml
+++ b/data/chips/STM32G041K8.yaml
@@ -34,7 +34,7 @@ cores:
     ADC1:
       address: 0x40012400
       kind: ADC:aditf4_v3_0
-      block: adc_v3/ADC
+      block: adc_g0/ADC
       pins:
       - pin: PA0
         signal: IN0

--- a/data/chips/STM32G041K8.yaml
+++ b/data/chips/STM32G041K8.yaml
@@ -270,6 +270,7 @@ cores:
     PWR:
       address: 0x40007000
       kind: PWR:STM32G0_pwr_v1_0
+      block: pwr_g0/PWR
     RCC:
       address: 0x40021000
       kind: RCC:STM32G0_64_rcc_v1_0

--- a/data/chips/STM32G041Y8.yaml
+++ b/data/chips/STM32G041Y8.yaml
@@ -32,7 +32,7 @@ cores:
     ADC1:
       address: 0x40012400
       kind: ADC:aditf4_v3_0
-      block: adc_v3/ADC
+      block: adc_g0/ADC
       pins:
       - pin: PA13
         signal: IN17

--- a/data/chips/STM32G041Y8.yaml
+++ b/data/chips/STM32G041Y8.yaml
@@ -268,6 +268,7 @@ cores:
     PWR:
       address: 0x40007000
       kind: PWR:STM32G0_pwr_v1_0
+      block: pwr_g0/PWR
     RCC:
       address: 0x40021000
       kind: RCC:STM32G0_64_rcc_v1_0

--- a/data/chips/STM32G050C6.yaml
+++ b/data/chips/STM32G050C6.yaml
@@ -189,6 +189,7 @@ cores:
     PWR:
       address: 0x40007000
       kind: PWR:STM32G0_pwr_v1_0
+      block: pwr_g0/PWR
     RCC:
       address: 0x40021000
       kind: RCC:STM32G06_rcc_v1_0

--- a/data/chips/STM32G050C6.yaml
+++ b/data/chips/STM32G050C6.yaml
@@ -21,7 +21,7 @@ cores:
     ADC1:
       address: 0x40012400
       kind: ADC:aditf4_v3_0
-      block: adc_v3/ADC
+      block: adc_g0/ADC
       pins:
       - pin: PA0
         signal: IN0

--- a/data/chips/STM32G050C8.yaml
+++ b/data/chips/STM32G050C8.yaml
@@ -189,6 +189,7 @@ cores:
     PWR:
       address: 0x40007000
       kind: PWR:STM32G0_pwr_v1_0
+      block: pwr_g0/PWR
     RCC:
       address: 0x40021000
       kind: RCC:STM32G06_rcc_v1_0

--- a/data/chips/STM32G050C8.yaml
+++ b/data/chips/STM32G050C8.yaml
@@ -21,7 +21,7 @@ cores:
     ADC1:
       address: 0x40012400
       kind: ADC:aditf4_v3_0
-      block: adc_v3/ADC
+      block: adc_g0/ADC
       pins:
       - pin: PA0
         signal: IN0

--- a/data/chips/STM32G050F6.yaml
+++ b/data/chips/STM32G050F6.yaml
@@ -171,6 +171,7 @@ cores:
     PWR:
       address: 0x40007000
       kind: PWR:STM32G0_pwr_v1_0
+      block: pwr_g0/PWR
     RCC:
       address: 0x40021000
       kind: RCC:STM32G06_rcc_v1_0

--- a/data/chips/STM32G050F6.yaml
+++ b/data/chips/STM32G050F6.yaml
@@ -21,7 +21,7 @@ cores:
     ADC1:
       address: 0x40012400
       kind: ADC:aditf4_v3_0
-      block: adc_v3/ADC
+      block: adc_g0/ADC
       pins:
       - pin: PB7
         signal: IN11

--- a/data/chips/STM32G050K6.yaml
+++ b/data/chips/STM32G050K6.yaml
@@ -171,6 +171,7 @@ cores:
     PWR:
       address: 0x40007000
       kind: PWR:STM32G0_pwr_v1_0
+      block: pwr_g0/PWR
     RCC:
       address: 0x40021000
       kind: RCC:STM32G06_rcc_v1_0

--- a/data/chips/STM32G050K6.yaml
+++ b/data/chips/STM32G050K6.yaml
@@ -21,7 +21,7 @@ cores:
     ADC1:
       address: 0x40012400
       kind: ADC:aditf4_v3_0
-      block: adc_v3/ADC
+      block: adc_g0/ADC
       pins:
       - pin: PA0
         signal: IN0

--- a/data/chips/STM32G050K8.yaml
+++ b/data/chips/STM32G050K8.yaml
@@ -171,6 +171,7 @@ cores:
     PWR:
       address: 0x40007000
       kind: PWR:STM32G0_pwr_v1_0
+      block: pwr_g0/PWR
     RCC:
       address: 0x40021000
       kind: RCC:STM32G06_rcc_v1_0

--- a/data/chips/STM32G050K8.yaml
+++ b/data/chips/STM32G050K8.yaml
@@ -21,7 +21,7 @@ cores:
     ADC1:
       address: 0x40012400
       kind: ADC:aditf4_v3_0
-      block: adc_v3/ADC
+      block: adc_g0/ADC
       pins:
       - pin: PA0
         signal: IN0

--- a/data/chips/STM32G051C6.yaml
+++ b/data/chips/STM32G051C6.yaml
@@ -26,7 +26,7 @@ cores:
     ADC1:
       address: 0x40012400
       kind: ADC:aditf4_v3_0
-      block: adc_v3/ADC
+      block: adc_g0/ADC
       pins:
       - pin: PA0
         signal: IN0

--- a/data/chips/STM32G051C6.yaml
+++ b/data/chips/STM32G051C6.yaml
@@ -363,6 +363,7 @@ cores:
     PWR:
       address: 0x40007000
       kind: PWR:STM32G0_pwr_v1_0
+      block: pwr_g0/PWR
     RCC:
       address: 0x40021000
       kind: RCC:STM32G06_rcc_v1_0

--- a/data/chips/STM32G051C8.yaml
+++ b/data/chips/STM32G051C8.yaml
@@ -26,7 +26,7 @@ cores:
     ADC1:
       address: 0x40012400
       kind: ADC:aditf4_v3_0
-      block: adc_v3/ADC
+      block: adc_g0/ADC
       pins:
       - pin: PA0
         signal: IN0

--- a/data/chips/STM32G051C8.yaml
+++ b/data/chips/STM32G051C8.yaml
@@ -363,6 +363,7 @@ cores:
     PWR:
       address: 0x40007000
       kind: PWR:STM32G0_pwr_v1_0
+      block: pwr_g0/PWR
     RCC:
       address: 0x40021000
       kind: RCC:STM32G06_rcc_v1_0

--- a/data/chips/STM32G051F6.yaml
+++ b/data/chips/STM32G051F6.yaml
@@ -322,6 +322,7 @@ cores:
     PWR:
       address: 0x40007000
       kind: PWR:STM32G0_pwr_v1_0
+      block: pwr_g0/PWR
     RCC:
       address: 0x40021000
       kind: RCC:STM32G06_rcc_v1_0

--- a/data/chips/STM32G051F6.yaml
+++ b/data/chips/STM32G051F6.yaml
@@ -24,7 +24,7 @@ cores:
     ADC1:
       address: 0x40012400
       kind: ADC:aditf4_v3_0
-      block: adc_v3/ADC
+      block: adc_g0/ADC
       pins:
       - pin: PB7
         signal: IN11

--- a/data/chips/STM32G051F8.yaml
+++ b/data/chips/STM32G051F8.yaml
@@ -324,6 +324,7 @@ cores:
     PWR:
       address: 0x40007000
       kind: PWR:STM32G0_pwr_v1_0
+      block: pwr_g0/PWR
     RCC:
       address: 0x40021000
       kind: RCC:STM32G06_rcc_v1_0

--- a/data/chips/STM32G051F8.yaml
+++ b/data/chips/STM32G051F8.yaml
@@ -26,7 +26,7 @@ cores:
     ADC1:
       address: 0x40012400
       kind: ADC:aditf4_v3_0
-      block: adc_v3/ADC
+      block: adc_g0/ADC
       pins:
       - pin: PA12
         signal: IN16

--- a/data/chips/STM32G051G6.yaml
+++ b/data/chips/STM32G051G6.yaml
@@ -24,7 +24,7 @@ cores:
     ADC1:
       address: 0x40012400
       kind: ADC:aditf4_v3_0
-      block: adc_v3/ADC
+      block: adc_g0/ADC
       pins:
       - pin: PA0
         signal: IN0

--- a/data/chips/STM32G051G6.yaml
+++ b/data/chips/STM32G051G6.yaml
@@ -312,6 +312,7 @@ cores:
     PWR:
       address: 0x40007000
       kind: PWR:STM32G0_pwr_v1_0
+      block: pwr_g0/PWR
     RCC:
       address: 0x40021000
       kind: RCC:STM32G06_rcc_v1_0

--- a/data/chips/STM32G051G8.yaml
+++ b/data/chips/STM32G051G8.yaml
@@ -24,7 +24,7 @@ cores:
     ADC1:
       address: 0x40012400
       kind: ADC:aditf4_v3_0
-      block: adc_v3/ADC
+      block: adc_g0/ADC
       pins:
       - pin: PA0
         signal: IN0

--- a/data/chips/STM32G051G8.yaml
+++ b/data/chips/STM32G051G8.yaml
@@ -312,6 +312,7 @@ cores:
     PWR:
       address: 0x40007000
       kind: PWR:STM32G0_pwr_v1_0
+      block: pwr_g0/PWR
     RCC:
       address: 0x40021000
       kind: RCC:STM32G06_rcc_v1_0

--- a/data/chips/STM32G051K6.yaml
+++ b/data/chips/STM32G051K6.yaml
@@ -26,7 +26,7 @@ cores:
     ADC1:
       address: 0x40012400
       kind: ADC:aditf4_v3_0
-      block: adc_v3/ADC
+      block: adc_g0/ADC
       pins:
       - pin: PA0
         signal: IN0

--- a/data/chips/STM32G051K6.yaml
+++ b/data/chips/STM32G051K6.yaml
@@ -324,6 +324,7 @@ cores:
     PWR:
       address: 0x40007000
       kind: PWR:STM32G0_pwr_v1_0
+      block: pwr_g0/PWR
     RCC:
       address: 0x40021000
       kind: RCC:STM32G06_rcc_v1_0

--- a/data/chips/STM32G051K8.yaml
+++ b/data/chips/STM32G051K8.yaml
@@ -26,7 +26,7 @@ cores:
     ADC1:
       address: 0x40012400
       kind: ADC:aditf4_v3_0
-      block: adc_v3/ADC
+      block: adc_g0/ADC
       pins:
       - pin: PA0
         signal: IN0

--- a/data/chips/STM32G051K8.yaml
+++ b/data/chips/STM32G051K8.yaml
@@ -324,6 +324,7 @@ cores:
     PWR:
       address: 0x40007000
       kind: PWR:STM32G0_pwr_v1_0
+      block: pwr_g0/PWR
     RCC:
       address: 0x40021000
       kind: RCC:STM32G06_rcc_v1_0

--- a/data/chips/STM32G061C6.yaml
+++ b/data/chips/STM32G061C6.yaml
@@ -26,7 +26,7 @@ cores:
     ADC1:
       address: 0x40012400
       kind: ADC:aditf4_v3_0
-      block: adc_v3/ADC
+      block: adc_g0/ADC
       pins:
       - pin: PA0
         signal: IN0

--- a/data/chips/STM32G061C6.yaml
+++ b/data/chips/STM32G061C6.yaml
@@ -375,6 +375,7 @@ cores:
     PWR:
       address: 0x40007000
       kind: PWR:STM32G0_pwr_v1_0
+      block: pwr_g0/PWR
     RCC:
       address: 0x40021000
       kind: RCC:STM32G06_rcc_v1_0

--- a/data/chips/STM32G061C8.yaml
+++ b/data/chips/STM32G061C8.yaml
@@ -26,7 +26,7 @@ cores:
     ADC1:
       address: 0x40012400
       kind: ADC:aditf4_v3_0
-      block: adc_v3/ADC
+      block: adc_g0/ADC
       pins:
       - pin: PA0
         signal: IN0

--- a/data/chips/STM32G061C8.yaml
+++ b/data/chips/STM32G061C8.yaml
@@ -375,6 +375,7 @@ cores:
     PWR:
       address: 0x40007000
       kind: PWR:STM32G0_pwr_v1_0
+      block: pwr_g0/PWR
     RCC:
       address: 0x40021000
       kind: RCC:STM32G06_rcc_v1_0

--- a/data/chips/STM32G061F6.yaml
+++ b/data/chips/STM32G061F6.yaml
@@ -24,7 +24,7 @@ cores:
     ADC1:
       address: 0x40012400
       kind: ADC:aditf4_v3_0
-      block: adc_v3/ADC
+      block: adc_g0/ADC
       pins:
       - pin: PB7
         signal: IN11

--- a/data/chips/STM32G061F6.yaml
+++ b/data/chips/STM32G061F6.yaml
@@ -334,6 +334,7 @@ cores:
     PWR:
       address: 0x40007000
       kind: PWR:STM32G0_pwr_v1_0
+      block: pwr_g0/PWR
     RCC:
       address: 0x40021000
       kind: RCC:STM32G06_rcc_v1_0

--- a/data/chips/STM32G061F8.yaml
+++ b/data/chips/STM32G061F8.yaml
@@ -336,6 +336,7 @@ cores:
     PWR:
       address: 0x40007000
       kind: PWR:STM32G0_pwr_v1_0
+      block: pwr_g0/PWR
     RCC:
       address: 0x40021000
       kind: RCC:STM32G06_rcc_v1_0

--- a/data/chips/STM32G061F8.yaml
+++ b/data/chips/STM32G061F8.yaml
@@ -26,7 +26,7 @@ cores:
     ADC1:
       address: 0x40012400
       kind: ADC:aditf4_v3_0
-      block: adc_v3/ADC
+      block: adc_g0/ADC
       pins:
       - pin: PA12
         signal: IN16

--- a/data/chips/STM32G061G6.yaml
+++ b/data/chips/STM32G061G6.yaml
@@ -24,7 +24,7 @@ cores:
     ADC1:
       address: 0x40012400
       kind: ADC:aditf4_v3_0
-      block: adc_v3/ADC
+      block: adc_g0/ADC
       pins:
       - pin: PA0
         signal: IN0

--- a/data/chips/STM32G061G6.yaml
+++ b/data/chips/STM32G061G6.yaml
@@ -324,6 +324,7 @@ cores:
     PWR:
       address: 0x40007000
       kind: PWR:STM32G0_pwr_v1_0
+      block: pwr_g0/PWR
     RCC:
       address: 0x40021000
       kind: RCC:STM32G06_rcc_v1_0

--- a/data/chips/STM32G061G8.yaml
+++ b/data/chips/STM32G061G8.yaml
@@ -24,7 +24,7 @@ cores:
     ADC1:
       address: 0x40012400
       kind: ADC:aditf4_v3_0
-      block: adc_v3/ADC
+      block: adc_g0/ADC
       pins:
       - pin: PA0
         signal: IN0

--- a/data/chips/STM32G061G8.yaml
+++ b/data/chips/STM32G061G8.yaml
@@ -324,6 +324,7 @@ cores:
     PWR:
       address: 0x40007000
       kind: PWR:STM32G0_pwr_v1_0
+      block: pwr_g0/PWR
     RCC:
       address: 0x40021000
       kind: RCC:STM32G06_rcc_v1_0

--- a/data/chips/STM32G061K6.yaml
+++ b/data/chips/STM32G061K6.yaml
@@ -336,6 +336,7 @@ cores:
     PWR:
       address: 0x40007000
       kind: PWR:STM32G0_pwr_v1_0
+      block: pwr_g0/PWR
     RCC:
       address: 0x40021000
       kind: RCC:STM32G06_rcc_v1_0

--- a/data/chips/STM32G061K6.yaml
+++ b/data/chips/STM32G061K6.yaml
@@ -26,7 +26,7 @@ cores:
     ADC1:
       address: 0x40012400
       kind: ADC:aditf4_v3_0
-      block: adc_v3/ADC
+      block: adc_g0/ADC
       pins:
       - pin: PA0
         signal: IN0

--- a/data/chips/STM32G061K8.yaml
+++ b/data/chips/STM32G061K8.yaml
@@ -336,6 +336,7 @@ cores:
     PWR:
       address: 0x40007000
       kind: PWR:STM32G0_pwr_v1_0
+      block: pwr_g0/PWR
     RCC:
       address: 0x40021000
       kind: RCC:STM32G06_rcc_v1_0

--- a/data/chips/STM32G061K8.yaml
+++ b/data/chips/STM32G061K8.yaml
@@ -26,7 +26,7 @@ cores:
     ADC1:
       address: 0x40012400
       kind: ADC:aditf4_v3_0
-      block: adc_v3/ADC
+      block: adc_g0/ADC
       pins:
       - pin: PA0
         signal: IN0

--- a/data/chips/STM32G070CB.yaml
+++ b/data/chips/STM32G070CB.yaml
@@ -32,7 +32,7 @@ cores:
     ADC1:
       address: 0x40012400
       kind: ADC:aditf4_v3_0
-      block: adc_v3/ADC
+      block: adc_g0/ADC
       pins:
       - pin: PA0
         signal: IN0

--- a/data/chips/STM32G070CB.yaml
+++ b/data/chips/STM32G070CB.yaml
@@ -191,6 +191,7 @@ cores:
     PWR:
       address: 0x40007000
       kind: PWR:STM32G0_pwr_v1_0
+      block: pwr_g0/PWR
     RCC:
       address: 0x40021000
       kind: RCC:STM32G05_rcc_v1_0

--- a/data/chips/STM32G070KB.yaml
+++ b/data/chips/STM32G070KB.yaml
@@ -32,7 +32,7 @@ cores:
     ADC1:
       address: 0x40012400
       kind: ADC:aditf4_v3_0
-      block: adc_v3/ADC
+      block: adc_g0/ADC
       pins:
       - pin: PA0
         signal: IN0

--- a/data/chips/STM32G070KB.yaml
+++ b/data/chips/STM32G070KB.yaml
@@ -173,6 +173,7 @@ cores:
     PWR:
       address: 0x40007000
       kind: PWR:STM32G0_pwr_v1_0
+      block: pwr_g0/PWR
     RCC:
       address: 0x40021000
       kind: RCC:STM32G05_rcc_v1_0

--- a/data/chips/STM32G070RB.yaml
+++ b/data/chips/STM32G070RB.yaml
@@ -32,7 +32,7 @@ cores:
     ADC1:
       address: 0x40012400
       kind: ADC:aditf4_v3_0
-      block: adc_v3/ADC
+      block: adc_g0/ADC
       pins:
       - pin: PA0
         signal: IN0

--- a/data/chips/STM32G070RB.yaml
+++ b/data/chips/STM32G070RB.yaml
@@ -195,6 +195,7 @@ cores:
     PWR:
       address: 0x40007000
       kind: PWR:STM32G0_pwr_v1_0
+      block: pwr_g0/PWR
     RCC:
       address: 0x40021000
       kind: RCC:STM32G05_rcc_v1_0

--- a/data/chips/STM32G071C6.yaml
+++ b/data/chips/STM32G071C6.yaml
@@ -26,7 +26,7 @@ cores:
     ADC1:
       address: 0x40012400
       kind: ADC:aditf4_v3_0
-      block: adc_v3/ADC
+      block: adc_g0/ADC
       pins:
       - pin: PA0
         signal: IN0

--- a/data/chips/STM32G071C6.yaml
+++ b/data/chips/STM32G071C6.yaml
@@ -353,6 +353,7 @@ cores:
     PWR:
       address: 0x40007000
       kind: PWR:STM32G0_pwr_v1_0
+      block: pwr_g0/PWR
     RCC:
       address: 0x40021000
       kind: RCC:STM32G05_rcc_v1_0

--- a/data/chips/STM32G071C8.yaml
+++ b/data/chips/STM32G071C8.yaml
@@ -34,7 +34,7 @@ cores:
     ADC1:
       address: 0x40012400
       kind: ADC:aditf4_v3_0
-      block: adc_v3/ADC
+      block: adc_g0/ADC
       pins:
       - pin: PA0
         signal: IN0

--- a/data/chips/STM32G071C8.yaml
+++ b/data/chips/STM32G071C8.yaml
@@ -361,6 +361,7 @@ cores:
     PWR:
       address: 0x40007000
       kind: PWR:STM32G0_pwr_v1_0
+      block: pwr_g0/PWR
     RCC:
       address: 0x40021000
       kind: RCC:STM32G05_rcc_v1_0

--- a/data/chips/STM32G071CB.yaml
+++ b/data/chips/STM32G071CB.yaml
@@ -34,7 +34,7 @@ cores:
     ADC1:
       address: 0x40012400
       kind: ADC:aditf4_v3_0
-      block: adc_v3/ADC
+      block: adc_g0/ADC
       pins:
       - pin: PA0
         signal: IN0

--- a/data/chips/STM32G071CB.yaml
+++ b/data/chips/STM32G071CB.yaml
@@ -361,6 +361,7 @@ cores:
     PWR:
       address: 0x40007000
       kind: PWR:STM32G0_pwr_v1_0
+      block: pwr_g0/PWR
     RCC:
       address: 0x40021000
       kind: RCC:STM32G05_rcc_v1_0

--- a/data/chips/STM32G071EB.yaml
+++ b/data/chips/STM32G071EB.yaml
@@ -32,7 +32,7 @@ cores:
     ADC1:
       address: 0x40012400
       kind: ADC:aditf4_v3_0
-      block: adc_v3/ADC
+      block: adc_g0/ADC
       pins:
       - pin: PA6
         signal: IN6

--- a/data/chips/STM32G071EB.yaml
+++ b/data/chips/STM32G071EB.yaml
@@ -306,6 +306,7 @@ cores:
     PWR:
       address: 0x40007000
       kind: PWR:STM32G0_pwr_v1_0
+      block: pwr_g0/PWR
     RCC:
       address: 0x40021000
       kind: RCC:STM32G05_rcc_v1_0

--- a/data/chips/STM32G071G6.yaml
+++ b/data/chips/STM32G071G6.yaml
@@ -24,7 +24,7 @@ cores:
     ADC1:
       address: 0x40012400
       kind: ADC:aditf4_v3_0
-      block: adc_v3/ADC
+      block: adc_g0/ADC
       pins:
       - pin: PA0
         signal: IN0

--- a/data/chips/STM32G071G6.yaml
+++ b/data/chips/STM32G071G6.yaml
@@ -302,6 +302,7 @@ cores:
     PWR:
       address: 0x40007000
       kind: PWR:STM32G0_pwr_v1_0
+      block: pwr_g0/PWR
     RCC:
       address: 0x40021000
       kind: RCC:STM32G05_rcc_v1_0

--- a/data/chips/STM32G071G8.yaml
+++ b/data/chips/STM32G071G8.yaml
@@ -34,7 +34,7 @@ cores:
     ADC1:
       address: 0x40012400
       kind: ADC:aditf4_v3_0
-      block: adc_v3/ADC
+      block: adc_g0/ADC
       pins:
       - pin: PA0
         signal: IN0

--- a/data/chips/STM32G071G8.yaml
+++ b/data/chips/STM32G071G8.yaml
@@ -286,6 +286,7 @@ cores:
     PWR:
       address: 0x40007000
       kind: PWR:STM32G0_pwr_v1_0
+      block: pwr_g0/PWR
     RCC:
       address: 0x40021000
       kind: RCC:STM32G05_rcc_v1_0

--- a/data/chips/STM32G071GB.yaml
+++ b/data/chips/STM32G071GB.yaml
@@ -34,7 +34,7 @@ cores:
     ADC1:
       address: 0x40012400
       kind: ADC:aditf4_v3_0
-      block: adc_v3/ADC
+      block: adc_g0/ADC
       pins:
       - pin: PA0
         signal: IN0

--- a/data/chips/STM32G071GB.yaml
+++ b/data/chips/STM32G071GB.yaml
@@ -286,6 +286,7 @@ cores:
     PWR:
       address: 0x40007000
       kind: PWR:STM32G0_pwr_v1_0
+      block: pwr_g0/PWR
     RCC:
       address: 0x40021000
       kind: RCC:STM32G05_rcc_v1_0

--- a/data/chips/STM32G071K6.yaml
+++ b/data/chips/STM32G071K6.yaml
@@ -26,7 +26,7 @@ cores:
     ADC1:
       address: 0x40012400
       kind: ADC:aditf4_v3_0
-      block: adc_v3/ADC
+      block: adc_g0/ADC
       pins:
       - pin: PA0
         signal: IN0

--- a/data/chips/STM32G071K6.yaml
+++ b/data/chips/STM32G071K6.yaml
@@ -314,6 +314,7 @@ cores:
     PWR:
       address: 0x40007000
       kind: PWR:STM32G0_pwr_v1_0
+      block: pwr_g0/PWR
     RCC:
       address: 0x40021000
       kind: RCC:STM32G05_rcc_v1_0

--- a/data/chips/STM32G071K8.yaml
+++ b/data/chips/STM32G071K8.yaml
@@ -38,7 +38,7 @@ cores:
     ADC1:
       address: 0x40012400
       kind: ADC:aditf4_v3_0
-      block: adc_v3/ADC
+      block: adc_g0/ADC
       pins:
       - pin: PA0
         signal: IN0

--- a/data/chips/STM32G071K8.yaml
+++ b/data/chips/STM32G071K8.yaml
@@ -306,6 +306,7 @@ cores:
     PWR:
       address: 0x40007000
       kind: PWR:STM32G0_pwr_v1_0
+      block: pwr_g0/PWR
     RCC:
       address: 0x40021000
       kind: RCC:STM32G05_rcc_v1_0

--- a/data/chips/STM32G071KB.yaml
+++ b/data/chips/STM32G071KB.yaml
@@ -38,7 +38,7 @@ cores:
     ADC1:
       address: 0x40012400
       kind: ADC:aditf4_v3_0
-      block: adc_v3/ADC
+      block: adc_g0/ADC
       pins:
       - pin: PA0
         signal: IN0

--- a/data/chips/STM32G071KB.yaml
+++ b/data/chips/STM32G071KB.yaml
@@ -306,6 +306,7 @@ cores:
     PWR:
       address: 0x40007000
       kind: PWR:STM32G0_pwr_v1_0
+      block: pwr_g0/PWR
     RCC:
       address: 0x40021000
       kind: RCC:STM32G05_rcc_v1_0

--- a/data/chips/STM32G071R6.yaml
+++ b/data/chips/STM32G071R6.yaml
@@ -24,7 +24,7 @@ cores:
     ADC1:
       address: 0x40012400
       kind: ADC:aditf4_v3_0
-      block: adc_v3/ADC
+      block: adc_g0/ADC
       pins:
       - pin: PA0
         signal: IN0

--- a/data/chips/STM32G071R6.yaml
+++ b/data/chips/STM32G071R6.yaml
@@ -392,6 +392,7 @@ cores:
     PWR:
       address: 0x40007000
       kind: PWR:STM32G0_pwr_v1_0
+      block: pwr_g0/PWR
     RCC:
       address: 0x40021000
       kind: RCC:STM32G05_rcc_v1_0

--- a/data/chips/STM32G071R8.yaml
+++ b/data/chips/STM32G071R8.yaml
@@ -32,7 +32,7 @@ cores:
     ADC1:
       address: 0x40012400
       kind: ADC:aditf4_v3_0
-      block: adc_v3/ADC
+      block: adc_g0/ADC
       pins:
       - pin: PA0
         signal: IN0

--- a/data/chips/STM32G071R8.yaml
+++ b/data/chips/STM32G071R8.yaml
@@ -400,6 +400,7 @@ cores:
     PWR:
       address: 0x40007000
       kind: PWR:STM32G0_pwr_v1_0
+      block: pwr_g0/PWR
     RCC:
       address: 0x40021000
       kind: RCC:STM32G05_rcc_v1_0

--- a/data/chips/STM32G071RB.yaml
+++ b/data/chips/STM32G071RB.yaml
@@ -402,6 +402,7 @@ cores:
     PWR:
       address: 0x40007000
       kind: PWR:STM32G0_pwr_v1_0
+      block: pwr_g0/PWR
     RCC:
       address: 0x40021000
       kind: RCC:STM32G05_rcc_v1_0

--- a/data/chips/STM32G071RB.yaml
+++ b/data/chips/STM32G071RB.yaml
@@ -34,7 +34,7 @@ cores:
     ADC1:
       address: 0x40012400
       kind: ADC:aditf4_v3_0
-      block: adc_v3/ADC
+      block: adc_g0/ADC
       pins:
       - pin: PA7
         signal: IN7

--- a/data/chips/STM32G081CB.yaml
+++ b/data/chips/STM32G081CB.yaml
@@ -34,7 +34,7 @@ cores:
     ADC1:
       address: 0x40012400
       kind: ADC:aditf4_v3_0
-      block: adc_v3/ADC
+      block: adc_g0/ADC
       pins:
       - pin: PA0
         signal: IN0

--- a/data/chips/STM32G081CB.yaml
+++ b/data/chips/STM32G081CB.yaml
@@ -373,6 +373,7 @@ cores:
     PWR:
       address: 0x40007000
       kind: PWR:STM32G0_pwr_v1_0
+      block: pwr_g0/PWR
     RCC:
       address: 0x40021000
       kind: RCC:STM32G05_rcc_v1_0

--- a/data/chips/STM32G081EB.yaml
+++ b/data/chips/STM32G081EB.yaml
@@ -32,7 +32,7 @@ cores:
     ADC1:
       address: 0x40012400
       kind: ADC:aditf4_v3_0
-      block: adc_v3/ADC
+      block: adc_g0/ADC
       pins:
       - pin: PA6
         signal: IN6

--- a/data/chips/STM32G081EB.yaml
+++ b/data/chips/STM32G081EB.yaml
@@ -318,6 +318,7 @@ cores:
     PWR:
       address: 0x40007000
       kind: PWR:STM32G0_pwr_v1_0
+      block: pwr_g0/PWR
     RCC:
       address: 0x40021000
       kind: RCC:STM32G05_rcc_v1_0

--- a/data/chips/STM32G081GB.yaml
+++ b/data/chips/STM32G081GB.yaml
@@ -298,6 +298,7 @@ cores:
     PWR:
       address: 0x40007000
       kind: PWR:STM32G0_pwr_v1_0
+      block: pwr_g0/PWR
     RCC:
       address: 0x40021000
       kind: RCC:STM32G05_rcc_v1_0

--- a/data/chips/STM32G081GB.yaml
+++ b/data/chips/STM32G081GB.yaml
@@ -34,7 +34,7 @@ cores:
     ADC1:
       address: 0x40012400
       kind: ADC:aditf4_v3_0
-      block: adc_v3/ADC
+      block: adc_g0/ADC
       pins:
       - pin: PA0
         signal: IN0

--- a/data/chips/STM32G081KB.yaml
+++ b/data/chips/STM32G081KB.yaml
@@ -318,6 +318,7 @@ cores:
     PWR:
       address: 0x40007000
       kind: PWR:STM32G0_pwr_v1_0
+      block: pwr_g0/PWR
     RCC:
       address: 0x40021000
       kind: RCC:STM32G05_rcc_v1_0

--- a/data/chips/STM32G081KB.yaml
+++ b/data/chips/STM32G081KB.yaml
@@ -38,7 +38,7 @@ cores:
     ADC1:
       address: 0x40012400
       kind: ADC:aditf4_v3_0
-      block: adc_v3/ADC
+      block: adc_g0/ADC
       pins:
       - pin: PA0
         signal: IN0

--- a/data/chips/STM32G081RB.yaml
+++ b/data/chips/STM32G081RB.yaml
@@ -34,7 +34,7 @@ cores:
     ADC1:
       address: 0x40012400
       kind: ADC:aditf4_v3_0
-      block: adc_v3/ADC
+      block: adc_g0/ADC
       pins:
       - pin: PA0
         signal: IN0

--- a/data/chips/STM32G081RB.yaml
+++ b/data/chips/STM32G081RB.yaml
@@ -414,6 +414,7 @@ cores:
     PWR:
       address: 0x40007000
       kind: PWR:STM32G0_pwr_v1_0
+      block: pwr_g0/PWR
     RCC:
       address: 0x40021000
       kind: RCC:STM32G05_rcc_v1_0

--- a/data/chips/STM32G0B0CE.yaml
+++ b/data/chips/STM32G0B0CE.yaml
@@ -245,6 +245,7 @@ cores:
     PWR:
       address: 0x40007000
       kind: PWR:STM32G0_pwr_v1_0
+      block: pwr_g0/PWR
     RCC:
       address: 0x40021000
       kind: RCC:STM32G0-512_rcc_v1_0

--- a/data/chips/STM32G0B0CE.yaml
+++ b/data/chips/STM32G0B0CE.yaml
@@ -29,7 +29,7 @@ cores:
     ADC1:
       address: 0x40012400
       kind: ADC:aditf4_v3_0
-      block: adc_v3/ADC
+      block: adc_g0/ADC
       pins:
       - pin: PA0
         signal: IN0

--- a/data/chips/STM32G0B0KE.yaml
+++ b/data/chips/STM32G0B0KE.yaml
@@ -224,6 +224,7 @@ cores:
     PWR:
       address: 0x40007000
       kind: PWR:STM32G0_pwr_v1_0
+      block: pwr_g0/PWR
     RCC:
       address: 0x40021000
       kind: RCC:STM32G0-512_rcc_v1_0

--- a/data/chips/STM32G0B0KE.yaml
+++ b/data/chips/STM32G0B0KE.yaml
@@ -29,7 +29,7 @@ cores:
     ADC1:
       address: 0x40012400
       kind: ADC:aditf4_v3_0
-      block: adc_v3/ADC
+      block: adc_g0/ADC
       pins:
       - pin: PA0
         signal: IN0

--- a/data/chips/STM32G0B0RE.yaml
+++ b/data/chips/STM32G0B0RE.yaml
@@ -255,6 +255,7 @@ cores:
     PWR:
       address: 0x40007000
       kind: PWR:STM32G0_pwr_v1_0
+      block: pwr_g0/PWR
     RCC:
       address: 0x40021000
       kind: RCC:STM32G0-512_rcc_v1_0

--- a/data/chips/STM32G0B0RE.yaml
+++ b/data/chips/STM32G0B0RE.yaml
@@ -29,7 +29,7 @@ cores:
     ADC1:
       address: 0x40012400
       kind: ADC:aditf4_v3_0
-      block: adc_v3/ADC
+      block: adc_g0/ADC
       pins:
       - pin: PA0
         signal: IN0

--- a/data/chips/STM32G0B0VE.yaml
+++ b/data/chips/STM32G0B0VE.yaml
@@ -255,6 +255,7 @@ cores:
     PWR:
       address: 0x40007000
       kind: PWR:STM32G0_pwr_v1_0
+      block: pwr_g0/PWR
     RCC:
       address: 0x40021000
       kind: RCC:STM32G0-512_rcc_v1_0

--- a/data/chips/STM32G0B0VE.yaml
+++ b/data/chips/STM32G0B0VE.yaml
@@ -29,7 +29,7 @@ cores:
     ADC1:
       address: 0x40012400
       kind: ADC:aditf4_v3_0
-      block: adc_v3/ADC
+      block: adc_g0/ADC
       pins:
       - pin: PA0
         signal: IN0

--- a/data/chips/STM32G0B1CB.yaml
+++ b/data/chips/STM32G0B1CB.yaml
@@ -38,7 +38,7 @@ cores:
     ADC1:
       address: 0x40012400
       kind: ADC:aditf4_v3_0
-      block: adc_v3/ADC
+      block: adc_g0/ADC
       pins:
       - pin: PA0
         signal: IN0

--- a/data/chips/STM32G0B1CB.yaml
+++ b/data/chips/STM32G0B1CB.yaml
@@ -529,6 +529,7 @@ cores:
     PWR:
       address: 0x40007000
       kind: PWR:STM32G0_pwr_v1_0
+      block: pwr_g0/PWR
     RCC:
       address: 0x40021000
       kind: RCC:STM32G0-512_rcc_v1_0

--- a/data/chips/STM32G0B1CC.yaml
+++ b/data/chips/STM32G0B1CC.yaml
@@ -38,7 +38,7 @@ cores:
     ADC1:
       address: 0x40012400
       kind: ADC:aditf4_v3_0
-      block: adc_v3/ADC
+      block: adc_g0/ADC
       pins:
       - pin: PA0
         signal: IN0

--- a/data/chips/STM32G0B1CC.yaml
+++ b/data/chips/STM32G0B1CC.yaml
@@ -529,6 +529,7 @@ cores:
     PWR:
       address: 0x40007000
       kind: PWR:STM32G0_pwr_v1_0
+      block: pwr_g0/PWR
     RCC:
       address: 0x40021000
       kind: RCC:STM32G0-512_rcc_v1_0

--- a/data/chips/STM32G0B1CE.yaml
+++ b/data/chips/STM32G0B1CE.yaml
@@ -38,7 +38,7 @@ cores:
     ADC1:
       address: 0x40012400
       kind: ADC:aditf4_v3_0
-      block: adc_v3/ADC
+      block: adc_g0/ADC
       pins:
       - pin: PA0
         signal: IN0

--- a/data/chips/STM32G0B1CE.yaml
+++ b/data/chips/STM32G0B1CE.yaml
@@ -529,6 +529,7 @@ cores:
     PWR:
       address: 0x40007000
       kind: PWR:STM32G0_pwr_v1_0
+      block: pwr_g0/PWR
     RCC:
       address: 0x40021000
       kind: RCC:STM32G0-512_rcc_v1_0

--- a/data/chips/STM32G0B1KB.yaml
+++ b/data/chips/STM32G0B1KB.yaml
@@ -441,6 +441,7 @@ cores:
     PWR:
       address: 0x40007000
       kind: PWR:STM32G0_pwr_v1_0
+      block: pwr_g0/PWR
     RCC:
       address: 0x40021000
       kind: RCC:STM32G0-512_rcc_v1_0

--- a/data/chips/STM32G0B1KB.yaml
+++ b/data/chips/STM32G0B1KB.yaml
@@ -38,7 +38,7 @@ cores:
     ADC1:
       address: 0x40012400
       kind: ADC:aditf4_v3_0
-      block: adc_v3/ADC
+      block: adc_g0/ADC
       pins:
       - pin: PA0
         signal: IN0

--- a/data/chips/STM32G0B1KC.yaml
+++ b/data/chips/STM32G0B1KC.yaml
@@ -441,6 +441,7 @@ cores:
     PWR:
       address: 0x40007000
       kind: PWR:STM32G0_pwr_v1_0
+      block: pwr_g0/PWR
     RCC:
       address: 0x40021000
       kind: RCC:STM32G0-512_rcc_v1_0

--- a/data/chips/STM32G0B1KC.yaml
+++ b/data/chips/STM32G0B1KC.yaml
@@ -38,7 +38,7 @@ cores:
     ADC1:
       address: 0x40012400
       kind: ADC:aditf4_v3_0
-      block: adc_v3/ADC
+      block: adc_g0/ADC
       pins:
       - pin: PA0
         signal: IN0

--- a/data/chips/STM32G0B1KE.yaml
+++ b/data/chips/STM32G0B1KE.yaml
@@ -441,6 +441,7 @@ cores:
     PWR:
       address: 0x40007000
       kind: PWR:STM32G0_pwr_v1_0
+      block: pwr_g0/PWR
     RCC:
       address: 0x40021000
       kind: RCC:STM32G0-512_rcc_v1_0

--- a/data/chips/STM32G0B1KE.yaml
+++ b/data/chips/STM32G0B1KE.yaml
@@ -38,7 +38,7 @@ cores:
     ADC1:
       address: 0x40012400
       kind: ADC:aditf4_v3_0
-      block: adc_v3/ADC
+      block: adc_g0/ADC
       pins:
       - pin: PA0
         signal: IN0

--- a/data/chips/STM32G0B1MB.yaml
+++ b/data/chips/STM32G0B1MB.yaml
@@ -32,7 +32,7 @@ cores:
     ADC1:
       address: 0x40012400
       kind: ADC:aditf4_v3_0
-      block: adc_v3/ADC
+      block: adc_g0/ADC
       pins:
       - pin: PA0
         signal: IN0

--- a/data/chips/STM32G0B1MB.yaml
+++ b/data/chips/STM32G0B1MB.yaml
@@ -647,6 +647,7 @@ cores:
     PWR:
       address: 0x40007000
       kind: PWR:STM32G0_pwr_v1_0
+      block: pwr_g0/PWR
     RCC:
       address: 0x40021000
       kind: RCC:STM32G0-512_rcc_v1_0

--- a/data/chips/STM32G0B1MC.yaml
+++ b/data/chips/STM32G0B1MC.yaml
@@ -32,7 +32,7 @@ cores:
     ADC1:
       address: 0x40012400
       kind: ADC:aditf4_v3_0
-      block: adc_v3/ADC
+      block: adc_g0/ADC
       pins:
       - pin: PA0
         signal: IN0

--- a/data/chips/STM32G0B1MC.yaml
+++ b/data/chips/STM32G0B1MC.yaml
@@ -647,6 +647,7 @@ cores:
     PWR:
       address: 0x40007000
       kind: PWR:STM32G0_pwr_v1_0
+      block: pwr_g0/PWR
     RCC:
       address: 0x40021000
       kind: RCC:STM32G0-512_rcc_v1_0

--- a/data/chips/STM32G0B1ME.yaml
+++ b/data/chips/STM32G0B1ME.yaml
@@ -32,7 +32,7 @@ cores:
     ADC1:
       address: 0x40012400
       kind: ADC:aditf4_v3_0
-      block: adc_v3/ADC
+      block: adc_g0/ADC
       pins:
       - pin: PA0
         signal: IN0

--- a/data/chips/STM32G0B1ME.yaml
+++ b/data/chips/STM32G0B1ME.yaml
@@ -647,6 +647,7 @@ cores:
     PWR:
       address: 0x40007000
       kind: PWR:STM32G0_pwr_v1_0
+      block: pwr_g0/PWR
     RCC:
       address: 0x40021000
       kind: RCC:STM32G0-512_rcc_v1_0

--- a/data/chips/STM32G0B1NE.yaml
+++ b/data/chips/STM32G0B1NE.yaml
@@ -535,6 +535,7 @@ cores:
     PWR:
       address: 0x40007000
       kind: PWR:STM32G0_pwr_v1_0
+      block: pwr_g0/PWR
     RCC:
       address: 0x40021000
       kind: RCC:STM32G0-512_rcc_v1_0

--- a/data/chips/STM32G0B1NE.yaml
+++ b/data/chips/STM32G0B1NE.yaml
@@ -24,7 +24,7 @@ cores:
     ADC1:
       address: 0x40012400
       kind: ADC:aditf4_v3_0
-      block: adc_v3/ADC
+      block: adc_g0/ADC
       pins:
       - pin: PB12
         signal: IN16

--- a/data/chips/STM32G0B1RB.yaml
+++ b/data/chips/STM32G0B1RB.yaml
@@ -614,6 +614,7 @@ cores:
     PWR:
       address: 0x40007000
       kind: PWR:STM32G0_pwr_v1_0
+      block: pwr_g0/PWR
     RCC:
       address: 0x40021000
       kind: RCC:STM32G0-512_rcc_v1_0

--- a/data/chips/STM32G0B1RB.yaml
+++ b/data/chips/STM32G0B1RB.yaml
@@ -36,7 +36,7 @@ cores:
     ADC1:
       address: 0x40012400
       kind: ADC:aditf4_v3_0
-      block: adc_v3/ADC
+      block: adc_g0/ADC
       pins:
       - pin: PA0
         signal: IN0

--- a/data/chips/STM32G0B1RC.yaml
+++ b/data/chips/STM32G0B1RC.yaml
@@ -614,6 +614,7 @@ cores:
     PWR:
       address: 0x40007000
       kind: PWR:STM32G0_pwr_v1_0
+      block: pwr_g0/PWR
     RCC:
       address: 0x40021000
       kind: RCC:STM32G0-512_rcc_v1_0

--- a/data/chips/STM32G0B1RC.yaml
+++ b/data/chips/STM32G0B1RC.yaml
@@ -36,7 +36,7 @@ cores:
     ADC1:
       address: 0x40012400
       kind: ADC:aditf4_v3_0
-      block: adc_v3/ADC
+      block: adc_g0/ADC
       pins:
       - pin: PA0
         signal: IN0

--- a/data/chips/STM32G0B1RE.yaml
+++ b/data/chips/STM32G0B1RE.yaml
@@ -614,6 +614,7 @@ cores:
     PWR:
       address: 0x40007000
       kind: PWR:STM32G0_pwr_v1_0
+      block: pwr_g0/PWR
     RCC:
       address: 0x40021000
       kind: RCC:STM32G0-512_rcc_v1_0

--- a/data/chips/STM32G0B1RE.yaml
+++ b/data/chips/STM32G0B1RE.yaml
@@ -36,7 +36,7 @@ cores:
     ADC1:
       address: 0x40012400
       kind: ADC:aditf4_v3_0
-      block: adc_v3/ADC
+      block: adc_g0/ADC
       pins:
       - pin: PA0
         signal: IN0

--- a/data/chips/STM32G0B1VB.yaml
+++ b/data/chips/STM32G0B1VB.yaml
@@ -34,7 +34,7 @@ cores:
     ADC1:
       address: 0x40012400
       kind: ADC:aditf4_v3_0
-      block: adc_v3/ADC
+      block: adc_g0/ADC
       pins:
       - pin: PA0
         signal: IN0

--- a/data/chips/STM32G0B1VB.yaml
+++ b/data/chips/STM32G0B1VB.yaml
@@ -667,6 +667,7 @@ cores:
     PWR:
       address: 0x40007000
       kind: PWR:STM32G0_pwr_v1_0
+      block: pwr_g0/PWR
     RCC:
       address: 0x40021000
       kind: RCC:STM32G0-512_rcc_v1_0

--- a/data/chips/STM32G0B1VC.yaml
+++ b/data/chips/STM32G0B1VC.yaml
@@ -34,7 +34,7 @@ cores:
     ADC1:
       address: 0x40012400
       kind: ADC:aditf4_v3_0
-      block: adc_v3/ADC
+      block: adc_g0/ADC
       pins:
       - pin: PA0
         signal: IN0

--- a/data/chips/STM32G0B1VC.yaml
+++ b/data/chips/STM32G0B1VC.yaml
@@ -667,6 +667,7 @@ cores:
     PWR:
       address: 0x40007000
       kind: PWR:STM32G0_pwr_v1_0
+      block: pwr_g0/PWR
     RCC:
       address: 0x40021000
       kind: RCC:STM32G0-512_rcc_v1_0

--- a/data/chips/STM32G0B1VE.yaml
+++ b/data/chips/STM32G0B1VE.yaml
@@ -34,7 +34,7 @@ cores:
     ADC1:
       address: 0x40012400
       kind: ADC:aditf4_v3_0
-      block: adc_v3/ADC
+      block: adc_g0/ADC
       pins:
       - pin: PA0
         signal: IN0

--- a/data/chips/STM32G0B1VE.yaml
+++ b/data/chips/STM32G0B1VE.yaml
@@ -667,6 +667,7 @@ cores:
     PWR:
       address: 0x40007000
       kind: PWR:STM32G0_pwr_v1_0
+      block: pwr_g0/PWR
     RCC:
       address: 0x40021000
       kind: RCC:STM32G0-512_rcc_v1_0

--- a/data/chips/STM32G0C1CC.yaml
+++ b/data/chips/STM32G0C1CC.yaml
@@ -38,7 +38,7 @@ cores:
     ADC1:
       address: 0x40012400
       kind: ADC:aditf4_v3_0
-      block: adc_v3/ADC
+      block: adc_g0/ADC
       pins:
       - pin: PA0
         signal: IN0

--- a/data/chips/STM32G0C1CC.yaml
+++ b/data/chips/STM32G0C1CC.yaml
@@ -541,6 +541,7 @@ cores:
     PWR:
       address: 0x40007000
       kind: PWR:STM32G0_pwr_v1_0
+      block: pwr_g0/PWR
     RCC:
       address: 0x40021000
       kind: RCC:STM32G0-512_rcc_v1_0

--- a/data/chips/STM32G0C1CE.yaml
+++ b/data/chips/STM32G0C1CE.yaml
@@ -38,7 +38,7 @@ cores:
     ADC1:
       address: 0x40012400
       kind: ADC:aditf4_v3_0
-      block: adc_v3/ADC
+      block: adc_g0/ADC
       pins:
       - pin: PA0
         signal: IN0

--- a/data/chips/STM32G0C1CE.yaml
+++ b/data/chips/STM32G0C1CE.yaml
@@ -541,6 +541,7 @@ cores:
     PWR:
       address: 0x40007000
       kind: PWR:STM32G0_pwr_v1_0
+      block: pwr_g0/PWR
     RCC:
       address: 0x40021000
       kind: RCC:STM32G0-512_rcc_v1_0

--- a/data/chips/STM32G0C1KC.yaml
+++ b/data/chips/STM32G0C1KC.yaml
@@ -453,6 +453,7 @@ cores:
     PWR:
       address: 0x40007000
       kind: PWR:STM32G0_pwr_v1_0
+      block: pwr_g0/PWR
     RCC:
       address: 0x40021000
       kind: RCC:STM32G0-512_rcc_v1_0

--- a/data/chips/STM32G0C1KC.yaml
+++ b/data/chips/STM32G0C1KC.yaml
@@ -38,7 +38,7 @@ cores:
     ADC1:
       address: 0x40012400
       kind: ADC:aditf4_v3_0
-      block: adc_v3/ADC
+      block: adc_g0/ADC
       pins:
       - pin: PA0
         signal: IN0

--- a/data/chips/STM32G0C1KE.yaml
+++ b/data/chips/STM32G0C1KE.yaml
@@ -453,6 +453,7 @@ cores:
     PWR:
       address: 0x40007000
       kind: PWR:STM32G0_pwr_v1_0
+      block: pwr_g0/PWR
     RCC:
       address: 0x40021000
       kind: RCC:STM32G0-512_rcc_v1_0

--- a/data/chips/STM32G0C1KE.yaml
+++ b/data/chips/STM32G0C1KE.yaml
@@ -38,7 +38,7 @@ cores:
     ADC1:
       address: 0x40012400
       kind: ADC:aditf4_v3_0
-      block: adc_v3/ADC
+      block: adc_g0/ADC
       pins:
       - pin: PA0
         signal: IN0

--- a/data/chips/STM32G0C1MC.yaml
+++ b/data/chips/STM32G0C1MC.yaml
@@ -32,7 +32,7 @@ cores:
     ADC1:
       address: 0x40012400
       kind: ADC:aditf4_v3_0
-      block: adc_v3/ADC
+      block: adc_g0/ADC
       pins:
       - pin: PA0
         signal: IN0

--- a/data/chips/STM32G0C1MC.yaml
+++ b/data/chips/STM32G0C1MC.yaml
@@ -659,6 +659,7 @@ cores:
     PWR:
       address: 0x40007000
       kind: PWR:STM32G0_pwr_v1_0
+      block: pwr_g0/PWR
     RCC:
       address: 0x40021000
       kind: RCC:STM32G0-512_rcc_v1_0

--- a/data/chips/STM32G0C1ME.yaml
+++ b/data/chips/STM32G0C1ME.yaml
@@ -32,7 +32,7 @@ cores:
     ADC1:
       address: 0x40012400
       kind: ADC:aditf4_v3_0
-      block: adc_v3/ADC
+      block: adc_g0/ADC
       pins:
       - pin: PA0
         signal: IN0

--- a/data/chips/STM32G0C1ME.yaml
+++ b/data/chips/STM32G0C1ME.yaml
@@ -659,6 +659,7 @@ cores:
     PWR:
       address: 0x40007000
       kind: PWR:STM32G0_pwr_v1_0
+      block: pwr_g0/PWR
     RCC:
       address: 0x40021000
       kind: RCC:STM32G0-512_rcc_v1_0

--- a/data/chips/STM32G0C1NE.yaml
+++ b/data/chips/STM32G0C1NE.yaml
@@ -547,6 +547,7 @@ cores:
     PWR:
       address: 0x40007000
       kind: PWR:STM32G0_pwr_v1_0
+      block: pwr_g0/PWR
     RCC:
       address: 0x40021000
       kind: RCC:STM32G0-512_rcc_v1_0

--- a/data/chips/STM32G0C1NE.yaml
+++ b/data/chips/STM32G0C1NE.yaml
@@ -24,7 +24,7 @@ cores:
     ADC1:
       address: 0x40012400
       kind: ADC:aditf4_v3_0
-      block: adc_v3/ADC
+      block: adc_g0/ADC
       pins:
       - pin: PB12
         signal: IN16

--- a/data/chips/STM32G0C1RC.yaml
+++ b/data/chips/STM32G0C1RC.yaml
@@ -626,6 +626,7 @@ cores:
     PWR:
       address: 0x40007000
       kind: PWR:STM32G0_pwr_v1_0
+      block: pwr_g0/PWR
     RCC:
       address: 0x40021000
       kind: RCC:STM32G0-512_rcc_v1_0

--- a/data/chips/STM32G0C1RC.yaml
+++ b/data/chips/STM32G0C1RC.yaml
@@ -36,7 +36,7 @@ cores:
     ADC1:
       address: 0x40012400
       kind: ADC:aditf4_v3_0
-      block: adc_v3/ADC
+      block: adc_g0/ADC
       pins:
       - pin: PA0
         signal: IN0

--- a/data/chips/STM32G0C1RE.yaml
+++ b/data/chips/STM32G0C1RE.yaml
@@ -626,6 +626,7 @@ cores:
     PWR:
       address: 0x40007000
       kind: PWR:STM32G0_pwr_v1_0
+      block: pwr_g0/PWR
     RCC:
       address: 0x40021000
       kind: RCC:STM32G0-512_rcc_v1_0

--- a/data/chips/STM32G0C1RE.yaml
+++ b/data/chips/STM32G0C1RE.yaml
@@ -36,7 +36,7 @@ cores:
     ADC1:
       address: 0x40012400
       kind: ADC:aditf4_v3_0
-      block: adc_v3/ADC
+      block: adc_g0/ADC
       pins:
       - pin: PA0
         signal: IN0

--- a/data/chips/STM32G0C1VC.yaml
+++ b/data/chips/STM32G0C1VC.yaml
@@ -34,7 +34,7 @@ cores:
     ADC1:
       address: 0x40012400
       kind: ADC:aditf4_v3_0
-      block: adc_v3/ADC
+      block: adc_g0/ADC
       pins:
       - pin: PA0
         signal: IN0

--- a/data/chips/STM32G0C1VC.yaml
+++ b/data/chips/STM32G0C1VC.yaml
@@ -679,6 +679,7 @@ cores:
     PWR:
       address: 0x40007000
       kind: PWR:STM32G0_pwr_v1_0
+      block: pwr_g0/PWR
     RCC:
       address: 0x40021000
       kind: RCC:STM32G0-512_rcc_v1_0

--- a/data/chips/STM32G0C1VE.yaml
+++ b/data/chips/STM32G0C1VE.yaml
@@ -34,7 +34,7 @@ cores:
     ADC1:
       address: 0x40012400
       kind: ADC:aditf4_v3_0
-      block: adc_v3/ADC
+      block: adc_g0/ADC
       pins:
       - pin: PA0
         signal: IN0

--- a/data/chips/STM32G0C1VE.yaml
+++ b/data/chips/STM32G0C1VE.yaml
@@ -679,6 +679,7 @@ cores:
     PWR:
       address: 0x40007000
       kind: PWR:STM32G0_pwr_v1_0
+      block: pwr_g0/PWR
     RCC:
       address: 0x40021000
       kind: RCC:STM32G0-512_rcc_v1_0

--- a/data/chips/STM32H723VE.yaml
+++ b/data/chips/STM32H723VE.yaml
@@ -158,10 +158,10 @@ cores:
       clock: AHB4
       dma_channels:
         ADC3:
-        - dmamux: DMAMUX2
-          request: 17
         - dmamux: DMAMUX1
           request: 115
+        - dmamux: DMAMUX2
+          request: 17
     ADC_COMMON:
       address: 0x40022300
       kind: ADC_COMMON:aditf5_v3_0

--- a/data/chips/STM32H723VG.yaml
+++ b/data/chips/STM32H723VG.yaml
@@ -158,10 +158,10 @@ cores:
       clock: AHB4
       dma_channels:
         ADC3:
-        - dmamux: DMAMUX2
-          request: 17
         - dmamux: DMAMUX1
           request: 115
+        - dmamux: DMAMUX2
+          request: 17
     ADC_COMMON:
       address: 0x40022300
       kind: ADC_COMMON:aditf5_v3_0

--- a/data/chips/STM32H723ZE.yaml
+++ b/data/chips/STM32H723ZE.yaml
@@ -194,10 +194,10 @@ cores:
       clock: AHB4
       dma_channels:
         ADC3:
-        - dmamux: DMAMUX2
-          request: 17
         - dmamux: DMAMUX1
           request: 115
+        - dmamux: DMAMUX2
+          request: 17
     ADC_COMMON:
       address: 0x40022300
       kind: ADC_COMMON:aditf5_v3_0

--- a/data/chips/STM32H723ZG.yaml
+++ b/data/chips/STM32H723ZG.yaml
@@ -194,10 +194,10 @@ cores:
       clock: AHB4
       dma_channels:
         ADC3:
-        - dmamux: DMAMUX2
-          request: 17
         - dmamux: DMAMUX1
           request: 115
+        - dmamux: DMAMUX2
+          request: 17
     ADC_COMMON:
       address: 0x40022300
       kind: ADC_COMMON:aditf5_v3_0

--- a/data/chips/STM32H725AE.yaml
+++ b/data/chips/STM32H725AE.yaml
@@ -230,10 +230,10 @@ cores:
       clock: AHB4
       dma_channels:
         ADC3:
-        - dmamux: DMAMUX2
-          request: 17
         - dmamux: DMAMUX1
           request: 115
+        - dmamux: DMAMUX2
+          request: 17
     ADC_COMMON:
       address: 0x40022300
       kind: ADC_COMMON:aditf5_v3_0

--- a/data/chips/STM32H725AG.yaml
+++ b/data/chips/STM32H725AG.yaml
@@ -230,10 +230,10 @@ cores:
       clock: AHB4
       dma_channels:
         ADC3:
-        - dmamux: DMAMUX2
-          request: 17
         - dmamux: DMAMUX1
           request: 115
+        - dmamux: DMAMUX2
+          request: 17
     ADC_COMMON:
       address: 0x40022300
       kind: ADC_COMMON:aditf5_v3_0

--- a/data/chips/STM32H725IE.yaml
+++ b/data/chips/STM32H725IE.yaml
@@ -194,10 +194,10 @@ cores:
       clock: AHB4
       dma_channels:
         ADC3:
-        - dmamux: DMAMUX2
-          request: 17
         - dmamux: DMAMUX1
           request: 115
+        - dmamux: DMAMUX2
+          request: 17
     ADC_COMMON:
       address: 0x40022300
       kind: ADC_COMMON:aditf5_v3_0

--- a/data/chips/STM32H725IG.yaml
+++ b/data/chips/STM32H725IG.yaml
@@ -194,10 +194,10 @@ cores:
       clock: AHB4
       dma_channels:
         ADC3:
-        - dmamux: DMAMUX2
-          request: 17
         - dmamux: DMAMUX1
           request: 115
+        - dmamux: DMAMUX2
+          request: 17
     ADC_COMMON:
       address: 0x40022300
       kind: ADC_COMMON:aditf5_v3_0

--- a/data/chips/STM32H725RE.yaml
+++ b/data/chips/STM32H725RE.yaml
@@ -150,10 +150,10 @@ cores:
       clock: AHB4
       dma_channels:
         ADC3:
-        - dmamux: DMAMUX2
-          request: 17
         - dmamux: DMAMUX1
           request: 115
+        - dmamux: DMAMUX2
+          request: 17
     ADC_COMMON:
       address: 0x40022300
       kind: ADC_COMMON:aditf5_v3_0

--- a/data/chips/STM32H725RG.yaml
+++ b/data/chips/STM32H725RG.yaml
@@ -150,10 +150,10 @@ cores:
       clock: AHB4
       dma_channels:
         ADC3:
-        - dmamux: DMAMUX2
-          request: 17
         - dmamux: DMAMUX1
           request: 115
+        - dmamux: DMAMUX2
+          request: 17
     ADC_COMMON:
       address: 0x40022300
       kind: ADC_COMMON:aditf5_v3_0

--- a/data/chips/STM32H725VE.yaml
+++ b/data/chips/STM32H725VE.yaml
@@ -158,10 +158,10 @@ cores:
       clock: AHB4
       dma_channels:
         ADC3:
-        - dmamux: DMAMUX2
-          request: 17
         - dmamux: DMAMUX1
           request: 115
+        - dmamux: DMAMUX2
+          request: 17
     ADC_COMMON:
       address: 0x40022300
       kind: ADC_COMMON:aditf5_v3_0

--- a/data/chips/STM32H725VG.yaml
+++ b/data/chips/STM32H725VG.yaml
@@ -154,10 +154,10 @@ cores:
       clock: AHB4
       dma_channels:
         ADC3:
-        - dmamux: DMAMUX2
-          request: 17
         - dmamux: DMAMUX1
           request: 115
+        - dmamux: DMAMUX2
+          request: 17
     ADC_COMMON:
       address: 0x40022300
       kind: ADC_COMMON:aditf5_v3_0

--- a/data/chips/STM32H725ZE.yaml
+++ b/data/chips/STM32H725ZE.yaml
@@ -178,10 +178,10 @@ cores:
       clock: AHB4
       dma_channels:
         ADC3:
-        - dmamux: DMAMUX2
-          request: 17
         - dmamux: DMAMUX1
           request: 115
+        - dmamux: DMAMUX2
+          request: 17
     ADC_COMMON:
       address: 0x40022300
       kind: ADC_COMMON:aditf5_v3_0

--- a/data/chips/STM32H725ZG.yaml
+++ b/data/chips/STM32H725ZG.yaml
@@ -178,10 +178,10 @@ cores:
       clock: AHB4
       dma_channels:
         ADC3:
-        - dmamux: DMAMUX2
-          request: 17
         - dmamux: DMAMUX1
           request: 115
+        - dmamux: DMAMUX2
+          request: 17
     ADC_COMMON:
       address: 0x40022300
       kind: ADC_COMMON:aditf5_v3_0

--- a/data/chips/STM32H730AB.yaml
+++ b/data/chips/STM32H730AB.yaml
@@ -230,10 +230,10 @@ cores:
       clock: AHB4
       dma_channels:
         ADC3:
-        - dmamux: DMAMUX2
-          request: 17
         - dmamux: DMAMUX1
           request: 115
+        - dmamux: DMAMUX2
+          request: 17
     ADC_COMMON:
       address: 0x40022300
       kind: ADC_COMMON:aditf5_v3_0

--- a/data/chips/STM32H730IB.yaml
+++ b/data/chips/STM32H730IB.yaml
@@ -194,10 +194,10 @@ cores:
       clock: AHB4
       dma_channels:
         ADC3:
-        - dmamux: DMAMUX2
-          request: 17
         - dmamux: DMAMUX1
           request: 115
+        - dmamux: DMAMUX2
+          request: 17
     ADC_COMMON:
       address: 0x40022300
       kind: ADC_COMMON:aditf5_v3_0

--- a/data/chips/STM32H730VB.yaml
+++ b/data/chips/STM32H730VB.yaml
@@ -158,10 +158,10 @@ cores:
       clock: AHB4
       dma_channels:
         ADC3:
-        - dmamux: DMAMUX2
-          request: 17
         - dmamux: DMAMUX1
           request: 115
+        - dmamux: DMAMUX2
+          request: 17
     ADC_COMMON:
       address: 0x40022300
       kind: ADC_COMMON:aditf5_v3_0

--- a/data/chips/STM32H730ZB.yaml
+++ b/data/chips/STM32H730ZB.yaml
@@ -194,10 +194,10 @@ cores:
       clock: AHB4
       dma_channels:
         ADC3:
-        - dmamux: DMAMUX2
-          request: 17
         - dmamux: DMAMUX1
           request: 115
+        - dmamux: DMAMUX2
+          request: 17
     ADC_COMMON:
       address: 0x40022300
       kind: ADC_COMMON:aditf5_v3_0

--- a/data/chips/STM32H733VG.yaml
+++ b/data/chips/STM32H733VG.yaml
@@ -158,10 +158,10 @@ cores:
       clock: AHB4
       dma_channels:
         ADC3:
-        - dmamux: DMAMUX2
-          request: 17
         - dmamux: DMAMUX1
           request: 115
+        - dmamux: DMAMUX2
+          request: 17
     ADC_COMMON:
       address: 0x40022300
       kind: ADC_COMMON:aditf5_v3_0

--- a/data/chips/STM32H733ZG.yaml
+++ b/data/chips/STM32H733ZG.yaml
@@ -194,10 +194,10 @@ cores:
       clock: AHB4
       dma_channels:
         ADC3:
-        - dmamux: DMAMUX2
-          request: 17
         - dmamux: DMAMUX1
           request: 115
+        - dmamux: DMAMUX2
+          request: 17
     ADC_COMMON:
       address: 0x40022300
       kind: ADC_COMMON:aditf5_v3_0

--- a/data/chips/STM32H735AG.yaml
+++ b/data/chips/STM32H735AG.yaml
@@ -230,10 +230,10 @@ cores:
       clock: AHB4
       dma_channels:
         ADC3:
-        - dmamux: DMAMUX2
-          request: 17
         - dmamux: DMAMUX1
           request: 115
+        - dmamux: DMAMUX2
+          request: 17
     ADC_COMMON:
       address: 0x40022300
       kind: ADC_COMMON:aditf5_v3_0

--- a/data/chips/STM32H735IG.yaml
+++ b/data/chips/STM32H735IG.yaml
@@ -194,10 +194,10 @@ cores:
       clock: AHB4
       dma_channels:
         ADC3:
-        - dmamux: DMAMUX2
-          request: 17
         - dmamux: DMAMUX1
           request: 115
+        - dmamux: DMAMUX2
+          request: 17
     ADC_COMMON:
       address: 0x40022300
       kind: ADC_COMMON:aditf5_v3_0

--- a/data/chips/STM32H735RG.yaml
+++ b/data/chips/STM32H735RG.yaml
@@ -150,10 +150,10 @@ cores:
       clock: AHB4
       dma_channels:
         ADC3:
-        - dmamux: DMAMUX2
-          request: 17
         - dmamux: DMAMUX1
           request: 115
+        - dmamux: DMAMUX2
+          request: 17
     ADC_COMMON:
       address: 0x40022300
       kind: ADC_COMMON:aditf5_v3_0

--- a/data/chips/STM32H735VG.yaml
+++ b/data/chips/STM32H735VG.yaml
@@ -154,10 +154,10 @@ cores:
       clock: AHB4
       dma_channels:
         ADC3:
-        - dmamux: DMAMUX2
-          request: 17
         - dmamux: DMAMUX1
           request: 115
+        - dmamux: DMAMUX2
+          request: 17
     ADC_COMMON:
       address: 0x40022300
       kind: ADC_COMMON:aditf5_v3_0

--- a/data/chips/STM32H735ZG.yaml
+++ b/data/chips/STM32H735ZG.yaml
@@ -178,10 +178,10 @@ cores:
       clock: AHB4
       dma_channels:
         ADC3:
-        - dmamux: DMAMUX2
-          request: 17
         - dmamux: DMAMUX1
           request: 115
+        - dmamux: DMAMUX2
+          request: 17
     ADC_COMMON:
       address: 0x40022300
       kind: ADC_COMMON:aditf5_v3_0

--- a/data/chips/STM32H742AG.yaml
+++ b/data/chips/STM32H742AG.yaml
@@ -211,10 +211,10 @@ cores:
       clock: AHB4
       dma_channels:
         ADC3:
-        - dmamux: DMAMUX2
-          request: 17
         - dmamux: DMAMUX1
           request: 115
+        - dmamux: DMAMUX2
+          request: 17
     ADC_COMMON:
       address: 0x40022300
       kind: ADC_COMMON:aditf5_v3_0

--- a/data/chips/STM32H742AI.yaml
+++ b/data/chips/STM32H742AI.yaml
@@ -211,10 +211,10 @@ cores:
       clock: AHB4
       dma_channels:
         ADC3:
-        - dmamux: DMAMUX2
-          request: 17
         - dmamux: DMAMUX1
           request: 115
+        - dmamux: DMAMUX2
+          request: 17
     ADC_COMMON:
       address: 0x40022300
       kind: ADC_COMMON:aditf5_v3_0

--- a/data/chips/STM32H742BG.yaml
+++ b/data/chips/STM32H742BG.yaml
@@ -211,10 +211,10 @@ cores:
       clock: AHB4
       dma_channels:
         ADC3:
-        - dmamux: DMAMUX2
-          request: 17
         - dmamux: DMAMUX1
           request: 115
+        - dmamux: DMAMUX2
+          request: 17
     ADC_COMMON:
       address: 0x40022300
       kind: ADC_COMMON:aditf5_v3_0

--- a/data/chips/STM32H742BI.yaml
+++ b/data/chips/STM32H742BI.yaml
@@ -211,10 +211,10 @@ cores:
       clock: AHB4
       dma_channels:
         ADC3:
-        - dmamux: DMAMUX2
-          request: 17
         - dmamux: DMAMUX1
           request: 115
+        - dmamux: DMAMUX2
+          request: 17
     ADC_COMMON:
       address: 0x40022300
       kind: ADC_COMMON:aditf5_v3_0

--- a/data/chips/STM32H742IG.yaml
+++ b/data/chips/STM32H742IG.yaml
@@ -213,10 +213,10 @@ cores:
       clock: AHB4
       dma_channels:
         ADC3:
-        - dmamux: DMAMUX2
-          request: 17
         - dmamux: DMAMUX1
           request: 115
+        - dmamux: DMAMUX2
+          request: 17
     ADC_COMMON:
       address: 0x40022300
       kind: ADC_COMMON:aditf5_v3_0

--- a/data/chips/STM32H742II.yaml
+++ b/data/chips/STM32H742II.yaml
@@ -213,10 +213,10 @@ cores:
       clock: AHB4
       dma_channels:
         ADC3:
-        - dmamux: DMAMUX2
-          request: 17
         - dmamux: DMAMUX1
           request: 115
+        - dmamux: DMAMUX2
+          request: 17
     ADC_COMMON:
       address: 0x40022300
       kind: ADC_COMMON:aditf5_v3_0

--- a/data/chips/STM32H742VG.yaml
+++ b/data/chips/STM32H742VG.yaml
@@ -163,10 +163,10 @@ cores:
       clock: AHB4
       dma_channels:
         ADC3:
-        - dmamux: DMAMUX2
-          request: 17
         - dmamux: DMAMUX1
           request: 115
+        - dmamux: DMAMUX2
+          request: 17
     ADC_COMMON:
       address: 0x40022300
       kind: ADC_COMMON:aditf5_v3_0

--- a/data/chips/STM32H742VI.yaml
+++ b/data/chips/STM32H742VI.yaml
@@ -163,10 +163,10 @@ cores:
       clock: AHB4
       dma_channels:
         ADC3:
-        - dmamux: DMAMUX2
-          request: 17
         - dmamux: DMAMUX1
           request: 115
+        - dmamux: DMAMUX2
+          request: 17
     ADC_COMMON:
       address: 0x40022300
       kind: ADC_COMMON:aditf5_v3_0

--- a/data/chips/STM32H742XG.yaml
+++ b/data/chips/STM32H742XG.yaml
@@ -243,10 +243,10 @@ cores:
       clock: AHB4
       dma_channels:
         ADC3:
-        - dmamux: DMAMUX2
-          request: 17
         - dmamux: DMAMUX1
           request: 115
+        - dmamux: DMAMUX2
+          request: 17
     ADC_COMMON:
       address: 0x40022300
       kind: ADC_COMMON:aditf5_v3_0

--- a/data/chips/STM32H742XI.yaml
+++ b/data/chips/STM32H742XI.yaml
@@ -243,10 +243,10 @@ cores:
       clock: AHB4
       dma_channels:
         ADC3:
-        - dmamux: DMAMUX2
-          request: 17
         - dmamux: DMAMUX1
           request: 115
+        - dmamux: DMAMUX2
+          request: 17
     ADC_COMMON:
       address: 0x40022300
       kind: ADC_COMMON:aditf5_v3_0

--- a/data/chips/STM32H742ZG.yaml
+++ b/data/chips/STM32H742ZG.yaml
@@ -197,10 +197,10 @@ cores:
       clock: AHB4
       dma_channels:
         ADC3:
-        - dmamux: DMAMUX2
-          request: 17
         - dmamux: DMAMUX1
           request: 115
+        - dmamux: DMAMUX2
+          request: 17
     ADC_COMMON:
       address: 0x40022300
       kind: ADC_COMMON:aditf5_v3_0

--- a/data/chips/STM32H742ZI.yaml
+++ b/data/chips/STM32H742ZI.yaml
@@ -197,10 +197,10 @@ cores:
       clock: AHB4
       dma_channels:
         ADC3:
-        - dmamux: DMAMUX2
-          request: 17
         - dmamux: DMAMUX1
           request: 115
+        - dmamux: DMAMUX2
+          request: 17
     ADC_COMMON:
       address: 0x40022300
       kind: ADC_COMMON:aditf5_v3_0

--- a/data/chips/STM32H743AG.yaml
+++ b/data/chips/STM32H743AG.yaml
@@ -211,10 +211,10 @@ cores:
       clock: AHB4
       dma_channels:
         ADC3:
-        - dmamux: DMAMUX2
-          request: 17
         - dmamux: DMAMUX1
           request: 115
+        - dmamux: DMAMUX2
+          request: 17
     ADC_COMMON:
       address: 0x40022300
       kind: ADC_COMMON:aditf5_v3_0

--- a/data/chips/STM32H743AI.yaml
+++ b/data/chips/STM32H743AI.yaml
@@ -211,10 +211,10 @@ cores:
       clock: AHB4
       dma_channels:
         ADC3:
-        - dmamux: DMAMUX2
-          request: 17
         - dmamux: DMAMUX1
           request: 115
+        - dmamux: DMAMUX2
+          request: 17
     ADC_COMMON:
       address: 0x40022300
       kind: ADC_COMMON:aditf5_v3_0

--- a/data/chips/STM32H743BG.yaml
+++ b/data/chips/STM32H743BG.yaml
@@ -211,10 +211,10 @@ cores:
       clock: AHB4
       dma_channels:
         ADC3:
-        - dmamux: DMAMUX2
-          request: 17
         - dmamux: DMAMUX1
           request: 115
+        - dmamux: DMAMUX2
+          request: 17
     ADC_COMMON:
       address: 0x40022300
       kind: ADC_COMMON:aditf5_v3_0

--- a/data/chips/STM32H743BI.yaml
+++ b/data/chips/STM32H743BI.yaml
@@ -211,10 +211,10 @@ cores:
       clock: AHB4
       dma_channels:
         ADC3:
-        - dmamux: DMAMUX2
-          request: 17
         - dmamux: DMAMUX1
           request: 115
+        - dmamux: DMAMUX2
+          request: 17
     ADC_COMMON:
       address: 0x40022300
       kind: ADC_COMMON:aditf5_v3_0

--- a/data/chips/STM32H743IG.yaml
+++ b/data/chips/STM32H743IG.yaml
@@ -213,10 +213,10 @@ cores:
       clock: AHB4
       dma_channels:
         ADC3:
-        - dmamux: DMAMUX2
-          request: 17
         - dmamux: DMAMUX1
           request: 115
+        - dmamux: DMAMUX2
+          request: 17
     ADC_COMMON:
       address: 0x40022300
       kind: ADC_COMMON:aditf5_v3_0

--- a/data/chips/STM32H743II.yaml
+++ b/data/chips/STM32H743II.yaml
@@ -213,10 +213,10 @@ cores:
       clock: AHB4
       dma_channels:
         ADC3:
-        - dmamux: DMAMUX2
-          request: 17
         - dmamux: DMAMUX1
           request: 115
+        - dmamux: DMAMUX2
+          request: 17
     ADC_COMMON:
       address: 0x40022300
       kind: ADC_COMMON:aditf5_v3_0

--- a/data/chips/STM32H743VG.yaml
+++ b/data/chips/STM32H743VG.yaml
@@ -163,10 +163,10 @@ cores:
       clock: AHB4
       dma_channels:
         ADC3:
-        - dmamux: DMAMUX2
-          request: 17
         - dmamux: DMAMUX1
           request: 115
+        - dmamux: DMAMUX2
+          request: 17
     ADC_COMMON:
       address: 0x40022300
       kind: ADC_COMMON:aditf5_v3_0

--- a/data/chips/STM32H743VI.yaml
+++ b/data/chips/STM32H743VI.yaml
@@ -163,10 +163,10 @@ cores:
       clock: AHB4
       dma_channels:
         ADC3:
-        - dmamux: DMAMUX2
-          request: 17
         - dmamux: DMAMUX1
           request: 115
+        - dmamux: DMAMUX2
+          request: 17
     ADC_COMMON:
       address: 0x40022300
       kind: ADC_COMMON:aditf5_v3_0

--- a/data/chips/STM32H743XG.yaml
+++ b/data/chips/STM32H743XG.yaml
@@ -243,10 +243,10 @@ cores:
       clock: AHB4
       dma_channels:
         ADC3:
-        - dmamux: DMAMUX2
-          request: 17
         - dmamux: DMAMUX1
           request: 115
+        - dmamux: DMAMUX2
+          request: 17
     ADC_COMMON:
       address: 0x40022300
       kind: ADC_COMMON:aditf5_v3_0

--- a/data/chips/STM32H743XI.yaml
+++ b/data/chips/STM32H743XI.yaml
@@ -243,10 +243,10 @@ cores:
       clock: AHB4
       dma_channels:
         ADC3:
-        - dmamux: DMAMUX2
-          request: 17
         - dmamux: DMAMUX1
           request: 115
+        - dmamux: DMAMUX2
+          request: 17
     ADC_COMMON:
       address: 0x40022300
       kind: ADC_COMMON:aditf5_v3_0

--- a/data/chips/STM32H743ZG.yaml
+++ b/data/chips/STM32H743ZG.yaml
@@ -197,10 +197,10 @@ cores:
       clock: AHB4
       dma_channels:
         ADC3:
-        - dmamux: DMAMUX2
-          request: 17
         - dmamux: DMAMUX1
           request: 115
+        - dmamux: DMAMUX2
+          request: 17
     ADC_COMMON:
       address: 0x40022300
       kind: ADC_COMMON:aditf5_v3_0

--- a/data/chips/STM32H743ZI.yaml
+++ b/data/chips/STM32H743ZI.yaml
@@ -197,10 +197,10 @@ cores:
       clock: AHB4
       dma_channels:
         ADC3:
-        - dmamux: DMAMUX2
-          request: 17
         - dmamux: DMAMUX1
           request: 115
+        - dmamux: DMAMUX2
+          request: 17
     ADC_COMMON:
       address: 0x40022300
       kind: ADC_COMMON:aditf5_v3_0

--- a/data/chips/STM32H745BG.yaml
+++ b/data/chips/STM32H745BG.yaml
@@ -214,11 +214,11 @@ cores:
       dma_channels:
         ADC3:
         - &id006
-          dmamux: DMAMUX2
-          request: 17
-        - &id007
           dmamux: DMAMUX1
           request: 115
+        - &id007
+          dmamux: DMAMUX2
+          request: 17
     ADC_COMMON:
       address: 0x40022300
       kind: ADC_COMMON:aditf5_v3_0

--- a/data/chips/STM32H745BI.yaml
+++ b/data/chips/STM32H745BI.yaml
@@ -214,11 +214,11 @@ cores:
       dma_channels:
         ADC3:
         - &id006
-          dmamux: DMAMUX2
-          request: 17
-        - &id007
           dmamux: DMAMUX1
           request: 115
+        - &id007
+          dmamux: DMAMUX2
+          request: 17
     ADC_COMMON:
       address: 0x40022300
       kind: ADC_COMMON:aditf5_v3_0

--- a/data/chips/STM32H745IG.yaml
+++ b/data/chips/STM32H745IG.yaml
@@ -202,11 +202,11 @@ cores:
       dma_channels:
         ADC3:
         - &id006
-          dmamux: DMAMUX2
-          request: 17
-        - &id007
           dmamux: DMAMUX1
           request: 115
+        - &id007
+          dmamux: DMAMUX2
+          request: 17
     ADC_COMMON:
       address: 0x40022300
       kind: ADC_COMMON:aditf5_v3_0

--- a/data/chips/STM32H745II.yaml
+++ b/data/chips/STM32H745II.yaml
@@ -202,11 +202,11 @@ cores:
       dma_channels:
         ADC3:
         - &id006
-          dmamux: DMAMUX2
-          request: 17
-        - &id007
           dmamux: DMAMUX1
           request: 115
+        - &id007
+          dmamux: DMAMUX2
+          request: 17
     ADC_COMMON:
       address: 0x40022300
       kind: ADC_COMMON:aditf5_v3_0

--- a/data/chips/STM32H745XG.yaml
+++ b/data/chips/STM32H745XG.yaml
@@ -246,11 +246,11 @@ cores:
       dma_channels:
         ADC3:
         - &id006
-          dmamux: DMAMUX2
-          request: 17
-        - &id007
           dmamux: DMAMUX1
           request: 115
+        - &id007
+          dmamux: DMAMUX2
+          request: 17
     ADC_COMMON:
       address: 0x40022300
       kind: ADC_COMMON:aditf5_v3_0

--- a/data/chips/STM32H745XI.yaml
+++ b/data/chips/STM32H745XI.yaml
@@ -246,11 +246,11 @@ cores:
       dma_channels:
         ADC3:
         - &id006
-          dmamux: DMAMUX2
-          request: 17
-        - &id007
           dmamux: DMAMUX1
           request: 115
+        - &id007
+          dmamux: DMAMUX2
+          request: 17
     ADC_COMMON:
       address: 0x40022300
       kind: ADC_COMMON:aditf5_v3_0

--- a/data/chips/STM32H745ZG.yaml
+++ b/data/chips/STM32H745ZG.yaml
@@ -186,11 +186,11 @@ cores:
       dma_channels:
         ADC3:
         - &id006
-          dmamux: DMAMUX2
-          request: 17
-        - &id007
           dmamux: DMAMUX1
           request: 115
+        - &id007
+          dmamux: DMAMUX2
+          request: 17
     ADC_COMMON:
       address: 0x40022300
       kind: ADC_COMMON:aditf5_v3_0

--- a/data/chips/STM32H745ZI.yaml
+++ b/data/chips/STM32H745ZI.yaml
@@ -186,11 +186,11 @@ cores:
       dma_channels:
         ADC3:
         - &id006
-          dmamux: DMAMUX2
-          request: 17
-        - &id007
           dmamux: DMAMUX1
           request: 115
+        - &id007
+          dmamux: DMAMUX2
+          request: 17
     ADC_COMMON:
       address: 0x40022300
       kind: ADC_COMMON:aditf5_v3_0

--- a/data/chips/STM32H747AG.yaml
+++ b/data/chips/STM32H747AG.yaml
@@ -200,11 +200,11 @@ cores:
       dma_channels:
         ADC3:
         - &id006
-          dmamux: DMAMUX2
-          request: 17
-        - &id007
           dmamux: DMAMUX1
           request: 115
+        - &id007
+          dmamux: DMAMUX2
+          request: 17
     ADC_COMMON:
       address: 0x40022300
       kind: ADC_COMMON:aditf5_v3_0

--- a/data/chips/STM32H747AI.yaml
+++ b/data/chips/STM32H747AI.yaml
@@ -200,11 +200,11 @@ cores:
       dma_channels:
         ADC3:
         - &id006
-          dmamux: DMAMUX2
-          request: 17
-        - &id007
           dmamux: DMAMUX1
           request: 115
+        - &id007
+          dmamux: DMAMUX2
+          request: 17
     ADC_COMMON:
       address: 0x40022300
       kind: ADC_COMMON:aditf5_v3_0

--- a/data/chips/STM32H747BG.yaml
+++ b/data/chips/STM32H747BG.yaml
@@ -214,11 +214,11 @@ cores:
       dma_channels:
         ADC3:
         - &id006
-          dmamux: DMAMUX2
-          request: 17
-        - &id007
           dmamux: DMAMUX1
           request: 115
+        - &id007
+          dmamux: DMAMUX2
+          request: 17
     ADC_COMMON:
       address: 0x40022300
       kind: ADC_COMMON:aditf5_v3_0

--- a/data/chips/STM32H747BI.yaml
+++ b/data/chips/STM32H747BI.yaml
@@ -214,11 +214,11 @@ cores:
       dma_channels:
         ADC3:
         - &id006
-          dmamux: DMAMUX2
-          request: 17
-        - &id007
           dmamux: DMAMUX1
           request: 115
+        - &id007
+          dmamux: DMAMUX2
+          request: 17
     ADC_COMMON:
       address: 0x40022300
       kind: ADC_COMMON:aditf5_v3_0

--- a/data/chips/STM32H747IG.yaml
+++ b/data/chips/STM32H747IG.yaml
@@ -200,11 +200,11 @@ cores:
       dma_channels:
         ADC3:
         - &id006
-          dmamux: DMAMUX2
-          request: 17
-        - &id007
           dmamux: DMAMUX1
           request: 115
+        - &id007
+          dmamux: DMAMUX2
+          request: 17
     ADC_COMMON:
       address: 0x40022300
       kind: ADC_COMMON:aditf5_v3_0

--- a/data/chips/STM32H747II.yaml
+++ b/data/chips/STM32H747II.yaml
@@ -200,11 +200,11 @@ cores:
       dma_channels:
         ADC3:
         - &id006
-          dmamux: DMAMUX2
-          request: 17
-        - &id007
           dmamux: DMAMUX1
           request: 115
+        - &id007
+          dmamux: DMAMUX2
+          request: 17
     ADC_COMMON:
       address: 0x40022300
       kind: ADC_COMMON:aditf5_v3_0

--- a/data/chips/STM32H747XG.yaml
+++ b/data/chips/STM32H747XG.yaml
@@ -246,11 +246,11 @@ cores:
       dma_channels:
         ADC3:
         - &id006
-          dmamux: DMAMUX2
-          request: 17
-        - &id007
           dmamux: DMAMUX1
           request: 115
+        - &id007
+          dmamux: DMAMUX2
+          request: 17
     ADC_COMMON:
       address: 0x40022300
       kind: ADC_COMMON:aditf5_v3_0

--- a/data/chips/STM32H747XI.yaml
+++ b/data/chips/STM32H747XI.yaml
@@ -246,11 +246,11 @@ cores:
       dma_channels:
         ADC3:
         - &id006
-          dmamux: DMAMUX2
-          request: 17
-        - &id007
           dmamux: DMAMUX1
           request: 115
+        - &id007
+          dmamux: DMAMUX2
+          request: 17
     ADC_COMMON:
       address: 0x40022300
       kind: ADC_COMMON:aditf5_v3_0

--- a/data/chips/STM32H747ZI.yaml
+++ b/data/chips/STM32H747ZI.yaml
@@ -184,11 +184,11 @@ cores:
       dma_channels:
         ADC3:
         - &id006
-          dmamux: DMAMUX2
-          request: 17
-        - &id007
           dmamux: DMAMUX1
           request: 115
+        - &id007
+          dmamux: DMAMUX2
+          request: 17
     ADC_COMMON:
       address: 0x40022300
       kind: ADC_COMMON:aditf5_v3_0

--- a/data/chips/STM32H750IB.yaml
+++ b/data/chips/STM32H750IB.yaml
@@ -213,10 +213,10 @@ cores:
       clock: AHB4
       dma_channels:
         ADC3:
-        - dmamux: DMAMUX2
-          request: 17
         - dmamux: DMAMUX1
           request: 115
+        - dmamux: DMAMUX2
+          request: 17
     ADC_COMMON:
       address: 0x40022300
       kind: ADC_COMMON:aditf5_v3_0

--- a/data/chips/STM32H750VB.yaml
+++ b/data/chips/STM32H750VB.yaml
@@ -161,10 +161,10 @@ cores:
       clock: AHB4
       dma_channels:
         ADC3:
-        - dmamux: DMAMUX2
-          request: 17
         - dmamux: DMAMUX1
           request: 115
+        - dmamux: DMAMUX2
+          request: 17
     ADC_COMMON:
       address: 0x40022300
       kind: ADC_COMMON:aditf5_v3_0

--- a/data/chips/STM32H750XB.yaml
+++ b/data/chips/STM32H750XB.yaml
@@ -243,10 +243,10 @@ cores:
       clock: AHB4
       dma_channels:
         ADC3:
-        - dmamux: DMAMUX2
-          request: 17
         - dmamux: DMAMUX1
           request: 115
+        - dmamux: DMAMUX2
+          request: 17
     ADC_COMMON:
       address: 0x40022300
       kind: ADC_COMMON:aditf5_v3_0

--- a/data/chips/STM32H750ZB.yaml
+++ b/data/chips/STM32H750ZB.yaml
@@ -197,10 +197,10 @@ cores:
       clock: AHB4
       dma_channels:
         ADC3:
-        - dmamux: DMAMUX2
-          request: 17
         - dmamux: DMAMUX1
           request: 115
+        - dmamux: DMAMUX2
+          request: 17
     ADC_COMMON:
       address: 0x40022300
       kind: ADC_COMMON:aditf5_v3_0

--- a/data/chips/STM32H753AI.yaml
+++ b/data/chips/STM32H753AI.yaml
@@ -211,10 +211,10 @@ cores:
       clock: AHB4
       dma_channels:
         ADC3:
-        - dmamux: DMAMUX2
-          request: 17
         - dmamux: DMAMUX1
           request: 115
+        - dmamux: DMAMUX2
+          request: 17
     ADC_COMMON:
       address: 0x40022300
       kind: ADC_COMMON:aditf5_v3_0

--- a/data/chips/STM32H753BI.yaml
+++ b/data/chips/STM32H753BI.yaml
@@ -211,10 +211,10 @@ cores:
       clock: AHB4
       dma_channels:
         ADC3:
-        - dmamux: DMAMUX2
-          request: 17
         - dmamux: DMAMUX1
           request: 115
+        - dmamux: DMAMUX2
+          request: 17
     ADC_COMMON:
       address: 0x40022300
       kind: ADC_COMMON:aditf5_v3_0

--- a/data/chips/STM32H753II.yaml
+++ b/data/chips/STM32H753II.yaml
@@ -213,10 +213,10 @@ cores:
       clock: AHB4
       dma_channels:
         ADC3:
-        - dmamux: DMAMUX2
-          request: 17
         - dmamux: DMAMUX1
           request: 115
+        - dmamux: DMAMUX2
+          request: 17
     ADC_COMMON:
       address: 0x40022300
       kind: ADC_COMMON:aditf5_v3_0

--- a/data/chips/STM32H753VI.yaml
+++ b/data/chips/STM32H753VI.yaml
@@ -163,10 +163,10 @@ cores:
       clock: AHB4
       dma_channels:
         ADC3:
-        - dmamux: DMAMUX2
-          request: 17
         - dmamux: DMAMUX1
           request: 115
+        - dmamux: DMAMUX2
+          request: 17
     ADC_COMMON:
       address: 0x40022300
       kind: ADC_COMMON:aditf5_v3_0

--- a/data/chips/STM32H753XI.yaml
+++ b/data/chips/STM32H753XI.yaml
@@ -243,10 +243,10 @@ cores:
       clock: AHB4
       dma_channels:
         ADC3:
-        - dmamux: DMAMUX2
-          request: 17
         - dmamux: DMAMUX1
           request: 115
+        - dmamux: DMAMUX2
+          request: 17
     ADC_COMMON:
       address: 0x40022300
       kind: ADC_COMMON:aditf5_v3_0

--- a/data/chips/STM32H753ZI.yaml
+++ b/data/chips/STM32H753ZI.yaml
@@ -197,10 +197,10 @@ cores:
       clock: AHB4
       dma_channels:
         ADC3:
-        - dmamux: DMAMUX2
-          request: 17
         - dmamux: DMAMUX1
           request: 115
+        - dmamux: DMAMUX2
+          request: 17
     ADC_COMMON:
       address: 0x40022300
       kind: ADC_COMMON:aditf5_v3_0

--- a/data/chips/STM32H755BI.yaml
+++ b/data/chips/STM32H755BI.yaml
@@ -214,11 +214,11 @@ cores:
       dma_channels:
         ADC3:
         - &id006
-          dmamux: DMAMUX2
-          request: 17
-        - &id007
           dmamux: DMAMUX1
           request: 115
+        - &id007
+          dmamux: DMAMUX2
+          request: 17
     ADC_COMMON:
       address: 0x40022300
       kind: ADC_COMMON:aditf5_v3_0

--- a/data/chips/STM32H755II.yaml
+++ b/data/chips/STM32H755II.yaml
@@ -202,11 +202,11 @@ cores:
       dma_channels:
         ADC3:
         - &id006
-          dmamux: DMAMUX2
-          request: 17
-        - &id007
           dmamux: DMAMUX1
           request: 115
+        - &id007
+          dmamux: DMAMUX2
+          request: 17
     ADC_COMMON:
       address: 0x40022300
       kind: ADC_COMMON:aditf5_v3_0

--- a/data/chips/STM32H755XI.yaml
+++ b/data/chips/STM32H755XI.yaml
@@ -246,11 +246,11 @@ cores:
       dma_channels:
         ADC3:
         - &id006
-          dmamux: DMAMUX2
-          request: 17
-        - &id007
           dmamux: DMAMUX1
           request: 115
+        - &id007
+          dmamux: DMAMUX2
+          request: 17
     ADC_COMMON:
       address: 0x40022300
       kind: ADC_COMMON:aditf5_v3_0

--- a/data/chips/STM32H755ZI.yaml
+++ b/data/chips/STM32H755ZI.yaml
@@ -186,11 +186,11 @@ cores:
       dma_channels:
         ADC3:
         - &id006
-          dmamux: DMAMUX2
-          request: 17
-        - &id007
           dmamux: DMAMUX1
           request: 115
+        - &id007
+          dmamux: DMAMUX2
+          request: 17
     ADC_COMMON:
       address: 0x40022300
       kind: ADC_COMMON:aditf5_v3_0

--- a/data/chips/STM32H757AI.yaml
+++ b/data/chips/STM32H757AI.yaml
@@ -200,11 +200,11 @@ cores:
       dma_channels:
         ADC3:
         - &id006
-          dmamux: DMAMUX2
-          request: 17
-        - &id007
           dmamux: DMAMUX1
           request: 115
+        - &id007
+          dmamux: DMAMUX2
+          request: 17
     ADC_COMMON:
       address: 0x40022300
       kind: ADC_COMMON:aditf5_v3_0

--- a/data/chips/STM32H757BI.yaml
+++ b/data/chips/STM32H757BI.yaml
@@ -214,11 +214,11 @@ cores:
       dma_channels:
         ADC3:
         - &id006
-          dmamux: DMAMUX2
-          request: 17
-        - &id007
           dmamux: DMAMUX1
           request: 115
+        - &id007
+          dmamux: DMAMUX2
+          request: 17
     ADC_COMMON:
       address: 0x40022300
       kind: ADC_COMMON:aditf5_v3_0

--- a/data/chips/STM32H757II.yaml
+++ b/data/chips/STM32H757II.yaml
@@ -200,11 +200,11 @@ cores:
       dma_channels:
         ADC3:
         - &id006
-          dmamux: DMAMUX2
-          request: 17
-        - &id007
           dmamux: DMAMUX1
           request: 115
+        - &id007
+          dmamux: DMAMUX2
+          request: 17
     ADC_COMMON:
       address: 0x40022300
       kind: ADC_COMMON:aditf5_v3_0

--- a/data/chips/STM32H757XI.yaml
+++ b/data/chips/STM32H757XI.yaml
@@ -246,11 +246,11 @@ cores:
       dma_channels:
         ADC3:
         - &id006
-          dmamux: DMAMUX2
-          request: 17
-        - &id007
           dmamux: DMAMUX1
           request: 115
+        - &id007
+          dmamux: DMAMUX2
+          request: 17
     ADC_COMMON:
       address: 0x40022300
       kind: ADC_COMMON:aditf5_v3_0

--- a/data/chips/STM32H757ZI.yaml
+++ b/data/chips/STM32H757ZI.yaml
@@ -184,11 +184,11 @@ cores:
       dma_channels:
         ADC3:
         - &id006
-          dmamux: DMAMUX2
-          request: 17
-        - &id007
           dmamux: DMAMUX1
           request: 115
+        - &id007
+          dmamux: DMAMUX2
+          request: 17
     ADC_COMMON:
       address: 0x40022300
       kind: ADC_COMMON:aditf5_v3_0

--- a/data/chips/STM32L100C6-A.yaml
+++ b/data/chips/STM32L100C6-A.yaml
@@ -156,18 +156,23 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32L100C6.yaml
+++ b/data/chips/STM32L100C6.yaml
@@ -154,18 +154,23 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32L100R8-A.yaml
+++ b/data/chips/STM32L100R8-A.yaml
@@ -183,18 +183,23 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32L100R8.yaml
+++ b/data/chips/STM32L100R8.yaml
@@ -181,18 +181,23 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32L100RB-A.yaml
+++ b/data/chips/STM32L100RB-A.yaml
@@ -183,18 +183,23 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32L100RB.yaml
+++ b/data/chips/STM32L100RB.yaml
@@ -181,18 +181,23 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32L100RC.yaml
+++ b/data/chips/STM32L100RC.yaml
@@ -197,18 +197,23 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32L151C6-A.yaml
+++ b/data/chips/STM32L151C6-A.yaml
@@ -161,21 +161,27 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x40021000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32L151C6.yaml
+++ b/data/chips/STM32L151C6.yaml
@@ -159,21 +159,27 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x40021000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32L151C8-A.yaml
+++ b/data/chips/STM32L151C8-A.yaml
@@ -161,21 +161,27 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x40021000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32L151C8.yaml
+++ b/data/chips/STM32L151C8.yaml
@@ -159,21 +159,27 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x40021000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32L151CB-A.yaml
+++ b/data/chips/STM32L151CB-A.yaml
@@ -161,21 +161,27 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x40021000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32L151CB.yaml
+++ b/data/chips/STM32L151CB.yaml
@@ -159,21 +159,27 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x40021000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32L151CC.yaml
+++ b/data/chips/STM32L151CC.yaml
@@ -175,21 +175,27 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x40021000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32L151QC.yaml
+++ b/data/chips/STM32L151QC.yaml
@@ -249,27 +249,35 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x40021000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x40021800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOG:
       address: 0x40021c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32L151QD.yaml
+++ b/data/chips/STM32L151QD.yaml
@@ -252,27 +252,35 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x40021000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x40021800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOG:
       address: 0x40021c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32L151QE.yaml
+++ b/data/chips/STM32L151QE.yaml
@@ -285,27 +285,35 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x40021000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x40021800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOG:
       address: 0x40021c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32L151R6-A.yaml
+++ b/data/chips/STM32L151R6-A.yaml
@@ -185,21 +185,27 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x40021000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32L151R6.yaml
+++ b/data/chips/STM32L151R6.yaml
@@ -183,21 +183,27 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x40021000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32L151R8-A.yaml
+++ b/data/chips/STM32L151R8-A.yaml
@@ -185,21 +185,27 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x40021000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32L151R8.yaml
+++ b/data/chips/STM32L151R8.yaml
@@ -183,21 +183,27 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x40021000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32L151RB-A.yaml
+++ b/data/chips/STM32L151RB-A.yaml
@@ -185,21 +185,27 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x40021000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32L151RB.yaml
+++ b/data/chips/STM32L151RB.yaml
@@ -183,21 +183,27 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x40021000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32L151RC-A.yaml
+++ b/data/chips/STM32L151RC-A.yaml
@@ -195,27 +195,35 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x40021000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x40021800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOG:
       address: 0x40021c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32L151RC.yaml
+++ b/data/chips/STM32L151RC.yaml
@@ -197,21 +197,27 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x40021000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32L151RD.yaml
+++ b/data/chips/STM32L151RD.yaml
@@ -200,27 +200,35 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x40021000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x40021800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOG:
       address: 0x40021c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32L151RE.yaml
+++ b/data/chips/STM32L151RE.yaml
@@ -225,27 +225,35 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x40021000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x40021800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOG:
       address: 0x40021c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32L151UC.yaml
+++ b/data/chips/STM32L151UC.yaml
@@ -197,21 +197,27 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x40021000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32L151V8-A.yaml
+++ b/data/chips/STM32L151V8-A.yaml
@@ -201,21 +201,27 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x40021000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32L151V8.yaml
+++ b/data/chips/STM32L151V8.yaml
@@ -199,21 +199,27 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x40021000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32L151VB-A.yaml
+++ b/data/chips/STM32L151VB-A.yaml
@@ -201,21 +201,27 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x40021000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32L151VB.yaml
+++ b/data/chips/STM32L151VB.yaml
@@ -199,21 +199,27 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x40021000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32L151VC-A.yaml
+++ b/data/chips/STM32L151VC-A.yaml
@@ -211,27 +211,35 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x40021000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x40021800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOG:
       address: 0x40021c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32L151VC.yaml
+++ b/data/chips/STM32L151VC.yaml
@@ -215,21 +215,27 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x40021000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32L151VD-X.yaml
+++ b/data/chips/STM32L151VD-X.yaml
@@ -247,27 +247,35 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x40021000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x40021800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOG:
       address: 0x40021c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32L151VD.yaml
+++ b/data/chips/STM32L151VD.yaml
@@ -214,27 +214,35 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x40021000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x40021800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOG:
       address: 0x40021c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32L151VE.yaml
+++ b/data/chips/STM32L151VE.yaml
@@ -247,27 +247,35 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x40021000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x40021800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOG:
       address: 0x40021c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32L151ZC.yaml
+++ b/data/chips/STM32L151ZC.yaml
@@ -253,27 +253,35 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x40021000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x40021800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOG:
       address: 0x40021c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32L151ZD.yaml
+++ b/data/chips/STM32L151ZD.yaml
@@ -256,27 +256,35 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x40021000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x40021800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOG:
       address: 0x40021c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32L151ZE.yaml
+++ b/data/chips/STM32L151ZE.yaml
@@ -290,27 +290,35 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x40021000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x40021800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOG:
       address: 0x40021c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32L152C6-A.yaml
+++ b/data/chips/STM32L152C6-A.yaml
@@ -161,21 +161,27 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x40021000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32L152C6.yaml
+++ b/data/chips/STM32L152C6.yaml
@@ -159,21 +159,27 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x40021000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32L152C8-A.yaml
+++ b/data/chips/STM32L152C8-A.yaml
@@ -161,21 +161,27 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x40021000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32L152C8.yaml
+++ b/data/chips/STM32L152C8.yaml
@@ -159,21 +159,27 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x40021000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32L152CB-A.yaml
+++ b/data/chips/STM32L152CB-A.yaml
@@ -161,21 +161,27 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x40021000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32L152CB.yaml
+++ b/data/chips/STM32L152CB.yaml
@@ -159,21 +159,27 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x40021000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32L152CC.yaml
+++ b/data/chips/STM32L152CC.yaml
@@ -175,21 +175,27 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x40021000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32L152QC.yaml
+++ b/data/chips/STM32L152QC.yaml
@@ -249,27 +249,35 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x40021000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x40021800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOG:
       address: 0x40021c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32L152QD.yaml
+++ b/data/chips/STM32L152QD.yaml
@@ -252,27 +252,35 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x40021000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x40021800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOG:
       address: 0x40021c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32L152QE.yaml
+++ b/data/chips/STM32L152QE.yaml
@@ -285,27 +285,35 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x40021000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x40021800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOG:
       address: 0x40021c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32L152R6-A.yaml
+++ b/data/chips/STM32L152R6-A.yaml
@@ -185,21 +185,27 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x40021000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32L152R6.yaml
+++ b/data/chips/STM32L152R6.yaml
@@ -183,21 +183,27 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x40021000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32L152R8-A.yaml
+++ b/data/chips/STM32L152R8-A.yaml
@@ -185,21 +185,27 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x40021000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32L152R8.yaml
+++ b/data/chips/STM32L152R8.yaml
@@ -183,21 +183,27 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x40021000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32L152RB-A.yaml
+++ b/data/chips/STM32L152RB-A.yaml
@@ -185,21 +185,27 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x40021000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32L152RB.yaml
+++ b/data/chips/STM32L152RB.yaml
@@ -183,21 +183,27 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x40021000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32L152RC-A.yaml
+++ b/data/chips/STM32L152RC-A.yaml
@@ -195,27 +195,35 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x40021000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x40021800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOG:
       address: 0x40021c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32L152RC.yaml
+++ b/data/chips/STM32L152RC.yaml
@@ -197,21 +197,27 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x40021000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32L152RD.yaml
+++ b/data/chips/STM32L152RD.yaml
@@ -200,27 +200,35 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x40021000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x40021800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOG:
       address: 0x40021c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32L152RE.yaml
+++ b/data/chips/STM32L152RE.yaml
@@ -225,27 +225,35 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x40021000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x40021800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOG:
       address: 0x40021c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32L152UC.yaml
+++ b/data/chips/STM32L152UC.yaml
@@ -197,21 +197,27 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x40021000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32L152V8-A.yaml
+++ b/data/chips/STM32L152V8-A.yaml
@@ -201,21 +201,27 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x40021000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32L152V8.yaml
+++ b/data/chips/STM32L152V8.yaml
@@ -199,21 +199,27 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x40021000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32L152VB-A.yaml
+++ b/data/chips/STM32L152VB-A.yaml
@@ -201,21 +201,27 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x40021000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32L152VB.yaml
+++ b/data/chips/STM32L152VB.yaml
@@ -199,21 +199,27 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x40021000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32L152VC-A.yaml
+++ b/data/chips/STM32L152VC-A.yaml
@@ -211,27 +211,35 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x40021000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x40021800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOG:
       address: 0x40021c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32L152VC.yaml
+++ b/data/chips/STM32L152VC.yaml
@@ -215,21 +215,27 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x40021000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32L152VD-X.yaml
+++ b/data/chips/STM32L152VD-X.yaml
@@ -245,27 +245,35 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x40021000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x40021800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOG:
       address: 0x40021c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32L152VD.yaml
+++ b/data/chips/STM32L152VD.yaml
@@ -214,27 +214,35 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x40021000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x40021800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOG:
       address: 0x40021c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32L152VE.yaml
+++ b/data/chips/STM32L152VE.yaml
@@ -247,27 +247,35 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x40021000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x40021800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOG:
       address: 0x40021c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32L152ZC.yaml
+++ b/data/chips/STM32L152ZC.yaml
@@ -253,27 +253,35 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x40021000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x40021800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOG:
       address: 0x40021c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32L152ZD.yaml
+++ b/data/chips/STM32L152ZD.yaml
@@ -256,27 +256,35 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x40021000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x40021800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOG:
       address: 0x40021c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32L152ZE.yaml
+++ b/data/chips/STM32L152ZE.yaml
@@ -290,27 +290,35 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x40021000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x40021800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOG:
       address: 0x40021c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32L162QC.yaml
+++ b/data/chips/STM32L162QC.yaml
@@ -259,27 +259,35 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x40021000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x40021800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOG:
       address: 0x40021c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32L162QD.yaml
+++ b/data/chips/STM32L162QD.yaml
@@ -262,27 +262,35 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x40021000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x40021800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOG:
       address: 0x40021c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32L162RC-A.yaml
+++ b/data/chips/STM32L162RC-A.yaml
@@ -205,27 +205,35 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x40021000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x40021800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOG:
       address: 0x40021c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32L162RC.yaml
+++ b/data/chips/STM32L162RC.yaml
@@ -207,21 +207,27 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x40021000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32L162RD.yaml
+++ b/data/chips/STM32L162RD.yaml
@@ -210,27 +210,35 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x40021000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x40021800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOG:
       address: 0x40021c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32L162RE.yaml
+++ b/data/chips/STM32L162RE.yaml
@@ -235,27 +235,35 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x40021000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x40021800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOG:
       address: 0x40021c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32L162VC-A.yaml
+++ b/data/chips/STM32L162VC-A.yaml
@@ -221,27 +221,35 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x40021000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x40021800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOG:
       address: 0x40021c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32L162VC.yaml
+++ b/data/chips/STM32L162VC.yaml
@@ -225,21 +225,27 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x40021000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32L162VD-X.yaml
+++ b/data/chips/STM32L162VD-X.yaml
@@ -255,27 +255,35 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x40021000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x40021800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOG:
       address: 0x40021c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32L162VD.yaml
+++ b/data/chips/STM32L162VD.yaml
@@ -224,27 +224,35 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x40021000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x40021800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOG:
       address: 0x40021c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32L162VE.yaml
+++ b/data/chips/STM32L162VE.yaml
@@ -257,27 +257,35 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x40021000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x40021800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOG:
       address: 0x40021c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32L162ZC.yaml
+++ b/data/chips/STM32L162ZC.yaml
@@ -263,27 +263,35 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x40021000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x40021800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOG:
       address: 0x40021c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32L162ZD.yaml
+++ b/data/chips/STM32L162ZD.yaml
@@ -266,27 +266,35 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x40021000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x40021800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOG:
       address: 0x40021c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32L162ZE.yaml
+++ b/data/chips/STM32L162ZE.yaml
@@ -300,27 +300,35 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x40021000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x40021800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOG:
       address: 0x40021c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/registers/adc_g0.yaml
+++ b/data/registers/adc_g0.yaml
@@ -1,0 +1,659 @@
+---
+block/ADC:
+  description: Analog to Digital Converter
+  items:
+    - name: ISR
+      description: ADC interrupt and status register
+      byte_offset: 0
+      fieldset: ISR
+    - name: IER
+      description: ADC interrupt enable register
+      byte_offset: 4
+      fieldset: IER
+    - name: CR
+      description: ADC control register
+      byte_offset: 8
+      fieldset: CR
+    - name: CFGR1
+      description: ADC configuration register 1
+      byte_offset: 12
+      fieldset: CFGR1
+    - name: CFGR2
+      description: ADC configuration register 2
+      byte_offset: 16
+      fieldset: CFGR2
+    - name: SMPR
+      description: ADC sampling time register
+      byte_offset: 20
+      fieldset: SMPR
+    - name: AWD1TR
+      description: watchdog threshold register
+      byte_offset: 32
+      fieldset: AWD1TR
+    - name: AWD2TR
+      description: watchdog threshold register
+      byte_offset: 36
+      fieldset: AWD2TR
+    - name: CHSELR
+      description: channel selection register
+      byte_offset: 40
+      fieldset: CHSELR
+    - name: CHSELR_1
+      description: channel selection register CHSELRMOD = 1 in ADC_CFGR1
+      byte_offset: 40
+      fieldset: CHSELR_1
+    - name: AWD3TR
+      description: watchdog threshold register
+      byte_offset: 44
+      fieldset: AWD3TR
+    - name: DR
+      description: ADC group regular conversion data register
+      byte_offset: 64
+      access: Read
+      fieldset: DR
+    - name: AWD2CR
+      description: ADC analog watchdog 2 configuration register
+      byte_offset: 160
+      fieldset: AWD2CR
+    - name: AWD3CR
+      description: ADC analog watchdog 3 configuration register
+      byte_offset: 164
+      fieldset: AWD3CR
+    - name: CALFACT
+      description: ADC calibration factors register
+      byte_offset: 180
+      fieldset: CALFACT
+    - name: CCR
+      description: ADC common control register
+      byte_offset: 776
+      fieldset: CCR
+    - name: HWCFGR6
+      description: Hardware Configuration Register
+      byte_offset: 984
+      fieldset: HWCFGR6
+    - name: HWCFGR5
+      description: Hardware Configuration Register
+      byte_offset: 988
+      fieldset: HWCFGR5
+    - name: HWCFGR4
+      description: Hardware Configuration Register
+      byte_offset: 992
+      fieldset: HWCFGR4
+    - name: HWCFGR3
+      description: Hardware Configuration Register
+      byte_offset: 996
+      fieldset: HWCFGR3
+    - name: HWCFGR2
+      description: Hardware Configuration Register
+      byte_offset: 1000
+      fieldset: HWCFGR2
+    - name: HWCFGR1
+      description: Hardware Configuration Register
+      byte_offset: 1004
+      fieldset: HWCFGR1
+    - name: HWCFGR0
+      description: Hardware Configuration Register
+      byte_offset: 1008
+      access: Read
+      fieldset: HWCFGR0
+    - name: VERR
+      description: EXTI IP Version register
+      byte_offset: 1012
+      access: Read
+      fieldset: VERR
+    - name: IPIDR
+      description: EXTI Identification register
+      byte_offset: 1016
+      access: Read
+      fieldset: IPIDR
+    - name: SIDR
+      description: EXTI Size ID register
+      byte_offset: 1020
+      access: Read
+      fieldset: SIDR
+fieldset/AWD1TR:
+  description: watchdog threshold register
+  fields:
+    - name: LT1
+      description: ADC analog watchdog 1 threshold low
+      bit_offset: 0
+      bit_size: 12
+    - name: HT1
+      description: ADC analog watchdog 1 threshold high
+      bit_offset: 16
+      bit_size: 12
+fieldset/AWD2CR:
+  description: ADC analog watchdog 2 configuration register
+  fields:
+    - name: AWD2CH
+      description: ADC analog watchdog 2 monitored channel selection
+      bit_offset: 0
+      bit_size: 19
+fieldset/AWD2TR:
+  description: watchdog threshold register
+  fields:
+    - name: LT2
+      description: ADC analog watchdog 2 threshold low
+      bit_offset: 0
+      bit_size: 12
+    - name: HT2
+      description: ADC analog watchdog 2 threshold high
+      bit_offset: 16
+      bit_size: 12
+fieldset/AWD3CR:
+  description: ADC analog watchdog 3 configuration register
+  fields:
+    - name: AWD3CH
+      description: ADC analog watchdog 3 monitored channel selection
+      bit_offset: 0
+      bit_size: 19
+fieldset/AWD3TR:
+  description: watchdog threshold register
+  fields:
+    - name: LT3
+      description: ADC analog watchdog 3 threshold high
+      bit_offset: 0
+      bit_size: 12
+    - name: HT3
+      description: ADC analog watchdog 3 threshold high
+      bit_offset: 16
+      bit_size: 12
+fieldset/CALFACT:
+  description: ADC calibration factors register
+  fields:
+    - name: CALFACT
+      description: ADC calibration factor in single-ended mode
+      bit_offset: 0
+      bit_size: 7
+fieldset/CCR:
+  description: ADC common control register
+  fields:
+    - name: PRESC
+      description: ADC prescaler
+      bit_offset: 18
+      bit_size: 4
+    - name: VREFEN
+      description: VREFINT enable
+      bit_offset: 22
+      bit_size: 1
+    - name: TSEN
+      description: Temperature sensor enable
+      bit_offset: 23
+      bit_size: 1
+    - name: VBATEN
+      description: VBAT enable
+      bit_offset: 24
+      bit_size: 1
+fieldset/CFGR1:
+  description: ADC configuration register 1
+  fields:
+    - name: DMAEN
+      description: ADC DMA transfer enable
+      bit_offset: 0
+      bit_size: 1
+    - name: DMACFG
+      description: ADC DMA transfer configuration
+      bit_offset: 1
+      bit_size: 1
+    - name: SCANDIR
+      description: Scan sequence direction
+      bit_offset: 2
+      bit_size: 1
+    - name: RES
+      description: ADC data resolution
+      bit_offset: 3
+      bit_size: 2
+      enum: RES
+    - name: ALIGN
+      description: ADC data alignement
+      bit_offset: 5
+      bit_size: 1
+    - name: EXTSEL
+      description: ADC group regular external trigger source
+      bit_offset: 6
+      bit_size: 3
+    - name: EXTEN
+      description: ADC group regular external trigger polarity
+      bit_offset: 10
+      bit_size: 2
+    - name: OVRMOD
+      description: ADC group regular overrun configuration
+      bit_offset: 12
+      bit_size: 1
+    - name: CONT
+      description: ADC group regular continuous conversion mode
+      bit_offset: 13
+      bit_size: 1
+    - name: WAIT
+      description: Wait conversion mode
+      bit_offset: 14
+      bit_size: 1
+    - name: AUTOFF
+      description: Auto-off mode
+      bit_offset: 15
+      bit_size: 1
+    - name: DISCEN
+      description: ADC group regular sequencer discontinuous mode
+      bit_offset: 16
+      bit_size: 1
+    - name: CHSELRMOD
+      description: Mode selection of the ADC_CHSELR register
+      bit_offset: 21
+      bit_size: 1
+    - name: AWD1SGL
+      description: ADC analog watchdog 1 monitoring a single channel or all channels
+      bit_offset: 22
+      bit_size: 1
+    - name: AWD1EN
+      description: ADC analog watchdog 1 enable on scope ADC group regular
+      bit_offset: 23
+      bit_size: 1
+    - name: AWDCH1CH
+      description: ADC analog watchdog 1 monitored channel selection
+      bit_offset: 26
+      bit_size: 5
+fieldset/CFGR2:
+  description: ADC configuration register 2
+  fields:
+    - name: OVSE
+      description: ADC oversampler enable on scope ADC group regular
+      bit_offset: 0
+      bit_size: 1
+    - name: OVSR
+      description: ADC oversampling ratio
+      bit_offset: 2
+      bit_size: 3
+    - name: OVSS
+      description: ADC oversampling shift
+      bit_offset: 5
+      bit_size: 4
+    - name: TOVS
+      description: ADC oversampling discontinuous mode (triggered mode) for ADC group regular
+      bit_offset: 9
+      bit_size: 1
+    - name: LFTRIG
+      description: Low frequency trigger mode enable
+      bit_offset: 29
+      bit_size: 1
+    - name: CKMODE
+      description: ADC clock mode
+      bit_offset: 30
+      bit_size: 2
+fieldset/CHSELR:
+  description: channel selection register
+  fields:
+    - name: CHSEL
+      description: Channel-x selection
+      bit_offset: 0
+      bit_size: 19
+fieldset/CHSELR_1:
+  description: channel selection register CHSELRMOD = 1 in ADC_CFGR1
+  fields:
+    - name: SQ1
+      description: conversion of the sequence
+      bit_offset: 0
+      bit_size: 4
+    - name: SQ2
+      description: conversion of the sequence
+      bit_offset: 4
+      bit_size: 4
+    - name: SQ3
+      description: conversion of the sequence
+      bit_offset: 8
+      bit_size: 4
+    - name: SQ4
+      description: conversion of the sequence
+      bit_offset: 12
+      bit_size: 4
+    - name: SQ5
+      description: conversion of the sequence
+      bit_offset: 16
+      bit_size: 4
+    - name: SQ6
+      description: conversion of the sequence
+      bit_offset: 20
+      bit_size: 4
+    - name: SQ7
+      description: conversion of the sequence
+      bit_offset: 24
+      bit_size: 4
+    - name: SQ8
+      description: conversion of the sequence
+      bit_offset: 28
+      bit_size: 4
+fieldset/CR:
+  description: ADC control register
+  fields:
+    - name: ADEN
+      description: ADC enable
+      bit_offset: 0
+      bit_size: 1
+    - name: ADDIS
+      description: ADC disable
+      bit_offset: 1
+      bit_size: 1
+    - name: ADSTART
+      description: ADC group regular conversion start
+      bit_offset: 2
+      bit_size: 1
+    - name: ADSTP
+      description: ADC group regular conversion stop
+      bit_offset: 4
+      bit_size: 1
+    - name: ADVREGEN
+      description: ADC voltage regulator enable
+      bit_offset: 28
+      bit_size: 1
+    - name: ADCAL
+      description: ADC calibration
+      bit_offset: 31
+      bit_size: 1
+fieldset/DR:
+  description: ADC group regular conversion data register
+  fields:
+    - name: regularDATA
+      description: ADC group regular conversion data
+      bit_offset: 0
+      bit_size: 16
+fieldset/HWCFGR0:
+  description: Hardware Configuration Register
+  fields:
+    - name: NUM_CHAN_24
+      description: NUM_CHAN_24
+      bit_offset: 0
+      bit_size: 4
+    - name: EXTRA_AWDS
+      description: Extra analog watchdog
+      bit_offset: 4
+      bit_size: 4
+    - name: OVS
+      description: Oversampling
+      bit_offset: 8
+      bit_size: 4
+fieldset/HWCFGR1:
+  description: Hardware Configuration Register
+  fields:
+    - name: CHMAP3
+      description: Input channel mapping
+      bit_offset: 0
+      bit_size: 5
+    - name: CHMAP2
+      description: Input channel mapping
+      bit_offset: 8
+      bit_size: 5
+    - name: CHMAP1
+      description: Input channel mapping
+      bit_offset: 16
+      bit_size: 5
+    - name: CHMAP0
+      description: Input channel mapping
+      bit_offset: 24
+      bit_size: 5
+fieldset/HWCFGR2:
+  description: Hardware Configuration Register
+  fields:
+    - name: CHMAP7
+      description: Input channel mapping
+      bit_offset: 0
+      bit_size: 5
+    - name: CHMAP6
+      description: Input channel mapping
+      bit_offset: 8
+      bit_size: 5
+    - name: CHMAP5
+      description: Input channel mapping
+      bit_offset: 16
+      bit_size: 5
+    - name: CHMAP4
+      description: Input channel mapping
+      bit_offset: 24
+      bit_size: 5
+fieldset/HWCFGR3:
+  description: Hardware Configuration Register
+  fields:
+    - name: CHMAP11
+      description: Input channel mapping
+      bit_offset: 0
+      bit_size: 5
+    - name: CHMAP10
+      description: Input channel mapping
+      bit_offset: 8
+      bit_size: 5
+    - name: CHMAP9
+      description: Input channel mapping
+      bit_offset: 16
+      bit_size: 5
+    - name: CHMAP8
+      description: Input channel mapping
+      bit_offset: 24
+      bit_size: 5
+fieldset/HWCFGR4:
+  description: Hardware Configuration Register
+  fields:
+    - name: CHMAP15
+      description: Input channel mapping
+      bit_offset: 0
+      bit_size: 5
+    - name: CHMAP14
+      description: Input channel mapping
+      bit_offset: 8
+      bit_size: 5
+    - name: CHMAP13
+      description: Input channel mapping
+      bit_offset: 16
+      bit_size: 5
+    - name: CHMAP12
+      description: Input channel mapping
+      bit_offset: 24
+      bit_size: 5
+fieldset/HWCFGR5:
+  description: Hardware Configuration Register
+  fields:
+    - name: CHMAP19
+      description: Input channel mapping
+      bit_offset: 0
+      bit_size: 5
+    - name: CHMAP18
+      description: Input channel mapping
+      bit_offset: 8
+      bit_size: 5
+    - name: CHMAP17
+      description: Input channel mapping
+      bit_offset: 16
+      bit_size: 5
+    - name: CHMAP16
+      description: Input channel mapping
+      bit_offset: 24
+      bit_size: 5
+fieldset/HWCFGR6:
+  description: Hardware Configuration Register
+  fields:
+    - name: CHMAP20
+      description: Input channel mapping
+      bit_offset: 0
+      bit_size: 5
+    - name: CHMAP21
+      description: Input channel mapping
+      bit_offset: 8
+      bit_size: 5
+    - name: CHMAP22
+      description: Input channel mapping
+      bit_offset: 16
+      bit_size: 5
+    - name: CHMAP23
+      description: Input channel mapping
+      bit_offset: 24
+      bit_size: 5
+fieldset/IER:
+  description: ADC interrupt enable register
+  fields:
+    - name: ADRDYIE
+      description: ADC ready interrupt
+      bit_offset: 0
+      bit_size: 1
+    - name: EOSMPIE
+      description: ADC group regular end of sampling interrupt
+      bit_offset: 1
+      bit_size: 1
+    - name: EOCIE
+      description: ADC group regular end of unitary conversion interrupt
+      bit_offset: 2
+      bit_size: 1
+    - name: EOSIE
+      description: ADC group regular end of sequence conversions interrupt
+      bit_offset: 3
+      bit_size: 1
+    - name: OVRIE
+      description: ADC group regular overrun interrupt
+      bit_offset: 4
+      bit_size: 1
+    - name: AWD1IE
+      description: ADC analog watchdog 1 interrupt
+      bit_offset: 7
+      bit_size: 1
+    - name: AWD2IE
+      description: ADC analog watchdog 2 interrupt
+      bit_offset: 8
+      bit_size: 1
+    - name: AWD3IE
+      description: ADC analog watchdog 3 interrupt
+      bit_offset: 9
+      bit_size: 1
+    - name: EOCALIE
+      description: End of calibration interrupt enable
+      bit_offset: 11
+      bit_size: 1
+    - name: CCRDYIE
+      description: Channel Configuration Ready Interrupt enable
+      bit_offset: 13
+      bit_size: 1
+fieldset/IPIDR:
+  description: EXTI Identification register
+  fields:
+    - name: IPID
+      description: IP Identification
+      bit_offset: 0
+      bit_size: 32
+fieldset/ISR:
+  description: ADC interrupt and status register
+  fields:
+    - name: ADRDY
+      description: ADC ready flag
+      bit_offset: 0
+      bit_size: 1
+    - name: EOSMP
+      description: ADC group regular end of sampling flag
+      bit_offset: 1
+      bit_size: 1
+    - name: EOC
+      description: ADC group regular end of unitary conversion flag
+      bit_offset: 2
+      bit_size: 1
+    - name: EOS
+      description: ADC group regular end of sequence conversions flag
+      bit_offset: 3
+      bit_size: 1
+    - name: OVR
+      description: ADC group regular overrun flag
+      bit_offset: 4
+      bit_size: 1
+    - name: AWD1
+      description: ADC analog watchdog 1 flag
+      bit_offset: 7
+      bit_size: 1
+    - name: AWD2
+      description: ADC analog watchdog 2 flag
+      bit_offset: 8
+      bit_size: 1
+    - name: AWD3
+      description: ADC analog watchdog 3 flag
+      bit_offset: 9
+      bit_size: 1
+    - name: EOCAL
+      description: End Of Calibration flag
+      bit_offset: 11
+      bit_size: 1
+    - name: CCRDY
+      description: Channel Configuration Ready flag
+      bit_offset: 13
+      bit_size: 1
+fieldset/SIDR:
+  description: EXTI Size ID register
+  fields:
+    - name: SID
+      description: Size Identification
+      bit_offset: 0
+      bit_size: 32
+fieldset/SMPR:
+  description: ADC sampling time register
+  fields:
+    - name: SMP1
+      description: Sampling time selection
+      bit_offset: 0
+      bit_size: 3
+      enum: SAMPLE_TIME
+    - name: SMP2
+      description: Sampling time selection
+      bit_offset: 4
+      bit_size: 3
+      enum: SAMPLE_TIME
+    - name: SMPSEL
+      description: Channel sampling time selection
+      bit_offset: 8
+      bit_size: 1
+      array:
+        len: 19
+        stride: 0
+fieldset/VERR:
+  description: EXTI IP Version register
+  fields:
+    - name: MINREV
+      description: Minor Revision number
+      bit_offset: 0
+      bit_size: 4
+    - name: MAJREV
+      description: Major Revision number
+      bit_offset: 4
+      bit_size: 4
+enum/SAMPLE_TIME:
+  bit_size: 3
+  variants:
+    - name: Cycles1_5
+      description: 1.5 ADC cycles
+      value: 0
+    - name: Cycles3_5
+      description: 3.5 ADC cycles
+      value: 1
+    - name: Cycles7_5
+      description: 7.5 ADC cycles
+      value: 2
+    - name: Cycles12_5
+      description: 12.5 ADC cycles
+      value: 3
+    - name: Cycles19_5
+      description: 19.5 ADC cycles
+      value: 4
+    - name: Cycles39_5
+      description: 39.5 ADC cycles
+      value: 5
+    - name: Cycles79_5
+      description: 79.5 ADC cycles
+      value: 6
+    - name: Cycles160_5
+      description: 160.5 ADC cycles
+      value: 7
+enum/RES:
+  bit_size: 2
+  variants:
+    - name: TwelveBit
+      description: 12-bit resolution
+      value: 0
+    - name: TenBit
+      description: 10-bit resolution
+      value: 1
+    - name: EightBit
+      description: 8-bit resolution
+      value: 2
+    - name: SixBit
+      description: 6-bit resolution
+      value: 3

--- a/data/registers/pwr_g0.yaml
+++ b/data/registers/pwr_g0.yaml
@@ -1,0 +1,782 @@
+---
+block/PWR:
+  description: Power control
+  items:
+    - name: CR1
+      description: Power control register 1
+      byte_offset: 0
+      fieldset: CR1
+    - name: CR2
+      description: Power control register 2
+      byte_offset: 4
+      fieldset: CR2
+    - name: CR3
+      description: Power control register 3
+      byte_offset: 8
+      fieldset: CR3
+    - name: CR4
+      description: Power control register 4
+      byte_offset: 12
+      fieldset: CR4
+    - name: SR1
+      description: Power status register 1
+      byte_offset: 16
+      access: Read
+      fieldset: SR1
+    - name: SR2
+      description: Power status register 2
+      byte_offset: 20
+      access: Read
+      fieldset: SR2
+    - name: SCR
+      description: Power status clear register
+      byte_offset: 24
+      access: Write
+      fieldset: SCR
+    - name: PUCRA
+      description: Power Port A pull-up control register
+      byte_offset: 32
+      fieldset: PUCRA
+    - name: PDCRA
+      description: Power Port A pull-down control register
+      byte_offset: 36
+      fieldset: PDCRA
+    - name: PUCRB
+      description: Power Port B pull-up control register
+      byte_offset: 40
+      fieldset: PUCRB
+    - name: PDCRB
+      description: Power Port B pull-down control register
+      byte_offset: 44
+      fieldset: PDCRB
+    - name: PUCRC
+      description: Power Port C pull-up control register
+      byte_offset: 48
+      fieldset: PUCRC
+    - name: PDCRC
+      description: Power Port C pull-down control register
+      byte_offset: 52
+      fieldset: PDCRC
+    - name: PUCRD
+      description: Power Port D pull-up control register
+      byte_offset: 56
+      fieldset: PUCRD
+    - name: PDCRD
+      description: Power Port D pull-down control register
+      byte_offset: 60
+      fieldset: PDCRD
+    - name: PUCRF
+      description: Power Port F pull-up control register
+      byte_offset: 72
+      fieldset: PUCRF
+    - name: PDCRF
+      description: Power Port F pull-down control register
+      byte_offset: 76
+      fieldset: PDCRF
+fieldset/CR1:
+  description: Power control register 1
+  fields:
+    - name: LPMS
+      description: Low-power mode selection
+      bit_offset: 0
+      bit_size: 3
+    - name: FPD_STOP
+      description: Flash memory powered down during Stop mode
+      bit_offset: 3
+      bit_size: 1
+    - name: FPD_LPRUN
+      description: Flash memory powered down during Low-power run mode
+      bit_offset: 4
+      bit_size: 1
+    - name: FPD_LPSLP
+      description: Flash memory powered down during Low-power sleep mode
+      bit_offset: 5
+      bit_size: 1
+    - name: DBP
+      description: Disable backup domain write protection
+      bit_offset: 8
+      bit_size: 1
+    - name: VOS
+      description: Voltage scaling range selection
+      bit_offset: 9
+      bit_size: 2
+    - name: LPR
+      description: Low-power run
+      bit_offset: 14
+      bit_size: 1
+fieldset/CR2:
+  description: Power control register 2
+  fields:
+    - name: PVDE
+      description: Power voltage detector enable
+      bit_offset: 0
+      bit_size: 1
+    - name: PVDFT
+      description: Power voltage detector falling threshold selection
+      bit_offset: 1
+      bit_size: 3
+    - name: PVDRT
+      description: Power voltage detector rising threshold selection
+      bit_offset: 4
+      bit_size: 3
+fieldset/CR3:
+  description: Power control register 3
+  fields:
+    - name: EWUP1
+      description: Enable Wakeup pin WKUP1
+      bit_offset: 0
+      bit_size: 1
+    - name: EWUP2
+      description: Enable Wakeup pin WKUP2
+      bit_offset: 1
+      bit_size: 1
+    - name: EWUP4
+      description: Enable Wakeup pin WKUP4
+      bit_offset: 3
+      bit_size: 1
+    - name: EWUP5
+      description: Enable WKUP5 wakeup pin
+      bit_offset: 4
+      bit_size: 1
+    - name: EWUP6
+      description: Enable WKUP6 wakeup pin
+      bit_offset: 5
+      bit_size: 1
+    - name: RRS
+      description: SRAM retention in Standby mode
+      bit_offset: 8
+      bit_size: 1
+    - name: ULPEN
+      description: Enable the periodical sampling mode for PDR detection
+      bit_offset: 9
+      bit_size: 1
+    - name: APC
+      description: Apply pull-up and pull-down configuration
+      bit_offset: 10
+      bit_size: 1
+    - name: EIWUL
+      description: Enable internal wakeup line
+      bit_offset: 15
+      bit_size: 1
+fieldset/CR4:
+  description: Power control register 4
+  fields:
+    - name: WP1
+      description: Wakeup pin WKUP1 polarity
+      bit_offset: 0
+      bit_size: 1
+    - name: WP2
+      description: Wakeup pin WKUP2 polarity
+      bit_offset: 1
+      bit_size: 1
+    - name: WP4
+      description: Wakeup pin WKUP4 polarity
+      bit_offset: 3
+      bit_size: 1
+    - name: WP5
+      description: Wakeup pin WKUP5 polarity
+      bit_offset: 4
+      bit_size: 1
+    - name: WP6
+      description: WKUP6 wakeup pin polarity
+      bit_offset: 5
+      bit_size: 1
+    - name: VBE
+      description: VBAT battery charging enable
+      bit_offset: 8
+      bit_size: 1
+    - name: VBRS
+      description: VBAT battery charging resistor selection
+      bit_offset: 9
+      bit_size: 1
+fieldset/PDCRA:
+  description: Power Port A pull-down control register
+  fields:
+    - name: PD0
+      description: Port A pull-down bit y (y=0..15)
+      bit_offset: 0
+      bit_size: 1
+    - name: PD1
+      description: Port A pull-down bit y (y=0..15)
+      bit_offset: 1
+      bit_size: 1
+    - name: PD2
+      description: Port A pull-down bit y (y=0..15)
+      bit_offset: 2
+      bit_size: 1
+    - name: PD3
+      description: Port A pull-down bit y (y=0..15)
+      bit_offset: 3
+      bit_size: 1
+    - name: PD4
+      description: Port A pull-down bit y (y=0..15)
+      bit_offset: 4
+      bit_size: 1
+    - name: PD5
+      description: Port A pull-down bit y (y=0..15)
+      bit_offset: 5
+      bit_size: 1
+    - name: PD6
+      description: Port A pull-down bit y (y=0..15)
+      bit_offset: 6
+      bit_size: 1
+    - name: PD7
+      description: Port A pull-down bit y (y=0..15)
+      bit_offset: 7
+      bit_size: 1
+    - name: PD8
+      description: Port A pull-down bit y (y=0..15)
+      bit_offset: 8
+      bit_size: 1
+    - name: PD9
+      description: Port A pull-down bit y (y=0..15)
+      bit_offset: 9
+      bit_size: 1
+    - name: PD10
+      description: Port A pull-down bit y (y=0..15)
+      bit_offset: 10
+      bit_size: 1
+    - name: PD11
+      description: Port A pull-down bit y (y=0..15)
+      bit_offset: 11
+      bit_size: 1
+    - name: PD12
+      description: Port A pull-down bit y (y=0..15)
+      bit_offset: 12
+      bit_size: 1
+    - name: PD13
+      description: Port A pull-down bit y (y=0..15)
+      bit_offset: 13
+      bit_size: 1
+    - name: PD14
+      description: Port A pull-down bit y (y=0..15)
+      bit_offset: 14
+      bit_size: 1
+    - name: PD15
+      description: Port A pull-down bit y (y=0..15)
+      bit_offset: 15
+      bit_size: 1
+fieldset/PDCRB:
+  description: Power Port B pull-down control register
+  fields:
+    - name: PD0
+      description: Port B pull-down bit y (y=0..15)
+      bit_offset: 0
+      bit_size: 1
+    - name: PD1
+      description: Port B pull-down bit y (y=0..15)
+      bit_offset: 1
+      bit_size: 1
+    - name: PD2
+      description: Port B pull-down bit y (y=0..15)
+      bit_offset: 2
+      bit_size: 1
+    - name: PD3
+      description: Port B pull-down bit y (y=0..15)
+      bit_offset: 3
+      bit_size: 1
+    - name: PD4
+      description: Port B pull-down bit y (y=0..15)
+      bit_offset: 4
+      bit_size: 1
+    - name: PD5
+      description: Port B pull-down bit y (y=0..15)
+      bit_offset: 5
+      bit_size: 1
+    - name: PD6
+      description: Port B pull-down bit y (y=0..15)
+      bit_offset: 6
+      bit_size: 1
+    - name: PD7
+      description: Port B pull-down bit y (y=0..15)
+      bit_offset: 7
+      bit_size: 1
+    - name: PD8
+      description: Port B pull-down bit y (y=0..15)
+      bit_offset: 8
+      bit_size: 1
+    - name: PD9
+      description: Port B pull-down bit y (y=0..15)
+      bit_offset: 9
+      bit_size: 1
+    - name: PD10
+      description: Port B pull-down bit y (y=0..15)
+      bit_offset: 10
+      bit_size: 1
+    - name: PD11
+      description: Port B pull-down bit y (y=0..15)
+      bit_offset: 11
+      bit_size: 1
+    - name: PD12
+      description: Port B pull-down bit y (y=0..15)
+      bit_offset: 12
+      bit_size: 1
+    - name: PD13
+      description: Port B pull-down bit y (y=0..15)
+      bit_offset: 13
+      bit_size: 1
+    - name: PD14
+      description: Port B pull-down bit y (y=0..15)
+      bit_offset: 14
+      bit_size: 1
+    - name: PD15
+      description: Port B pull-down bit y (y=0..15)
+      bit_offset: 15
+      bit_size: 1
+fieldset/PDCRC:
+  description: Power Port C pull-down control register
+  fields:
+    - name: PD0
+      description: Port C pull-down bit y (y=0..15)
+      bit_offset: 0
+      bit_size: 1
+    - name: PD1
+      description: Port C pull-down bit y (y=0..15)
+      bit_offset: 1
+      bit_size: 1
+    - name: PD2
+      description: Port C pull-down bit y (y=0..15)
+      bit_offset: 2
+      bit_size: 1
+    - name: PD3
+      description: Port C pull-down bit y (y=0..15)
+      bit_offset: 3
+      bit_size: 1
+    - name: PD4
+      description: Port C pull-down bit y (y=0..15)
+      bit_offset: 4
+      bit_size: 1
+    - name: PD5
+      description: Port C pull-down bit y (y=0..15)
+      bit_offset: 5
+      bit_size: 1
+    - name: PD6
+      description: Port C pull-down bit y (y=0..15)
+      bit_offset: 6
+      bit_size: 1
+    - name: PD7
+      description: Port C pull-down bit y (y=0..15)
+      bit_offset: 7
+      bit_size: 1
+    - name: PD8
+      description: Port C pull-down bit y (y=0..15)
+      bit_offset: 8
+      bit_size: 1
+    - name: PD9
+      description: Port C pull-down bit y (y=0..15)
+      bit_offset: 9
+      bit_size: 1
+    - name: PD10
+      description: Port C pull-down bit y (y=0..15)
+      bit_offset: 10
+      bit_size: 1
+    - name: PD11
+      description: Port C pull-down bit y (y=0..15)
+      bit_offset: 11
+      bit_size: 1
+    - name: PD12
+      description: Port C pull-down bit y (y=0..15)
+      bit_offset: 12
+      bit_size: 1
+    - name: PD13
+      description: Port C pull-down bit y (y=0..15)
+      bit_offset: 13
+      bit_size: 1
+    - name: PD14
+      description: Port C pull-down bit y (y=0..15)
+      bit_offset: 14
+      bit_size: 1
+    - name: PD15
+      description: Port C pull-down bit y (y=0..15)
+      bit_offset: 15
+      bit_size: 1
+fieldset/PDCRD:
+  description: Power Port D pull-down control register
+  fields:
+    - name: PD0
+      description: Port D pull-down bit y (y=0..15)
+      bit_offset: 0
+      bit_size: 1
+    - name: PD1
+      description: Port D pull-down bit y (y=0..15)
+      bit_offset: 1
+      bit_size: 1
+    - name: PD2
+      description: Port D pull-down bit y (y=0..15)
+      bit_offset: 2
+      bit_size: 1
+    - name: PD3
+      description: Port D pull-down bit y (y=0..15)
+      bit_offset: 3
+      bit_size: 1
+    - name: PD4
+      description: Port D pull-down bit y (y=0..15)
+      bit_offset: 4
+      bit_size: 1
+    - name: PD5
+      description: Port D pull-down bit y (y=0..15)
+      bit_offset: 5
+      bit_size: 1
+    - name: PD6
+      description: Port D pull-down bit y (y=0..15)
+      bit_offset: 6
+      bit_size: 1
+    - name: PD8
+      description: Port D pull-down bit y (y=0..15)
+      bit_offset: 8
+      bit_size: 1
+    - name: PD9
+      description: Port D pull-down bit y (y=0..15)
+      bit_offset: 9
+      bit_size: 1
+fieldset/PDCRF:
+  description: Power Port F pull-down control register
+  fields:
+    - name: PD0
+      description: Port F pull-down bit y (y=0..15)
+      bit_offset: 0
+      bit_size: 1
+    - name: PD1
+      description: Port F pull-down bit y (y=0..15)
+      bit_offset: 1
+      bit_size: 1
+    - name: PD2
+      description: Port F pull-down bit y (y=0..15)
+      bit_offset: 2
+      bit_size: 1
+fieldset/PUCRA:
+  description: Power Port A pull-up control register
+  fields:
+    - name: PU0
+      description: Port A pull-up bit y (y=0..15)
+      bit_offset: 0
+      bit_size: 1
+    - name: PU1
+      description: Port A pull-up bit y (y=0..15)
+      bit_offset: 1
+      bit_size: 1
+    - name: PU2
+      description: Port A pull-up bit y (y=0..15)
+      bit_offset: 2
+      bit_size: 1
+    - name: PU3
+      description: Port A pull-up bit y (y=0..15)
+      bit_offset: 3
+      bit_size: 1
+    - name: PU4
+      description: Port A pull-up bit y (y=0..15)
+      bit_offset: 4
+      bit_size: 1
+    - name: PU5
+      description: Port A pull-up bit y (y=0..15)
+      bit_offset: 5
+      bit_size: 1
+    - name: PU6
+      description: Port A pull-up bit y (y=0..15)
+      bit_offset: 6
+      bit_size: 1
+    - name: PU7
+      description: Port A pull-up bit y (y=0..15)
+      bit_offset: 7
+      bit_size: 1
+    - name: PU8
+      description: Port A pull-up bit y (y=0..15)
+      bit_offset: 8
+      bit_size: 1
+    - name: PU9
+      description: Port A pull-up bit y (y=0..15)
+      bit_offset: 9
+      bit_size: 1
+    - name: PU10
+      description: Port A pull-up bit y (y=0..15)
+      bit_offset: 10
+      bit_size: 1
+    - name: PU11
+      description: Port A pull-up bit y (y=0..15)
+      bit_offset: 11
+      bit_size: 1
+    - name: PU12
+      description: Port A pull-up bit y (y=0..15)
+      bit_offset: 12
+      bit_size: 1
+    - name: PU13
+      description: Port A pull-up bit y (y=0..15)
+      bit_offset: 13
+      bit_size: 1
+    - name: PU14
+      description: Port A pull-up bit y (y=0..15)
+      bit_offset: 14
+      bit_size: 1
+    - name: PU15
+      description: Port A pull-up bit y (y=0..15)
+      bit_offset: 15
+      bit_size: 1
+fieldset/PUCRB:
+  description: Power Port B pull-up control register
+  fields:
+    - name: PU0
+      description: Port B pull-up bit y (y=0..15)
+      bit_offset: 0
+      bit_size: 1
+    - name: PU1
+      description: Port B pull-up bit y (y=0..15)
+      bit_offset: 1
+      bit_size: 1
+    - name: PU2
+      description: Port B pull-up bit y (y=0..15)
+      bit_offset: 2
+      bit_size: 1
+    - name: PU3
+      description: Port B pull-up bit y (y=0..15)
+      bit_offset: 3
+      bit_size: 1
+    - name: PU4
+      description: Port B pull-up bit y (y=0..15)
+      bit_offset: 4
+      bit_size: 1
+    - name: PU5
+      description: Port B pull-up bit y (y=0..15)
+      bit_offset: 5
+      bit_size: 1
+    - name: PU6
+      description: Port B pull-up bit y (y=0..15)
+      bit_offset: 6
+      bit_size: 1
+    - name: PU7
+      description: Port B pull-up bit y (y=0..15)
+      bit_offset: 7
+      bit_size: 1
+    - name: PU8
+      description: Port B pull-up bit y (y=0..15)
+      bit_offset: 8
+      bit_size: 1
+    - name: PU9
+      description: Port B pull-up bit y (y=0..15)
+      bit_offset: 9
+      bit_size: 1
+    - name: PU10
+      description: Port B pull-up bit y (y=0..15)
+      bit_offset: 10
+      bit_size: 1
+    - name: PU11
+      description: Port B pull-up bit y (y=0..15)
+      bit_offset: 11
+      bit_size: 1
+    - name: PU12
+      description: Port B pull-up bit y (y=0..15)
+      bit_offset: 12
+      bit_size: 1
+    - name: PU13
+      description: Port B pull-up bit y (y=0..15)
+      bit_offset: 13
+      bit_size: 1
+    - name: PU14
+      description: Port B pull-up bit y (y=0..15)
+      bit_offset: 14
+      bit_size: 1
+    - name: PU15
+      description: Port B pull-up bit y (y=0..15)
+      bit_offset: 15
+      bit_size: 1
+fieldset/PUCRC:
+  description: Power Port C pull-up control register
+  fields:
+    - name: PU0
+      description: Port C pull-up bit y (y=0..15)
+      bit_offset: 0
+      bit_size: 1
+    - name: PU1
+      description: Port C pull-up bit y (y=0..15)
+      bit_offset: 1
+      bit_size: 1
+    - name: PU2
+      description: Port C pull-up bit y (y=0..15)
+      bit_offset: 2
+      bit_size: 1
+    - name: PU3
+      description: Port C pull-up bit y (y=0..15)
+      bit_offset: 3
+      bit_size: 1
+    - name: PU4
+      description: Port C pull-up bit y (y=0..15)
+      bit_offset: 4
+      bit_size: 1
+    - name: PU5
+      description: Port C pull-up bit y (y=0..15)
+      bit_offset: 5
+      bit_size: 1
+    - name: PU6
+      description: Port C pull-up bit y (y=0..15)
+      bit_offset: 6
+      bit_size: 1
+    - name: PU7
+      description: Port C pull-up bit y (y=0..15)
+      bit_offset: 7
+      bit_size: 1
+    - name: PU8
+      description: Port C pull-up bit y (y=0..15)
+      bit_offset: 8
+      bit_size: 1
+    - name: PU9
+      description: Port C pull-up bit y (y=0..15)
+      bit_offset: 9
+      bit_size: 1
+    - name: PU10
+      description: Port C pull-up bit y (y=0..15)
+      bit_offset: 10
+      bit_size: 1
+    - name: PU11
+      description: Port C pull-up bit y (y=0..15)
+      bit_offset: 11
+      bit_size: 1
+    - name: PU12
+      description: Port C pull-up bit y (y=0..15)
+      bit_offset: 12
+      bit_size: 1
+    - name: PU13
+      description: Port C pull-up bit y (y=0..15)
+      bit_offset: 13
+      bit_size: 1
+    - name: PU14
+      description: Port C pull-up bit y (y=0..15)
+      bit_offset: 14
+      bit_size: 1
+    - name: PU15
+      description: Port C pull-up bit y (y=0..15)
+      bit_offset: 15
+      bit_size: 1
+fieldset/PUCRD:
+  description: Power Port D pull-up control register
+  fields:
+    - name: PU0
+      description: Port D pull-up bit y (y=0..15)
+      bit_offset: 0
+      bit_size: 1
+    - name: PU1
+      description: Port D pull-up bit y (y=0..15)
+      bit_offset: 1
+      bit_size: 1
+    - name: PU2
+      description: Port D pull-up bit y (y=0..15)
+      bit_offset: 2
+      bit_size: 1
+    - name: PU3
+      description: Port D pull-up bit y (y=0..15)
+      bit_offset: 3
+      bit_size: 1
+    - name: PU4
+      description: Port D pull-up bit y (y=0..15)
+      bit_offset: 4
+      bit_size: 1
+    - name: PU5
+      description: Port D pull-up bit y (y=0..15)
+      bit_offset: 5
+      bit_size: 1
+    - name: PU6
+      description: Port D pull-up bit y (y=0..15)
+      bit_offset: 6
+      bit_size: 1
+    - name: PU8
+      description: Port D pull-up bit y (y=0..15)
+      bit_offset: 8
+      bit_size: 1
+    - name: PU9
+      description: Port D pull-up bit y (y=0..15)
+      bit_offset: 9
+      bit_size: 1
+fieldset/PUCRF:
+  description: Power Port F pull-up control register
+  fields:
+    - name: PU0
+      description: Port F pull-up bit y (y=0..15)
+      bit_offset: 0
+      bit_size: 1
+    - name: PU1
+      description: Port F pull-up bit y (y=0..15)
+      bit_offset: 1
+      bit_size: 1
+    - name: PU2
+      description: Port F pull-up bit y (y=0..15)
+      bit_offset: 2
+      bit_size: 1
+fieldset/SCR:
+  description: Power status clear register
+  fields:
+    - name: CWUF1
+      description: Clear wakeup flag 1
+      bit_offset: 0
+      bit_size: 1
+    - name: CWUF2
+      description: Clear wakeup flag 2
+      bit_offset: 1
+      bit_size: 1
+    - name: CWUF4
+      description: Clear wakeup flag 4
+      bit_offset: 3
+      bit_size: 1
+    - name: CWUF5
+      description: Clear wakeup flag 5
+      bit_offset: 4
+      bit_size: 1
+    - name: CWUF6
+      description: Clear wakeup flag 6
+      bit_offset: 5
+      bit_size: 1
+    - name: CSBF
+      description: Clear standby flag
+      bit_offset: 8
+      bit_size: 1
+fieldset/SR1:
+  description: Power status register 1
+  fields:
+    - name: WUF1
+      description: Wakeup flag 1
+      bit_offset: 0
+      bit_size: 1
+    - name: WUF2
+      description: Wakeup flag 2
+      bit_offset: 1
+      bit_size: 1
+    - name: WUF4
+      description: Wakeup flag 4
+      bit_offset: 3
+      bit_size: 1
+    - name: WUF5
+      description: Wakeup flag 5
+      bit_offset: 4
+      bit_size: 1
+    - name: WUF6
+      description: Wakeup flag 6
+      bit_offset: 5
+      bit_size: 1
+    - name: SBF
+      description: Standby flag
+      bit_offset: 8
+      bit_size: 1
+    - name: WUFI
+      description: Wakeup flag internal
+      bit_offset: 15
+      bit_size: 1
+fieldset/SR2:
+  description: Power status register 2
+  fields:
+    - name: FLASH_RDY
+      description: Flash ready flag
+      bit_offset: 7
+      bit_size: 1
+    - name: REGLPS
+      description: Low-power regulator started
+      bit_offset: 8
+      bit_size: 1
+    - name: REGLPF
+      description: Low-power regulator flag
+      bit_offset: 9
+      bit_size: 1
+    - name: VOSF
+      description: Voltage scaling flag
+      bit_offset: 10
+      bit_size: 1
+    - name: PVDO
+      description: Power voltage detector output
+      bit_offset: 11
+      bit_size: 1

--- a/parse.py
+++ b/parse.py
@@ -340,7 +340,7 @@ perimap = [
     ('.*:DAC:dacif_v2_0', 'dac_v2/DAC'),
     ('.*:DAC:dacif_v3_0', 'dac_v2/DAC'),
     ('.*:ADC:aditf5_v2_0', 'adc_v3/ADC'),
-    ('STM32G0.*:ADC:.*', 'adc_v3/ADC'),
+    ('STM32G0.*:ADC:.*', 'adc_g0/ADC'),
     ('STM32G0.*:ADC_COMMON:.*', 'adccommon_v3/ADC_COMMON'),
     ('.*:ADC_COMMON:aditf5_v2_0', 'adccommon_v3/ADC_COMMON'),
     ('.*:ADC_COMMON:aditf4_v3_0_WL', 'adccommon_v3/ADC_COMMON'),

--- a/parse.py
+++ b/parse.py
@@ -384,6 +384,7 @@ perimap = [
 
     ('.*:STM32L0_crs_v1_0', 'crs_l0/CRS'),
     ('.*SDMMC:sdmmc2_v1_0', 'sdmmc_v2/SDMMC'),
+    ('.*:STM32G0_pwr_v1_0', 'pwr_g0/PWR'),
     ('STM32H7(42|43|53|50).*:STM32H7_pwr_v1_0', 'pwr_h7/PWR'),
     ('.*:STM32H7_pwr_v1_0', 'pwr_h7smps/PWR'),
     ('.*:STM32F4_pwr_v1_0', 'pwr_f4/PWR'),


### PR DESCRIPTION
It appears that ST changed the register layout (particularly surrounding channel selection) quite drastically in the G0 series.

Note that the first commit captures changes that aren't due to this patch but rather were from simply rerunning `parse.py`.

Also added `PWR` support.