### PR TITLE
Add L4 flash register

### DIFF
--- a/data/chips/STM32F100C4.yaml
+++ b/data/chips/STM32F100C4.yaml
@@ -101,6 +101,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32F1_flash_v1_0
+      block: flash_f1/FLASH
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO

--- a/data/chips/STM32F100C6.yaml
+++ b/data/chips/STM32F100C6.yaml
@@ -101,6 +101,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32F1_flash_v1_0
+      block: flash_f1/FLASH
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO

--- a/data/chips/STM32F100C8.yaml
+++ b/data/chips/STM32F100C8.yaml
@@ -101,6 +101,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32F1_flash_v1_0
+      block: flash_f1/FLASH
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO

--- a/data/chips/STM32F100CB.yaml
+++ b/data/chips/STM32F100CB.yaml
@@ -101,6 +101,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32F1_flash_v1_0
+      block: flash_f1/FLASH
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO

--- a/data/chips/STM32F100R4.yaml
+++ b/data/chips/STM32F100R4.yaml
@@ -115,6 +115,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32F1_flash_v1_0
+      block: flash_f1/FLASH
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO

--- a/data/chips/STM32F100R6.yaml
+++ b/data/chips/STM32F100R6.yaml
@@ -115,6 +115,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32F1_flash_v1_0
+      block: flash_f1/FLASH
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO

--- a/data/chips/STM32F100R8.yaml
+++ b/data/chips/STM32F100R8.yaml
@@ -115,6 +115,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32F1_flash_v1_0
+      block: flash_f1/FLASH
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO

--- a/data/chips/STM32F100RB.yaml
+++ b/data/chips/STM32F100RB.yaml
@@ -115,6 +115,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32F1_flash_v1_0
+      block: flash_f1/FLASH
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO

--- a/data/chips/STM32F100RC.yaml
+++ b/data/chips/STM32F100RC.yaml
@@ -125,6 +125,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32F1_flash_v1_0
+      block: flash_f1/FLASH
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO

--- a/data/chips/STM32F100RD.yaml
+++ b/data/chips/STM32F100RD.yaml
@@ -125,6 +125,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32F1_flash_v1_0
+      block: flash_f1/FLASH
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO

--- a/data/chips/STM32F100RE.yaml
+++ b/data/chips/STM32F100RE.yaml
@@ -125,6 +125,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32F1_flash_v1_0
+      block: flash_f1/FLASH
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO

--- a/data/chips/STM32F100V8.yaml
+++ b/data/chips/STM32F100V8.yaml
@@ -113,6 +113,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32F1_flash_v1_0
+      block: flash_f1/FLASH
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO

--- a/data/chips/STM32F100VB.yaml
+++ b/data/chips/STM32F100VB.yaml
@@ -113,6 +113,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32F1_flash_v1_0
+      block: flash_f1/FLASH
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO

--- a/data/chips/STM32F100VC.yaml
+++ b/data/chips/STM32F100VC.yaml
@@ -125,6 +125,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32F1_flash_v1_0
+      block: flash_f1/FLASH
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO

--- a/data/chips/STM32F100VD.yaml
+++ b/data/chips/STM32F100VD.yaml
@@ -125,6 +125,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32F1_flash_v1_0
+      block: flash_f1/FLASH
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO

--- a/data/chips/STM32F100VE.yaml
+++ b/data/chips/STM32F100VE.yaml
@@ -125,6 +125,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32F1_flash_v1_0
+      block: flash_f1/FLASH
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO

--- a/data/chips/STM32F100ZC.yaml
+++ b/data/chips/STM32F100ZC.yaml
@@ -125,6 +125,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32F1_flash_v1_0
+      block: flash_f1/FLASH
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO

--- a/data/chips/STM32F100ZD.yaml
+++ b/data/chips/STM32F100ZD.yaml
@@ -125,6 +125,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32F1_flash_v1_0
+      block: flash_f1/FLASH
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO

--- a/data/chips/STM32F100ZE.yaml
+++ b/data/chips/STM32F100ZE.yaml
@@ -125,6 +125,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32F1_flash_v1_0
+      block: flash_f1/FLASH
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO

--- a/data/chips/STM32F101C4.yaml
+++ b/data/chips/STM32F101C4.yaml
@@ -85,6 +85,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32F1_flash_v1_0
+      block: flash_f1/FLASH
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO

--- a/data/chips/STM32F101C6.yaml
+++ b/data/chips/STM32F101C6.yaml
@@ -85,6 +85,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32F1_flash_v1_0
+      block: flash_f1/FLASH
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO

--- a/data/chips/STM32F101C8.yaml
+++ b/data/chips/STM32F101C8.yaml
@@ -87,6 +87,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32F1_flash_v1_0
+      block: flash_f1/FLASH
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO

--- a/data/chips/STM32F101CB.yaml
+++ b/data/chips/STM32F101CB.yaml
@@ -87,6 +87,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32F1_flash_v1_0
+      block: flash_f1/FLASH
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO

--- a/data/chips/STM32F101R4.yaml
+++ b/data/chips/STM32F101R4.yaml
@@ -97,6 +97,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32F1_flash_v1_0
+      block: flash_f1/FLASH
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO

--- a/data/chips/STM32F101R6.yaml
+++ b/data/chips/STM32F101R6.yaml
@@ -97,6 +97,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32F1_flash_v1_0
+      block: flash_f1/FLASH
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO

--- a/data/chips/STM32F101R8.yaml
+++ b/data/chips/STM32F101R8.yaml
@@ -97,6 +97,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32F1_flash_v1_0
+      block: flash_f1/FLASH
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO

--- a/data/chips/STM32F101RB.yaml
+++ b/data/chips/STM32F101RB.yaml
@@ -97,6 +97,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32F1_flash_v1_0
+      block: flash_f1/FLASH
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO

--- a/data/chips/STM32F101RC.yaml
+++ b/data/chips/STM32F101RC.yaml
@@ -120,6 +120,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32F1_flash_v1_0
+      block: flash_f1/FLASH
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO

--- a/data/chips/STM32F101RD.yaml
+++ b/data/chips/STM32F101RD.yaml
@@ -120,6 +120,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32F1_flash_v1_0
+      block: flash_f1/FLASH
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO

--- a/data/chips/STM32F101RE.yaml
+++ b/data/chips/STM32F101RE.yaml
@@ -120,6 +120,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32F1_flash_v1_0
+      block: flash_f1/FLASH
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO

--- a/data/chips/STM32F101RF.yaml
+++ b/data/chips/STM32F101RF.yaml
@@ -120,6 +120,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32F1_flash_v1_0
+      block: flash_f1/FLASH
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO

--- a/data/chips/STM32F101RG.yaml
+++ b/data/chips/STM32F101RG.yaml
@@ -120,6 +120,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32F1_flash_v1_0
+      block: flash_f1/FLASH
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO

--- a/data/chips/STM32F101T4.yaml
+++ b/data/chips/STM32F101T4.yaml
@@ -85,6 +85,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32F1_flash_v1_0
+      block: flash_f1/FLASH
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO

--- a/data/chips/STM32F101T6.yaml
+++ b/data/chips/STM32F101T6.yaml
@@ -85,6 +85,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32F1_flash_v1_0
+      block: flash_f1/FLASH
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO

--- a/data/chips/STM32F101T8.yaml
+++ b/data/chips/STM32F101T8.yaml
@@ -85,6 +85,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32F1_flash_v1_0
+      block: flash_f1/FLASH
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO

--- a/data/chips/STM32F101TB.yaml
+++ b/data/chips/STM32F101TB.yaml
@@ -85,6 +85,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32F1_flash_v1_0
+      block: flash_f1/FLASH
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO

--- a/data/chips/STM32F101V8.yaml
+++ b/data/chips/STM32F101V8.yaml
@@ -97,6 +97,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32F1_flash_v1_0
+      block: flash_f1/FLASH
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO

--- a/data/chips/STM32F101VB.yaml
+++ b/data/chips/STM32F101VB.yaml
@@ -97,6 +97,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32F1_flash_v1_0
+      block: flash_f1/FLASH
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO

--- a/data/chips/STM32F101VC.yaml
+++ b/data/chips/STM32F101VC.yaml
@@ -120,6 +120,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32F1_flash_v1_0
+      block: flash_f1/FLASH
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO

--- a/data/chips/STM32F101VD.yaml
+++ b/data/chips/STM32F101VD.yaml
@@ -120,6 +120,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32F1_flash_v1_0
+      block: flash_f1/FLASH
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO

--- a/data/chips/STM32F101VE.yaml
+++ b/data/chips/STM32F101VE.yaml
@@ -120,6 +120,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32F1_flash_v1_0
+      block: flash_f1/FLASH
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO

--- a/data/chips/STM32F101VF.yaml
+++ b/data/chips/STM32F101VF.yaml
@@ -120,6 +120,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32F1_flash_v1_0
+      block: flash_f1/FLASH
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO

