### PR TITLE
Stm32wl55 pwr

### DIFF
--- a/data/chips/STM32F030C6.yaml
+++ b/data/chips/STM32F030C6.yaml
@@ -87,18 +87,23 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F030C8.yaml
+++ b/data/chips/STM32F030C8.yaml
@@ -87,18 +87,23 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F030CC.yaml
+++ b/data/chips/STM32F030CC.yaml
@@ -89,18 +89,23 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F030F4.yaml
+++ b/data/chips/STM32F030F4.yaml
@@ -85,18 +85,23 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F030K6.yaml
+++ b/data/chips/STM32F030K6.yaml
@@ -87,18 +87,23 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F030R8.yaml
+++ b/data/chips/STM32F030R8.yaml
@@ -99,18 +99,23 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F030RC.yaml
+++ b/data/chips/STM32F030RC.yaml
@@ -101,18 +101,23 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F031C4.yaml
+++ b/data/chips/STM32F031C4.yaml
@@ -87,15 +87,19 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F031C6.yaml
+++ b/data/chips/STM32F031C6.yaml
@@ -87,15 +87,19 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F031E6.yaml
+++ b/data/chips/STM32F031E6.yaml
@@ -87,15 +87,19 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F031F4.yaml
+++ b/data/chips/STM32F031F4.yaml
@@ -85,15 +85,19 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F031F6.yaml
+++ b/data/chips/STM32F031F6.yaml
@@ -85,15 +85,19 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F031G4.yaml
+++ b/data/chips/STM32F031G4.yaml
@@ -87,15 +87,19 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F031G6.yaml
+++ b/data/chips/STM32F031G6.yaml
@@ -87,15 +87,19 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F031K4.yaml
+++ b/data/chips/STM32F031K4.yaml
@@ -87,15 +87,19 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F031K6.yaml
+++ b/data/chips/STM32F031K6.yaml
@@ -89,15 +89,19 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F038C6.yaml
+++ b/data/chips/STM32F038C6.yaml
@@ -87,15 +87,19 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F038E6.yaml
+++ b/data/chips/STM32F038E6.yaml
@@ -87,15 +87,19 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F038F6.yaml
+++ b/data/chips/STM32F038F6.yaml
@@ -83,15 +83,19 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F038G6.yaml
+++ b/data/chips/STM32F038G6.yaml
@@ -85,15 +85,19 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F038K6.yaml
+++ b/data/chips/STM32F038K6.yaml
@@ -87,15 +87,19 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F042C4.yaml
+++ b/data/chips/STM32F042C4.yaml
@@ -116,15 +116,19 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F042C6.yaml
+++ b/data/chips/STM32F042C6.yaml
@@ -116,15 +116,19 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F042F4.yaml
+++ b/data/chips/STM32F042F4.yaml
@@ -109,15 +109,19 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F042F6.yaml
+++ b/data/chips/STM32F042F6.yaml
@@ -109,15 +109,19 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F042G4.yaml
+++ b/data/chips/STM32F042G4.yaml
@@ -111,15 +111,19 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F042G6.yaml
+++ b/data/chips/STM32F042G6.yaml
@@ -111,15 +111,19 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F042K4.yaml
+++ b/data/chips/STM32F042K4.yaml
@@ -113,15 +113,19 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F042K6.yaml
+++ b/data/chips/STM32F042K6.yaml
@@ -113,15 +113,19 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F042T6.yaml
+++ b/data/chips/STM32F042T6.yaml
@@ -111,15 +111,19 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F048C6.yaml
+++ b/data/chips/STM32F048C6.yaml
@@ -91,15 +91,19 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F048G6.yaml
+++ b/data/chips/STM32F048G6.yaml
@@ -89,15 +89,19 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F048T6.yaml
+++ b/data/chips/STM32F048T6.yaml
@@ -91,15 +91,19 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F051C4.yaml
+++ b/data/chips/STM32F051C4.yaml
@@ -154,18 +154,23 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F051C6.yaml
+++ b/data/chips/STM32F051C6.yaml
@@ -154,18 +154,23 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F051C8.yaml
+++ b/data/chips/STM32F051C8.yaml
@@ -154,18 +154,23 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F051K4.yaml
+++ b/data/chips/STM32F051K4.yaml
@@ -154,18 +154,23 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F051K6.yaml
+++ b/data/chips/STM32F051K6.yaml
@@ -154,18 +154,23 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F051K8.yaml
+++ b/data/chips/STM32F051K8.yaml
@@ -154,18 +154,23 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F051R4.yaml
+++ b/data/chips/STM32F051R4.yaml
@@ -164,18 +164,23 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F051R6.yaml
+++ b/data/chips/STM32F051R6.yaml
@@ -164,18 +164,23 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F051R8.yaml
+++ b/data/chips/STM32F051R8.yaml
@@ -166,18 +166,23 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F051T8.yaml
+++ b/data/chips/STM32F051T8.yaml
@@ -152,18 +152,23 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F058C8.yaml
+++ b/data/chips/STM32F058C8.yaml
@@ -152,18 +152,23 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F058R8.yaml
+++ b/data/chips/STM32F058R8.yaml
@@ -166,18 +166,23 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F058T8.yaml
+++ b/data/chips/STM32F058T8.yaml
@@ -152,18 +152,23 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F070C6.yaml
+++ b/data/chips/STM32F070C6.yaml
@@ -87,18 +87,23 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F070CB.yaml
+++ b/data/chips/STM32F070CB.yaml
@@ -87,18 +87,23 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F070F6.yaml
+++ b/data/chips/STM32F070F6.yaml
@@ -85,18 +85,23 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F070RB.yaml
+++ b/data/chips/STM32F070RB.yaml
@@ -99,18 +99,23 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F071C8.yaml
+++ b/data/chips/STM32F071C8.yaml
@@ -154,21 +154,27 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x48001000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F071CB.yaml
+++ b/data/chips/STM32F071CB.yaml
@@ -156,21 +156,27 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x48001000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F071RB.yaml
+++ b/data/chips/STM32F071RB.yaml
@@ -164,21 +164,27 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x48001000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F071V8.yaml
+++ b/data/chips/STM32F071V8.yaml
@@ -166,21 +166,27 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x48001000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F071VB.yaml
+++ b/data/chips/STM32F071VB.yaml
@@ -166,21 +166,27 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x48001000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F072C8.yaml
+++ b/data/chips/STM32F072C8.yaml
@@ -177,21 +177,27 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x48001000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F072CB.yaml
+++ b/data/chips/STM32F072CB.yaml
@@ -179,21 +179,27 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x48001000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F072R8.yaml
+++ b/data/chips/STM32F072R8.yaml
@@ -187,21 +187,27 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x48001000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F072RB.yaml
+++ b/data/chips/STM32F072RB.yaml
@@ -191,21 +191,27 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x48001000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F072V8.yaml
+++ b/data/chips/STM32F072V8.yaml
@@ -195,21 +195,27 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x48001000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F072VB.yaml
+++ b/data/chips/STM32F072VB.yaml
@@ -195,21 +195,27 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x48001000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F078CB.yaml
+++ b/data/chips/STM32F078CB.yaml
@@ -156,21 +156,27 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x48001000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F078RB.yaml
+++ b/data/chips/STM32F078RB.yaml
@@ -166,21 +166,27 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x48001000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F078VB.yaml
+++ b/data/chips/STM32F078VB.yaml
@@ -166,21 +166,27 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x48001000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F091CB.yaml
+++ b/data/chips/STM32F091CB.yaml
@@ -189,21 +189,27 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x48001000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F091CC.yaml
+++ b/data/chips/STM32F091CC.yaml
@@ -189,21 +189,27 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x48001000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F091RB.yaml
+++ b/data/chips/STM32F091RB.yaml
@@ -199,21 +199,27 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x48001000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F091RC.yaml
+++ b/data/chips/STM32F091RC.yaml
@@ -203,21 +203,27 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x48001000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F091VB.yaml
+++ b/data/chips/STM32F091VB.yaml
@@ -205,21 +205,27 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x48001000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F091VC.yaml
+++ b/data/chips/STM32F091VC.yaml
@@ -207,21 +207,27 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x48001000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F098CC.yaml
+++ b/data/chips/STM32F098CC.yaml
@@ -189,21 +189,27 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x48001000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F098RC.yaml
+++ b/data/chips/STM32F098RC.yaml
@@ -203,21 +203,27 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x48001000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F098VC.yaml
+++ b/data/chips/STM32F098VC.yaml
@@ -207,21 +207,27 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x48001000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F100C4.yaml
+++ b/data/chips/STM32F100C4.yaml
@@ -104,18 +104,23 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOE:
       address: 0x40011800
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F100C6.yaml
+++ b/data/chips/STM32F100C6.yaml
@@ -104,18 +104,23 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOE:
       address: 0x40011800
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F100C8.yaml
+++ b/data/chips/STM32F100C8.yaml
@@ -104,18 +104,23 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOE:
       address: 0x40011800
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F100CB.yaml
+++ b/data/chips/STM32F100CB.yaml
@@ -104,18 +104,23 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOE:
       address: 0x40011800
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F100R4.yaml
+++ b/data/chips/STM32F100R4.yaml
@@ -118,18 +118,23 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOE:
       address: 0x40011800
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F100R6.yaml
+++ b/data/chips/STM32F100R6.yaml
@@ -118,18 +118,23 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOE:
       address: 0x40011800
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F100R8.yaml
+++ b/data/chips/STM32F100R8.yaml
@@ -118,18 +118,23 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOE:
       address: 0x40011800
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F100RB.yaml
+++ b/data/chips/STM32F100RB.yaml
@@ -118,18 +118,23 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOE:
       address: 0x40011800
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F100RC.yaml
+++ b/data/chips/STM32F100RC.yaml
@@ -128,24 +128,31 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOE:
       address: 0x40011800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOF:
       address: 0x40011c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOG:
       address: 0x40012000
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F100RD.yaml
+++ b/data/chips/STM32F100RD.yaml
@@ -128,24 +128,31 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOE:
       address: 0x40011800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOF:
       address: 0x40011c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOG:
       address: 0x40012000
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F100RE.yaml
+++ b/data/chips/STM32F100RE.yaml
@@ -128,24 +128,31 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOE:
       address: 0x40011800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOF:
       address: 0x40011c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOG:
       address: 0x40012000
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F100V8.yaml
+++ b/data/chips/STM32F100V8.yaml
@@ -116,18 +116,23 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOE:
       address: 0x40011800
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F100VB.yaml
+++ b/data/chips/STM32F100VB.yaml
@@ -116,18 +116,23 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOE:
       address: 0x40011800
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F100VC.yaml
+++ b/data/chips/STM32F100VC.yaml
@@ -128,24 +128,31 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOE:
       address: 0x40011800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOF:
       address: 0x40011c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOG:
       address: 0x40012000
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F100VD.yaml
+++ b/data/chips/STM32F100VD.yaml
@@ -128,24 +128,31 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOE:
       address: 0x40011800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOF:
       address: 0x40011c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOG:
       address: 0x40012000
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F100VE.yaml
+++ b/data/chips/STM32F100VE.yaml
@@ -128,24 +128,31 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOE:
       address: 0x40011800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOF:
       address: 0x40011c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOG:
       address: 0x40012000
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F100ZC.yaml
+++ b/data/chips/STM32F100ZC.yaml
@@ -128,24 +128,31 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOE:
       address: 0x40011800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOF:
       address: 0x40011c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOG:
       address: 0x40012000
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F100ZD.yaml
+++ b/data/chips/STM32F100ZD.yaml
@@ -128,24 +128,31 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOE:
       address: 0x40011800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOF:
       address: 0x40011c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOG:
       address: 0x40012000
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F100ZE.yaml
+++ b/data/chips/STM32F100ZE.yaml
@@ -128,24 +128,31 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOE:
       address: 0x40011800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOF:
       address: 0x40011c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOG:
       address: 0x40012000
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F101C4.yaml
+++ b/data/chips/STM32F101C4.yaml
@@ -88,15 +88,19 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F101C6.yaml
+++ b/data/chips/STM32F101C6.yaml
@@ -88,15 +88,19 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F101C8.yaml
+++ b/data/chips/STM32F101C8.yaml
@@ -90,18 +90,23 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOE:
       address: 0x40011800
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F101CB.yaml
+++ b/data/chips/STM32F101CB.yaml
@@ -90,18 +90,23 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOE:
       address: 0x40011800
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F101R4.yaml
+++ b/data/chips/STM32F101R4.yaml
@@ -100,15 +100,19 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F101R6.yaml
+++ b/data/chips/STM32F101R6.yaml
@@ -100,15 +100,19 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F101R8.yaml
+++ b/data/chips/STM32F101R8.yaml
@@ -100,18 +100,23 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOE:
       address: 0x40011800
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F101RB.yaml
+++ b/data/chips/STM32F101RB.yaml
@@ -100,18 +100,23 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOE:
       address: 0x40011800
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F101RC.yaml
+++ b/data/chips/STM32F101RC.yaml
@@ -123,24 +123,31 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOE:
       address: 0x40011800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOF:
       address: 0x40011c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOG:
       address: 0x40012000
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F101RD.yaml
+++ b/data/chips/STM32F101RD.yaml
@@ -123,24 +123,31 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOE:
       address: 0x40011800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOF:
       address: 0x40011c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOG:
       address: 0x40012000
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F101RE.yaml
+++ b/data/chips/STM32F101RE.yaml
@@ -123,24 +123,31 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOE:
       address: 0x40011800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOF:
       address: 0x40011c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOG:
       address: 0x40012000
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F101RF.yaml
+++ b/data/chips/STM32F101RF.yaml
@@ -123,24 +123,31 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOE:
       address: 0x40011800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOF:
       address: 0x40011c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOG:
       address: 0x40012000
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F101RG.yaml
+++ b/data/chips/STM32F101RG.yaml
@@ -123,24 +123,31 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOE:
       address: 0x40011800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOF:
       address: 0x40011c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOG:
       address: 0x40012000
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F101T4.yaml
+++ b/data/chips/STM32F101T4.yaml
@@ -88,15 +88,19 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F101T6.yaml
+++ b/data/chips/STM32F101T6.yaml
@@ -88,15 +88,19 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F101T8.yaml
+++ b/data/chips/STM32F101T8.yaml
@@ -88,18 +88,23 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOE:
       address: 0x40011800
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F101TB.yaml
+++ b/data/chips/STM32F101TB.yaml
@@ -88,18 +88,23 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOE:
       address: 0x40011800
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F101V8.yaml
+++ b/data/chips/STM32F101V8.yaml
@@ -100,18 +100,23 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOE:
       address: 0x40011800
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F101VB.yaml
+++ b/data/chips/STM32F101VB.yaml
@@ -100,18 +100,23 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOE:
       address: 0x40011800
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F101VC.yaml
+++ b/data/chips/STM32F101VC.yaml
@@ -123,24 +123,31 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOE:
       address: 0x40011800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOF:
       address: 0x40011c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOG:
       address: 0x40012000
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F101VD.yaml
+++ b/data/chips/STM32F101VD.yaml
@@ -123,24 +123,31 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOE:
       address: 0x40011800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOF:
       address: 0x40011c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOG:
       address: 0x40012000
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F101VE.yaml
+++ b/data/chips/STM32F101VE.yaml
@@ -123,24 +123,31 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOE:
       address: 0x40011800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOF:
       address: 0x40011c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOG:
       address: 0x40012000
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F101VF.yaml
+++ b/data/chips/STM32F101VF.yaml
@@ -123,24 +123,31 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOE:
       address: 0x40011800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOF:
       address: 0x40011c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOG:
       address: 0x40012000
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F101VG.yaml
+++ b/data/chips/STM32F101VG.yaml
@@ -123,24 +123,31 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOE:
       address: 0x40011800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOF:
       address: 0x40011c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOG:
       address: 0x40012000
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F101ZC.yaml
+++ b/data/chips/STM32F101ZC.yaml
@@ -123,24 +123,31 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOE:
       address: 0x40011800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOF:
       address: 0x40011c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOG:
       address: 0x40012000
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F101ZD.yaml
+++ b/data/chips/STM32F101ZD.yaml
@@ -123,24 +123,31 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOE:
       address: 0x40011800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOF:
       address: 0x40011c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOG:
       address: 0x40012000
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F101ZE.yaml
+++ b/data/chips/STM32F101ZE.yaml
@@ -123,24 +123,31 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOE:
       address: 0x40011800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOF:
       address: 0x40011c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOG:
       address: 0x40012000
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F101ZF.yaml
+++ b/data/chips/STM32F101ZF.yaml
@@ -123,24 +123,31 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOE:
       address: 0x40011800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOF:
       address: 0x40011c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOG:
       address: 0x40012000
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F101ZG.yaml
+++ b/data/chips/STM32F101ZG.yaml
@@ -123,24 +123,31 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOE:
       address: 0x40011800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOF:
       address: 0x40011c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOG:
       address: 0x40012000
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F102C4.yaml
+++ b/data/chips/STM32F102C4.yaml
@@ -88,15 +88,19 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F102C6.yaml
+++ b/data/chips/STM32F102C6.yaml
@@ -88,15 +88,19 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F102C8.yaml
+++ b/data/chips/STM32F102C8.yaml
@@ -88,15 +88,19 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F102CB.yaml
+++ b/data/chips/STM32F102CB.yaml
@@ -88,15 +88,19 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F102R4.yaml
+++ b/data/chips/STM32F102R4.yaml
@@ -100,15 +100,19 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F102R6.yaml
+++ b/data/chips/STM32F102R6.yaml
@@ -100,15 +100,19 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F102R8.yaml
+++ b/data/chips/STM32F102R8.yaml
@@ -100,15 +100,19 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F102RB.yaml
+++ b/data/chips/STM32F102RB.yaml
@@ -100,15 +100,19 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F103C4.yaml
+++ b/data/chips/STM32F103C4.yaml
@@ -114,15 +114,19 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F103C6.yaml
+++ b/data/chips/STM32F103C6.yaml
@@ -116,15 +116,19 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F103C8.yaml
+++ b/data/chips/STM32F103C8.yaml
@@ -114,18 +114,23 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOE:
       address: 0x40011800
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F103CB.yaml
+++ b/data/chips/STM32F103CB.yaml
@@ -116,18 +116,23 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOE:
       address: 0x40011800
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F103R4.yaml
+++ b/data/chips/STM32F103R4.yaml
@@ -140,15 +140,19 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F103R6.yaml
+++ b/data/chips/STM32F103R6.yaml
@@ -140,15 +140,19 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F103R8.yaml
+++ b/data/chips/STM32F103R8.yaml
@@ -140,18 +140,23 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOE:
       address: 0x40011800
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F103RB.yaml
+++ b/data/chips/STM32F103RB.yaml
@@ -140,18 +140,23 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOE:
       address: 0x40011800
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F103RC.yaml
+++ b/data/chips/STM32F103RC.yaml
@@ -183,24 +183,31 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOE:
       address: 0x40011800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOF:
       address: 0x40011c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOG:
       address: 0x40012000
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F103RD.yaml
+++ b/data/chips/STM32F103RD.yaml
@@ -183,24 +183,31 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOE:
       address: 0x40011800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOF:
       address: 0x40011c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOG:
       address: 0x40012000
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F103RE.yaml
+++ b/data/chips/STM32F103RE.yaml
@@ -183,24 +183,31 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOE:
       address: 0x40011800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOF:
       address: 0x40011c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOG:
       address: 0x40012000
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F103RF.yaml
+++ b/data/chips/STM32F103RF.yaml
@@ -187,24 +187,31 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOE:
       address: 0x40011800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOF:
       address: 0x40011c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOG:
       address: 0x40012000
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F103RG.yaml
+++ b/data/chips/STM32F103RG.yaml
@@ -187,24 +187,31 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOE:
       address: 0x40011800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOF:
       address: 0x40011c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOG:
       address: 0x40012000
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F103T4.yaml
+++ b/data/chips/STM32F103T4.yaml
@@ -114,15 +114,19 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F103T6.yaml
+++ b/data/chips/STM32F103T6.yaml
@@ -114,15 +114,19 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F103T8.yaml
+++ b/data/chips/STM32F103T8.yaml
@@ -114,18 +114,23 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOE:
       address: 0x40011800
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F103TB.yaml
+++ b/data/chips/STM32F103TB.yaml
@@ -114,18 +114,23 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOE:
       address: 0x40011800
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F103V8.yaml
+++ b/data/chips/STM32F103V8.yaml
@@ -140,18 +140,23 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOE:
       address: 0x40011800
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F103VB.yaml
+++ b/data/chips/STM32F103VB.yaml
@@ -142,18 +142,23 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOE:
       address: 0x40011800
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F103VC.yaml
+++ b/data/chips/STM32F103VC.yaml
@@ -189,24 +189,31 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOE:
       address: 0x40011800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOF:
       address: 0x40011c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOG:
       address: 0x40012000
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F103VD.yaml
+++ b/data/chips/STM32F103VD.yaml
@@ -189,24 +189,31 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOE:
       address: 0x40011800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOF:
       address: 0x40011c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOG:
       address: 0x40012000
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F103VE.yaml
+++ b/data/chips/STM32F103VE.yaml
@@ -189,24 +189,31 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOE:
       address: 0x40011800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOF:
       address: 0x40011c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOG:
       address: 0x40012000
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F103VF.yaml
+++ b/data/chips/STM32F103VF.yaml
@@ -187,24 +187,31 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOE:
       address: 0x40011800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOF:
       address: 0x40011c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOG:
       address: 0x40012000
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F103VG.yaml
+++ b/data/chips/STM32F103VG.yaml
@@ -187,24 +187,31 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOE:
       address: 0x40011800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOF:
       address: 0x40011c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOG:
       address: 0x40012000
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F103ZC.yaml
+++ b/data/chips/STM32F103ZC.yaml
@@ -199,24 +199,31 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOE:
       address: 0x40011800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOF:
       address: 0x40011c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOG:
       address: 0x40012000
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F103ZD.yaml
+++ b/data/chips/STM32F103ZD.yaml
@@ -199,24 +199,31 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOE:
       address: 0x40011800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOF:
       address: 0x40011c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOG:
       address: 0x40012000
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F103ZE.yaml
+++ b/data/chips/STM32F103ZE.yaml
@@ -199,24 +199,31 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOE:
       address: 0x40011800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOF:
       address: 0x40011c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOG:
       address: 0x40012000
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F103ZF.yaml
+++ b/data/chips/STM32F103ZF.yaml
@@ -199,24 +199,31 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOE:
       address: 0x40011800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOF:
       address: 0x40011c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOG:
       address: 0x40012000
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F103ZG.yaml
+++ b/data/chips/STM32F103ZG.yaml
@@ -199,24 +199,31 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOE:
       address: 0x40011800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOF:
       address: 0x40011c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOG:
       address: 0x40012000
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F105R8.yaml
+++ b/data/chips/STM32F105R8.yaml
@@ -200,18 +200,23 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOE:
       address: 0x40011800
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F105RB.yaml
+++ b/data/chips/STM32F105RB.yaml
@@ -200,18 +200,23 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOE:
       address: 0x40011800
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F105RC.yaml
+++ b/data/chips/STM32F105RC.yaml
@@ -200,18 +200,23 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOE:
       address: 0x40011800
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F105V8.yaml
+++ b/data/chips/STM32F105V8.yaml
@@ -206,18 +206,23 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOE:
       address: 0x40011800
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F105VB.yaml
+++ b/data/chips/STM32F105VB.yaml
@@ -206,18 +206,23 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOE:
       address: 0x40011800
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F105VC.yaml
+++ b/data/chips/STM32F105VC.yaml
@@ -204,18 +204,23 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOE:
       address: 0x40011800
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F107RB.yaml
+++ b/data/chips/STM32F107RB.yaml
@@ -246,18 +246,23 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOE:
       address: 0x40011800
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F107RC.yaml
+++ b/data/chips/STM32F107RC.yaml
@@ -246,18 +246,23 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOE:
       address: 0x40011800
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F107VB.yaml
+++ b/data/chips/STM32F107VB.yaml
@@ -262,18 +262,23 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOE:
       address: 0x40011800
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F107VC.yaml
+++ b/data/chips/STM32F107VC.yaml
@@ -264,18 +264,23 @@ cores:
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOB:
       address: 0x40010c00
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOC:
       address: 0x40011000
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOD:
       address: 0x40011400
       block: gpio_v1/GPIO
