### PR TITLE
Add initial register mapping for STM32 F1 AFIO and FLASH

### DIFF
--- a/data/registers/afio_f1.yaml
+++ b/data/registers/afio_f1.yaml
@@ -1,0 +1,141 @@
+---
+block/AFIO:
+  description: Alternate function I/O and debug configuration
+  items:
+    - name: EVCR
+      description: event control register
+      byte_offset: 0
+      reset_value: 0
+      fieldset: EVCR
+    - name: MAPR
+      description: AF remap and debug I/O configuration register
+      byte_offset: 4
+      reset_value: 0
+      fieldset: MAPR
+    - name: EXTICR
+      description: external interrupt configuration register
+      array:
+        len: 4
+        stride: 4
+      byte_offset: 8
+      reset_value: 0
+      fieldset: EXTICR
+    - name: MAPR2
+      description: AF remap and debug I/O configuration register2
+      byte_offset: 28
+      reset_value: 0
+      fieldset: MAPR2
+fieldset/EVCR:
+  description: event control register
+  fields:
+    - name: EVOE
+      description: Event output enable
+      bit_offset: 7
+      bit_size: 1
+    - name: PORT
+      description: Port selection
+      bit_offset: 4
+      bit_size: 3
+    - name: PIN
+      description: Pin selection (x = A .. E)
+      bit_offset: 0
+      bit_size: 4
+fieldset/MAPR:
+  description: AF remap and debug I/O configuration register
+  fields:
+    - name: SWJ_CFG
+      description: Serial wire JTAG configuration
+      bit_offset: 24
+      bit_size: 3
+    - name: ADC2_ETRGREG_REMAP
+      description: ADC2 external trigger regular conversion remapping
+      bit_offset: 20
+      bit_size: 1
+    - name: ADC2_ETRGINJ_REMAP
+      description: ADC2 external trigger injected conversion remapping
+      bit_offset: 19
+      bit_size: 1
+    - name: ADC1_ETRGREG_REMAP
+      description: ADC1 external trigger regular conversion remapping
+      bit_offset: 18
+      bit_size: 1
+    - name: ADC1_ETRGINJ_REMAP
+      description: ADC1 external trigger injected conversion remapping
+      bit_offset: 17
+      bit_size: 1
+    - name: TIM5CH4_IREMAP
+      description: TIM5 channel4 internal remap
+      bit_offset: 16
+      bit_size: 1
+    - name: PD01_REMAP
+      description: Port D0/Port D1 mapping on OSC_IN/OSC_OUT
+      bit_offset: 15
+      bit_size: 1
+    - name: CAN_REMAP
+      description: CAN alternate function remapping
+      bit_offset: 13
+      bit_size: 2
+    - name: TIM4_REMAP
+      description: TIM4 remapping
+      bit_offset: 12
+      bit_size: 1
+    - name: TIMx_REMAP
+      description: TIMx remapping
+      bit_offset: 6
+      bit_size: 2
+      array:
+        len: 3
+        stride: 2
+    - name: USART3_REMAP
+      description: USART3 remapping
+      bit_offset: 4
+      bit_size: 2
+    - name: USART2_REMAP
+      description: USART2 remapping
+      bit_offset: 3
+      bit_size: 1
+    - name: USART1_REMAP
+      description: USART1 remapping
+      bit_offset: 2
+      bit_size: 1
+    - name: SPI1_REMAP
+      description: SPI1 remapping
+      bit_offset: 0
+      bit_size: 1
+fieldset/EXTICR:
+  description: external interrupt configuration register
+  fields:
+    - name: EXTI
+      description: EXTI x configuration
+      bit_offset: 0
+      bit_size: 4
+      array:
+        len: 4
+        stride: 4
+fieldset/MAPR2:
+  description: AF remap and debug I/O configuration register2
+  fields:
+    - name: FSMC_NADV
+      description: Serial wire JTAG configuration
+      bit_offset: 10
+      bit_size: 1
+    - name: TIM14_REMAP
+      description: TIM14 remapping
+      bit_offset: 9
+      bit_size: 1
+    - name: TIM13_REMAP
+      description: TIM13 remapping
+      bit_offset: 8
+      bit_size: 1
+    - name: TIM11_REMAP
+      description: TIM11 remapping
+      bit_offset: 7
+      bit_size: 1
+    - name: TIM10_REMAP
+      description: TIM10 remapping
+      bit_offset: 6
+      bit_size: 1
+    - name: TIM9_REMAP
+      description: TIM9 remapping
+      bit_offset: 5
+      bit_size: 1