--- a/data/chips/STM32F101VG.yaml
+++ b/data/chips/STM32F101VG.yaml
@@ -120,6 +120,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32F1_flash_v1_0
+      block: flash_f1/FLASH
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO

--- a/data/chips/STM32F101ZC.yaml
+++ b/data/chips/STM32F101ZC.yaml
@@ -120,6 +120,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32F1_flash_v1_0
+      block: flash_f1/FLASH
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO

--- a/data/chips/STM32F101ZD.yaml
+++ b/data/chips/STM32F101ZD.yaml
@@ -120,6 +120,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32F1_flash_v1_0
+      block: flash_f1/FLASH
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO

--- a/data/chips/STM32F101ZE.yaml
+++ b/data/chips/STM32F101ZE.yaml
@@ -120,6 +120,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32F1_flash_v1_0
+      block: flash_f1/FLASH
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO

--- a/data/chips/STM32F101ZF.yaml
+++ b/data/chips/STM32F101ZF.yaml
@@ -120,6 +120,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32F1_flash_v1_0
+      block: flash_f1/FLASH
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO

--- a/data/chips/STM32F101ZG.yaml
+++ b/data/chips/STM32F101ZG.yaml
@@ -120,6 +120,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32F1_flash_v1_0
+      block: flash_f1/FLASH
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO

--- a/data/chips/STM32F102C4.yaml
+++ b/data/chips/STM32F102C4.yaml
@@ -85,6 +85,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32F1_flash_v1_0
+      block: flash_f1/FLASH
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO

--- a/data/chips/STM32F102C6.yaml
+++ b/data/chips/STM32F102C6.yaml
@@ -85,6 +85,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32F1_flash_v1_0
+      block: flash_f1/FLASH
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO

--- a/data/chips/STM32F102C8.yaml
+++ b/data/chips/STM32F102C8.yaml
@@ -85,6 +85,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32F1_flash_v1_0
+      block: flash_f1/FLASH
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO

--- a/data/chips/STM32F102CB.yaml
+++ b/data/chips/STM32F102CB.yaml
@@ -85,6 +85,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32F1_flash_v1_0
+      block: flash_f1/FLASH
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO

--- a/data/chips/STM32F102R4.yaml
+++ b/data/chips/STM32F102R4.yaml
@@ -97,6 +97,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32F1_flash_v1_0
+      block: flash_f1/FLASH
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO

--- a/data/chips/STM32F102R6.yaml
+++ b/data/chips/STM32F102R6.yaml
@@ -97,6 +97,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32F1_flash_v1_0
+      block: flash_f1/FLASH
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO

--- a/data/chips/STM32F102R8.yaml
+++ b/data/chips/STM32F102R8.yaml
@@ -97,6 +97,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32F1_flash_v1_0
+      block: flash_f1/FLASH
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO

--- a/data/chips/STM32F102RB.yaml
+++ b/data/chips/STM32F102RB.yaml
@@ -97,6 +97,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32F1_flash_v1_0
+      block: flash_f1/FLASH
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO

--- a/data/chips/STM32F103C4.yaml
+++ b/data/chips/STM32F103C4.yaml
@@ -111,6 +111,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32F1_flash_v1_0
+      block: flash_f1/FLASH
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO

--- a/data/chips/STM32F103C6.yaml
+++ b/data/chips/STM32F103C6.yaml
@@ -113,6 +113,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32F1_flash_v1_0
+      block: flash_f1/FLASH
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO

--- a/data/chips/STM32F103C8.yaml
+++ b/data/chips/STM32F103C8.yaml
@@ -111,6 +111,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32F1_flash_v1_0
+      block: flash_f1/FLASH
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO

--- a/data/chips/STM32F103CB.yaml
+++ b/data/chips/STM32F103CB.yaml
@@ -113,6 +113,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32F1_flash_v1_0
+      block: flash_f1/FLASH
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO

--- a/data/chips/STM32F103R4.yaml
+++ b/data/chips/STM32F103R4.yaml
@@ -137,6 +137,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32F1_flash_v1_0
+      block: flash_f1/FLASH
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO

--- a/data/chips/STM32F103R6.yaml
+++ b/data/chips/STM32F103R6.yaml
@@ -137,6 +137,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32F1_flash_v1_0
+      block: flash_f1/FLASH
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO

--- a/data/chips/STM32F103R8.yaml
+++ b/data/chips/STM32F103R8.yaml
@@ -137,6 +137,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32F1_flash_v1_0
+      block: flash_f1/FLASH
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO

--- a/data/chips/STM32F103RB.yaml
+++ b/data/chips/STM32F103RB.yaml
@@ -137,6 +137,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32F1_flash_v1_0
+      block: flash_f1/FLASH
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO

--- a/data/chips/STM32F103RC.yaml
+++ b/data/chips/STM32F103RC.yaml
@@ -180,6 +180,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32F1_flash_v1_0
+      block: flash_f1/FLASH
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO

--- a/data/chips/STM32F103RD.yaml
+++ b/data/chips/STM32F103RD.yaml
@@ -180,6 +180,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32F1_flash_v1_0
+      block: flash_f1/FLASH
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO

--- a/data/chips/STM32F103RE.yaml
+++ b/data/chips/STM32F103RE.yaml
@@ -180,6 +180,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32F1_flash_v1_0
+      block: flash_f1/FLASH
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO

--- a/data/chips/STM32F103RF.yaml
+++ b/data/chips/STM32F103RF.yaml
@@ -184,6 +184,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32F1_flash_v1_0
+      block: flash_f1/FLASH
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO

--- a/data/chips/STM32F103RG.yaml
+++ b/data/chips/STM32F103RG.yaml
@@ -184,6 +184,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32F1_flash_v1_0
+      block: flash_f1/FLASH
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO

--- a/data/chips/STM32F103T4.yaml
+++ b/data/chips/STM32F103T4.yaml
@@ -111,6 +111,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32F1_flash_v1_0
+      block: flash_f1/FLASH
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO

--- a/data/chips/STM32F103T6.yaml
+++ b/data/chips/STM32F103T6.yaml
@@ -111,6 +111,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32F1_flash_v1_0
+      block: flash_f1/FLASH
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO

--- a/data/chips/STM32F103T8.yaml
+++ b/data/chips/STM32F103T8.yaml
@@ -111,6 +111,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32F1_flash_v1_0
+      block: flash_f1/FLASH
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO

--- a/data/chips/STM32F103TB.yaml
+++ b/data/chips/STM32F103TB.yaml
@@ -111,6 +111,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32F1_flash_v1_0
+      block: flash_f1/FLASH
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO

--- a/data/chips/STM32F103V8.yaml
+++ b/data/chips/STM32F103V8.yaml
@@ -137,6 +137,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32F1_flash_v1_0
+      block: flash_f1/FLASH
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO

--- a/data/chips/STM32F103VB.yaml
+++ b/data/chips/STM32F103VB.yaml
@@ -139,6 +139,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32F1_flash_v1_0
+      block: flash_f1/FLASH
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO

--- a/data/chips/STM32F103VC.yaml
+++ b/data/chips/STM32F103VC.yaml
@@ -186,6 +186,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32F1_flash_v1_0
+      block: flash_f1/FLASH
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO

--- a/data/chips/STM32F103VD.yaml
+++ b/data/chips/STM32F103VD.yaml
@@ -186,6 +186,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32F1_flash_v1_0
+      block: flash_f1/FLASH
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO

--- a/data/chips/STM32F103VE.yaml
+++ b/data/chips/STM32F103VE.yaml
@@ -186,6 +186,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32F1_flash_v1_0
+      block: flash_f1/FLASH
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO

--- a/data/chips/STM32F103VF.yaml
+++ b/data/chips/STM32F103VF.yaml
@@ -184,6 +184,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32F1_flash_v1_0
+      block: flash_f1/FLASH
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO

--- a/data/chips/STM32F103VG.yaml
+++ b/data/chips/STM32F103VG.yaml
@@ -184,6 +184,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32F1_flash_v1_0
+      block: flash_f1/FLASH
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO

--- a/data/chips/STM32F103ZC.yaml
+++ b/data/chips/STM32F103ZC.yaml
@@ -196,6 +196,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32F1_flash_v1_0
+      block: flash_f1/FLASH
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO

--- a/data/chips/STM32F103ZD.yaml
+++ b/data/chips/STM32F103ZD.yaml
@@ -196,6 +196,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32F1_flash_v1_0
+      block: flash_f1/FLASH
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO

--- a/data/chips/STM32F103ZE.yaml
+++ b/data/chips/STM32F103ZE.yaml
@@ -196,6 +196,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32F1_flash_v1_0
+      block: flash_f1/FLASH
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO

--- a/data/chips/STM32F103ZF.yaml
+++ b/data/chips/STM32F103ZF.yaml
@@ -196,6 +196,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32F1_flash_v1_0
+      block: flash_f1/FLASH
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO

--- a/data/chips/STM32F103ZG.yaml
+++ b/data/chips/STM32F103ZG.yaml
@@ -196,6 +196,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32F1_flash_v1_0
+      block: flash_f1/FLASH
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO

--- a/data/chips/STM32F105R8.yaml
+++ b/data/chips/STM32F105R8.yaml
@@ -197,6 +197,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32F1_flash_v1_0
+      block: flash_f1/FLASH
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO

--- a/data/chips/STM32F105RB.yaml
+++ b/data/chips/STM32F105RB.yaml
@@ -197,6 +197,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32F1_flash_v1_0
+      block: flash_f1/FLASH
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO

--- a/data/chips/STM32F105RC.yaml
+++ b/data/chips/STM32F105RC.yaml
@@ -197,6 +197,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32F1_flash_v1_0
+      block: flash_f1/FLASH
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO

--- a/data/chips/STM32F105V8.yaml
+++ b/data/chips/STM32F105V8.yaml
@@ -203,6 +203,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32F1_flash_v1_0
+      block: flash_f1/FLASH
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO

--- a/data/chips/STM32F105VB.yaml
+++ b/data/chips/STM32F105VB.yaml
@@ -203,6 +203,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32F1_flash_v1_0
+      block: flash_f1/FLASH
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO

--- a/data/chips/STM32F105VC.yaml
+++ b/data/chips/STM32F105VC.yaml
@@ -201,6 +201,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32F1_flash_v1_0
+      block: flash_f1/FLASH
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO

--- a/data/chips/STM32F107RB.yaml
+++ b/data/chips/STM32F107RB.yaml
@@ -243,6 +243,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32F1_flash_v1_0
+      block: flash_f1/FLASH
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO

--- a/data/chips/STM32F107RC.yaml
+++ b/data/chips/STM32F107RC.yaml
@@ -243,6 +243,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32F1_flash_v1_0
+      block: flash_f1/FLASH
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO

--- a/data/chips/STM32F107VB.yaml
+++ b/data/chips/STM32F107VB.yaml
@@ -259,6 +259,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32F1_flash_v1_0
+      block: flash_f1/FLASH
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO

--- a/data/chips/STM32F107VC.yaml
+++ b/data/chips/STM32F107VC.yaml
@@ -261,6 +261,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32F1_flash_v1_0
+      block: flash_f1/FLASH
     GPIOA:
       address: 0x40010800
       block: gpio_v1/GPIO

--- a/data/chips/STM32L412C8.yaml
+++ b/data/chips/STM32L412C8.yaml
@@ -170,6 +170,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32L4_flash_v1_0
+      block: flash_l4/FLASH
       clock: AHB1
     GPIOA:
       address: 0x48000000

--- a/data/chips/STM32L412CB.yaml
+++ b/data/chips/STM32L412CB.yaml
@@ -174,6 +174,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32L4_flash_v1_0
+      block: flash_l4/FLASH
       clock: AHB1
     GPIOA:
       address: 0x48000000

--- a/data/chips/STM32L412K8.yaml
+++ b/data/chips/STM32L412K8.yaml
@@ -165,6 +165,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32L4_flash_v1_0
+      block: flash_l4/FLASH
       clock: AHB1
     GPIOA:
       address: 0x48000000

--- a/data/chips/STM32L412KB.yaml
+++ b/data/chips/STM32L412KB.yaml
@@ -165,6 +165,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32L4_flash_v1_0
+      block: flash_l4/FLASH
       clock: AHB1
     GPIOA:
       address: 0x48000000

--- a/data/chips/STM32L412R8.yaml
+++ b/data/chips/STM32L412R8.yaml
@@ -198,6 +198,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32L4_flash_v1_0
+      block: flash_l4/FLASH
       clock: AHB1
     GPIOA:
       address: 0x48000000

--- a/data/chips/STM32L412RB.yaml
+++ b/data/chips/STM32L412RB.yaml
@@ -196,6 +196,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32L4_flash_v1_0
+      block: flash_l4/FLASH
       clock: AHB1
     GPIOA:
       address: 0x48000000

--- a/data/chips/STM32L412T8.yaml
+++ b/data/chips/STM32L412T8.yaml
@@ -168,6 +168,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32L4_flash_v1_0
+      block: flash_l4/FLASH
       clock: AHB1
     GPIOA:
       address: 0x48000000

--- a/data/chips/STM32L412TB.yaml
+++ b/data/chips/STM32L412TB.yaml
@@ -170,6 +170,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32L4_flash_v1_0
+      block: flash_l4/FLASH
       clock: AHB1
     GPIOA:
       address: 0x48000000

--- a/data/chips/STM32L422CB.yaml
+++ b/data/chips/STM32L422CB.yaml
@@ -184,6 +184,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32L4_flash_v1_0
+      block: flash_l4/FLASH
       clock: AHB1
     GPIOA:
       address: 0x48000000

--- a/data/chips/STM32L422KB.yaml
+++ b/data/chips/STM32L422KB.yaml
@@ -179,6 +179,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32L4_flash_v1_0
+      block: flash_l4/FLASH
       clock: AHB1
     GPIOA:
       address: 0x48000000

--- a/data/chips/STM32L422RB.yaml
+++ b/data/chips/STM32L422RB.yaml
@@ -212,6 +212,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32L4_flash_v1_0
+      block: flash_l4/FLASH
       clock: AHB1
     GPIOA:
       address: 0x48000000

--- a/data/chips/STM32L422TB.yaml
+++ b/data/chips/STM32L422TB.yaml
@@ -182,6 +182,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32L4_flash_v1_0
+      block: flash_l4/FLASH
       clock: AHB1
     GPIOA:
       address: 0x48000000

--- a/data/chips/STM32L431CB.yaml
+++ b/data/chips/STM32L431CB.yaml
@@ -215,6 +215,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32L4_flash_v1_0
+      block: flash_l4/FLASH
       clock: AHB1
     GPIOA:
       address: 0x48000000

--- a/data/chips/STM32L431CC.yaml
+++ b/data/chips/STM32L431CC.yaml
@@ -215,6 +215,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32L4_flash_v1_0
+      block: flash_l4/FLASH
       clock: AHB1
     GPIOA:
       address: 0x48000000

--- a/data/chips/STM32L431KB.yaml
+++ b/data/chips/STM32L431KB.yaml
@@ -195,6 +195,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32L4_flash_v1_0
+      block: flash_l4/FLASH
       clock: AHB1
     GPIOA:
       address: 0x48000000

--- a/data/chips/STM32L431KC.yaml
+++ b/data/chips/STM32L431KC.yaml
@@ -195,6 +195,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32L4_flash_v1_0
+      block: flash_l4/FLASH
       clock: AHB1
     GPIOA:
       address: 0x48000000

--- a/data/chips/STM32L431RB.yaml
+++ b/data/chips/STM32L431RB.yaml
@@ -229,6 +229,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32L4_flash_v1_0
+      block: flash_l4/FLASH
       clock: AHB1
     GPIOA:
       address: 0x48000000

--- a/data/chips/STM32L431RC.yaml
+++ b/data/chips/STM32L431RC.yaml
@@ -229,6 +229,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32L4_flash_v1_0
+      block: flash_l4/FLASH
       clock: AHB1
     GPIOA:
       address: 0x48000000

--- a/data/chips/STM32L431VC.yaml
+++ b/data/chips/STM32L431VC.yaml
@@ -233,6 +233,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32L4_flash_v1_0
+      block: flash_l4/FLASH
       clock: AHB1
     GPIOA:
       address: 0x48000000

--- a/data/chips/STM32L432KB.yaml
+++ b/data/chips/STM32L432KB.yaml
@@ -195,6 +195,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32L4_flash_v1_0
+      block: flash_l4/FLASH
       clock: AHB1
     GPIOA:
       address: 0x48000000

--- a/data/chips/STM32L432KC.yaml
+++ b/data/chips/STM32L432KC.yaml
@@ -195,6 +195,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32L4_flash_v1_0
+      block: flash_l4/FLASH
       clock: AHB1
     GPIOA:
       address: 0x48000000

--- a/data/chips/STM32L433CB.yaml
+++ b/data/chips/STM32L433CB.yaml
@@ -215,6 +215,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32L4_flash_v1_0
+      block: flash_l4/FLASH
       clock: AHB1
     GPIOA:
       address: 0x48000000

--- a/data/chips/STM32L433CC.yaml
+++ b/data/chips/STM32L433CC.yaml
@@ -215,6 +215,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32L4_flash_v1_0
+      block: flash_l4/FLASH
       clock: AHB1
     GPIOA:
       address: 0x48000000

--- a/data/chips/STM32L433RB.yaml
+++ b/data/chips/STM32L433RB.yaml
@@ -229,6 +229,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32L4_flash_v1_0
+      block: flash_l4/FLASH
       clock: AHB1
     GPIOA:
       address: 0x48000000

--- a/data/chips/STM32L433RC.yaml
+++ b/data/chips/STM32L433RC.yaml
@@ -227,6 +227,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32L4_flash_v1_0
+      block: flash_l4/FLASH
       clock: AHB1
     GPIOA:
       address: 0x48000000