+      clock: APB2
     GPIOE:
       address: 0x40011800
       block: gpio_v1/GPIO
+      clock: APB2
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32F301C6.yaml
+++ b/data/chips/STM32F301C6.yaml
@@ -150,18 +150,23 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F301C8.yaml
+++ b/data/chips/STM32F301C8.yaml
@@ -152,18 +152,23 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F301K6.yaml
+++ b/data/chips/STM32F301K6.yaml
@@ -123,18 +123,23 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F301K8.yaml
+++ b/data/chips/STM32F301K8.yaml
@@ -123,18 +123,23 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F301R6.yaml
+++ b/data/chips/STM32F301R6.yaml
@@ -161,18 +161,23 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F301R8.yaml
+++ b/data/chips/STM32F301R8.yaml
@@ -161,18 +161,23 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F302C6.yaml
+++ b/data/chips/STM32F302C6.yaml
@@ -173,18 +173,23 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F302C8.yaml
+++ b/data/chips/STM32F302C8.yaml
@@ -175,18 +175,23 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F302CB.yaml
+++ b/data/chips/STM32F302CB.yaml
@@ -227,21 +227,26 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x48001000
       block: gpio_v2/GPIO
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F302CC.yaml
+++ b/data/chips/STM32F302CC.yaml
@@ -227,21 +227,26 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x48001000
       block: gpio_v2/GPIO
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F302K6.yaml
+++ b/data/chips/STM32F302K6.yaml
@@ -138,18 +138,23 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F302K8.yaml
+++ b/data/chips/STM32F302K8.yaml
@@ -138,18 +138,23 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F302R6.yaml
+++ b/data/chips/STM32F302R6.yaml
@@ -184,18 +184,23 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F302R8.yaml
+++ b/data/chips/STM32F302R8.yaml
@@ -184,18 +184,23 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F302RB.yaml
+++ b/data/chips/STM32F302RB.yaml
@@ -255,21 +255,26 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x48001000
       block: gpio_v2/GPIO
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F302RC.yaml
+++ b/data/chips/STM32F302RC.yaml
@@ -255,21 +255,26 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x48001000
       block: gpio_v2/GPIO
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F302RD.yaml
+++ b/data/chips/STM32F302RD.yaml
@@ -248,21 +248,26 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x48001000
       block: gpio_v2/GPIO
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOG:
       address: 0x48001800
       block: gpio_v2/GPIO

--- a/data/chips/STM32F302RE.yaml
+++ b/data/chips/STM32F302RE.yaml
@@ -251,21 +251,26 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x48001000
       block: gpio_v2/GPIO
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOG:
       address: 0x48001800
       block: gpio_v2/GPIO

--- a/data/chips/STM32F302VB.yaml
+++ b/data/chips/STM32F302VB.yaml
@@ -273,21 +273,26 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x48001000
       block: gpio_v2/GPIO
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F302VC.yaml
+++ b/data/chips/STM32F302VC.yaml
@@ -270,21 +270,26 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x48001000
       block: gpio_v2/GPIO
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F302VD.yaml
+++ b/data/chips/STM32F302VD.yaml
@@ -264,21 +264,26 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x48001000
       block: gpio_v2/GPIO
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOG:
       address: 0x48001800
       block: gpio_v2/GPIO

--- a/data/chips/STM32F302VE.yaml
+++ b/data/chips/STM32F302VE.yaml
@@ -267,21 +267,26 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x48001000
       block: gpio_v2/GPIO
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOG:
       address: 0x48001800
       block: gpio_v2/GPIO

--- a/data/chips/STM32F302ZD.yaml
+++ b/data/chips/STM32F302ZD.yaml
@@ -267,21 +267,26 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x48001000
       block: gpio_v2/GPIO
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOG:
       address: 0x48001800
       block: gpio_v2/GPIO

--- a/data/chips/STM32F302ZE.yaml
+++ b/data/chips/STM32F302ZE.yaml
@@ -270,21 +270,26 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x48001000
       block: gpio_v2/GPIO
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOG:
       address: 0x48001800
       block: gpio_v2/GPIO

--- a/data/chips/STM32F303C6.yaml
+++ b/data/chips/STM32F303C6.yaml
@@ -206,18 +206,23 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F303C8.yaml
+++ b/data/chips/STM32F303C8.yaml
@@ -216,18 +216,23 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F303CB.yaml
+++ b/data/chips/STM32F303CB.yaml
@@ -302,21 +302,26 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x48001000
       block: gpio_v2/GPIO
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F303CC.yaml
+++ b/data/chips/STM32F303CC.yaml
@@ -302,21 +302,26 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x48001000
       block: gpio_v2/GPIO
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F303K6.yaml
+++ b/data/chips/STM32F303K6.yaml
@@ -167,18 +167,23 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F303K8.yaml
+++ b/data/chips/STM32F303K8.yaml
@@ -167,18 +167,23 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F303R6.yaml
+++ b/data/chips/STM32F303R6.yaml
@@ -229,18 +229,23 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F303R8.yaml
+++ b/data/chips/STM32F303R8.yaml
@@ -229,18 +229,23 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F303RB.yaml
+++ b/data/chips/STM32F303RB.yaml
@@ -343,21 +343,26 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x48001000
       block: gpio_v2/GPIO
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F303RC.yaml
+++ b/data/chips/STM32F303RC.yaml
@@ -343,21 +343,26 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x48001000
       block: gpio_v2/GPIO
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F303RD.yaml
+++ b/data/chips/STM32F303RD.yaml
@@ -336,21 +336,26 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x48001000
       block: gpio_v2/GPIO
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOG:
       address: 0x48001800
       block: gpio_v2/GPIO

--- a/data/chips/STM32F303RE.yaml
+++ b/data/chips/STM32F303RE.yaml
@@ -339,21 +339,26 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x48001000
       block: gpio_v2/GPIO
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOG:
       address: 0x48001800
       block: gpio_v2/GPIO

--- a/data/chips/STM32F303VB.yaml
+++ b/data/chips/STM32F303VB.yaml
@@ -413,21 +413,26 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x48001000
       block: gpio_v2/GPIO
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F303VC.yaml
+++ b/data/chips/STM32F303VC.yaml
@@ -398,21 +398,26 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x48001000
       block: gpio_v2/GPIO
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F303VD.yaml
+++ b/data/chips/STM32F303VD.yaml
@@ -400,21 +400,26 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x48001000
       block: gpio_v2/GPIO
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOG:
       address: 0x48001800
       block: gpio_v2/GPIO

--- a/data/chips/STM32F303VE.yaml
+++ b/data/chips/STM32F303VE.yaml
@@ -393,21 +393,26 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x48001000
       block: gpio_v2/GPIO
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOG:
       address: 0x48001800
       block: gpio_v2/GPIO

--- a/data/chips/STM32F303ZD.yaml
+++ b/data/chips/STM32F303ZD.yaml
@@ -403,21 +403,26 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x48001000
       block: gpio_v2/GPIO
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOG:
       address: 0x48001800
       block: gpio_v2/GPIO

--- a/data/chips/STM32F303ZE.yaml
+++ b/data/chips/STM32F303ZE.yaml
@@ -406,21 +406,26 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x48001000
       block: gpio_v2/GPIO
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOG:
       address: 0x48001800
       block: gpio_v2/GPIO

--- a/data/chips/STM32F318C8.yaml
+++ b/data/chips/STM32F318C8.yaml
@@ -150,18 +150,23 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F318K8.yaml
+++ b/data/chips/STM32F318K8.yaml
@@ -121,18 +121,23 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F328C8.yaml
+++ b/data/chips/STM32F328C8.yaml
@@ -202,18 +202,23 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F334C4.yaml
+++ b/data/chips/STM32F334C4.yaml
@@ -206,18 +206,23 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     HRTIM1:
       address: 0x40017400
       kind: HRTIM:hrtim_v1_0

--- a/data/chips/STM32F334C6.yaml
+++ b/data/chips/STM32F334C6.yaml
@@ -206,18 +206,23 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     HRTIM1:
       address: 0x40017400
       kind: HRTIM:hrtim_v1_0

--- a/data/chips/STM32F334C8.yaml
+++ b/data/chips/STM32F334C8.yaml
@@ -216,18 +216,23 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     HRTIM1:
       address: 0x40017400
       kind: HRTIM:hrtim_v1_0

--- a/data/chips/STM32F334K4.yaml
+++ b/data/chips/STM32F334K4.yaml
@@ -167,18 +167,23 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     HRTIM1:
       address: 0x40017400
       kind: HRTIM:hrtim_v1_0

--- a/data/chips/STM32F334K6.yaml
+++ b/data/chips/STM32F334K6.yaml
@@ -167,18 +167,23 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     HRTIM1:
       address: 0x40017400
       kind: HRTIM:hrtim_v1_0

--- a/data/chips/STM32F334K8.yaml
+++ b/data/chips/STM32F334K8.yaml
@@ -167,18 +167,23 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     HRTIM1:
       address: 0x40017400
       kind: HRTIM:hrtim_v1_0

--- a/data/chips/STM32F334R6.yaml
+++ b/data/chips/STM32F334R6.yaml
@@ -229,18 +229,23 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     HRTIM1:
       address: 0x40017400
       kind: HRTIM:hrtim_v1_0

--- a/data/chips/STM32F334R8.yaml
+++ b/data/chips/STM32F334R8.yaml
@@ -229,18 +229,23 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     HRTIM1:
       address: 0x40017400
       kind: HRTIM:hrtim_v1_0

--- a/data/chips/STM32F358CC.yaml
+++ b/data/chips/STM32F358CC.yaml
@@ -296,21 +296,26 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x48001000
       block: gpio_v2/GPIO
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F358RC.yaml
+++ b/data/chips/STM32F358RC.yaml
@@ -337,21 +337,26 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x48001000
       block: gpio_v2/GPIO
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F358VC.yaml
+++ b/data/chips/STM32F358VC.yaml
@@ -407,21 +407,26 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x48001000
       block: gpio_v2/GPIO
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F373C8.yaml
+++ b/data/chips/STM32F373C8.yaml
@@ -188,21 +188,26 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x48001000
       block: gpio_v2/GPIO
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F373CB.yaml
+++ b/data/chips/STM32F373CB.yaml
@@ -188,21 +188,26 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x48001000
       block: gpio_v2/GPIO
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F373CC.yaml
+++ b/data/chips/STM32F373CC.yaml
@@ -188,21 +188,26 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x48001000
       block: gpio_v2/GPIO
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F373R8.yaml
+++ b/data/chips/STM32F373R8.yaml
@@ -205,21 +205,26 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x48001000
       block: gpio_v2/GPIO
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F373RB.yaml
+++ b/data/chips/STM32F373RB.yaml
@@ -205,21 +205,26 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x48001000
       block: gpio_v2/GPIO
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F373RC.yaml
+++ b/data/chips/STM32F373RC.yaml
@@ -205,21 +205,26 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x48001000
       block: gpio_v2/GPIO
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F373V8.yaml
+++ b/data/chips/STM32F373V8.yaml
@@ -213,21 +213,26 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x48001000
       block: gpio_v2/GPIO
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F373VB.yaml
+++ b/data/chips/STM32F373VB.yaml
@@ -213,21 +213,26 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x48001000
       block: gpio_v2/GPIO
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F373VC.yaml
+++ b/data/chips/STM32F373VC.yaml
@@ -213,21 +213,26 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x48001000
       block: gpio_v2/GPIO
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F378CC.yaml
+++ b/data/chips/STM32F378CC.yaml
@@ -188,21 +188,26 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x48001000
       block: gpio_v2/GPIO
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F378RC.yaml
+++ b/data/chips/STM32F378RC.yaml
@@ -207,21 +207,26 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x48001000
       block: gpio_v2/GPIO
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F378VC.yaml
+++ b/data/chips/STM32F378VC.yaml
@@ -213,21 +213,26 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x48001000
       block: gpio_v2/GPIO
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c2_v1_1