--- a/data/registers/flash_f1.yaml
+++ b/data/registers/flash_f1.yaml
@@ -1,0 +1,27 @@
+---
+block/FLASH:
+  description: Flash
+  items:
+    - name: ACR
+      description: Flash access control register
+      byte_offset: 0
+      fieldset: ACR
+fieldset/ACR:
+  description: Flash access control register
+  fields:
+    - name: LATENCY
+      description: LATENCY
+      bit_offset: 0
+      bit_size: 3
+    - name: HLFCYA
+      description: HLFCYA
+      bit_offset: 3
+      bit_size: 1
+    - name: PRFTBE
+      description: PRFTBE
+      bit_offset: 4
+      bit_size: 1
+    - name: PRFTBS
+      description: PRFTBS
+      bit_offset: 5
+      bit_size: 1

--- a/data/registers/flash_f1.yaml
+++ b/data/registers/flash_f1.yaml
@@ -1,27 +1,193 @@
----
 block/FLASH:
-  description: Flash
+  description: FLASH
   items:
-    - name: ACR
-      description: Flash access control register
-      byte_offset: 0
-      fieldset: ACR
+  - byte_offset: 0
+    description: Flash access control register
+    fieldset: ACR
+    name: ACR
+  - access: Write
+    byte_offset: 4
+    description: Flash key register
+    fieldset: KEYR
+    name: KEYR
+  - access: Write
+    byte_offset: 8
+    description: Flash option key register
+    fieldset: OPTKEYR
+    name: OPTKEYR
+  - byte_offset: 12
+    description: Status register
+    fieldset: SR
+    name: SR
+  - byte_offset: 16
+    description: Control register
+    fieldset: CR
+    name: CR
+  - access: Write
+    byte_offset: 20
+    description: Flash address register
+    fieldset: AR
+    name: AR
+  - access: Read
+    byte_offset: 28
+    description: Option byte register
+    fieldset: OBR
+    name: OBR
+  - access: Read
+    byte_offset: 32
+    description: Write protection register
+    fieldset: WRPR
+    name: WRPR
+enum/LATENCY:
+  bit_size: 3
+  variants:
+  - description: "Zero wait state, if 0 < SYSCLK\u2264 24 MHz"
+    name: WS0
+    value: 0
+  - description: "One wait state, if 24 MHz < SYSCLK \u2264 48 MHz"
+    name: WS1
+    value: 1
+  - description: "Two wait states, if 48 MHz < SYSCLK \u2264 72 MHz"
+    name: WS2
+    value: 2
 fieldset/ACR:
   description: Flash access control register
   fields:
-    - name: LATENCY
-      description: LATENCY
-      bit_offset: 0
-      bit_size: 3
-    - name: HLFCYA
-      description: HLFCYA
-      bit_offset: 3
-      bit_size: 1
-    - name: PRFTBE
-      description: PRFTBE
-      bit_offset: 4
-      bit_size: 1
-    - name: PRFTBS
-      description: PRFTBS
-      bit_offset: 5
-      bit_size: 1
+  - bit_offset: 0
+    bit_size: 3
+    description: Latency
+    enum: LATENCY
+    name: LATENCY
+  - bit_offset: 3
+    bit_size: 1
+    description: Flash half cycle access enable
+    name: HLFCYA
+  - bit_offset: 4
+    bit_size: 1
+    description: Prefetch buffer enable
+    name: PRFTBE
+  - bit_offset: 5
+    bit_size: 1
+    description: Prefetch buffer status
+    name: PRFTBS
+fieldset/AR:
+  description: Flash address register
+  fields:
+  - bit_offset: 0
+    bit_size: 32
+    description: Flash Address
+    name: FAR
+fieldset/CR:
+  description: Control register
+  fields:
+  - bit_offset: 0
+    bit_size: 1
+    description: Programming
+    name: PG
+  - bit_offset: 1
+    bit_size: 1
+    description: Page Erase
+    name: PER
+  - bit_offset: 2
+    bit_size: 1
+    description: Mass Erase
+    name: MER
+  - bit_offset: 4
+    bit_size: 1
+    description: Option byte programming
+    name: OPTPG
+  - bit_offset: 5
+    bit_size: 1
+    description: Option byte erase
+    name: OPTER
+  - bit_offset: 6
+    bit_size: 1
+    description: Start
+    name: STRT
+  - bit_offset: 7
+    bit_size: 1
+    description: Lock
+    name: LOCK
+  - bit_offset: 9
+    bit_size: 1
+    description: Option bytes write enable
+    name: OPTWRE
+  - bit_offset: 10
+    bit_size: 1
+    description: Error interrupt enable
+    name: ERRIE
+  - bit_offset: 12
+    bit_size: 1
+    description: End of operation interrupt enable
+    name: EOPIE
+fieldset/KEYR:
+  description: Flash key register
+  fields:
+  - bit_offset: 0
+    bit_size: 32
+    description: FPEC key
+    name: KEY
+fieldset/OBR:
+  description: Option byte register
+  fields:
+  - bit_offset: 0
+    bit_size: 1
+    description: Option byte error
+    name: OPTERR
+  - bit_offset: 1
+    bit_size: 1
+    description: Read protection
+    name: RDPRT
+  - bit_offset: 2
+    bit_size: 1
+    description: WDG_SW
+    name: WDG_SW
+  - bit_offset: 3
+    bit_size: 1
+    description: nRST_STOP
+    name: nRST_STOP
+  - bit_offset: 4
+    bit_size: 1
+    description: nRST_STDBY
+    name: nRST_STDBY
+  - bit_offset: 10
+    bit_size: 8
+    description: Data0
+    name: Data0
+  - bit_offset: 18
+    bit_size: 8
+    description: Data1
+    name: Data1
+fieldset/OPTKEYR:
+  description: Flash option key register
+  fields:
+  - bit_offset: 0
+    bit_size: 32
+    description: Option byte key
+    name: OPTKEY
+fieldset/SR:
+  description: Status register
+  fields:
+  - bit_offset: 0
+    bit_size: 1
+    description: Busy
+    name: BSY
+  - bit_offset: 2
+    bit_size: 1
+    description: Programming error
+    name: PGERR
+  - bit_offset: 4
+    bit_size: 1
+    description: Write protection error
+    name: WRPRTERR
+  - bit_offset: 5
+    bit_size: 1
+    description: End of operation
+    name: EOP
+fieldset/WRPR:
+  description: Write protection register
+  fields:
+  - bit_offset: 0
+    bit_size: 32
+    description: Write protect
+    name: WRP

--- a/parse.py
+++ b/parse.py
@@ -375,6 +375,8 @@ perimap = [
     ('STM32WL5.*:RCC:.*', 'rcc_wl5/RCC'),
     ('STM32WLE.*:RCC:.*', 'rcc_wle/RCC'),
 
+    ('STM32F1.*:AFIO:.*', 'afio_f1/AFIO'),
+
     ('STM32L5.*:EXTI:.*', 'exti_l5/EXTI'),
     ('STM32G0.*:EXTI:.*', 'exti_g0/EXTI'),
     ('STM32H7.*:EXTI:.*', 'exti_h7/EXTI'),
@@ -392,6 +394,7 @@ perimap = [
     ('.*:STM32WL_pwr_v1_0', 'pwr_wl5/PWR'),
     ('.*:STM32H7_flash_v1_0', 'flash_h7/FLASH'),
     ('.*:STM32F0_flash_v1_0', 'flash_f0/FLASH'),
+    ('.*:STM32F1_flash_v1_0', 'flash_f1/FLASH'),
     ('.*:STM32F4_flash_v1_0', 'flash_f4/FLASH'),
     ('.*TIM\d.*:gptimer.*', 'timer_v1/TIM_GP16'),
     ('.*ETH:ethermac110_v3_0', 'eth_v2/ETH'),


### PR DESCRIPTION
Added just the register needed for STM32 F1 support in Embassy. Not sure if `afio_f1` should be `afio_v1` (AFIO is needed for EXTI control for `gpio_v1`, so renaming probably makes sense).