--- a/data/chips/STM32L433VC.yaml
+++ b/data/chips/STM32L433VC.yaml
@@ -233,6 +233,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32L4_flash_v1_0
+      block: flash_l4/FLASH
       clock: AHB1
     GPIOA:
       address: 0x48000000

--- a/data/chips/STM32L442KC.yaml
+++ b/data/chips/STM32L442KC.yaml
@@ -212,6 +212,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32L4_flash_v1_0
+      block: flash_l4/FLASH
       clock: AHB1
     GPIOA:
       address: 0x48000000

--- a/data/chips/STM32L443CC.yaml
+++ b/data/chips/STM32L443CC.yaml
@@ -232,6 +232,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32L4_flash_v1_0
+      block: flash_l4/FLASH
       clock: AHB1
     GPIOA:
       address: 0x48000000

--- a/data/chips/STM32L443RC.yaml
+++ b/data/chips/STM32L443RC.yaml
@@ -246,6 +246,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32L4_flash_v1_0
+      block: flash_l4/FLASH
       clock: AHB1
     GPIOA:
       address: 0x48000000

--- a/data/chips/STM32L443VC.yaml
+++ b/data/chips/STM32L443VC.yaml
@@ -250,6 +250,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32L4_flash_v1_0
+      block: flash_l4/FLASH
       clock: AHB1
     GPIOA:
       address: 0x48000000

--- a/data/chips/STM32L451CC.yaml
+++ b/data/chips/STM32L451CC.yaml
@@ -219,6 +219,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32L4_flash_v1_0
+      block: flash_l4/FLASH
       clock: AHB1
     GPIOA:
       address: 0x48000000

--- a/data/chips/STM32L451CE.yaml
+++ b/data/chips/STM32L451CE.yaml
@@ -221,6 +221,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32L4_flash_v1_0
+      block: flash_l4/FLASH
       clock: AHB1
     GPIOA:
       address: 0x48000000

--- a/data/chips/STM32L451RC.yaml
+++ b/data/chips/STM32L451RC.yaml
@@ -239,6 +239,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32L4_flash_v1_0
+      block: flash_l4/FLASH
       clock: AHB1
     GPIOA:
       address: 0x48000000

--- a/data/chips/STM32L451RE.yaml
+++ b/data/chips/STM32L451RE.yaml
@@ -239,6 +239,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32L4_flash_v1_0
+      block: flash_l4/FLASH
       clock: AHB1
     GPIOA:
       address: 0x48000000

--- a/data/chips/STM32L451VC.yaml
+++ b/data/chips/STM32L451VC.yaml
@@ -243,6 +243,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32L4_flash_v1_0
+      block: flash_l4/FLASH
       clock: AHB1
     GPIOA:
       address: 0x48000000

--- a/data/chips/STM32L451VE.yaml
+++ b/data/chips/STM32L451VE.yaml
@@ -243,6 +243,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32L4_flash_v1_0
+      block: flash_l4/FLASH
       clock: AHB1
     GPIOA:
       address: 0x48000000

--- a/data/chips/STM32L452CC.yaml
+++ b/data/chips/STM32L452CC.yaml
@@ -219,6 +219,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32L4_flash_v1_0
+      block: flash_l4/FLASH
       clock: AHB1
     GPIOA:
       address: 0x48000000

--- a/data/chips/STM32L452CE.yaml
+++ b/data/chips/STM32L452CE.yaml
@@ -221,6 +221,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32L4_flash_v1_0
+      block: flash_l4/FLASH
       clock: AHB1
     GPIOA:
       address: 0x48000000

--- a/data/chips/STM32L452RC.yaml
+++ b/data/chips/STM32L452RC.yaml
@@ -239,6 +239,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32L4_flash_v1_0
+      block: flash_l4/FLASH
       clock: AHB1
     GPIOA:
       address: 0x48000000

--- a/data/chips/STM32L452RE.yaml
+++ b/data/chips/STM32L452RE.yaml
@@ -237,6 +237,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32L4_flash_v1_0
+      block: flash_l4/FLASH
       clock: AHB1
     GPIOA:
       address: 0x48000000

--- a/data/chips/STM32L452VC.yaml
+++ b/data/chips/STM32L452VC.yaml
@@ -243,6 +243,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32L4_flash_v1_0
+      block: flash_l4/FLASH
       clock: AHB1
     GPIOA:
       address: 0x48000000

--- a/data/chips/STM32L452VE.yaml
+++ b/data/chips/STM32L452VE.yaml
@@ -243,6 +243,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32L4_flash_v1_0
+      block: flash_l4/FLASH
       clock: AHB1
     GPIOA:
       address: 0x48000000

--- a/data/chips/STM32L462CE.yaml
+++ b/data/chips/STM32L462CE.yaml
@@ -238,6 +238,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32L4_flash_v1_0
+      block: flash_l4/FLASH
       clock: AHB1
     GPIOA:
       address: 0x48000000

--- a/data/chips/STM32L462RE.yaml
+++ b/data/chips/STM32L462RE.yaml
@@ -256,6 +256,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32L4_flash_v1_0
+      block: flash_l4/FLASH
       clock: AHB1
     GPIOA:
       address: 0x48000000

--- a/data/chips/STM32L462VE.yaml
+++ b/data/chips/STM32L462VE.yaml
@@ -260,6 +260,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32L4_flash_v1_0
+      block: flash_l4/FLASH
       clock: AHB1
     GPIOA:
       address: 0x48000000

--- a/data/chips/STM32L471QE.yaml
+++ b/data/chips/STM32L471QE.yaml
@@ -268,6 +268,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32L4_flash_v1_0
+      block: flash_l4/FLASH
       clock: AHB1
     GPIOA:
       address: 0x48000000

--- a/data/chips/STM32L471QG.yaml
+++ b/data/chips/STM32L471QG.yaml
@@ -268,6 +268,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32L4_flash_v1_0
+      block: flash_l4/FLASH
       clock: AHB1
     GPIOA:
       address: 0x48000000

--- a/data/chips/STM32L471RE.yaml
+++ b/data/chips/STM32L471RE.yaml
@@ -256,6 +256,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32L4_flash_v1_0
+      block: flash_l4/FLASH
       clock: AHB1
     GPIOA:
       address: 0x48000000

--- a/data/chips/STM32L471RG.yaml
+++ b/data/chips/STM32L471RG.yaml
@@ -256,6 +256,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32L4_flash_v1_0
+      block: flash_l4/FLASH
       clock: AHB1
     GPIOA:
       address: 0x48000000

--- a/data/chips/STM32L471VE.yaml
+++ b/data/chips/STM32L471VE.yaml
@@ -262,6 +262,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32L4_flash_v1_0
+      block: flash_l4/FLASH
       clock: AHB1
     GPIOA:
       address: 0x48000000

--- a/data/chips/STM32L471VG.yaml
+++ b/data/chips/STM32L471VG.yaml
@@ -262,6 +262,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32L4_flash_v1_0
+      block: flash_l4/FLASH
       clock: AHB1
     GPIOA:
       address: 0x48000000

--- a/data/chips/STM32L471ZE.yaml
+++ b/data/chips/STM32L471ZE.yaml
@@ -280,6 +280,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32L4_flash_v1_0
+      block: flash_l4/FLASH
       clock: AHB1
     GPIOA:
       address: 0x48000000

--- a/data/chips/STM32L471ZG.yaml
+++ b/data/chips/STM32L471ZG.yaml
@@ -280,6 +280,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32L4_flash_v1_0
+      block: flash_l4/FLASH
       clock: AHB1
     GPIOA:
       address: 0x48000000

--- a/data/chips/STM32L475RC.yaml
+++ b/data/chips/STM32L475RC.yaml
@@ -256,6 +256,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32L4_flash_v1_0
+      block: flash_l4/FLASH
       clock: AHB1
     GPIOA:
       address: 0x48000000

--- a/data/chips/STM32L475RE.yaml
+++ b/data/chips/STM32L475RE.yaml
@@ -256,6 +256,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32L4_flash_v1_0
+      block: flash_l4/FLASH
       clock: AHB1
     GPIOA:
       address: 0x48000000

--- a/data/chips/STM32L475RG.yaml
+++ b/data/chips/STM32L475RG.yaml
@@ -256,6 +256,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32L4_flash_v1_0
+      block: flash_l4/FLASH
       clock: AHB1
     GPIOA:
       address: 0x48000000

--- a/data/chips/STM32L475VC.yaml
+++ b/data/chips/STM32L475VC.yaml
@@ -262,6 +262,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32L4_flash_v1_0
+      block: flash_l4/FLASH
       clock: AHB1
     GPIOA:
       address: 0x48000000

--- a/data/chips/STM32L475VE.yaml
+++ b/data/chips/STM32L475VE.yaml
@@ -262,6 +262,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32L4_flash_v1_0
+      block: flash_l4/FLASH
       clock: AHB1
     GPIOA:
       address: 0x48000000