--- a/data/chips/STM32F398VE.yaml
+++ b/data/chips/STM32F398VE.yaml
@@ -395,21 +395,26 @@ cores:
     GPIOA:
       address: 0x48000000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x48000400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x48000800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x48000c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x48001000
       block: gpio_v2/GPIO
     GPIOF:
       address: 0x48001400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOG:
       address: 0x48001800
       block: gpio_v2/GPIO

--- a/data/chips/STM32L100C6-A.yaml
+++ b/data/chips/STM32L100C6-A.yaml
@@ -156,18 +156,23 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32L100C6.yaml
+++ b/data/chips/STM32L100C6.yaml
@@ -154,18 +154,23 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32L100R8-A.yaml
+++ b/data/chips/STM32L100R8-A.yaml
@@ -183,18 +183,23 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32L100R8.yaml
+++ b/data/chips/STM32L100R8.yaml
@@ -181,18 +181,23 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32L100RB-A.yaml
+++ b/data/chips/STM32L100RB-A.yaml
@@ -183,18 +183,23 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32L100RB.yaml
+++ b/data/chips/STM32L100RB.yaml
@@ -181,18 +181,23 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32L100RC.yaml
+++ b/data/chips/STM32L100RC.yaml
@@ -197,18 +197,23 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32L151C6-A.yaml
+++ b/data/chips/STM32L151C6-A.yaml
@@ -161,21 +161,27 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x40021000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32L151C6.yaml
+++ b/data/chips/STM32L151C6.yaml
@@ -159,21 +159,27 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x40021000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32L151C8-A.yaml
+++ b/data/chips/STM32L151C8-A.yaml
@@ -161,21 +161,27 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x40021000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32L151C8.yaml
+++ b/data/chips/STM32L151C8.yaml
@@ -159,21 +159,27 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x40021000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32L151CB-A.yaml
+++ b/data/chips/STM32L151CB-A.yaml
@@ -161,21 +161,27 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x40021000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32L151CB.yaml
+++ b/data/chips/STM32L151CB.yaml
@@ -159,21 +159,27 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x40021000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32L151CC.yaml
+++ b/data/chips/STM32L151CC.yaml
@@ -175,21 +175,27 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x40021000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32L151QC.yaml
+++ b/data/chips/STM32L151QC.yaml
@@ -249,27 +249,35 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x40021000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x40021800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOG:
       address: 0x40021c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32L151QD.yaml
+++ b/data/chips/STM32L151QD.yaml
@@ -252,27 +252,35 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x40021000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x40021800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOG:
       address: 0x40021c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32L151QE.yaml
+++ b/data/chips/STM32L151QE.yaml
@@ -285,27 +285,35 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x40021000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x40021800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOG:
       address: 0x40021c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32L151R6-A.yaml
+++ b/data/chips/STM32L151R6-A.yaml
@@ -185,21 +185,27 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x40021000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32L151R6.yaml
+++ b/data/chips/STM32L151R6.yaml
@@ -183,21 +183,27 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x40021000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32L151R8-A.yaml
+++ b/data/chips/STM32L151R8-A.yaml
@@ -185,21 +185,27 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x40021000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32L151R8.yaml
+++ b/data/chips/STM32L151R8.yaml
@@ -183,21 +183,27 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x40021000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32L151RB-A.yaml
+++ b/data/chips/STM32L151RB-A.yaml
@@ -185,21 +185,27 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x40021000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32L151RB.yaml
+++ b/data/chips/STM32L151RB.yaml
@@ -183,21 +183,27 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x40021000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32L151RC-A.yaml
+++ b/data/chips/STM32L151RC-A.yaml
@@ -195,27 +195,35 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x40021000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x40021800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOG:
       address: 0x40021c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32L151RC.yaml
+++ b/data/chips/STM32L151RC.yaml
@@ -197,21 +197,27 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x40021000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32L151RD.yaml
+++ b/data/chips/STM32L151RD.yaml
@@ -200,27 +200,35 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x40021000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x40021800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOG:
       address: 0x40021c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32L151RE.yaml
+++ b/data/chips/STM32L151RE.yaml
@@ -225,27 +225,35 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x40021000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x40021800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOG:
       address: 0x40021c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32L151UC.yaml
+++ b/data/chips/STM32L151UC.yaml
@@ -197,21 +197,27 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x40021000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32L151V8-A.yaml
+++ b/data/chips/STM32L151V8-A.yaml
@@ -201,21 +201,27 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x40021000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32L151V8.yaml
+++ b/data/chips/STM32L151V8.yaml
@@ -199,21 +199,27 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x40021000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32L151VB-A.yaml
+++ b/data/chips/STM32L151VB-A.yaml
@@ -201,21 +201,27 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x40021000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32L151VB.yaml
+++ b/data/chips/STM32L151VB.yaml
@@ -199,21 +199,27 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x40021000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32L151VC-A.yaml
+++ b/data/chips/STM32L151VC-A.yaml
@@ -211,27 +211,35 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x40021000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x40021800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOG:
       address: 0x40021c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32L151VC.yaml
+++ b/data/chips/STM32L151VC.yaml
@@ -215,21 +215,27 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x40021000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32L151VD-X.yaml
+++ b/data/chips/STM32L151VD-X.yaml
@@ -247,27 +247,35 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x40021000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x40021800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOG:
       address: 0x40021c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32L151VD.yaml
+++ b/data/chips/STM32L151VD.yaml
@@ -214,27 +214,35 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x40021000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x40021800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOG:
       address: 0x40021c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32L151VE.yaml
+++ b/data/chips/STM32L151VE.yaml
@@ -247,27 +247,35 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x40021000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x40021800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOG:
       address: 0x40021c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32L151ZC.yaml
+++ b/data/chips/STM32L151ZC.yaml
@@ -253,27 +253,35 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x40021000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x40021800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOG:
       address: 0x40021c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32L151ZD.yaml
+++ b/data/chips/STM32L151ZD.yaml
@@ -256,27 +256,35 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x40021000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x40021800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOG:
       address: 0x40021c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32L151ZE.yaml
+++ b/data/chips/STM32L151ZE.yaml
@@ -290,27 +290,35 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x40021000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x40021800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOG:
       address: 0x40021c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32L152C6-A.yaml
+++ b/data/chips/STM32L152C6-A.yaml
@@ -161,21 +161,27 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x40021000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32L152C6.yaml
+++ b/data/chips/STM32L152C6.yaml
@@ -159,21 +159,27 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x40021000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32L152C8-A.yaml
+++ b/data/chips/STM32L152C8-A.yaml
@@ -161,21 +161,27 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x40021000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32L152C8.yaml
+++ b/data/chips/STM32L152C8.yaml
@@ -159,21 +159,27 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x40021000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32L152CB-A.yaml
+++ b/data/chips/STM32L152CB-A.yaml
@@ -161,21 +161,27 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x40021000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32L152CB.yaml
+++ b/data/chips/STM32L152CB.yaml
@@ -159,21 +159,27 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x40021000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32L152CC.yaml
+++ b/data/chips/STM32L152CC.yaml
@@ -175,21 +175,27 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x40021000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32L152QC.yaml
+++ b/data/chips/STM32L152QC.yaml
@@ -249,27 +249,35 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x40021000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x40021800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOG:
       address: 0x40021c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32L152QD.yaml
+++ b/data/chips/STM32L152QD.yaml
@@ -252,27 +252,35 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x40021000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x40021800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOG:
       address: 0x40021c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32L152QE.yaml
+++ b/data/chips/STM32L152QE.yaml
@@ -285,27 +285,35 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x40021000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x40021800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOG:
       address: 0x40021c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32L152R6-A.yaml
+++ b/data/chips/STM32L152R6-A.yaml
@@ -185,21 +185,27 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x40021000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32L152R6.yaml
+++ b/data/chips/STM32L152R6.yaml
@@ -183,21 +183,27 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x40021000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32L152R8-A.yaml
+++ b/data/chips/STM32L152R8-A.yaml
@@ -185,21 +185,27 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x40021000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32L152R8.yaml
+++ b/data/chips/STM32L152R8.yaml
@@ -183,21 +183,27 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x40021000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32L152RB-A.yaml
+++ b/data/chips/STM32L152RB-A.yaml
@@ -185,21 +185,27 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x40021000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32L152RB.yaml
+++ b/data/chips/STM32L152RB.yaml
@@ -183,21 +183,27 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x40021000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32L152RC-A.yaml
+++ b/data/chips/STM32L152RC-A.yaml
@@ -195,27 +195,35 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x40021000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x40021800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOG:
       address: 0x40021c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32L152RC.yaml
+++ b/data/chips/STM32L152RC.yaml
@@ -197,21 +197,27 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x40021000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32L152RD.yaml
+++ b/data/chips/STM32L152RD.yaml
@@ -200,27 +200,35 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x40021000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x40021800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOG:
       address: 0x40021c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32L152RE.yaml
+++ b/data/chips/STM32L152RE.yaml
@@ -225,27 +225,35 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x40021000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x40021800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOG:
       address: 0x40021c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32L152UC.yaml
+++ b/data/chips/STM32L152UC.yaml
@@ -197,21 +197,27 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x40021000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32L152V8-A.yaml
+++ b/data/chips/STM32L152V8-A.yaml
@@ -201,21 +201,27 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x40021000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32L152V8.yaml
+++ b/data/chips/STM32L152V8.yaml
@@ -199,21 +199,27 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x40021000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32L152VB-A.yaml
+++ b/data/chips/STM32L152VB-A.yaml
@@ -201,21 +201,27 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x40021000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32L152VB.yaml
+++ b/data/chips/STM32L152VB.yaml
@@ -199,21 +199,27 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x40021000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32L152VC-A.yaml
+++ b/data/chips/STM32L152VC-A.yaml
@@ -211,27 +211,35 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x40021000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x40021800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOG:
       address: 0x40021c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32L152VC.yaml
+++ b/data/chips/STM32L152VC.yaml
@@ -215,21 +215,27 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x40021000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32L152VD-X.yaml
+++ b/data/chips/STM32L152VD-X.yaml
@@ -245,27 +245,35 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x40021000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x40021800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOG:
       address: 0x40021c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32L152VD.yaml
+++ b/data/chips/STM32L152VD.yaml
@@ -214,27 +214,35 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x40021000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x40021800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOG:
       address: 0x40021c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32L152VE.yaml
+++ b/data/chips/STM32L152VE.yaml
@@ -247,27 +247,35 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x40021000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x40021800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOG:
       address: 0x40021c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32L152ZC.yaml
+++ b/data/chips/STM32L152ZC.yaml
@@ -253,27 +253,35 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x40021000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x40021800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOG:
       address: 0x40021c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32L152ZD.yaml
+++ b/data/chips/STM32L152ZD.yaml
@@ -256,27 +256,35 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x40021000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x40021800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOG:
       address: 0x40021c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32L152ZE.yaml
+++ b/data/chips/STM32L152ZE.yaml
@@ -290,27 +290,35 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x40021000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x40021800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOG:
       address: 0x40021c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32L162QC.yaml
+++ b/data/chips/STM32L162QC.yaml
@@ -259,27 +259,35 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x40021000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x40021800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOG:
       address: 0x40021c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32L162QD.yaml
+++ b/data/chips/STM32L162QD.yaml
@@ -262,27 +262,35 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x40021000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x40021800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOG:
       address: 0x40021c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32L162RC-A.yaml
+++ b/data/chips/STM32L162RC-A.yaml
@@ -205,27 +205,35 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x40021000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x40021800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOG:
       address: 0x40021c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32L162RC.yaml
+++ b/data/chips/STM32L162RC.yaml
@@ -207,21 +207,27 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x40021000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32L162RD.yaml
+++ b/data/chips/STM32L162RD.yaml
@@ -210,27 +210,35 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x40021000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x40021800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOG:
       address: 0x40021c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32L162RE.yaml
+++ b/data/chips/STM32L162RE.yaml
@@ -235,27 +235,35 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x40021000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x40021800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOG:
       address: 0x40021c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32L162VC-A.yaml
+++ b/data/chips/STM32L162VC-A.yaml
@@ -221,27 +221,35 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x40021000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x40021800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOG:
       address: 0x40021c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32L162VC.yaml
+++ b/data/chips/STM32L162VC.yaml
@@ -225,21 +225,27 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x40021000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32L162VD-X.yaml
+++ b/data/chips/STM32L162VD-X.yaml
@@ -255,27 +255,35 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x40021000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x40021800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOG:
       address: 0x40021c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32L162VD.yaml
+++ b/data/chips/STM32L162VD.yaml
@@ -224,27 +224,35 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x40021000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x40021800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOG:
       address: 0x40021c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32L162VE.yaml
+++ b/data/chips/STM32L162VE.yaml
@@ -257,27 +257,35 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x40021000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x40021800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOG:
       address: 0x40021c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32L162ZC.yaml
+++ b/data/chips/STM32L162ZC.yaml
@@ -263,27 +263,35 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x40021000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x40021800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOG:
       address: 0x40021c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32L162ZD.yaml
+++ b/data/chips/STM32L162ZD.yaml
@@ -266,27 +266,35 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x40021000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x40021800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOG:
       address: 0x40021c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32L162ZE.yaml
+++ b/data/chips/STM32L162ZE.yaml
@@ -300,27 +300,35 @@ cores:
     GPIOA:
       address: 0x40020000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOB:
       address: 0x40020400
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOC:
       address: 0x40020800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOD:
       address: 0x40020c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOE:
       address: 0x40021000
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOF:
       address: 0x40021800
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOG:
       address: 0x40021c00
       block: gpio_v2/GPIO
+      clock: AHB
     GPIOH:
       address: 0x40021400
       block: gpio_v2/GPIO
+      clock: AHB
     I2C1:
       address: 0x40005400
       kind: I2C:i2c1_v1_5

--- a/data/chips/STM32WL54CC.yaml
+++ b/data/chips/STM32WL54CC.yaml
@@ -415,6 +415,7 @@ cores:
     PWR:
       address: 0x58000400
       kind: PWR:STM32WL_pwr_v1_0
+      block: pwr_wl5/PWR
       pins: &id024
       - pin: PB3
         signal: WKUP3
@@ -565,14 +566,27 @@ cores:
       address: 0x58010000
       kind: SUBGHZ:STM32WLxx_v1_0
       block: spi_v2/SPI
+      pins: &id033
+      - pin: PA4
+        signal: NSS
+        af: 13
+      - pin: PA5
+        signal: SCK
+        af: 13
+      - pin: PA6
+        signal: MISO
+        af: 13
+      - pin: PA7
+        signal: MOSI
+        af: 13
       clock: APB3
       dma_channels:
         RX:
-        - &id033
+        - &id034
           dmamux: DMAMUX1
           request: 41
         TX:
-        - &id034
+        - &id035
           dmamux: DMAMUX1
           request: 42
     SYSCFG:
@@ -584,7 +598,7 @@ cores:
       address: 0x40012c00
       kind: TIM1_8WL5:gptimer2_v3_x
       block: timer_v1/TIM_GP16
-      pins: &id035
+      pins: &id036
       - pin: PB7
         signal: BKIN
         af: 3
@@ -626,38 +640,38 @@ cores:
       clock: APB2
       dma_channels:
         CH1:
-        - &id036
+        - &id037
           dmamux: DMAMUX1
           request: 23
         CH2:
-        - &id037
+        - &id038
           dmamux: DMAMUX1
           request: 24
         CH3:
-        - &id038
+        - &id039
           dmamux: DMAMUX1
           request: 25
         CH4:
-        - &id039
+        - &id040
           dmamux: DMAMUX1
           request: 26
         COM:
-        - &id040
+        - &id041
           dmamux: DMAMUX1
           request: 29
         TRIG:
-        - &id041
+        - &id042
           dmamux: DMAMUX1
           request: 28
         UP:
-        - &id042
+        - &id043
           dmamux: DMAMUX1
           request: 27
     TIM16:
       address: 0x40014400
       kind: TIM1_8WL5:gptimer2_v3_x
       block: timer_v1/TIM_GP16
-      pins: &id043
+      pins: &id044
       - pin: PB5
         signal: BKIN
         af: 14
@@ -678,18 +692,18 @@ cores:
       clock: APB2
       dma_channels:
         CH1:
-        - &id044
+        - &id045
           dmamux: DMAMUX1
           request: 35
         UP:
-        - &id045
+        - &id046
           dmamux: DMAMUX1
           request: 36
     TIM17:
       address: 0x40014800
       kind: TIM1_8WL5:gptimer2_v3_x
       block: timer_v1/TIM_GP16
-      pins: &id046
+      pins: &id047
       - pin: PB4
         signal: BKIN
         af: 14
@@ -710,18 +724,18 @@ cores:
       clock: APB2
       dma_channels:
         CH1:
-        - &id047
+        - &id048
           dmamux: DMAMUX1
           request: 37
         UP:
-        - &id048
+        - &id049
           dmamux: DMAMUX1
           request: 38
     TIM2:
       address: 0x40000000
       kind: TIM1_8WL5:gptimer2_v3_x
       block: timer_v1/TIM_GP16
-      pins: &id049
+      pins: &id050
       - pin: PB3
         signal: CH2
         af: 1
@@ -759,23 +773,23 @@ cores:
         UP: TIM2
       dma_channels:
         CH1:
-        - &id050
+        - &id051
           dmamux: DMAMUX1
           request: 30
         CH2:
-        - &id051
+        - &id052
           dmamux: DMAMUX1
           request: 31
         CH3:
-        - &id052
+        - &id053
           dmamux: DMAMUX1
           request: 32
         CH4:
-        - &id053
+        - &id054
           dmamux: DMAMUX1
           request: 33
         UP:
-        - &id054
+        - &id055
           dmamux: DMAMUX1
           request: 34
     USART1:
@@ -783,7 +797,7 @@ cores:
       kind: USART:sci3_v2_1
       clock: APB2
       block: usart_v2/USART
-      pins: &id055
+      pins: &id056
       - pin: PB3
         signal: DE
         af: 7
@@ -830,18 +844,18 @@ cores:
         GLOBAL: USART1
       dma_channels:
         RX:
-        - &id056
+        - &id057
           dmamux: DMAMUX1
           request: 17
         TX:
-        - &id057
+        - &id058
           dmamux: DMAMUX1
           request: 18
     USART2:
       address: 0x40004400
       kind: USART:sci3_v2_1
       block: usart_v2/USART
-      pins: &id058
+      pins: &id059
       - pin: PA0
         signal: CTS
         af: 7
@@ -867,11 +881,11 @@ cores:
         GLOBAL: USART2
       dma_channels:
         RX:
-        - &id059
+        - &id060
           dmamux: DMAMUX1
           request: 19
         TX:
-        - &id060
+        - &id061
           dmamux: DMAMUX1
           request: 20
     VREFBUF:
@@ -1185,6 +1199,7 @@ cores:
     PWR:
       address: 0x58000400
       kind: PWR:STM32WL_pwr_v1_0
+      block: pwr_wl5/PWR
       pins: *id024
     RCC:
       address: 0x58000000
@@ -1234,12 +1249,13 @@ cores:
       address: 0x58010000
       kind: SUBGHZ:STM32WLxx_v1_0
       block: spi_v2/SPI
+      pins: *id033
       clock: APB3
       dma_channels:
         RX:
-        - *id033
-        TX:
         - *id034
+        TX:
+        - *id035
     SYSCFG:
       address: 0x40010000
       kind: SYS:STM32WL5xx_sys_v1_0
@@ -1249,29 +1265,29 @@ cores:
       address: 0x40012c00
       kind: TIM1_8WL5:gptimer2_v3_x
       block: timer_v1/TIM_GP16
-      pins: *id035
+      pins: *id036
       interrupts: {}
       clock: APB2
       dma_channels:
         CH1:
-        - *id036
-        CH2:
         - *id037
-        CH3:
+        CH2:
         - *id038
-        CH4:
+        CH3:
         - *id039
-        COM:
+        CH4:
         - *id040
-        TRIG:
+        COM:
         - *id041
-        UP:
+        TRIG:
         - *id042
+        UP:
+        - *id043
     TIM16:
       address: 0x40014400
       kind: TIM1_8WL5:gptimer2_v3_x
       block: timer_v1/TIM_GP16
-      pins: *id043
+      pins: *id044
       interrupts:
         BRK: TIM16
         COM: TIM16
@@ -1280,14 +1296,14 @@ cores:
       clock: APB2
       dma_channels:
         CH1:
-        - *id044
-        UP:
         - *id045
+        UP:
+        - *id046
     TIM17:
       address: 0x40014800
       kind: TIM1_8WL5:gptimer2_v3_x
       block: timer_v1/TIM_GP16
-      pins: *id046
+      pins: *id047
       interrupts:
         BRK: TIM17
         COM: TIM17
@@ -1296,14 +1312,14 @@ cores:
       clock: APB2
       dma_channels:
         CH1:
-        - *id047
-        UP:
         - *id048
+        UP:
+        - *id049
     TIM2:
       address: 0x40000000
       kind: TIM1_8WL5:gptimer2_v3_x
       block: timer_v1/TIM_GP16
-      pins: *id049
+      pins: *id050
       interrupts:
         BRK: TIM2
         COM: TIM2
@@ -1311,40 +1327,40 @@ cores:
         UP: TIM2
       dma_channels:
         CH1:
-        - *id050
-        CH2:
         - *id051
-        CH3:
+        CH2:
         - *id052
-        CH4:
+        CH3:
         - *id053
-        UP:
+        CH4:
         - *id054
+        UP:
+        - *id055
     USART1:
       address: 0x40013800
       kind: USART:sci3_v2_1
       clock: APB2
       block: usart_v2/USART
-      pins: *id055
+      pins: *id056
       interrupts:
         GLOBAL: USART1
       dma_channels:
         RX:
-        - *id056
-        TX:
         - *id057
+        TX:
+        - *id058
     USART2:
       address: 0x40004400
       kind: USART:sci3_v2_1
       block: usart_v2/USART
-      pins: *id058
+      pins: *id059
       interrupts:
         GLOBAL: USART2
       dma_channels:
         RX:
-        - *id059
-        TX:
         - *id060
+        TX:
+        - *id061
     VREFBUF:
       address: 0x40010030
       kind: VREFBUF:STM32WL_vrefbuf_v1_0

--- a/data/chips/STM32WL54JC.yaml
+++ b/data/chips/STM32WL54JC.yaml
@@ -495,6 +495,7 @@ cores:
     PWR:
       address: 0x58000400
       kind: PWR:STM32WL_pwr_v1_0
+      block: pwr_wl5/PWR
       pins: &id024
       - pin: PB3
         signal: WKUP3
@@ -669,14 +670,27 @@ cores:
       address: 0x58010000
       kind: SUBGHZ:STM32WLxx_v1_0
       block: spi_v2/SPI
+      pins: &id033
+      - pin: PA6
+        signal: MISO
+        af: 13
+      - pin: PA7
+        signal: MOSI
+        af: 13
+      - pin: PA4
+        signal: NSS
+        af: 13
+      - pin: PA5
+        signal: SCK
+        af: 13
       clock: APB3
       dma_channels:
         RX:
-        - &id033
+        - &id034
           dmamux: DMAMUX1
           request: 41
         TX:
-        - &id034
+        - &id035
           dmamux: DMAMUX1
           request: 42
     SYSCFG:
@@ -688,7 +702,7 @@ cores:
       address: 0x40012c00
       kind: TIM1_8WL5:gptimer2_v3_x
       block: timer_v1/TIM_GP16
-      pins: &id035
+      pins: &id036
       - pin: PA12
         signal: ETR
         af: 1
@@ -742,38 +756,38 @@ cores:
       clock: APB2
       dma_channels:
         CH1:
-        - &id036
+        - &id037
           dmamux: DMAMUX1
           request: 23
         CH2:
-        - &id037
+        - &id038
           dmamux: DMAMUX1
           request: 24
         CH3:
-        - &id038
+        - &id039
           dmamux: DMAMUX1
           request: 25
         CH4:
-        - &id039
+        - &id040
           dmamux: DMAMUX1
           request: 26
         COM:
-        - &id040
+        - &id041
           dmamux: DMAMUX1
           request: 29
         TRIG:
-        - &id041
+        - &id042
           dmamux: DMAMUX1
           request: 28
         UP:
-        - &id042
+        - &id043
           dmamux: DMAMUX1
           request: 27
     TIM16:
       address: 0x40014400
       kind: TIM1_8WL5:gptimer2_v3_x
       block: timer_v1/TIM_GP16
-      pins: &id043
+      pins: &id044
       - pin: PB5
         signal: BKIN
         af: 14
@@ -794,18 +808,18 @@ cores:
       clock: APB2
       dma_channels:
         CH1:
-        - &id044
+        - &id045
           dmamux: DMAMUX1
           request: 35
         UP:
-        - &id045
+        - &id046
           dmamux: DMAMUX1
           request: 36
     TIM17:
       address: 0x40014800
       kind: TIM1_8WL5:gptimer2_v3_x
       block: timer_v1/TIM_GP16
-      pins: &id046
+      pins: &id047
       - pin: PB4
         signal: BKIN
         af: 14
@@ -829,18 +843,18 @@ cores:
       clock: APB2
       dma_channels:
         CH1:
-        - &id047
+        - &id048
           dmamux: DMAMUX1
           request: 37
         UP:
-        - &id048
+        - &id049
           dmamux: DMAMUX1
           request: 38
     TIM2:
       address: 0x40000000
       kind: TIM1_8WL5:gptimer2_v3_x
       block: timer_v1/TIM_GP16
-      pins: &id049
+      pins: &id050
       - pin: PA15
         signal: CH1
         af: 1
@@ -884,23 +898,23 @@ cores:
         UP: TIM2
       dma_channels:
         CH1:
-        - &id050
+        - &id051
           dmamux: DMAMUX1
           request: 30
         CH2:
-        - &id051
+        - &id052
           dmamux: DMAMUX1
           request: 31
         CH3:
-        - &id052
+        - &id053
           dmamux: DMAMUX1
           request: 32
         CH4:
-        - &id053
+        - &id054
           dmamux: DMAMUX1
           request: 33
         UP:
-        - &id054
+        - &id055
           dmamux: DMAMUX1
           request: 34
     USART1:
@@ -908,7 +922,7 @@ cores:
       kind: USART:sci3_v2_1
       clock: APB2
       block: usart_v2/USART
-      pins: &id055
+      pins: &id056
       - pin: PA12
         signal: DE
         af: 7
@@ -955,18 +969,18 @@ cores:
         GLOBAL: USART1
       dma_channels:
         RX:
-        - &id056
+        - &id057
           dmamux: DMAMUX1
           request: 17
         TX:
-        - &id057
+        - &id058
           dmamux: DMAMUX1
           request: 18
     USART2:
       address: 0x40004400
       kind: USART:sci3_v2_1
       block: usart_v2/USART
-      pins: &id058
+      pins: &id059
       - pin: PA0
         signal: CTS
         af: 7
@@ -992,17 +1006,17 @@ cores:
         GLOBAL: USART2
       dma_channels:
         RX:
-        - &id059
+        - &id060
           dmamux: DMAMUX1
           request: 19
         TX:
-        - &id060
+        - &id061
           dmamux: DMAMUX1
           request: 20
     VREFBUF:
       address: 0x40010030
       kind: VREFBUF:STM32WL_vrefbuf_v1_0
-      pins: &id061
+      pins: &id062
       - pin: VREF+
         signal: OUT
     WWDG:
@@ -1313,6 +1327,7 @@ cores:
     PWR:
       address: 0x58000400
       kind: PWR:STM32WL_pwr_v1_0
+      block: pwr_wl5/PWR
       pins: *id024
     RCC:
       address: 0x58000000
@@ -1362,12 +1377,13 @@ cores:
       address: 0x58010000
       kind: SUBGHZ:STM32WLxx_v1_0
       block: spi_v2/SPI
+      pins: *id033
       clock: APB3
       dma_channels:
         RX:
-        - *id033
-        TX:
         - *id034
+        TX:
+        - *id035
     SYSCFG:
       address: 0x40010000
       kind: SYS:STM32WL5xx_sys_v1_0
@@ -1377,29 +1393,29 @@ cores:
       address: 0x40012c00
       kind: TIM1_8WL5:gptimer2_v3_x
       block: timer_v1/TIM_GP16
-      pins: *id035
+      pins: *id036
       interrupts: {}
       clock: APB2
       dma_channels:
         CH1:
-        - *id036
-        CH2:
         - *id037
-        CH3:
+        CH2:
         - *id038
-        CH4:
+        CH3:
         - *id039
-        COM:
+        CH4:
         - *id040
-        TRIG:
+        COM:
         - *id041
-        UP:
+        TRIG:
         - *id042
+        UP:
+        - *id043
     TIM16:
       address: 0x40014400
       kind: TIM1_8WL5:gptimer2_v3_x
       block: timer_v1/TIM_GP16
-      pins: *id043
+      pins: *id044
       interrupts:
         BRK: TIM16
         COM: TIM16
@@ -1408,14 +1424,14 @@ cores:
       clock: APB2
       dma_channels:
         CH1:
-        - *id044
-        UP:
         - *id045
+        UP:
+        - *id046
     TIM17:
       address: 0x40014800
       kind: TIM1_8WL5:gptimer2_v3_x
       block: timer_v1/TIM_GP16
-      pins: *id046
+      pins: *id047
       interrupts:
         BRK: TIM17
         COM: TIM17
@@ -1424,14 +1440,14 @@ cores:
       clock: APB2
       dma_channels:
         CH1:
-        - *id047
-        UP:
         - *id048
+        UP:
+        - *id049
     TIM2:
       address: 0x40000000
       kind: TIM1_8WL5:gptimer2_v3_x
       block: timer_v1/TIM_GP16
-      pins: *id049
+      pins: *id050
       interrupts:
         BRK: TIM2
         COM: TIM2
@@ -1439,44 +1455,44 @@ cores:
         UP: TIM2
       dma_channels:
         CH1:
-        - *id050
-        CH2:
         - *id051
-        CH3:
+        CH2:
         - *id052
-        CH4:
+        CH3:
         - *id053
-        UP:
+        CH4:
         - *id054
+        UP:
+        - *id055
     USART1:
       address: 0x40013800
       kind: USART:sci3_v2_1
       clock: APB2
       block: usart_v2/USART
-      pins: *id055
+      pins: *id056
       interrupts:
         GLOBAL: USART1
       dma_channels:
         RX:
-        - *id056
-        TX:
         - *id057
+        TX:
+        - *id058
     USART2:
       address: 0x40004400
       kind: USART:sci3_v2_1
       block: usart_v2/USART
-      pins: *id058
+      pins: *id059
       interrupts:
         GLOBAL: USART2
       dma_channels:
         RX:
-        - *id059
-        TX:
         - *id060
+        TX:
+        - *id061
     VREFBUF:
       address: 0x40010030
       kind: VREFBUF:STM32WL_vrefbuf_v1_0
-      pins: *id061
+      pins: *id062
     WWDG:
       address: 0x40002c00
       kind: WWDG:wwdg1_v2_0

--- a/data/chips/STM32WL55CC.yaml
+++ b/data/chips/STM32WL55CC.yaml
@@ -415,6 +415,7 @@ cores:
     PWR:
       address: 0x58000400
       kind: PWR:STM32WL_pwr_v1_0
+      block: pwr_wl5/PWR
       pins: &id024
       - pin: PB3
         signal: WKUP3
@@ -565,14 +566,27 @@ cores:
       address: 0x58010000
       kind: SUBGHZ:STM32WLxx_v1_0
       block: spi_v2/SPI
+      pins: &id033
+      - pin: PA4
+        signal: NSS
+        af: 13
+      - pin: PA5
+        signal: SCK
+        af: 13
+      - pin: PA6
+        signal: MISO
+        af: 13
+      - pin: PA7
+        signal: MOSI
+        af: 13
       clock: APB3
       dma_channels:
         RX:
-        - &id033
+        - &id034
           dmamux: DMAMUX1
           request: 41
         TX:
-        - &id034
+        - &id035
           dmamux: DMAMUX1
           request: 42
     SYSCFG:
@@ -584,7 +598,7 @@ cores:
       address: 0x40012c00
       kind: TIM1_8WL5:gptimer2_v3_x
       block: timer_v1/TIM_GP16
-      pins: &id035
+      pins: &id036
       - pin: PB7
         signal: BKIN
         af: 3
@@ -626,38 +640,38 @@ cores:
       clock: APB2
       dma_channels:
         CH1:
-        - &id036
+        - &id037
           dmamux: DMAMUX1
           request: 23
         CH2:
-        - &id037
+        - &id038
           dmamux: DMAMUX1
           request: 24
         CH3:
-        - &id038
+        - &id039
           dmamux: DMAMUX1
           request: 25
         CH4:
-        - &id039
+        - &id040
           dmamux: DMAMUX1
           request: 26
         COM:
-        - &id040
+        - &id041
           dmamux: DMAMUX1
           request: 29
         TRIG:
-        - &id041
+        - &id042
           dmamux: DMAMUX1
           request: 28
         UP:
-        - &id042
+        - &id043
           dmamux: DMAMUX1
           request: 27
     TIM16:
       address: 0x40014400
       kind: TIM1_8WL5:gptimer2_v3_x
       block: timer_v1/TIM_GP16
-      pins: &id043
+      pins: &id044
       - pin: PB5
         signal: BKIN
         af: 14
@@ -678,18 +692,18 @@ cores:
       clock: APB2
       dma_channels:
         CH1:
-        - &id044
+        - &id045
           dmamux: DMAMUX1
           request: 35
         UP:
-        - &id045
+        - &id046
           dmamux: DMAMUX1
           request: 36
     TIM17:
       address: 0x40014800
       kind: TIM1_8WL5:gptimer2_v3_x
       block: timer_v1/TIM_GP16
-      pins: &id046
+      pins: &id047
       - pin: PB4
         signal: BKIN
         af: 14