--- a/data/chips/STM32L475VG.yaml
+++ b/data/chips/STM32L475VG.yaml
@@ -262,6 +262,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32L4_flash_v1_0
+      block: flash_l4/FLASH
       clock: AHB1
     GPIOA:
       address: 0x48000000

--- a/data/chips/STM32L476JE.yaml
+++ b/data/chips/STM32L476JE.yaml
@@ -256,6 +256,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32L4_flash_v1_0
+      block: flash_l4/FLASH
       clock: AHB1
     GPIOA:
       address: 0x48000000

--- a/data/chips/STM32L476JG.yaml
+++ b/data/chips/STM32L476JG.yaml
@@ -252,6 +252,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32L4_flash_v1_0
+      block: flash_l4/FLASH
       clock: AHB1
     GPIOA:
       address: 0x48000000

--- a/data/chips/STM32L476ME.yaml
+++ b/data/chips/STM32L476ME.yaml
@@ -256,6 +256,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32L4_flash_v1_0
+      block: flash_l4/FLASH
       clock: AHB1
     GPIOA:
       address: 0x48000000

--- a/data/chips/STM32L476MG.yaml
+++ b/data/chips/STM32L476MG.yaml
@@ -256,6 +256,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32L4_flash_v1_0
+      block: flash_l4/FLASH
       clock: AHB1
     GPIOA:
       address: 0x48000000

--- a/data/chips/STM32L476QE.yaml
+++ b/data/chips/STM32L476QE.yaml
@@ -268,6 +268,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32L4_flash_v1_0
+      block: flash_l4/FLASH
       clock: AHB1
     GPIOA:
       address: 0x48000000

--- a/data/chips/STM32L476QG.yaml
+++ b/data/chips/STM32L476QG.yaml
@@ -268,6 +268,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32L4_flash_v1_0
+      block: flash_l4/FLASH
       clock: AHB1
     GPIOA:
       address: 0x48000000

--- a/data/chips/STM32L476RC.yaml
+++ b/data/chips/STM32L476RC.yaml
@@ -256,6 +256,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32L4_flash_v1_0
+      block: flash_l4/FLASH
       clock: AHB1
     GPIOA:
       address: 0x48000000

--- a/data/chips/STM32L476RE.yaml
+++ b/data/chips/STM32L476RE.yaml
@@ -256,6 +256,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32L4_flash_v1_0
+      block: flash_l4/FLASH
       clock: AHB1
     GPIOA:
       address: 0x48000000

--- a/data/chips/STM32L476RG.yaml
+++ b/data/chips/STM32L476RG.yaml
@@ -256,6 +256,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32L4_flash_v1_0
+      block: flash_l4/FLASH
       clock: AHB1
     GPIOA:
       address: 0x48000000

--- a/data/chips/STM32L476VC.yaml
+++ b/data/chips/STM32L476VC.yaml
@@ -262,6 +262,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32L4_flash_v1_0
+      block: flash_l4/FLASH
       clock: AHB1
     GPIOA:
       address: 0x48000000

--- a/data/chips/STM32L476VE.yaml
+++ b/data/chips/STM32L476VE.yaml
@@ -262,6 +262,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32L4_flash_v1_0
+      block: flash_l4/FLASH
       clock: AHB1
     GPIOA:
       address: 0x48000000

--- a/data/chips/STM32L476VG.yaml
+++ b/data/chips/STM32L476VG.yaml
@@ -262,6 +262,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32L4_flash_v1_0
+      block: flash_l4/FLASH
       clock: AHB1
     GPIOA:
       address: 0x48000000

--- a/data/chips/STM32L476ZE.yaml
+++ b/data/chips/STM32L476ZE.yaml
@@ -278,6 +278,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32L4_flash_v1_0
+      block: flash_l4/FLASH
       clock: AHB1
     GPIOA:
       address: 0x48000000

--- a/data/chips/STM32L476ZG.yaml
+++ b/data/chips/STM32L476ZG.yaml
@@ -279,6 +279,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32L4_flash_v1_0
+      block: flash_l4/FLASH
       clock: AHB1
     GPIOA:
       address: 0x48000000

--- a/data/chips/STM32L485JC.yaml
+++ b/data/chips/STM32L485JC.yaml
@@ -262,6 +262,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32L4_flash_v1_0
+      block: flash_l4/FLASH
       clock: AHB1
     GPIOA:
       address: 0x48000000

--- a/data/chips/STM32L485JE.yaml
+++ b/data/chips/STM32L485JE.yaml
@@ -262,6 +262,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32L4_flash_v1_0
+      block: flash_l4/FLASH
       clock: AHB1
     GPIOA:
       address: 0x48000000

--- a/data/chips/STM32L486JG.yaml
+++ b/data/chips/STM32L486JG.yaml
@@ -273,6 +273,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32L4_flash_v1_0
+      block: flash_l4/FLASH
       clock: AHB1
     GPIOA:
       address: 0x48000000

--- a/data/chips/STM32L486QG.yaml
+++ b/data/chips/STM32L486QG.yaml
@@ -285,6 +285,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32L4_flash_v1_0
+      block: flash_l4/FLASH
       clock: AHB1
     GPIOA:
       address: 0x48000000

--- a/data/chips/STM32L486RG.yaml
+++ b/data/chips/STM32L486RG.yaml
@@ -273,6 +273,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32L4_flash_v1_0
+      block: flash_l4/FLASH
       clock: AHB1
     GPIOA:
       address: 0x48000000

--- a/data/chips/STM32L486VG.yaml
+++ b/data/chips/STM32L486VG.yaml
@@ -279,6 +279,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32L4_flash_v1_0
+      block: flash_l4/FLASH
       clock: AHB1
     GPIOA:
       address: 0x48000000

--- a/data/chips/STM32L486ZG.yaml
+++ b/data/chips/STM32L486ZG.yaml
@@ -295,6 +295,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32L4_flash_v1_0
+      block: flash_l4/FLASH
       clock: AHB1
     GPIOA:
       address: 0x48000000

--- a/data/chips/STM32L496AE.yaml
+++ b/data/chips/STM32L496AE.yaml
@@ -468,6 +468,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32L4_flash_v1_0
+      block: flash_l4/FLASH
       clock: AHB1
     GPIOA:
       address: 0x48000000

--- a/data/chips/STM32L496AG.yaml
+++ b/data/chips/STM32L496AG.yaml
@@ -464,6 +464,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32L4_flash_v1_0
+      block: flash_l4/FLASH
       clock: AHB1
     GPIOA:
       address: 0x48000000

--- a/data/chips/STM32L496QE.yaml
+++ b/data/chips/STM32L496QE.yaml
@@ -400,6 +400,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32L4_flash_v1_0
+      block: flash_l4/FLASH
       clock: AHB1
     GPIOA:
       address: 0x48000000

--- a/data/chips/STM32L496QG.yaml
+++ b/data/chips/STM32L496QG.yaml
@@ -399,6 +399,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32L4_flash_v1_0
+      block: flash_l4/FLASH
       clock: AHB1
     GPIOA:
       address: 0x48000000

--- a/data/chips/STM32L496RE.yaml
+++ b/data/chips/STM32L496RE.yaml
@@ -355,6 +355,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32L4_flash_v1_0
+      block: flash_l4/FLASH
       clock: AHB1
     GPIOA:
       address: 0x48000000

--- a/data/chips/STM32L496RG.yaml
+++ b/data/chips/STM32L496RG.yaml
@@ -348,6 +348,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32L4_flash_v1_0
+      block: flash_l4/FLASH
       clock: AHB1
     GPIOA:
       address: 0x48000000

--- a/data/chips/STM32L496VE.yaml
+++ b/data/chips/STM32L496VE.yaml
@@ -388,6 +388,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32L4_flash_v1_0
+      block: flash_l4/FLASH
       clock: AHB1
     GPIOA:
       address: 0x48000000

--- a/data/chips/STM32L496VG.yaml
+++ b/data/chips/STM32L496VG.yaml
@@ -379,6 +379,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32L4_flash_v1_0
+      block: flash_l4/FLASH
       clock: AHB1
     GPIOA:
       address: 0x48000000

--- a/data/chips/STM32L496WG.yaml
+++ b/data/chips/STM32L496WG.yaml
@@ -369,6 +369,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32L4_flash_v1_0
+      block: flash_l4/FLASH
       clock: AHB1
     GPIOA:
       address: 0x48000000

--- a/data/chips/STM32L496ZE.yaml
+++ b/data/chips/STM32L496ZE.yaml
@@ -413,6 +413,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32L4_flash_v1_0
+      block: flash_l4/FLASH
       clock: AHB1
     GPIOA:
       address: 0x48000000

--- a/data/chips/STM32L496ZG.yaml
+++ b/data/chips/STM32L496ZG.yaml
@@ -409,6 +409,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32L4_flash_v1_0
+      block: flash_l4/FLASH
       clock: AHB1
     GPIOA:
       address: 0x48000000