@@ -710,18 +724,18 @@ cores:
       clock: APB2
       dma_channels:
         CH1:
-        - &id047
+        - &id048
           dmamux: DMAMUX1
           request: 37
         UP:
-        - &id048
+        - &id049
           dmamux: DMAMUX1
           request: 38
     TIM2:
       address: 0x40000000
       kind: TIM1_8WL5:gptimer2_v3_x
       block: timer_v1/TIM_GP16
-      pins: &id049
+      pins: &id050
       - pin: PB3
         signal: CH2
         af: 1
@@ -759,23 +773,23 @@ cores:
         UP: TIM2
       dma_channels:
         CH1:
-        - &id050
+        - &id051
           dmamux: DMAMUX1
           request: 30
         CH2:
-        - &id051
+        - &id052
           dmamux: DMAMUX1
           request: 31
         CH3:
-        - &id052
+        - &id053
           dmamux: DMAMUX1
           request: 32
         CH4:
-        - &id053
+        - &id054
           dmamux: DMAMUX1
           request: 33
         UP:
-        - &id054
+        - &id055
           dmamux: DMAMUX1
           request: 34
     USART1:
@@ -783,7 +797,7 @@ cores:
       kind: USART:sci3_v2_1
       clock: APB2
       block: usart_v2/USART
-      pins: &id055
+      pins: &id056
       - pin: PB3
         signal: DE
         af: 7
@@ -830,18 +844,18 @@ cores:
         GLOBAL: USART1
       dma_channels:
         RX:
-        - &id056
+        - &id057
           dmamux: DMAMUX1
           request: 17
         TX:
-        - &id057
+        - &id058
           dmamux: DMAMUX1
           request: 18
     USART2:
       address: 0x40004400
       kind: USART:sci3_v2_1
       block: usart_v2/USART
-      pins: &id058
+      pins: &id059
       - pin: PA0
         signal: CTS
         af: 7
@@ -867,11 +881,11 @@ cores:
         GLOBAL: USART2
       dma_channels:
         RX:
-        - &id059
+        - &id060
           dmamux: DMAMUX1
           request: 19
         TX:
-        - &id060
+        - &id061
           dmamux: DMAMUX1
           request: 20
     VREFBUF:
@@ -1185,6 +1199,7 @@ cores:
     PWR:
       address: 0x58000400
       kind: PWR:STM32WL_pwr_v1_0
+      block: pwr_wl5/PWR
       pins: *id024
     RCC:
       address: 0x58000000
@@ -1234,12 +1249,13 @@ cores:
       address: 0x58010000
       kind: SUBGHZ:STM32WLxx_v1_0
       block: spi_v2/SPI
+      pins: *id033
       clock: APB3
       dma_channels:
         RX:
-        - *id033
-        TX:
         - *id034
+        TX:
+        - *id035
     SYSCFG:
       address: 0x40010000
       kind: SYS:STM32WL5xx_sys_v1_0
@@ -1249,29 +1265,29 @@ cores:
       address: 0x40012c00
       kind: TIM1_8WL5:gptimer2_v3_x
       block: timer_v1/TIM_GP16
-      pins: *id035
+      pins: *id036
       interrupts: {}
       clock: APB2
       dma_channels:
         CH1:
-        - *id036
-        CH2:
         - *id037
-        CH3:
+        CH2:
         - *id038
-        CH4:
+        CH3:
         - *id039
-        COM:
+        CH4:
         - *id040
-        TRIG:
+        COM:
         - *id041
-        UP:
+        TRIG:
         - *id042
+        UP:
+        - *id043
     TIM16:
       address: 0x40014400
       kind: TIM1_8WL5:gptimer2_v3_x
       block: timer_v1/TIM_GP16
-      pins: *id043
+      pins: *id044
       interrupts:
         BRK: TIM16
         COM: TIM16
@@ -1280,14 +1296,14 @@ cores:
       clock: APB2
       dma_channels:
         CH1:
-        - *id044
-        UP:
         - *id045
+        UP:
+        - *id046
     TIM17:
       address: 0x40014800
       kind: TIM1_8WL5:gptimer2_v3_x
       block: timer_v1/TIM_GP16
-      pins: *id046
+      pins: *id047
       interrupts:
         BRK: TIM17
         COM: TIM17
@@ -1296,14 +1312,14 @@ cores:
       clock: APB2
       dma_channels:
         CH1:
-        - *id047
-        UP:
         - *id048
+        UP:
+        - *id049
     TIM2:
       address: 0x40000000
       kind: TIM1_8WL5:gptimer2_v3_x
       block: timer_v1/TIM_GP16
-      pins: *id049
+      pins: *id050
       interrupts:
         BRK: TIM2
         COM: TIM2
@@ -1311,40 +1327,40 @@ cores:
         UP: TIM2
       dma_channels:
         CH1:
-        - *id050
-        CH2:
         - *id051
-        CH3:
+        CH2:
         - *id052
-        CH4:
+        CH3:
         - *id053
-        UP:
+        CH4:
         - *id054
+        UP:
+        - *id055
     USART1:
       address: 0x40013800
       kind: USART:sci3_v2_1
       clock: APB2
       block: usart_v2/USART
-      pins: *id055
+      pins: *id056
       interrupts:
         GLOBAL: USART1
       dma_channels:
         RX:
-        - *id056
-        TX:
         - *id057
+        TX:
+        - *id058
     USART2:
       address: 0x40004400
       kind: USART:sci3_v2_1
       block: usart_v2/USART
-      pins: *id058
+      pins: *id059
       interrupts:
         GLOBAL: USART2
       dma_channels:
         RX:
-        - *id059
-        TX:
         - *id060
+        TX:
+        - *id061
     VREFBUF:
       address: 0x40010030
       kind: VREFBUF:STM32WL_vrefbuf_v1_0

--- a/data/chips/STM32WL55JC.yaml
+++ b/data/chips/STM32WL55JC.yaml
@@ -495,6 +495,7 @@ cores:
     PWR:
       address: 0x58000400
       kind: PWR:STM32WL_pwr_v1_0
+      block: pwr_wl5/PWR
       pins: &id024
       - pin: PB3
         signal: WKUP3
@@ -669,14 +670,27 @@ cores:
       address: 0x58010000
       kind: SUBGHZ:STM32WLxx_v1_0
       block: spi_v2/SPI
+      pins: &id033
+      - pin: PA6
+        signal: MISO
+        af: 13
+      - pin: PA7
+        signal: MOSI
+        af: 13
+      - pin: PA4
+        signal: NSS
+        af: 13
+      - pin: PA5
+        signal: SCK
+        af: 13
       clock: APB3
       dma_channels:
         RX:
-        - &id033
+        - &id034
           dmamux: DMAMUX1
           request: 41
         TX:
-        - &id034
+        - &id035
           dmamux: DMAMUX1
           request: 42
     SYSCFG:
@@ -688,7 +702,7 @@ cores:
       address: 0x40012c00
       kind: TIM1_8WL5:gptimer2_v3_x
       block: timer_v1/TIM_GP16
-      pins: &id035
+      pins: &id036
       - pin: PA12
         signal: ETR
         af: 1
@@ -742,38 +756,38 @@ cores:
       clock: APB2
       dma_channels:
         CH1:
-        - &id036
+        - &id037
           dmamux: DMAMUX1
           request: 23
         CH2:
-        - &id037
+        - &id038
           dmamux: DMAMUX1
           request: 24
         CH3:
-        - &id038
+        - &id039
           dmamux: DMAMUX1
           request: 25
         CH4:
-        - &id039
+        - &id040
           dmamux: DMAMUX1
           request: 26
         COM:
-        - &id040
+        - &id041
           dmamux: DMAMUX1
           request: 29
         TRIG:
-        - &id041
+        - &id042
           dmamux: DMAMUX1
           request: 28
         UP:
-        - &id042
+        - &id043
           dmamux: DMAMUX1
           request: 27
     TIM16:
       address: 0x40014400
       kind: TIM1_8WL5:gptimer2_v3_x
       block: timer_v1/TIM_GP16
-      pins: &id043
+      pins: &id044
       - pin: PB5
         signal: BKIN
         af: 14
@@ -794,18 +808,18 @@ cores:
       clock: APB2
       dma_channels:
         CH1:
-        - &id044
+        - &id045
           dmamux: DMAMUX1
           request: 35
         UP:
-        - &id045
+        - &id046
           dmamux: DMAMUX1
           request: 36
     TIM17:
       address: 0x40014800
       kind: TIM1_8WL5:gptimer2_v3_x
       block: timer_v1/TIM_GP16
-      pins: &id046
+      pins: &id047
       - pin: PB4
         signal: BKIN
         af: 14
@@ -829,18 +843,18 @@ cores:
       clock: APB2
       dma_channels:
         CH1:
-        - &id047
+        - &id048
           dmamux: DMAMUX1
           request: 37
         UP:
-        - &id048
+        - &id049
           dmamux: DMAMUX1
           request: 38
     TIM2:
       address: 0x40000000
       kind: TIM1_8WL5:gptimer2_v3_x
       block: timer_v1/TIM_GP16
-      pins: &id049
+      pins: &id050
       - pin: PA15
         signal: CH1
         af: 1
@@ -884,23 +898,23 @@ cores:
         UP: TIM2
       dma_channels:
         CH1:
-        - &id050
+        - &id051
           dmamux: DMAMUX1
           request: 30
         CH2:
-        - &id051
+        - &id052
           dmamux: DMAMUX1
           request: 31
         CH3:
-        - &id052
+        - &id053
           dmamux: DMAMUX1
           request: 32
         CH4:
-        - &id053
+        - &id054
           dmamux: DMAMUX1
           request: 33
         UP:
-        - &id054
+        - &id055
           dmamux: DMAMUX1
           request: 34
     USART1:
@@ -908,7 +922,7 @@ cores:
       kind: USART:sci3_v2_1
       clock: APB2
       block: usart_v2/USART
-      pins: &id055
+      pins: &id056
       - pin: PA12
         signal: DE
         af: 7
@@ -955,18 +969,18 @@ cores:
         GLOBAL: USART1
       dma_channels:
         RX:
-        - &id056
+        - &id057
           dmamux: DMAMUX1
           request: 17
         TX:
-        - &id057
+        - &id058
           dmamux: DMAMUX1
           request: 18
     USART2:
       address: 0x40004400
       kind: USART:sci3_v2_1
       block: usart_v2/USART
-      pins: &id058
+      pins: &id059
       - pin: PA0
         signal: CTS
         af: 7
@@ -992,17 +1006,17 @@ cores:
         GLOBAL: USART2
       dma_channels:
         RX:
-        - &id059
+        - &id060
           dmamux: DMAMUX1
           request: 19
         TX:
-        - &id060
+        - &id061
           dmamux: DMAMUX1
           request: 20
     VREFBUF:
       address: 0x40010030
       kind: VREFBUF:STM32WL_vrefbuf_v1_0
-      pins: &id061
+      pins: &id062
       - pin: VREF+
         signal: OUT
     WWDG:
@@ -1313,6 +1327,7 @@ cores:
     PWR:
       address: 0x58000400
       kind: PWR:STM32WL_pwr_v1_0
+      block: pwr_wl5/PWR
       pins: *id024
     RCC:
       address: 0x58000000
@@ -1362,12 +1377,13 @@ cores:
       address: 0x58010000
       kind: SUBGHZ:STM32WLxx_v1_0
       block: spi_v2/SPI
+      pins: *id033
       clock: APB3
       dma_channels:
         RX:
-        - *id033
-        TX:
         - *id034
+        TX:
+        - *id035
     SYSCFG:
       address: 0x40010000
       kind: SYS:STM32WL5xx_sys_v1_0
@@ -1377,29 +1393,29 @@ cores:
       address: 0x40012c00
       kind: TIM1_8WL5:gptimer2_v3_x
       block: timer_v1/TIM_GP16
-      pins: *id035
+      pins: *id036
       interrupts: {}
       clock: APB2
       dma_channels:
         CH1:
-        - *id036
-        CH2:
         - *id037
-        CH3:
+        CH2:
         - *id038
-        CH4:
+        CH3:
         - *id039
-        COM:
+        CH4:
         - *id040
-        TRIG:
+        COM:
         - *id041
-        UP:
+        TRIG:
         - *id042
+        UP:
+        - *id043
     TIM16:
       address: 0x40014400
       kind: TIM1_8WL5:gptimer2_v3_x
       block: timer_v1/TIM_GP16
-      pins: *id043
+      pins: *id044
       interrupts:
         BRK: TIM16
         COM: TIM16
@@ -1408,14 +1424,14 @@ cores:
       clock: APB2
       dma_channels:
         CH1:
-        - *id044
-        UP:
         - *id045
+        UP:
+        - *id046
     TIM17:
       address: 0x40014800
       kind: TIM1_8WL5:gptimer2_v3_x
       block: timer_v1/TIM_GP16
-      pins: *id046
+      pins: *id047
       interrupts:
         BRK: TIM17
         COM: TIM17
@@ -1424,14 +1440,14 @@ cores:
       clock: APB2
       dma_channels:
         CH1:
-        - *id047
-        UP:
         - *id048
+        UP:
+        - *id049
     TIM2:
       address: 0x40000000
       kind: TIM1_8WL5:gptimer2_v3_x
       block: timer_v1/TIM_GP16
-      pins: *id049
+      pins: *id050
       interrupts:
         BRK: TIM2
         COM: TIM2
@@ -1439,44 +1455,44 @@ cores:
         UP: TIM2
       dma_channels:
         CH1:
-        - *id050
-        CH2:
         - *id051
-        CH3:
+        CH2:
         - *id052
-        CH4:
+        CH3:
         - *id053
-        UP:
+        CH4:
         - *id054
+        UP:
+        - *id055
     USART1:
       address: 0x40013800
       kind: USART:sci3_v2_1
       clock: APB2
       block: usart_v2/USART
-      pins: *id055
+      pins: *id056
       interrupts:
         GLOBAL: USART1
       dma_channels:
         RX:
-        - *id056
-        TX:
         - *id057
+        TX:
+        - *id058
     USART2:
       address: 0x40004400
       kind: USART:sci3_v2_1
       block: usart_v2/USART
-      pins: *id058
+      pins: *id059
       interrupts:
         GLOBAL: USART2
       dma_channels:
         RX:
-        - *id059
-        TX:
         - *id060
+        TX:
+        - *id061
     VREFBUF:
       address: 0x40010030
       kind: VREFBUF:STM32WL_vrefbuf_v1_0
-      pins: *id061
+      pins: *id062
     WWDG:
       address: 0x40002c00
       kind: WWDG:wwdg1_v2_0

--- a/data/chips/STM32WL55UC.yaml
+++ b/data/chips/STM32WL55UC.yaml
@@ -365,6 +365,7 @@ cores:
     PWR:
       address: 0x58000400
       kind: PWR:STM32WL_pwr_v1_0
+      block: pwr_wl5/PWR
       pins: &id024
       - pin: PB3
         signal: WKUP3
@@ -496,14 +497,27 @@ cores:
       address: 0x58010000
       kind: SUBGHZ:STM32WLxx_v1_0
       block: spi_v2/SPI
+      pins: &id033
+      - pin: PA7
+        signal: MOSI
+        af: 13
+      - pin: PA6
+        signal: MISO
+        af: 13
+      - pin: PA5
+        signal: SCK
+        af: 13
+      - pin: PA4
+        signal: NSS
+        af: 13
       clock: APB3
       dma_channels:
         RX:
-        - &id033
+        - &id034
           dmamux: DMAMUX1
           request: 41
         TX:
-        - &id034
+        - &id035
           dmamux: DMAMUX1
           request: 42
     SYSCFG:
@@ -515,7 +529,7 @@ cores:
       address: 0x40012c00
       kind: TIM1_8WL5:gptimer2_v3_x
       block: timer_v1/TIM_GP16
-      pins: &id035
+      pins: &id036
       - pin: PA10
         signal: CH3
         af: 1
@@ -548,38 +562,38 @@ cores:
       clock: APB2
       dma_channels:
         CH1:
-        - &id036
+        - &id037
           dmamux: DMAMUX1
           request: 23
         CH2:
-        - &id037
+        - &id038
           dmamux: DMAMUX1
           request: 24
         CH3:
-        - &id038
+        - &id039
           dmamux: DMAMUX1
           request: 25
         CH4:
-        - &id039
+        - &id040
           dmamux: DMAMUX1
           request: 26
         COM:
-        - &id040
+        - &id041
           dmamux: DMAMUX1
           request: 29
         TRIG:
-        - &id041
+        - &id042
           dmamux: DMAMUX1
           request: 28
         UP:
-        - &id042
+        - &id043
           dmamux: DMAMUX1
           request: 27
     TIM16:
       address: 0x40014400
       kind: TIM1_8WL5:gptimer2_v3_x
       block: timer_v1/TIM_GP16
-      pins: &id043
+      pins: &id044
       - pin: PA6
         signal: CH1
         af: 14
@@ -591,18 +605,18 @@ cores:
       clock: APB2
       dma_channels:
         CH1:
-        - &id044
+        - &id045
           dmamux: DMAMUX1
           request: 35
         UP:
-        - &id045
+        - &id046
           dmamux: DMAMUX1
           request: 36
     TIM17:
       address: 0x40014800
       kind: TIM1_8WL5:gptimer2_v3_x
       block: timer_v1/TIM_GP16
-      pins: &id046
+      pins: &id047
       - pin: PA10
         signal: BKIN
         af: 14
@@ -620,18 +634,18 @@ cores:
       clock: APB2
       dma_channels:
         CH1:
-        - &id047
+        - &id048
           dmamux: DMAMUX1
           request: 37
         UP:
-        - &id048
+        - &id049
           dmamux: DMAMUX1
           request: 38
     TIM2:
       address: 0x40000000
       kind: TIM1_8WL5:gptimer2_v3_x
       block: timer_v1/TIM_GP16
-      pins: &id049
+      pins: &id050
       - pin: PA15
         signal: CH1
         af: 1
@@ -669,23 +683,23 @@ cores:
         UP: TIM2
       dma_channels:
         CH1:
-        - &id050
+        - &id051
           dmamux: DMAMUX1
           request: 30
         CH2:
-        - &id051
+        - &id052
           dmamux: DMAMUX1
           request: 31
         CH3:
-        - &id052
+        - &id053
           dmamux: DMAMUX1
           request: 32
         CH4:
-        - &id053
+        - &id054
           dmamux: DMAMUX1
           request: 33
         UP:
-        - &id054
+        - &id055
           dmamux: DMAMUX1
           request: 34
     USART1:
@@ -693,7 +707,7 @@ cores:
       kind: USART:sci3_v2_1
       clock: APB2
       block: usart_v2/USART
-      pins: &id055
+      pins: &id056
       - pin: PA10
         signal: RX
         af: 7
@@ -731,18 +745,18 @@ cores:
         GLOBAL: USART1
       dma_channels:
         RX:
-        - &id056
+        - &id057
           dmamux: DMAMUX1
           request: 17
         TX:
-        - &id057
+        - &id058
           dmamux: DMAMUX1
           request: 18
     USART2:
       address: 0x40004400
       kind: USART:sci3_v2_1
       block: usart_v2/USART
-      pins: &id058
+      pins: &id059
       - pin: PA3
         signal: RX
         af: 7
@@ -768,11 +782,11 @@ cores:
         GLOBAL: USART2
       dma_channels:
         RX:
-        - &id059
+        - &id060
           dmamux: DMAMUX1
           request: 19
         TX:
-        - &id060
+        - &id061
           dmamux: DMAMUX1
           request: 20
     VREFBUF:
@@ -1086,6 +1100,7 @@ cores:
     PWR:
       address: 0x58000400
       kind: PWR:STM32WL_pwr_v1_0
+      block: pwr_wl5/PWR
       pins: *id024
     RCC:
       address: 0x58000000
@@ -1135,12 +1150,13 @@ cores:
       address: 0x58010000
       kind: SUBGHZ:STM32WLxx_v1_0
       block: spi_v2/SPI
+      pins: *id033
       clock: APB3
       dma_channels:
         RX:
-        - *id033
-        TX:
         - *id034
+        TX:
+        - *id035
     SYSCFG:
       address: 0x40010000
       kind: SYS:STM32WL5xx_sys_v1_0
@@ -1150,29 +1166,29 @@ cores:
       address: 0x40012c00
       kind: TIM1_8WL5:gptimer2_v3_x
       block: timer_v1/TIM_GP16
-      pins: *id035
+      pins: *id036
       interrupts: {}
       clock: APB2
       dma_channels:
         CH1:
-        - *id036
-        CH2:
         - *id037
-        CH3:
+        CH2:
         - *id038
-        CH4:
+        CH3:
         - *id039
-        COM:
+        CH4:
         - *id040
-        TRIG:
+        COM:
         - *id041
-        UP:
+        TRIG:
         - *id042
+        UP:
+        - *id043
     TIM16:
       address: 0x40014400
       kind: TIM1_8WL5:gptimer2_v3_x
       block: timer_v1/TIM_GP16
-      pins: *id043
+      pins: *id044
       interrupts:
         BRK: TIM16
         COM: TIM16
@@ -1181,14 +1197,14 @@ cores:
       clock: APB2
       dma_channels:
         CH1:
-        - *id044
-        UP:
         - *id045
+        UP:
+        - *id046
     TIM17:
       address: 0x40014800
       kind: TIM1_8WL5:gptimer2_v3_x
       block: timer_v1/TIM_GP16
-      pins: *id046
+      pins: *id047
       interrupts:
         BRK: TIM17
         COM: TIM17
@@ -1197,14 +1213,14 @@ cores:
       clock: APB2
       dma_channels:
         CH1:
-        - *id047
-        UP:
         - *id048
+        UP:
+        - *id049
     TIM2:
       address: 0x40000000
       kind: TIM1_8WL5:gptimer2_v3_x
       block: timer_v1/TIM_GP16
-      pins: *id049
+      pins: *id050
       interrupts:
         BRK: TIM2
         COM: TIM2
@@ -1212,40 +1228,40 @@ cores:
         UP: TIM2
       dma_channels:
         CH1:
-        - *id050
-        CH2:
         - *id051
-        CH3:
+        CH2:
         - *id052
-        CH4:
+        CH3:
         - *id053
-        UP:
+        CH4:
         - *id054
+        UP:
+        - *id055
     USART1:
       address: 0x40013800
       kind: USART:sci3_v2_1
       clock: APB2
       block: usart_v2/USART
-      pins: *id055
+      pins: *id056
       interrupts:
         GLOBAL: USART1
       dma_channels:
         RX:
-        - *id056
-        TX:
         - *id057
+        TX:
+        - *id058
     USART2:
       address: 0x40004400
       kind: USART:sci3_v2_1
       block: usart_v2/USART
-      pins: *id058
+      pins: *id059
       interrupts:
         GLOBAL: USART2
       dma_channels:
         RX:
-        - *id059
-        TX:
         - *id060
+        TX:
+        - *id061
     VREFBUF:
       address: 0x40010030
       kind: VREFBUF:STM32WL_vrefbuf_v1_0

--- a/data/chips/STM32WLE4C8.yaml
+++ b/data/chips/STM32WLE4C8.yaml
@@ -389,6 +389,7 @@ cores:
     PWR:
       address: 0x58000400
       kind: PWR:STM32WL_pwr_v1_0
+      block: pwr_wl5/PWR
       pins:
       - pin: PB3
         signal: WKUP3
@@ -535,6 +536,19 @@ cores:
       address: 0x58010000
       kind: SUBGHZ:STM32WLxx_v1_0
       block: spi_v2/SPI
+      pins:
+      - pin: PA4
+        signal: NSS
+        af: 13
+      - pin: PA5
+        signal: SCK
+        af: 13
+      - pin: PA6
+        signal: MISO
+        af: 13
+      - pin: PA7
+        signal: MOSI
+        af: 13
       clock: APB3
       dma_channels:
         RX:

--- a/data/chips/STM32WLE4CB.yaml
+++ b/data/chips/STM32WLE4CB.yaml
@@ -389,6 +389,7 @@ cores:
     PWR:
       address: 0x58000400
       kind: PWR:STM32WL_pwr_v1_0
+      block: pwr_wl5/PWR
       pins:
       - pin: PB3
         signal: WKUP3
@@ -535,6 +536,19 @@ cores:
       address: 0x58010000
       kind: SUBGHZ:STM32WLxx_v1_0
       block: spi_v2/SPI
+      pins:
+      - pin: PA4
+        signal: NSS
+        af: 13
+      - pin: PA5
+        signal: SCK
+        af: 13
+      - pin: PA6
+        signal: MISO
+        af: 13
+      - pin: PA7
+        signal: MOSI
+        af: 13
       clock: APB3
       dma_channels:
         RX:

--- a/data/chips/STM32WLE4CC.yaml
+++ b/data/chips/STM32WLE4CC.yaml
@@ -397,6 +397,7 @@ cores:
     PWR:
       address: 0x58000400
       kind: PWR:STM32WL_pwr_v1_0
+      block: pwr_wl5/PWR
       pins:
       - pin: PB3
         signal: WKUP3
@@ -543,6 +544,19 @@ cores:
       address: 0x58010000
       kind: SUBGHZ:STM32WLxx_v1_0
       block: spi_v2/SPI
+      pins:
+      - pin: PA4
+        signal: NSS
+        af: 13
+      - pin: PA5
+        signal: SCK
+        af: 13
+      - pin: PA6
+        signal: MISO
+        af: 13
+      - pin: PA7
+        signal: MOSI
+        af: 13
       clock: APB3
       dma_channels:
         RX:

--- a/data/chips/STM32WLE4J8.yaml
+++ b/data/chips/STM32WLE4J8.yaml
@@ -469,6 +469,7 @@ cores:
     PWR:
       address: 0x58000400
       kind: PWR:STM32WL_pwr_v1_0
+      block: pwr_wl5/PWR
       pins:
       - pin: PB3
         signal: WKUP3
@@ -639,6 +640,19 @@ cores:
       address: 0x58010000
       kind: SUBGHZ:STM32WLxx_v1_0
       block: spi_v2/SPI
+      pins:
+      - pin: PA6
+        signal: MISO
+        af: 13
+      - pin: PA7
+        signal: MOSI
+        af: 13
+      - pin: PA4
+        signal: NSS
+        af: 13
+      - pin: PA5
+        signal: SCK
+        af: 13
       clock: APB3
       dma_channels:
         RX:

--- a/data/chips/STM32WLE4JB.yaml
+++ b/data/chips/STM32WLE4JB.yaml
@@ -469,6 +469,7 @@ cores:
     PWR:
       address: 0x58000400
       kind: PWR:STM32WL_pwr_v1_0
+      block: pwr_wl5/PWR
       pins:
       - pin: PB3
         signal: WKUP3
@@ -639,6 +640,19 @@ cores:
       address: 0x58010000
       kind: SUBGHZ:STM32WLxx_v1_0
       block: spi_v2/SPI
+      pins:
+      - pin: PA6
+        signal: MISO
+        af: 13
+      - pin: PA7
+        signal: MOSI
+        af: 13
+      - pin: PA4
+        signal: NSS
+        af: 13
+      - pin: PA5
+        signal: SCK
+        af: 13
       clock: APB3
       dma_channels:
         RX:

--- a/data/chips/STM32WLE4JC.yaml
+++ b/data/chips/STM32WLE4JC.yaml
@@ -477,6 +477,7 @@ cores:
     PWR:
       address: 0x58000400
       kind: PWR:STM32WL_pwr_v1_0
+      block: pwr_wl5/PWR
       pins:
       - pin: PB3
         signal: WKUP3
@@ -647,6 +648,19 @@ cores:
       address: 0x58010000
       kind: SUBGHZ:STM32WLxx_v1_0
       block: spi_v2/SPI
+      pins:
+      - pin: PA6
+        signal: MISO
+        af: 13
+      - pin: PA7
+        signal: MOSI
+        af: 13
+      - pin: PA4
+        signal: NSS
+        af: 13
+      - pin: PA5
+        signal: SCK
+        af: 13
       clock: APB3
       dma_channels:
         RX:

--- a/data/chips/STM32WLE5C8.yaml
+++ b/data/chips/STM32WLE5C8.yaml
@@ -397,6 +397,7 @@ cores:
     PWR:
       address: 0x58000400
       kind: PWR:STM32WL_pwr_v1_0
+      block: pwr_wl5/PWR
       pins:
       - pin: PB3
         signal: WKUP3
@@ -543,6 +544,19 @@ cores:
       address: 0x58010000
       kind: SUBGHZ:STM32WLxx_v1_0
       block: spi_v2/SPI
+      pins:
+      - pin: PA4
+        signal: NSS
+        af: 13
+      - pin: PA5
+        signal: SCK
+        af: 13
+      - pin: PA6
+        signal: MISO
+        af: 13
+      - pin: PA7
+        signal: MOSI
+        af: 13
       clock: APB3
       dma_channels:
         RX:

--- a/data/chips/STM32WLE5CB.yaml
+++ b/data/chips/STM32WLE5CB.yaml
@@ -397,6 +397,7 @@ cores:
     PWR:
       address: 0x58000400
       kind: PWR:STM32WL_pwr_v1_0
+      block: pwr_wl5/PWR
       pins:
       - pin: PB3
         signal: WKUP3
@@ -543,6 +544,19 @@ cores:
       address: 0x58010000
       kind: SUBGHZ:STM32WLxx_v1_0
       block: spi_v2/SPI
+      pins:
+      - pin: PA4
+        signal: NSS
+        af: 13
+      - pin: PA5
+        signal: SCK
+        af: 13
+      - pin: PA6
+        signal: MISO
+        af: 13
+      - pin: PA7
+        signal: MOSI
+        af: 13
       clock: APB3
       dma_channels:
         RX:

--- a/data/chips/STM32WLE5CC.yaml
+++ b/data/chips/STM32WLE5CC.yaml
@@ -397,6 +397,7 @@ cores:
     PWR:
       address: 0x58000400
       kind: PWR:STM32WL_pwr_v1_0
+      block: pwr_wl5/PWR
       pins:
       - pin: PB3
         signal: WKUP3
@@ -543,6 +544,19 @@ cores:
       address: 0x58010000
       kind: SUBGHZ:STM32WLxx_v1_0
       block: spi_v2/SPI
+      pins:
+      - pin: PA4
+        signal: NSS
+        af: 13
+      - pin: PA5
+        signal: SCK
+        af: 13
+      - pin: PA6
+        signal: MISO
+        af: 13
+      - pin: PA7
+        signal: MOSI
+        af: 13
       clock: APB3
       dma_channels:
         RX:

--- a/data/chips/STM32WLE5J8.yaml
+++ b/data/chips/STM32WLE5J8.yaml
@@ -477,6 +477,7 @@ cores:
     PWR:
       address: 0x58000400
       kind: PWR:STM32WL_pwr_v1_0
+      block: pwr_wl5/PWR
       pins:
       - pin: PB3
         signal: WKUP3
@@ -647,6 +648,19 @@ cores:
       address: 0x58010000
       kind: SUBGHZ:STM32WLxx_v1_0
       block: spi_v2/SPI
+      pins:
+      - pin: PA6
+        signal: MISO
+        af: 13
+      - pin: PA7
+        signal: MOSI
+        af: 13
+      - pin: PA4
+        signal: NSS
+        af: 13
+      - pin: PA5
+        signal: SCK
+        af: 13
       clock: APB3
       dma_channels:
         RX:

--- a/data/chips/STM32WLE5JB.yaml
+++ b/data/chips/STM32WLE5JB.yaml
@@ -477,6 +477,7 @@ cores:
     PWR:
       address: 0x58000400
       kind: PWR:STM32WL_pwr_v1_0
+      block: pwr_wl5/PWR
       pins:
       - pin: PB3
         signal: WKUP3
@@ -647,6 +648,19 @@ cores:
       address: 0x58010000
       kind: SUBGHZ:STM32WLxx_v1_0
       block: spi_v2/SPI
+      pins:
+      - pin: PA6
+        signal: MISO
+        af: 13
+      - pin: PA7
+        signal: MOSI
+        af: 13
+      - pin: PA4
+        signal: NSS
+        af: 13
+      - pin: PA5
+        signal: SCK
+        af: 13
       clock: APB3
       dma_channels:
         RX:

--- a/data/chips/STM32WLE5JC.yaml
+++ b/data/chips/STM32WLE5JC.yaml
@@ -477,6 +477,7 @@ cores:
     PWR:
       address: 0x58000400
       kind: PWR:STM32WL_pwr_v1_0
+      block: pwr_wl5/PWR
       pins:
       - pin: PB3
         signal: WKUP3
@@ -647,6 +648,19 @@ cores:
       address: 0x58010000
       kind: SUBGHZ:STM32WLxx_v1_0
       block: spi_v2/SPI
+      pins:
+      - pin: PA6
+        signal: MISO
+        af: 13
+      - pin: PA7
+        signal: MOSI
+        af: 13
+      - pin: PA4
+        signal: NSS
+        af: 13
+      - pin: PA5
+        signal: SCK
+        af: 13
       clock: APB3
       dma_channels:
         RX:

--- a/data/chips/STM32WLE5U8.yaml
+++ b/data/chips/STM32WLE5U8.yaml
@@ -347,6 +347,7 @@ cores:
     PWR:
       address: 0x58000400
       kind: PWR:STM32WL_pwr_v1_0
+      block: pwr_wl5/PWR
       pins:
       - pin: PB3
         signal: WKUP3
@@ -474,6 +475,19 @@ cores:
       address: 0x58010000
       kind: SUBGHZ:STM32WLxx_v1_0
       block: spi_v2/SPI
+      pins:
+      - pin: PA7
+        signal: MOSI
+        af: 13
+      - pin: PA6
+        signal: MISO
+        af: 13
+      - pin: PA5
+        signal: SCK
+        af: 13
+      - pin: PA4
+        signal: NSS
+        af: 13
       clock: APB3
       dma_channels:
         RX:

--- a/data/chips/STM32WLE5UB.yaml
+++ b/data/chips/STM32WLE5UB.yaml
@@ -347,6 +347,7 @@ cores:
     PWR:
       address: 0x58000400
       kind: PWR:STM32WL_pwr_v1_0
+      block: pwr_wl5/PWR
       pins:
       - pin: PB3
         signal: WKUP3
@@ -474,6 +475,19 @@ cores:
       address: 0x58010000
       kind: SUBGHZ:STM32WLxx_v1_0
       block: spi_v2/SPI
+      pins:
+      - pin: PA7
+        signal: MOSI
+        af: 13
+      - pin: PA6
+        signal: MISO
+        af: 13
+      - pin: PA5
+        signal: SCK
+        af: 13
+      - pin: PA4
+        signal: NSS
+        af: 13
       clock: APB3
       dma_channels:
         RX:

--- a/data/registers/pwr_wl5.yaml
+++ b/data/registers/pwr_wl5.yaml
@@ -1,0 +1,1112 @@
+---
+block/PWR:
+  description: Power control
+  items:
+    - name: CR1
+      description: Power control register 1
+      byte_offset: 0
+      fieldset: CR1
+    - name: CR2
+      description: Power control register 2
+      byte_offset: 4
+      fieldset: CR2
+    - name: CR3
+      description: Power control register 3
+      byte_offset: 8
+      fieldset: CR3
+    - name: CR4
+      description: Power control register 4
+      byte_offset: 12
+      fieldset: CR4
+    - name: SR1
+      description: Power status register 1
+      byte_offset: 16
+      access: Read
+      fieldset: SR1
+    - name: SR2
+      description: Power status register 2
+      byte_offset: 20
+      access: Read
+      fieldset: SR2
+    - name: SCR
+      description: Power status clear register
+      byte_offset: 24
+      access: Write
+      fieldset: SCR
+    - name: CR5
+      description: Power control register 5
+      byte_offset: 28
+      fieldset: CR5
+    - name: PUCRA
+      description: Power Port A pull-up control register
+      byte_offset: 32
+      fieldset: PUCRA
+    - name: PDCRA
+      description: Power Port A pull-down control register
+      byte_offset: 36
+      fieldset: PDCRA
+    - name: PUCRB
+      description: Power Port B pull-up control register
+      byte_offset: 40
+      fieldset: PUCRB
+    - name: PDCRB
+      description: Power Port B pull-down control register
+      byte_offset: 44
+      fieldset: PDCRB
+    - name: PUCRC
+      description: Power Port C pull-up control register
+      byte_offset: 48
+      fieldset: PUCRC
+    - name: PDCRC
+      description: Power Port C pull-down control register
+      byte_offset: 52
+      fieldset: PDCRC
+    - name: PUCRH
+      description: Power Port H pull-up control register
+      byte_offset: 88
+      fieldset: PUCRH
+    - name: PDCRH
+      description: Power Port H pull-down control register
+      byte_offset: 92
+      fieldset: PDCRH
+    - name: C2CR1
+      description: "Power CPU2 control register 1 [dual core device only]"
+      byte_offset: 128
+      fieldset: C2CR1
+    - name: C2CR3
+      description: "Power CPU2 control register 3 [dual core device only]"
+      byte_offset: 132
+      fieldset: C2CR3
+    - name: EXTSCR
+      description: Power extended status and status clear register
+      byte_offset: 136
+      fieldset: EXTSCR
+    - name: SECCFGR
+      description: "Power security configuration register [dual core device only]"
+      byte_offset: 140
+      fieldset: SECCFGR
+    - name: SUBGHZSPICR
+      description: Power SPI3 control register
+      byte_offset: 144
+      fieldset: SUBGHZSPICR
+    - name: RSSCMDR
+      description: "RSS Command register [dual core device only]"
+      byte_offset: 152
+      fieldset: RSSCMDR
+fieldset/C2CR1:
+  description: "Power CPU2 control register 1 [dual core device only]"
+  fields:
+    - name: LPMS
+      description: Low-power mode selection for CPU2
+      bit_offset: 0
+      bit_size: 3
+    - name: FPDR
+      description: Flash memory power down mode during LPRun for CPU2
+      bit_offset: 4
+      bit_size: 1
+    - name: FPDS
+      description: Flash memory power down mode during LPSleep for CPU2
+      bit_offset: 5
+      bit_size: 1
+fieldset/C2CR3:
+  description: "Power CPU2 control register 3 [dual core device only]"
+  fields:
+    - name: EWUP
+      description: Enable Wakeup pin WKUP1 for CPU2
+      bit_offset: 0
+      bit_size: 1
+      array:
+        len: 3
+        stride: 1
+    - name: EWPVD
+      description: Enable wakeup PVD for CPU2
+      bit_offset: 8
+      bit_size: 1
+    - name: APC
+      description: Apply pull-up and pull-down configuration for CPU2
+      bit_offset: 10
+      bit_size: 1
+    - name: EWRFBUSY
+      description: EWRFBUSY
+      bit_offset: 11
+      bit_size: 1
+    - name: EWRFIRQ
+      description: akeup for CPU2
+      bit_offset: 13
+      bit_size: 1
+    - name: EIWUL
+      description: Enable internal wakeup line for CPU2
+      bit_offset: 15
+      bit_size: 1
+fieldset/CR1:
+  description: Power control register 1
+  fields:
+    - name: LPMS
+      description: Low-power mode selection for CPU1
+      bit_offset: 0
+      bit_size: 3
+      enum: LPMS
+    - name: SUBGHZSPINSSSEL
+      description: sub-GHz SPI NSS source select
+      bit_offset: 3
+      bit_size: 1
+      enum: SUBGHZSPINSSSEL
+    - name: FPDR
+      description: Flash memory power down mode during LPRun for CPU1
+      bit_offset: 4
+      bit_size: 1
+      enum: FPDR
+    - name: FPDS
+      description: Flash memory power down mode during LPSleep for CPU1
+      bit_offset: 5
+      bit_size: 1
+      enum: FPDS
+    - name: DBP
+      description: Disable backup domain write protection
+      bit_offset: 8
+      bit_size: 1
+      enum: DBP
+    - name: VOS
+      description: Voltage scaling range selection
+      bit_offset: 9
+      bit_size: 2
+      enum: VOS
+    - name: LPR
+      description: Low-power run
+      bit_offset: 14
+      bit_size: 1
+      enum: LPR
+fieldset/CR2:
+  description: Power control register 2
+  fields:
+    - name: PVDE
+      description: Power voltage detector enable
+      bit_offset: 0
+      bit_size: 1
+      enum: PVDE
+    - name: PLS
+      description: Power voltage detector level selection.
+      bit_offset: 1
+      bit_size: 3
+      enum: PLS
+    - name: PVME
+      description: "Peripheral voltage monitoring 3 enable: VDDA vs. 1.62V"
+      bit_offset: 6
+      bit_size: 1
+      array:
+        len: 1
+        stride: 0
+      enum: PVME
+fieldset/CR3:
+  description: Power control register 3
+  fields:
+    - name: EWUP
+      description: Enable Wakeup pin WKUP1 for CPU1
+      bit_offset: 0
+      bit_size: 1
+      array:
+        len: 3
+        stride: 1
+      enum: EWUP
+    - name: EULPEN
+      description: Ultra-low-power enable
+      bit_offset: 7
+      bit_size: 1
+      enum: EULPEN
+    - name: EWPVD
+      description: Enable wakeup PVD for CPU1
+      bit_offset: 8
+      bit_size: 1
+      enum: EWPVD
+    - name: RRS
+      description: SRAM2 retention in Standby mode
+      bit_offset: 9
+      bit_size: 1
+      enum: RRS
+    - name: APC
+      description: Apply pull-up and pull-down configuration from CPU1
+      bit_offset: 10
+      bit_size: 1
+      enum: APC
+    - name: EWRFBUSY
+      description: Enable Radio BUSY Wakeup from Standby for CPU1
+      bit_offset: 11
+      bit_size: 1
+      enum: EWRFBUSY
+    - name: EWRFIRQ
+      description: akeup for CPU1
+      bit_offset: 13
+      bit_size: 1
+      enum: EWRFIRQ
+    - name: EC2H
+      description: nable CPU2 Hold interrupt for CPU1
+      bit_offset: 14
+      bit_size: 1
+    - name: EIWUL
+      description: Enable internal wakeup line for CPU1
+      bit_offset: 15
+      bit_size: 1
+      enum: EIWUL
+fieldset/CR4:
+  description: Power control register 4
+  fields:
+    - name: WP
+      description: Wakeup pin WKUP1 polarity
+      bit_offset: 0
+      bit_size: 1
+      array:
+        len: 3
+        stride: 1
+      enum: WP
+    - name: VBE
+      description: VBAT battery charging enable
+      bit_offset: 8
+      bit_size: 1
+      enum: VBE
+    - name: VBRS
+      description: VBAT battery charging resistor selection
+      bit_offset: 9
+      bit_size: 1
+      enum: VBRS
+    - name: WRFBUSYP
+      description: Wakeup Radio BUSY polarity
+      bit_offset: 11
+      bit_size: 1
+      enum: WRFBUSYP
+    - name: C2BOOT
+      description: oot CPU2 after reset or wakeup from Stop or Standby modes.
+      bit_offset: 15
+      bit_size: 1
+fieldset/CR5:
+  description: Power control register 5
+  fields:
+    - name: RFEOLEN
+      description: Enable Radio End Of Life detector enabled
+      bit_offset: 14
+      bit_size: 1
+      enum: RFEOLEN
+    - name: SMPSEN
+      description: Enable SMPS Step Down converter SMPS mode enabled.
+      bit_offset: 15
+      bit_size: 1
+      enum: SMPSEN
+fieldset/EXTSCR:
+  description: Power extended status and status clear register
+  fields:
+    - name: C1CSSF
+      description: Clear CPU1 Stop Standby flags
+      bit_offset: 0
+      bit_size: 1
+      enum_write: CCSSFW
+    - name: C2CSSF
+      description: lear CPU2 Stop Standby flags
+      bit_offset: 1
+      bit_size: 1
+    - name: C1SBF
+      description: System Standby flag for CPU1. (no core states retained)
+      bit_offset: 8
+      bit_size: 1
+      enum: CSBF
+    - name: C1STOP2F
+      description: System Stop2 flag for CPU1. (partial core states retained)
+      bit_offset: 9
+      bit_size: 1
+      enum: CSTOPF
+    - name: C1STOPF
+      description: "System Stop0, 1 flag for CPU1. (All core states retained)"
+      bit_offset: 10
+      bit_size: 1
+      enum: CSTOPF
+    - name: C2SBF
+      description: ystem Standby flag for CPU2. (no core states retained)
+      bit_offset: 11
+      bit_size: 1
+    - name: C2STOP2F
+      description: ystem Stop2 flag for CPU2. (partial core states retained)
+      bit_offset: 12
+      bit_size: 1
+    - name: C2STOPF
+      description: "ystem Stop0, 1 flag for CPU2. (All core states retained)"
+      bit_offset: 13
+      bit_size: 1
+    - name: C1DS
+      description: CPU1 deepsleep mode
+      bit_offset: 14
+      bit_size: 1
+      enum: CDS
+    - name: C2DS
+      description: PU2 deepsleep mode
+      bit_offset: 15
+      bit_size: 1
+fieldset/PDCRA:
+  description: Power Port A pull-down control register
+  fields:
+    - name: PD
+      description: PD0
+      bit_offset: 0
+      bit_size: 1
+      array:
+        len: 16
+        stride: 1
+      enum: PDCRA_PD
+fieldset/PDCRB:
+  description: Power Port B pull-down control register
+  fields:
+    - name: PD
+      description: PD0
+      bit_offset: 0
+      bit_size: 1
+      array:
+        len: 16
+        stride: 1
+      enum: PDCRB_PD
+fieldset/PDCRC:
+  description: Power Port C pull-down control register
+  fields:
+    - name: PD
+      description: PD0
+      bit_offset: 0
+      bit_size: 1
+      array:
+        offsets:
+          - 0
+          - 1
+          - 2
+          - 3
+          - 4
+          - 5
+          - 6
+          - 13
+          - 14
+          - 15
+      enum: PD
+fieldset/PDCRH:
+  description: Power Port H pull-down control register
+  fields:
+    - name: PD
+      description: pull-down
+      bit_offset: 3
+      bit_size: 1
+      array:
+        len: 1
+        stride: 0
+      enum: PD
+fieldset/PUCRA:
+  description: Power Port A pull-up control register
+  fields:
+    - name: PU
+      description: PU0
+      bit_offset: 0
+      bit_size: 1
+      array:
+        len: 16
+        stride: 1
+      enum: PUCRA_PU
+fieldset/PUCRB:
+  description: Power Port B pull-up control register
+  fields:
+    - name: PU
+      description: PU0
+      bit_offset: 0
+      bit_size: 1
+      array:
+        len: 16
+        stride: 1
+      enum: PUCRB_PU
+fieldset/PUCRC:
+  description: Power Port C pull-up control register
+  fields:
+    - name: PU
+      description: PU0
+      bit_offset: 0
+      bit_size: 1
+      array:
+        offsets:
+          - 0
+          - 1
+          - 2
+          - 3
+          - 4
+          - 5
+          - 6
+          - 13
+          - 14
+          - 15
+      enum: PU
+fieldset/PUCRH:
+  description: Power Port H pull-up control register
+  fields:
+    - name: PU
+      description: pull-up
+      bit_offset: 3
+      bit_size: 1
+      array:
+        len: 1
+        stride: 0
+      enum: PU
+fieldset/RSSCMDR:
+  description: "RSS Command register [dual core device only]"
+  fields:
+    - name: RSSCMD
+      description: RSS command
+      bit_offset: 0
+      bit_size: 8
+fieldset/SCR:
+  description: Power status clear register
+  fields:
+    - name: CWUF
+      description: Clear wakeup flag 1
+      bit_offset: 0
+      bit_size: 1
+      array:
+        len: 3
+        stride: 1
+      enum_write: CWUFW
+    - name: CWPVDF
+      description: Clear wakeup PVD interrupt flag
+      bit_offset: 8
+      bit_size: 1
+      enum_write: CWPVDFW
+    - name: CWRFBUSYF
+      description: Clear wakeup Radio BUSY flag
+      bit_offset: 11
+      bit_size: 1
+      enum_write: CWRFBUSYFW
+    - name: CC2HF
+      description: lear CPU2 Hold interrupt flag
+      bit_offset: 14
+      bit_size: 1
+fieldset/SECCFGR:
+  description: "Power security configuration register [dual core device only]"
+  fields:
+    - name: C2EWILA
+      description: wakeup on CPU2 illegal access interrupt enable
+      bit_offset: 15
+      bit_size: 1
+fieldset/SR1:
+  description: Power status register 1
+  fields:
+    - name: WUF
+      description: Wakeup flag 1
+      bit_offset: 0
+      bit_size: 1
+      array:
+        len: 3
+        stride: 1
+      enum: WUF
+    - name: WPVDF
+      description: Wakeup PVD flag
+      bit_offset: 8
+      bit_size: 1
+      enum: WPVDF
+    - name: WRFBUSYF
+      description: Radio BUSY wakeup flag
+      bit_offset: 11
+      bit_size: 1
+      enum: WRFBUSYF
+    - name: C2HF
+      description: PU2 Hold interrupt flag
+      bit_offset: 14
+      bit_size: 1
+    - name: WUFI
+      description: Internal wakeup interrupt flag
+      bit_offset: 15
+      bit_size: 1
+      enum: WUFI
+fieldset/SR2:
+  description: Power status register 2
+  fields:
+    - name: C2BOOTS
+      description: PU2 boot/wakeup request source information
+      bit_offset: 0
+      bit_size: 1
+    - name: RFBUSYS
+      description: Radio BUSY signal status
+      bit_offset: 1
+      bit_size: 1
+      enum: RFBUSYS
+    - name: RFBUSYMS
+      description: Radio BUSY masked signal status
+      bit_offset: 2
+      bit_size: 1
+      enum: RFBUSYMS
+    - name: SMPSRDY
+      description: SMPS ready flag
+      bit_offset: 3
+      bit_size: 1
+      enum: SMPSRDY
+    - name: LDORDY
+      description: LDO ready flag
+      bit_offset: 4
+      bit_size: 1
+      enum: LDORDY
+    - name: RFEOLF
+      description: Radio end of life flag
+      bit_offset: 5
+      bit_size: 1
+      enum: RFEOLF
+    - name: REGMRS
+      description: regulator2 low power flag
+      bit_offset: 6
+      bit_size: 1
+      enum: REGMRS
+    - name: FLASHRDY
+      description: Flash ready
+      bit_offset: 7
+      bit_size: 1
+      enum: FLASHRDY
+    - name: REGLPS
+      description: regulator1 started
+      bit_offset: 8
+      bit_size: 1
+      enum: REGLPS
+    - name: REGLPF
+      description: regulator1 low power flag
+      bit_offset: 9
+      bit_size: 1
+      enum: REGLPF
+    - name: VOSF
+      description: Voltage scaling flag
+      bit_offset: 10
+      bit_size: 1
+      enum: VOSF
+    - name: PVDO
+      description: Power voltage detector output
+      bit_offset: 11
+      bit_size: 1
+      enum: PVDO
+    - name: PVMO
+      description: "Peripheral voltage monitoring output: VDDA vs. 1.62 V"
+      bit_offset: 14
+      bit_size: 1
+      array:
+        len: 1
+        stride: 0
+      enum: PVMO
+fieldset/SUBGHZSPICR:
+  description: Power SPI3 control register
+  fields:
+    - name: NSS
+      description: sub-GHz SPI NSS control
+      bit_offset: 15
+      bit_size: 1
+      enum: NSS
+enum/APC:
+  bit_size: 1
+  variants:
+    - name: Disabled
+      description: I/O pull-up and pull-down configurations defined in the PWR_PUCRx and PWR_PDCRx registers are applied
+      value: 0
+    - name: Enabled
+      description: PWR_PUCRx and PWR_PDCRx registers are NOT applied to the I/Os
+      value: 1
+enum/CCSSFW:
+  bit_size: 1
+  variants:
+    - name: Clear
+      description: Setting this bit clears the C1STOPF and C1SBF bits
+      value: 1
+enum/CDS:
+  bit_size: 1
+  variants:
+    - name: RunningOrSleep
+      description: CPU is running or in sleep
+      value: 0
+    - name: DeepSleep
+      description: CPU is in Deep-Sleep
+      value: 1
+enum/CSBF:
+  bit_size: 1
+  variants:
+    - name: NoStandby
+      description: System has not been in Standby mode
+      value: 0
+    - name: Standby
+      description: System has been in Standby mode
+      value: 1
+enum/CSTOPF:
+  bit_size: 1
+  variants:
+    - name: NoStop
+      description: System has not been in Stop 2 mode
+      value: 0
+    - name: Stop
+      description: System has been in Stop 2 mode
+      value: 1
+enum/CWPVDFW:
+  bit_size: 1
+  variants:
+    - name: Clear
+      description: Setting this bit clears the WPVDF flag in the PWR_SR1. This bit is always read as 0.
+      value: 1
+enum/CWRFBUSYFW:
+  bit_size: 1
+  variants:
+    - name: Clear
+      description: Setting this bit clears the WRFBUSYF flag in the PWR_SR1. This bit is always read 0.
+      value: 1
+enum/CWUFW:
+  bit_size: 1
+  variants:
+    - name: Clear
+      description: Setting this bit clears the WUF2 flag in the PWR_SR1 register. This bit is always read as 0.
+      value: 1
+enum/DBP:
+  bit_size: 1
+  variants:
+    - name: Disabled
+      description: Access to RTC and backup registers disabled
+      value: 0
+    - name: Enabled
+      description: Access to RTC and backup registers enabled
+      value: 1
+enum/EIWUL:
+  bit_size: 1
+  variants:
+    - name: Disabled
+      description: Internal wakeup line interrupt to CPU disabled
+      value: 0
+    - name: Enabled
+      description: Internal wakeup line interrupt to CPU enabled
+      value: 1
+enum/EULPEN:
+  bit_size: 1
+  variants:
+    - name: Disabled
+      description: Disable (the supply voltage is monitored continuously)
+      value: 0
+    - name: Enabled
+      description: "Enable, when set, the supply voltage is sampled for PDR/BOR reset condition only periodically"
+      value: 1
+enum/EWPVD:
+  bit_size: 1
+  variants:
+    - name: Disabled
+      description: PVD not enabled by the sub-GHz radio active state
+      value: 0
+    - name: Enabled
+      description: PVD enabled while the sub-GHz radio is active
+      value: 1
+enum/EWRFBUSY:
+  bit_size: 1
+  variants:
+    - name: Disabled
+      description: Radio Busy is disabled and does not trigger a wakeup from Standby event to CPUwhen a rising or a falling edge occurs
+      value: 0
+    - name: Enabled
+      description: Radio Busy is enabled and triggers a wakeup from Standby event to CPUwhen a rising or a falling edge occurs. The active edge is configured via the WRFBUSYP bit in PWR_CR4
+      value: 1
+enum/EWRFIRQ:
+  bit_size: 1
+  variants:
+    - name: Disabled
+      description: "Radio IRQ[2:0] is disabled and does not trigger a wakeup from Standby event to CPU."
+      value: 0
+    - name: Enabled
+      description: "Radio IRQ[2:0] is enabled and triggers a wakeup from Standby event to CPU."
+      value: 1
+enum/EWUP:
+  bit_size: 1
+  variants:
+    - name: Disabled
+      description: WKUP pin 3 is used for general purpose I/Os. An event on the WKUP pin 3 does not wakeup the device from Standby mode
+      value: 0
+    - name: Enabled
+      description: WKUP pin 3 is used for wakeup from Standby mode and forced in input pull down configuration (rising edge on WKUP pin 3wakes-up the system from Standby mode)
+      value: 1
+enum/FLASHRDY:
+  bit_size: 1
+  variants:
+    - name: NotReady
+      description: Flash memory not ready to be accessed
+      value: 0
+    - name: Ready
+      description: Flash memory ready to be accessed
+      value: 1
+enum/FPDR:
+  bit_size: 1
+  variants:
+    - name: Idle
+      description: Flash memory in Idle mode when system is in LPRun mode
+      value: 0
+    - name: PowerDown
+      description: Flash memory in Power-down mode when system is in LPRun mode
+      value: 1
+enum/FPDS:
+  bit_size: 1
+  variants:
+    - name: Idle
+      description: Flash memory in Idle mode when system is in LPSleep mode
+      value: 0
+    - name: PowerDown
+      description: Flash memory in Power-down mode when system is in LPSleep mode
+      value: 1
+enum/LDORDY:
+  bit_size: 1
+  variants:
+    - name: NotReady
+      description: LDO not ready or off
+      value: 0
+    - name: Ready
+      description: LDO ready
+      value: 1
+enum/LPMS:
+  bit_size: 3
+  variants:
+    - name: Stop0
+      description: Stop 0 mode
+      value: 0
+    - name: Stop1
+      description: Stop 1 mode
+      value: 1
+    - name: Stop2
+      description: Stop 2 mode
+      value: 2
+    - name: Standby
+      description: Standby mode
+      value: 3
+    - name: Shutdown
+      description: Shutdown mode
+      value: 4
+enum/LPR:
+  bit_size: 1
+  variants:
+    - name: MainMode
+      description: Voltage regulator in Main mode in Low-power run mode
+      value: 0
+    - name: LowPowerMode
+      description: Voltage regulator in low-power mode in Low-power run mode
+      value: 1
+enum/NSS:
+  bit_size: 1
+  variants:
+    - name: Low
+      description: Sub-GHz SPI NSS signal at level low
+      value: 0
+    - name: High
+      description: Sub-GHz SPI NSS signal is at level high
+      value: 1
+enum/PD:
+  bit_size: 1
+  variants:
+    - name: Disabled
+      description: "Disable the pull-down on PC[y] when both APC bits are set in PWR control register 3 (PWR_CR3)"
+      value: 0
+    - name: Enabled
+      description: "Enable the pull-down on PC[y] when both APC bits are set in PWR control register 3 (PWR_CR3)"
+      value: 1
+enum/PDCRA_PD:
+  bit_size: 1
+  variants:
+    - name: Disabled
+      description: "Disable the pull-down on PA[y] when both APC bits are set in PWR control register 3 (PWR_CR3)"
+      value: 0
+    - name: Enabled
+      description: "Enable the pull-down on PA[y] when both APC bits are set in PWR control register 3 (PWR_CR3)"
+      value: 1
+enum/PDCRB_PD:
+  bit_size: 1
+  variants:
+    - name: Disabled
+      description: "Disable the pull-down on PB[y] when both APC bits are set in PWR control register 3 (PWR_CR3)"
+      value: 0
+    - name: Enabled
+      description: "Enable the pull-down on PB[y] when both APC bits are set in PWR control register 3 (PWR_CR3)"
+      value: 1
+enum/PDCRC_PD:
+  bit_size: 1
+  variants:
+    - name: Disabled
+      description: "Disable the pull-down on PC[y] when both APC bits are set in PWR control register 3 (PWR_CR3)"
+      value: 0
+    - name: Enabled
+      description: "Enable the pull-down on PC[y] when both APC bits are set in PWR control register 3 (PWR_CR3)"
+      value: 1
+enum/PLS:
+  bit_size: 3
+  variants:
+    - name: V2_0
+      description: 2.0V
+      value: 0
+    - name: V2_2
+      description: 2.2V
+      value: 1
+    - name: V2_4
+      description: 2.4V
+      value: 2
+    - name: V2_5
+      description: 2.5V
+      value: 3
+    - name: V2_6
+      description: 2.6V
+      value: 4
+    - name: V2_8
+      description: 2.8V
+      value: 5
+    - name: V2_9
+      description: 2.9V
+      value: 6
+    - name: External
+      description: External input analog voltage PVD_IN (compared internally to VREFINT)
+      value: 7
+enum/PU:
+  bit_size: 1
+  variants:
+    - name: Disabled
+      description: "Disable pull-up on PC[y] when both APC bits are set in PWR control register 3 (PWR_CR3)"
+      value: 0
+    - name: Enabled
+      description: "Enable pull-up on PC[y] when both APC bits are set in PWR control register 3 (PWR_CR3). The pull-up is not activated if the corresponding PC[y] bit is also set"
+      value: 1
+enum/PUCRA_PU:
+  bit_size: 1
+  variants:
+    - name: Disabled
+      description: "Disable pull-up on PA[y] when both APC bits are set in PWR control register 3 (PWR_CR3)"
+      value: 0
+    - name: Enabled
+      description: "Enable pull-up on PA[y] when both APC bits are set in PWR control register 3 (PWR_CR3). The pull-up is not activated if the corresponding PA[y] bit is also set"
+      value: 1
+enum/PUCRB_PU:
+  bit_size: 1
+  variants:
+    - name: Disabled
+      description: "Disable pull-up on PB[y] when both APC bits are set in PWR control register 3 (PWR_CR3)"
+      value: 0
+    - name: Enabled
+      description: "Enable pull-up on PB[y] when both APC bits are set in PWR control register 3 (PWR_CR3). The pull-up is not activated if the corresponding PB[y] bit is also set"
+      value: 1
+enum/PUCRC_PU:
+  bit_size: 1
+  variants:
+    - name: Disabled
+      description: "Disable pull-up on PC[y] when both APC bits are set in PWR control register 3 (PWR_CR3)"
+      value: 0
+    - name: Enabled
+      description: "Enable pull-up on PC[y] when both APC bits are set in PWR control register 3 (PWR_CR3). The pull-up is not activated if the corresponding PC[y] bit is also set"
+      value: 1
+enum/PVDE:
+  bit_size: 1
+  variants:
+    - name: Disabled
+      description: PVD Disabled
+      value: 0
+    - name: Enabled
+      description: PVD Enabled
+      value: 1
+enum/PVDO:
+  bit_size: 1
+  variants:
+    - name: Above
+      description: VDD or voltage level on PVD_IN above the selected PVD threshold
+      value: 0
+    - name: Below
+      description: VDD or voltage level on PVD_IN below the selected PVD threshold
+      value: 1
+enum/PVME:
+  bit_size: 1
+  variants:
+    - name: Disabled
+      description: PVM3 (VDDA monitoring versus 1.62 V threshold) disable
+      value: 0
+    - name: Enabled
+      description: PVM3 (VDDA monitoring versus 1.62 V threshold) enable
+      value: 1
+enum/PVMO:
+  bit_size: 1
+  variants:
+    - name: Above
+      description: VDDA voltage above PVM3 threshold (around 1.62 V)
+      value: 0
+    - name: Below
+      description: VDDA voltage below PVM3 threshold (around 1.62 V)
+      value: 1
+enum/REGLPF:
+  bit_size: 1
+  variants:
+    - name: Main
+      description: Main regulator (MR) ready and used
+      value: 0
+    - name: LowPower
+      description: Low-power regulator (LPR) used
+      value: 1
+enum/REGLPS:
+  bit_size: 1
+  variants:
+    - name: NotReady
+      description: LPR not ready
+      value: 0
+    - name: Ready
+      description: LPR ready
+      value: 1
+enum/REGMRS:
+  bit_size: 1
+  variants:
+    - name: V_DD
+      description: Main regulator supplied directly from VDD
+      value: 0
+    - name: LDO_SMPS
+      description: Main regulator supplied through LDO or SMPS
+      value: 1
+enum/RFBUSYMS:
+  bit_size: 1
+  variants:
+    - name: NotBusy
+      description: radio busy masked signal low (not busy)
+      value: 0
+    - name: Busy
+      description: radio busy masked signal high (busy)
+      value: 1
+enum/RFBUSYS:
+  bit_size: 1
+  variants:
+    - name: NotBusy
+      description: radio busy signal low (not busy)
+      value: 0
+    - name: Busy
+      description: radio busy signal high (busy)
+      value: 1
+enum/RFEOLEN:
+  bit_size: 1
+  variants:
+    - name: Disabled
+      description: Radio end-of-life detector disabled
+      value: 0
+    - name: Enabled
+      description: Radio end-of-life detector enabled
+      value: 1
+enum/RFEOLF:
+  bit_size: 1
+  variants:
+    - name: Above
+      description: Supply voltage above radio end-of-life operating low level
+      value: 0
+    - name: Below
+      description: Supply voltage below radio end-of-life operating low level
+      value: 1
+enum/RRS:
+  bit_size: 1
+  variants:
+    - name: PowerOff
+      description: SRAM2 powered off in Standby mode (SRAM2 content lost)
+      value: 0
+    - name: OnLPR
+      description: SRAM2 powered by the low-power regulator in Standby mode (SRAM2 content kept)
+      value: 1
+enum/SMPSEN:
+  bit_size: 1
+  variants:
+    - name: Disabled
+      description: SMPS step-down converter SMPS mode disabled (LDO mode enabled)
+      value: 0
+    - name: Enabled
+      description: SMPS step-down converter SMPS mode enabled
+      value: 1
+enum/SMPSRDY:
+  bit_size: 1
+  variants:
+    - name: NotReady
+      description: SMPS step-down converter not ready or off
+      value: 0
+    - name: Ready
+      description: SMPS step-down converter ready
+      value: 1
+enum/SUBGHZSPINSSSEL:
+  bit_size: 1
+  variants:
+    - name: SUBGHZSPICR
+      description: sub-GHz SPI NSS signal driven from PWR_SUBGHZSPICR.NSS (RFBUSYMS functionality enabled)
+      value: 0
+    - name: LPTIM3
+      description: sub-GHz SPI NSS signal driven from LPTIM3_OUT (RFBUSYMS functionality disabled)
+      value: 1
+enum/VBE:
+  bit_size: 1
+  variants:
+    - name: Disabled
+      description: VBAT battery charging disabled
+      value: 0
+    - name: Enabled
+      description: VBAT battery charging enabled
+      value: 1
+enum/VBRS:
+  bit_size: 1
+  variants:
+    - name: R5k
+      description: VBAT charging through a 5 kΩ resistor
+      value: 0
+    - name: R1_5k
+      description: VBAT charging through a 1.5 kΩ resistor
+      value: 1
+enum/VOS:
+  bit_size: 2
+  variants:
+    - name: V1_2
+      description: 1.2 V (range 1)
+      value: 1
+    - name: V1_0
+      description: 1.0 V (range 2)
+      value: 2
+enum/VOSF:
+  bit_size: 1
+  variants:
+    - name: Ready
+      description: Regulator ready in the selected voltage range
+      value: 0
+    - name: Change
+      description: Regulator output voltage changed to the required voltage level
+      value: 1
+enum/WP:
+  bit_size: 1
+  variants:
+    - name: RisingEdge
+      description: Detection on high level (rising edge)
+      value: 0
+    - name: FallingEdge
+      description: Detection on low level (falling edge)
+      value: 1
+enum/WPVDF:
+  bit_size: 1
+  variants:
+    - name: Clear
+      description: No wakeup event detected on PVD
+      value: 0
+    - name: Wakeup
+      description: Wakeup event detected on PVD
+      value: 1
+enum/WRFBUSYF:
+  bit_size: 1
+  variants:
+    - name: Clear
+      description: No wakeup event detected on radio busy
+      value: 0
+    - name: Wakeup
+      description: Wakeup event detected on radio busy
+      value: 1
+enum/WRFBUSYP:
+  bit_size: 1
+  variants:
+    - name: RisingEdge
+      description: Detection on high level (rising edge)
+      value: 0
+    - name: FallingEdge
+      description: Detection on low level (falling edge)
+      value: 1
+enum/WUF:
+  bit_size: 1
+  variants:
+    - name: Clear
+      description: No wakeup event detected on WKUP3
+      value: 0
+    - name: Wakeup
+      description: Wakeup event detected on WKUP3
+      value: 1
+enum/WUFI:
+  bit_size: 1
+  variants:
+    - name: Clear
+      description: All internal wakeup sources are cleared
+      value: 0
+    - name: Wakeup
+      description: wakeup is detected on the internal wakeup line
+      value: 1