--- a/data/chips/STM32L4A6AG.yaml
+++ b/data/chips/STM32L4A6AG.yaml
@@ -481,6 +481,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32L4_flash_v1_0
+      block: flash_l4/FLASH
       clock: AHB1
     GPIOA:
       address: 0x48000000

--- a/data/chips/STM32L4A6QG.yaml
+++ b/data/chips/STM32L4A6QG.yaml
@@ -416,6 +416,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32L4_flash_v1_0
+      block: flash_l4/FLASH
       clock: AHB1
     GPIOA:
       address: 0x48000000

--- a/data/chips/STM32L4A6RG.yaml
+++ b/data/chips/STM32L4A6RG.yaml
@@ -365,6 +365,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32L4_flash_v1_0
+      block: flash_l4/FLASH
       clock: AHB1
     GPIOA:
       address: 0x48000000

--- a/data/chips/STM32L4A6VG.yaml
+++ b/data/chips/STM32L4A6VG.yaml
@@ -396,6 +396,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32L4_flash_v1_0
+      block: flash_l4/FLASH
       clock: AHB1
     GPIOA:
       address: 0x48000000

--- a/data/chips/STM32L4A6ZG.yaml
+++ b/data/chips/STM32L4A6ZG.yaml
@@ -426,6 +426,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32L4_flash_v1_0
+      block: flash_l4/FLASH
       clock: AHB1
     GPIOA:
       address: 0x48000000

--- a/data/chips/STM32L4P5AE.yaml
+++ b/data/chips/STM32L4P5AE.yaml
@@ -427,6 +427,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32L4_flash_v1_0
+      block: flash_l4/FLASH
       clock: AHB1
     GPIOA:
       address: 0x48000000

--- a/data/chips/STM32L4P5AG.yaml
+++ b/data/chips/STM32L4P5AG.yaml
@@ -423,6 +423,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32L4_flash_v1_0
+      block: flash_l4/FLASH
       clock: AHB1
     GPIOA:
       address: 0x48000000

--- a/data/chips/STM32L4P5CE.yaml
+++ b/data/chips/STM32L4P5CE.yaml
@@ -226,6 +226,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32L4_flash_v1_0
+      block: flash_l4/FLASH
       clock: AHB1
     GPIOA:
       address: 0x48000000

--- a/data/chips/STM32L4P5CG.yaml
+++ b/data/chips/STM32L4P5CG.yaml
@@ -224,6 +224,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32L4_flash_v1_0
+      block: flash_l4/FLASH
       clock: AHB1
     GPIOA:
       address: 0x48000000

--- a/data/chips/STM32L4P5QE.yaml
+++ b/data/chips/STM32L4P5QE.yaml
@@ -361,6 +361,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32L4_flash_v1_0
+      block: flash_l4/FLASH
       clock: AHB1
     GPIOA:
       address: 0x48000000

--- a/data/chips/STM32L4P5QG.yaml
+++ b/data/chips/STM32L4P5QG.yaml
@@ -360,6 +360,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32L4_flash_v1_0
+      block: flash_l4/FLASH
       clock: AHB1
     GPIOA:
       address: 0x48000000

--- a/data/chips/STM32L4P5RE.yaml
+++ b/data/chips/STM32L4P5RE.yaml
@@ -322,6 +322,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32L4_flash_v1_0
+      block: flash_l4/FLASH
       clock: AHB1
     GPIOA:
       address: 0x48000000

--- a/data/chips/STM32L4P5RG.yaml
+++ b/data/chips/STM32L4P5RG.yaml
@@ -315,6 +315,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32L4_flash_v1_0
+      block: flash_l4/FLASH
       clock: AHB1
     GPIOA:
       address: 0x48000000

--- a/data/chips/STM32L4P5VE.yaml
+++ b/data/chips/STM32L4P5VE.yaml
@@ -348,6 +348,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32L4_flash_v1_0
+      block: flash_l4/FLASH
       clock: AHB1
     GPIOA:
       address: 0x48000000

--- a/data/chips/STM32L4P5VG.yaml
+++ b/data/chips/STM32L4P5VG.yaml
@@ -346,6 +346,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32L4_flash_v1_0
+      block: flash_l4/FLASH
       clock: AHB1
     GPIOA:
       address: 0x48000000

--- a/data/chips/STM32L4P5ZE.yaml
+++ b/data/chips/STM32L4P5ZE.yaml
@@ -364,6 +364,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32L4_flash_v1_0
+      block: flash_l4/FLASH
       clock: AHB1
     GPIOA:
       address: 0x48000000

--- a/data/chips/STM32L4P5ZG.yaml
+++ b/data/chips/STM32L4P5ZG.yaml
@@ -360,6 +360,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32L4_flash_v1_0
+      block: flash_l4/FLASH
       clock: AHB1
     GPIOA:
       address: 0x48000000

--- a/data/chips/STM32L4Q5AG.yaml
+++ b/data/chips/STM32L4Q5AG.yaml
@@ -436,6 +436,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32L4_flash_v1_0
+      block: flash_l4/FLASH
       clock: AHB1
     GPIOA:
       address: 0x48000000

--- a/data/chips/STM32L4Q5CG.yaml
+++ b/data/chips/STM32L4Q5CG.yaml
@@ -237,6 +237,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32L4_flash_v1_0
+      block: flash_l4/FLASH
       clock: AHB1
     GPIOA:
       address: 0x48000000

--- a/data/chips/STM32L4Q5QG.yaml
+++ b/data/chips/STM32L4Q5QG.yaml
@@ -373,6 +373,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32L4_flash_v1_0
+      block: flash_l4/FLASH
       clock: AHB1
     GPIOA:
       address: 0x48000000

--- a/data/chips/STM32L4Q5RG.yaml
+++ b/data/chips/STM32L4Q5RG.yaml
@@ -328,6 +328,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32L4_flash_v1_0
+      block: flash_l4/FLASH
       clock: AHB1
     GPIOA:
       address: 0x48000000

--- a/data/chips/STM32L4Q5VG.yaml
+++ b/data/chips/STM32L4Q5VG.yaml
@@ -359,6 +359,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32L4_flash_v1_0
+      block: flash_l4/FLASH
       clock: AHB1
     GPIOA:
       address: 0x48000000

--- a/data/chips/STM32L4Q5ZG.yaml
+++ b/data/chips/STM32L4Q5ZG.yaml
@@ -373,6 +373,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32L4_flash_v1_0
+      block: flash_l4/FLASH
       clock: AHB1
     GPIOA:
       address: 0x48000000

--- a/data/chips/STM32L4R5AG.yaml
+++ b/data/chips/STM32L4R5AG.yaml
@@ -383,6 +383,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32L4_flash_v1_0
+      block: flash_l4/FLASH
       clock: AHB1
     GPIOA:
       address: 0x48000000

--- a/data/chips/STM32L4R5AI.yaml
+++ b/data/chips/STM32L4R5AI.yaml
@@ -383,6 +383,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32L4_flash_v1_0
+      block: flash_l4/FLASH
       clock: AHB1
     GPIOA:
       address: 0x48000000

--- a/data/chips/STM32L4R5QG.yaml
+++ b/data/chips/STM32L4R5QG.yaml
@@ -317,6 +317,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32L4_flash_v1_0
+      block: flash_l4/FLASH
       clock: AHB1
     GPIOA:
       address: 0x48000000

--- a/data/chips/STM32L4R5QI.yaml
+++ b/data/chips/STM32L4R5QI.yaml
@@ -317,6 +317,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32L4_flash_v1_0
+      block: flash_l4/FLASH
       clock: AHB1
     GPIOA:
       address: 0x48000000

--- a/data/chips/STM32L4R5VG.yaml
+++ b/data/chips/STM32L4R5VG.yaml
@@ -311,6 +311,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32L4_flash_v1_0
+      block: flash_l4/FLASH
       clock: AHB1
     GPIOA:
       address: 0x48000000

--- a/data/chips/STM32L4R5VI.yaml
+++ b/data/chips/STM32L4R5VI.yaml
@@ -311,6 +311,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32L4_flash_v1_0
+      block: flash_l4/FLASH
       clock: AHB1
     GPIOA:
       address: 0x48000000

--- a/data/chips/STM32L4R5ZG.yaml
+++ b/data/chips/STM32L4R5ZG.yaml
@@ -319,6 +319,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32L4_flash_v1_0
+      block: flash_l4/FLASH
       clock: AHB1
     GPIOA:
       address: 0x48000000

--- a/data/chips/STM32L4R5ZI.yaml
+++ b/data/chips/STM32L4R5ZI.yaml
@@ -318,6 +318,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32L4_flash_v1_0
+      block: flash_l4/FLASH
       clock: AHB1
     GPIOA:
       address: 0x48000000

--- a/data/chips/STM32L4R7AI.yaml
+++ b/data/chips/STM32L4R7AI.yaml
@@ -383,6 +383,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32L4_flash_v1_0
+      block: flash_l4/FLASH
       clock: AHB1
     GFXMMU:
       address: 0x4002c000