--- a/parse.py
+++ b/parse.py
@@ -387,6 +387,7 @@ perimap = [
     ('STM32H7(42|43|53|50).*:STM32H7_pwr_v1_0', 'pwr_h7/PWR'),
     ('.*:STM32H7_pwr_v1_0', 'pwr_h7smps/PWR'),
     ('.*:STM32F4_pwr_v1_0', 'pwr_f4/PWR'),
+    ('.*:STM32WL_pwr_v1_0', 'pwr_wl5/PWR'),
     ('.*:STM32H7_flash_v1_0', 'flash_h7/FLASH'),
     ('.*:STM32F0_flash_v1_0', 'flash_f0/FLASH'),
     ('.*:STM32F4_flash_v1_0', 'flash_f4/FLASH'),

--- a/parse.py
+++ b/parse.py
@@ -714,6 +714,11 @@ def parse_chips():
                         signal_name = parts[1]
                         if signal_name.startswith("EXTI"):
                             continue
+                        if peri_name.startswith("DEBUG") and signal_name.startswith("SUBGHZSPI"):
+                            parts = signal_name.split('-', 1)
+                            if len(parts) == 2:
+                                peri_name = parts[0]
+                                signal_name = removesuffix(parts[1], "OUT")
                         if not peri_name in pins:
                             pins[peri_name] = []
                         entry = OrderedDict({
@@ -1057,6 +1062,11 @@ def parse_gpio_af():
             afs = {}
             for signal in children(pin, 'PinSignal'):
                 func = signal['@Name']
+                if func.startswith("DEBUG_SUBGHZSPI"):
+                    func = removeprefix(func, "DEBUG_")
+                    parts = func.split('-', 2)
+                    if len(parts) > 1:
+                        func = parts[0] + '_' + removesuffix(parts[1], "OUT")
                 afn = signal['SpecificParameter']['PossibleValue'].split('_')[1]
                 afn = int(removeprefix(afn, 'AF'))
                 afs[func] = afn


### PR DESCRIPTION
* Add PWR peripheral for STM32WL5*
* Handle SUBGHZ peripheral pins so that its properly recognized as a SPI peripheral by the macros
* Regenerate data