--- a/data/chips/STM32L4R7VI.yaml
+++ b/data/chips/STM32L4R7VI.yaml
@@ -311,6 +311,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32L4_flash_v1_0
+      block: flash_l4/FLASH
       clock: AHB1
     GFXMMU:
       address: 0x4002c000

--- a/data/chips/STM32L4R7ZI.yaml
+++ b/data/chips/STM32L4R7ZI.yaml
@@ -320,6 +320,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32L4_flash_v1_0
+      block: flash_l4/FLASH
       clock: AHB1
     GFXMMU:
       address: 0x4002c000

--- a/data/chips/STM32L4R9AG.yaml
+++ b/data/chips/STM32L4R9AG.yaml
@@ -370,6 +370,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32L4_flash_v1_0
+      block: flash_l4/FLASH
       clock: AHB1
     GFXMMU:
       address: 0x4002c000

--- a/data/chips/STM32L4R9AI.yaml
+++ b/data/chips/STM32L4R9AI.yaml
@@ -370,6 +370,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32L4_flash_v1_0
+      block: flash_l4/FLASH
       clock: AHB1
     GFXMMU:
       address: 0x4002c000

--- a/data/chips/STM32L4R9VG.yaml
+++ b/data/chips/STM32L4R9VG.yaml
@@ -301,6 +301,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32L4_flash_v1_0
+      block: flash_l4/FLASH
       clock: AHB1
     GFXMMU:
       address: 0x4002c000

--- a/data/chips/STM32L4R9VI.yaml
+++ b/data/chips/STM32L4R9VI.yaml
@@ -301,6 +301,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32L4_flash_v1_0
+      block: flash_l4/FLASH
       clock: AHB1
     GFXMMU:
       address: 0x4002c000

--- a/data/chips/STM32L4R9ZG.yaml
+++ b/data/chips/STM32L4R9ZG.yaml
@@ -321,6 +321,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32L4_flash_v1_0
+      block: flash_l4/FLASH
       clock: AHB1
     GFXMMU:
       address: 0x4002c000

--- a/data/chips/STM32L4R9ZI.yaml
+++ b/data/chips/STM32L4R9ZI.yaml
@@ -320,6 +320,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32L4_flash_v1_0
+      block: flash_l4/FLASH
       clock: AHB1
     GFXMMU:
       address: 0x4002c000

--- a/data/chips/STM32L4S5AI.yaml
+++ b/data/chips/STM32L4S5AI.yaml
@@ -396,6 +396,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32L4_flash_v1_0
+      block: flash_l4/FLASH
       clock: AHB1
     GPIOA:
       address: 0x48000000

--- a/data/chips/STM32L4S5QI.yaml
+++ b/data/chips/STM32L4S5QI.yaml
@@ -330,6 +330,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32L4_flash_v1_0
+      block: flash_l4/FLASH
       clock: AHB1
     GPIOA:
       address: 0x48000000

--- a/data/chips/STM32L4S5VI.yaml
+++ b/data/chips/STM32L4S5VI.yaml
@@ -324,6 +324,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32L4_flash_v1_0
+      block: flash_l4/FLASH
       clock: AHB1
     GPIOA:
       address: 0x48000000

--- a/data/chips/STM32L4S5ZI.yaml
+++ b/data/chips/STM32L4S5ZI.yaml
@@ -332,6 +332,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32L4_flash_v1_0
+      block: flash_l4/FLASH
       clock: AHB1
     GPIOA:
       address: 0x48000000

--- a/data/chips/STM32L4S7AI.yaml
+++ b/data/chips/STM32L4S7AI.yaml
@@ -396,6 +396,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32L4_flash_v1_0
+      block: flash_l4/FLASH
       clock: AHB1
     GFXMMU:
       address: 0x4002c000

--- a/data/chips/STM32L4S7VI.yaml
+++ b/data/chips/STM32L4S7VI.yaml
@@ -324,6 +324,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32L4_flash_v1_0
+      block: flash_l4/FLASH
       clock: AHB1
     GFXMMU:
       address: 0x4002c000

--- a/data/chips/STM32L4S7ZI.yaml
+++ b/data/chips/STM32L4S7ZI.yaml
@@ -333,6 +333,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32L4_flash_v1_0
+      block: flash_l4/FLASH
       clock: AHB1
     GFXMMU:
       address: 0x4002c000

--- a/data/chips/STM32L4S9AI.yaml
+++ b/data/chips/STM32L4S9AI.yaml
@@ -383,6 +383,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32L4_flash_v1_0
+      block: flash_l4/FLASH
       clock: AHB1
     GFXMMU:
       address: 0x4002c000

--- a/data/chips/STM32L4S9VI.yaml
+++ b/data/chips/STM32L4S9VI.yaml
@@ -314,6 +314,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32L4_flash_v1_0
+      block: flash_l4/FLASH
       clock: AHB1
     GFXMMU:
       address: 0x4002c000

--- a/data/chips/STM32L4S9ZI.yaml
+++ b/data/chips/STM32L4S9ZI.yaml
@@ -334,6 +334,7 @@ cores:
     FLASH:
       address: 0x40022000
       kind: FLASH:STM32L4_flash_v1_0
+      block: flash_l4/FLASH
       clock: AHB1
     GFXMMU:
       address: 0x4002c000

--- a/data/registers/flash_l4.yaml
+++ b/data/registers/flash_l4.yaml
@@ -1,0 +1,408 @@
+block/FLASH:
+  description: Flash
+  items:
+  - byte_offset: 0
+    description: Access control register
+    fieldset: ACR
+    name: ACR
+  - access: Write
+    byte_offset: 4
+    description: Power down key register
+    fieldset: PDKEYR
+    name: PDKEYR
+  - access: Write
+    byte_offset: 8
+    description: Flash key register
+    fieldset: KEYR
+    name: KEYR
+  - access: Write
+    byte_offset: 12
+    description: Option byte key register
+    fieldset: OPTKEYR
+    name: OPTKEYR
+  - byte_offset: 16
+    description: Status register
+    fieldset: SR
+    name: SR
+  - byte_offset: 20
+    description: Flash control register
+    fieldset: CR
+    name: CR
+  - byte_offset: 24
+    description: Flash ECC register
+    fieldset: ECCR
+    name: ECCR
+  - byte_offset: 32
+    description: Flash option register
+    fieldset: OPTR
+    name: OPTR
+  - byte_offset: 36
+    description: Flash Bank 1 PCROP Start address register
+    fieldset: PCROP1SR
+    name: PCROP1SR
+  - byte_offset: 40
+    description: Flash Bank 1 PCROP End address register
+    fieldset: PCROP1ER
+    name: PCROP1ER
+  - byte_offset: 44
+    description: Flash Bank 1 WRP area A address register
+    fieldset: WRP1AR
+    name: WRP1AR
+  - byte_offset: 48
+    description: Flash Bank 1 WRP area B address register
+    fieldset: WRP1BR
+    name: WRP1BR
+  - byte_offset: 68
+    description: Flash Bank 2 PCROP Start address register
+    fieldset: PCROP2SR
+    name: PCROP2SR
+  - byte_offset: 72
+    description: Flash Bank 2 PCROP End address register
+    fieldset: PCROP2ER
+    name: PCROP2ER
+  - byte_offset: 76
+    description: Flash Bank 2 WRP area A address register
+    fieldset: WRP2AR
+    name: WRP2AR
+  - byte_offset: 80
+    description: Flash Bank 2 WRP area B address register
+    fieldset: WRP2BR
+    name: WRP2BR
+fieldset/ACR:
+  description: Access control register
+  fields:
+  - bit_offset: 0
+    bit_size: 3
+    description: Latency
+    name: LATENCY
+  - bit_offset: 8
+    bit_size: 1
+    description: Prefetch enable
+    name: PRFTEN
+  - bit_offset: 9
+    bit_size: 1
+    description: Instruction cache enable
+    name: ICEN
+  - bit_offset: 10
+    bit_size: 1
+    description: Data cache enable
+    name: DCEN
+  - bit_offset: 11
+    bit_size: 1
+    description: Instruction cache reset
+    name: ICRST
+  - bit_offset: 12
+    bit_size: 1
+    description: Data cache reset
+    name: DCRST
+  - bit_offset: 13
+    bit_size: 1
+    description: Flash Power-down mode during Low-power run mode
+    name: RUN_PD
+  - bit_offset: 14
+    bit_size: 1
+    description: Flash Power-down mode during Low-power sleep mode
+    name: SLEEP_PD
+fieldset/CR:
+  description: Flash control register
+  fields:
+  - bit_offset: 0
+    bit_size: 1
+    description: Programming
+    name: PG
+  - bit_offset: 1
+    bit_size: 1
+    description: Page erase
+    name: PER
+  - array:
+      len: 2
+      stride: 13
+    bit_offset: 2
+    bit_size: 1
+    description: Bank 1 Mass erase
+    name: MER
+  - bit_offset: 3
+    bit_size: 8
+    description: Page number
+    name: PNB
+  - bit_offset: 11
+    bit_size: 1
+    description: Bank erase
+    name: BKER
+  - bit_offset: 16
+    bit_size: 1
+    description: Start
+    name: START
+  - bit_offset: 17
+    bit_size: 1
+    description: Options modification start
+    name: OPTSTRT
+  - bit_offset: 18
+    bit_size: 1
+    description: Fast programming
+    name: FSTPG
+  - bit_offset: 24
+    bit_size: 1
+    description: End of operation interrupt enable
+    name: EOPIE
+  - bit_offset: 25
+    bit_size: 1
+    description: Error interrupt enable
+    name: ERRIE
+  - bit_offset: 26
+    bit_size: 1
+    description: PCROP read error interrupt enable
+    name: RDERRIE
+  - bit_offset: 27
+    bit_size: 1
+    description: Force the option byte loading
+    name: OBL_LAUNCH
+  - bit_offset: 30
+    bit_size: 1
+    description: Options Lock
+    name: OPTLOCK
+  - bit_offset: 31
+    bit_size: 1
+    description: FLASH_CR Lock
+    name: LOCK
+fieldset/ECCR:
+  description: Flash ECC register
+  fields:
+  - bit_offset: 0
+    bit_size: 19
+    description: ECC fail address
+    name: ADDR_ECC
+  - bit_offset: 19
+    bit_size: 1
+    description: ECC fail bank
+    name: BK_ECC
+  - bit_offset: 20
+    bit_size: 1
+    description: System Flash ECC fail
+    name: SYSF_ECC
+  - bit_offset: 24
+    bit_size: 1
+    description: ECC correction interrupt enable
+    name: ECCIE
+  - bit_offset: 30
+    bit_size: 1
+    description: ECC correction
+    name: ECCC
+  - bit_offset: 31
+    bit_size: 1
+    description: ECC detection
+    name: ECCD
+fieldset/KEYR:
+  description: Flash key register
+  fields:
+  - bit_offset: 0
+    bit_size: 32
+    description: KEYR
+    name: KEYR
+fieldset/OPTKEYR:
+  description: Option byte key register
+  fields:
+  - bit_offset: 0
+    bit_size: 32
+    description: Option byte key
+    name: OPTKEYR
+fieldset/OPTR:
+  description: Flash option register
+  fields:
+  - bit_offset: 0
+    bit_size: 8
+    description: Read protection level
+    name: RDP
+  - bit_offset: 8
+    bit_size: 3
+    description: BOR reset Level
+    name: BOR_LEV
+  - bit_offset: 12
+    bit_size: 1
+    description: nRST_STOP
+    name: nRST_STOP
+  - bit_offset: 13
+    bit_size: 1
+    description: nRST_STDBY
+    name: nRST_STDBY
+  - bit_offset: 16
+    bit_size: 1
+    description: Independent watchdog selection
+    name: IDWG_SW
+  - bit_offset: 17
+    bit_size: 1
+    description: Independent watchdog counter freeze in Stop mode
+    name: IWDG_STOP
+  - bit_offset: 18
+    bit_size: 1
+    description: Independent watchdog counter freeze in Standby mode
+    name: IWDG_STDBY
+  - bit_offset: 19
+    bit_size: 1
+    description: Window watchdog selection
+    name: WWDG_SW
+  - array:
+      len: 1
+      stride: 0
+    bit_offset: 20
+    bit_size: 1
+    description: Dual-bank boot
+    name: BFB
+  - bit_offset: 21
+    bit_size: 1
+    description: Dual-Bank on 512 KB or 256 KB Flash memory devices
+    name: DUALBANK
+  - bit_offset: 23
+    bit_size: 1
+    description: Boot configuration
+    name: nBOOT1
+  - bit_offset: 24
+    bit_size: 1
+    description: SRAM2 parity check enable
+    name: SRAM2_PE
+  - bit_offset: 25
+    bit_size: 1
+    description: SRAM2 Erase when system reset
+    name: SRAM2_RST
+  - bit_offset: 26
+    bit_size: 1
+    description: Software BOOT0
+    name: nSWBOOT0
+  - bit_offset: 27
+    bit_size: 1
+    description: nBOOT0 option bit
+    name: nBOOT0
+fieldset/PCROP1ER:
+  description: Flash Bank 1 PCROP End address register
+  fields:
+  - bit_offset: 0
+    bit_size: 16
+    description: Bank 1 PCROP area end offset
+    name: PCROP1_END
+  - bit_offset: 31
+    bit_size: 1
+    description: PCROP area preserved when RDP level decreased
+    name: PCROP_RDP
+fieldset/PCROP1SR:
+  description: Flash Bank 1 PCROP Start address register
+  fields:
+  - bit_offset: 0
+    bit_size: 16
+    description: Bank 1 PCROP area start offset
+    name: PCROP1_STRT
+fieldset/PCROP2ER:
+  description: Flash Bank 2 PCROP End address register
+  fields:
+  - bit_offset: 0
+    bit_size: 16
+    description: Bank 2 PCROP area end offset
+    name: PCROP2_END
+fieldset/PCROP2SR:
+  description: Flash Bank 2 PCROP Start address register
+  fields:
+  - bit_offset: 0
+    bit_size: 16
+    description: Bank 2 PCROP area start offset
+    name: PCROP2_STRT
+fieldset/PDKEYR:
+  description: Power down key register
+  fields:
+  - bit_offset: 0
+    bit_size: 32
+    description: RUN_PD in FLASH_ACR key
+    name: PDKEYR
+fieldset/SR:
+  description: Status register
+  fields:
+  - bit_offset: 0
+    bit_size: 1
+    description: End of operation
+    name: EOP
+  - bit_offset: 1
+    bit_size: 1
+    description: Operation error
+    name: OPERR
+  - bit_offset: 3
+    bit_size: 1
+    description: Programming error
+    name: PROGERR
+  - bit_offset: 4
+    bit_size: 1
+    description: Write protected error
+    name: WRPERR
+  - bit_offset: 5
+    bit_size: 1
+    description: Programming alignment error
+    name: PGAERR
+  - bit_offset: 6
+    bit_size: 1
+    description: Size error
+    name: SIZERR
+  - bit_offset: 7
+    bit_size: 1
+    description: Programming sequence error
+    name: PGSERR
+  - bit_offset: 8
+    bit_size: 1
+    description: Fast programming data miss error
+    name: MISERR
+  - bit_offset: 9
+    bit_size: 1
+    description: Fast programming error
+    name: FASTERR
+  - bit_offset: 14
+    bit_size: 1
+    description: PCROP read error
+    name: RDERR
+  - bit_offset: 15
+    bit_size: 1
+    description: Option validity error
+    name: OPTVERR
+  - bit_offset: 16
+    bit_size: 1
+    description: Busy
+    name: BSY
+fieldset/WRP1AR:
+  description: Flash Bank 1 WRP area A address register
+  fields:
+  - bit_offset: 0
+    bit_size: 8
+    description: Bank 1 WRP first area tart offset
+    name: WRP1A_STRT
+  - bit_offset: 16
+    bit_size: 8
+    description: Bank 1 WRP first area A end offset
+    name: WRP1A_END
+fieldset/WRP1BR:
+  description: Flash Bank 1 WRP area B address register
+  fields:
+  - bit_offset: 0
+    bit_size: 8
+    description: Bank 1 WRP second area B start offset
+    name: WRP1B_STRT
+  - bit_offset: 16
+    bit_size: 8
+    description: Bank 1 WRP second area B end offset
+    name: WRP1B_END
+fieldset/WRP2AR:
+  description: Flash Bank 2 WRP area A address register
+  fields:
+  - bit_offset: 0
+    bit_size: 8
+    description: Bank 2 WRP first area A start offset
+    name: WRP2A_STRT
+  - bit_offset: 16
+    bit_size: 8
+    description: Bank 2 WRP first area A end offset
+    name: WRP2A_END
+fieldset/WRP2BR:
+  description: Flash Bank 2 WRP area B address register
+  fields:
+  - bit_offset: 0
+    bit_size: 8
+    description: Bank 2 WRP second area B start offset
+    name: WRP2B_STRT
+  - bit_offset: 16
+    bit_size: 8
+    description: Bank 2 WRP second area B end offset
+    name: WRP2B_END

--- a/parse.py
+++ b/parse.py
@@ -397,6 +397,7 @@ perimap = [
     ('.*:STM32F0_flash_v1_0', 'flash_f0/FLASH'),
     ('.*:STM32F1_flash_v1_0', 'flash_f1/FLASH'),
     ('.*:STM32F4_flash_v1_0', 'flash_f4/FLASH'),
+    ('.*:STM32L4_flash_v1_0', 'flash_l4/FLASH'),
     ('.*TIM\d.*:gptimer.*', 'timer_v1/TIM_GP16'),
     ('.*ETH:ethermac110_v3_0', 'eth_v2/ETH'),
 


### PR DESCRIPTION
This adds the flash register for L4 devices, needed for a PR I'm about to make in embassy for additional L4 clock sources.