### PR TITLE
Add `SYSCFG`, `PWR`, `FLASH` and `SPI` registers for `STM32F3`

### DIFF
--- a/data/chips/STM32F301C6.yaml
+++ b/data/chips/STM32F301C6.yaml
@@ -309,6 +309,7 @@ cores:
       block: exti_v1/EXTI
     FLASH:
       address: 0x40022000
+      block: flash_f3/FLASH
     GPIOA:
       address: 0x48000000
       rcc:
@@ -518,6 +519,7 @@ cores:
           reset:
             register: APB1RSTR
             field: PWRRST
+      block: pwr_f3/PWR
     RCC:
       address: 0x40021000
       block: rcc_f3/RCC
@@ -549,6 +551,7 @@ cores:
           reset:
             register: APB1RSTR
             field: SPI2RST
+      block: spi_v2/SPI
       pins:
       - pin: PA10
         signal: MISO
@@ -592,6 +595,7 @@ cores:
           reset:
             register: APB1RSTR
             field: SPI3RST
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -635,6 +639,7 @@ cores:
           reset:
             register: APB2RSTR
             field: SYSCFGRST
+      block: syscfg_f3/SYSCFG
     TIM1:
       address: 0x40012c00
       rcc:

--- a/data/chips/STM32F301C8.yaml
+++ b/data/chips/STM32F301C8.yaml
@@ -315,6 +315,7 @@ cores:
       block: exti_v1/EXTI
     FLASH:
       address: 0x40022000
+      block: flash_f3/FLASH
     GPIOA:
       address: 0x48000000
       rcc:
@@ -524,6 +525,7 @@ cores:
           reset:
             register: APB1RSTR
             field: PWRRST
+      block: pwr_f3/PWR
     RCC:
       address: 0x40021000
       block: rcc_f3/RCC
@@ -555,6 +557,7 @@ cores:
           reset:
             register: APB1RSTR
             field: SPI2RST
+      block: spi_v2/SPI
       pins:
       - pin: PA10
         signal: MISO
@@ -598,6 +601,7 @@ cores:
           reset:
             register: APB1RSTR
             field: SPI3RST
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -641,6 +645,7 @@ cores:
           reset:
             register: APB2RSTR
             field: SYSCFGRST
+      block: syscfg_f3/SYSCFG
     TIM1:
       address: 0x40012c00
       rcc:

--- a/data/chips/STM32F301K6.yaml
+++ b/data/chips/STM32F301K6.yaml
@@ -296,6 +296,7 @@ cores:
       block: exti_v1/EXTI
     FLASH:
       address: 0x40022000
+      block: flash_f3/FLASH
     GPIOA:
       address: 0x48000000
       rcc:
@@ -501,6 +502,7 @@ cores:
           reset:
             register: APB1RSTR
             field: PWRRST
+      block: pwr_f3/PWR
     RCC:
       address: 0x40021000
       block: rcc_f3/RCC
@@ -532,6 +534,7 @@ cores:
           reset:
             register: APB1RSTR
             field: SPI2RST
+      block: spi_v2/SPI
       pins:
       - pin: PA10
         signal: MISO
@@ -575,6 +578,7 @@ cores:
           reset:
             register: APB1RSTR
             field: SPI3RST
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -618,6 +622,7 @@ cores:
           reset:
             register: APB2RSTR
             field: SYSCFGRST
+      block: syscfg_f3/SYSCFG
     TIM1:
       address: 0x40012c00
       rcc:

--- a/data/chips/STM32F301K8.yaml
+++ b/data/chips/STM32F301K8.yaml
@@ -300,6 +300,7 @@ cores:
       block: exti_v1/EXTI
     FLASH:
       address: 0x40022000
+      block: flash_f3/FLASH
     GPIOA:
       address: 0x48000000
       rcc:
@@ -505,6 +506,7 @@ cores:
           reset:
             register: APB1RSTR
             field: PWRRST
+      block: pwr_f3/PWR
     RCC:
       address: 0x40021000
       block: rcc_f3/RCC
@@ -536,6 +538,7 @@ cores:
           reset:
             register: APB1RSTR
             field: SPI2RST
+      block: spi_v2/SPI
       pins:
       - pin: PA10
         signal: MISO
@@ -579,6 +582,7 @@ cores:
           reset:
             register: APB1RSTR
             field: SPI3RST
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -622,6 +626,7 @@ cores:
           reset:
             register: APB2RSTR
             field: SYSCFGRST
+      block: syscfg_f3/SYSCFG
     TIM1:
       address: 0x40012c00
       rcc:

--- a/data/chips/STM32F301R6.yaml
+++ b/data/chips/STM32F301R6.yaml
@@ -317,6 +317,7 @@ cores:
       block: exti_v1/EXTI
     FLASH:
       address: 0x40022000
+      block: flash_f3/FLASH
     GPIOA:
       address: 0x48000000
       rcc:
@@ -530,6 +531,7 @@ cores:
           reset:
             register: APB1RSTR
             field: PWRRST
+      block: pwr_f3/PWR
     RCC:
       address: 0x40021000
       block: rcc_f3/RCC
@@ -561,6 +563,7 @@ cores:
           reset:
             register: APB1RSTR
             field: SPI2RST
+      block: spi_v2/SPI
       pins:
       - pin: PA10
         signal: MISO
@@ -604,6 +607,7 @@ cores:
           reset:
             register: APB1RSTR
             field: SPI3RST
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -647,6 +651,7 @@ cores:
           reset:
             register: APB2RSTR
             field: SYSCFGRST
+      block: syscfg_f3/SYSCFG
     TIM1:
       address: 0x40012c00
       rcc:

--- a/data/chips/STM32F301R8.yaml
+++ b/data/chips/STM32F301R8.yaml
@@ -321,6 +321,7 @@ cores:
       block: exti_v1/EXTI
     FLASH:
       address: 0x40022000
+      block: flash_f3/FLASH
     GPIOA:
       address: 0x48000000
       rcc:
@@ -534,6 +535,7 @@ cores:
           reset:
             register: APB1RSTR
             field: PWRRST
+      block: pwr_f3/PWR
     RCC:
       address: 0x40021000
       block: rcc_f3/RCC
@@ -565,6 +567,7 @@ cores:
           reset:
             register: APB1RSTR
             field: SPI2RST
+      block: spi_v2/SPI
       pins:
       - pin: PA10
         signal: MISO
@@ -608,6 +611,7 @@ cores:
           reset:
             register: APB1RSTR
             field: SPI3RST
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -651,6 +655,7 @@ cores:
           reset:
             register: APB2RSTR
             field: SYSCFGRST
+      block: syscfg_f3/SYSCFG
     TIM1:
       address: 0x40012c00
       rcc:

--- a/data/chips/STM32F302C6.yaml
+++ b/data/chips/STM32F302C6.yaml
@@ -347,6 +347,7 @@ cores:
       block: exti_v1/EXTI
     FLASH:
       address: 0x40022000
+      block: flash_f3/FLASH
     GPIOA:
       address: 0x48000000
       rcc:
@@ -556,6 +557,7 @@ cores:
           reset:
             register: APB1RSTR
             field: PWRRST
+      block: pwr_f3/PWR
     RCC:
       address: 0x40021000
       block: rcc_f3/RCC
@@ -587,6 +589,7 @@ cores:
           reset:
             register: APB1RSTR
             field: SPI2RST
+      block: spi_v2/SPI
       pins:
       - pin: PA10
         signal: MISO
@@ -630,6 +633,7 @@ cores:
           reset:
             register: APB1RSTR
             field: SPI3RST
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -673,6 +677,7 @@ cores:
           reset:
             register: APB2RSTR
             field: SYSCFGRST
+      block: syscfg_f3/SYSCFG
     TIM1:
       address: 0x40012c00
       rcc:

--- a/data/chips/STM32F302C8.yaml
+++ b/data/chips/STM32F302C8.yaml
@@ -349,6 +349,7 @@ cores:
       block: exti_v1/EXTI
     FLASH:
       address: 0x40022000
+      block: flash_f3/FLASH
     GPIOA:
       address: 0x48000000
       rcc:
@@ -558,6 +559,7 @@ cores:
           reset:
             register: APB1RSTR
             field: PWRRST
+      block: pwr_f3/PWR
     RCC:
       address: 0x40021000
       block: rcc_f3/RCC
@@ -589,6 +591,7 @@ cores:
           reset:
             register: APB1RSTR
             field: SPI2RST
+      block: spi_v2/SPI
       pins:
       - pin: PA10
         signal: MISO
@@ -632,6 +635,7 @@ cores:
           reset:
             register: APB1RSTR
             field: SPI3RST
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -675,6 +679,7 @@ cores:
           reset:
             register: APB2RSTR
             field: SYSCFGRST
+      block: syscfg_f3/SYSCFG
     TIM1:
       address: 0x40012c00
       rcc:

--- a/data/chips/STM32F302CB.yaml
+++ b/data/chips/STM32F302CB.yaml
@@ -406,6 +406,7 @@ cores:
       block: exti_v1/EXTI
     FLASH:
       address: 0x40022000
+      block: flash_f3/FLASH
     GPIOA:
       address: 0x48000000
       rcc:
@@ -622,6 +623,7 @@ cores:
           reset:
             register: APB1RSTR
             field: PWRRST
+      block: pwr_f3/PWR
     RCC:
       address: 0x40021000
       block: rcc_f3/RCC
@@ -653,6 +655,7 @@ cores:
           reset:
             register: APB2RSTR
             field: SPI1RST
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -696,6 +699,7 @@ cores:
           reset:
             register: APB1RSTR
             field: SPI2RST
+      block: spi_v2/SPI
       pins:
       - pin: PB12
         signal: NSS
@@ -736,6 +740,7 @@ cores:
           reset:
             register: APB1RSTR
             field: SPI3RST
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -779,6 +784,7 @@ cores:
           reset:
             register: APB2RSTR
             field: SYSCFGRST
+      block: syscfg_f3/SYSCFG
     TIM1:
       address: 0x40012c00
       rcc:

--- a/data/chips/STM32F302CC.yaml
+++ b/data/chips/STM32F302CC.yaml
@@ -406,6 +406,7 @@ cores:
       block: exti_v1/EXTI
     FLASH:
       address: 0x40022000
+      block: flash_f3/FLASH
     GPIOA:
       address: 0x48000000
       rcc:
@@ -622,6 +623,7 @@ cores:
           reset:
             register: APB1RSTR
             field: PWRRST
+      block: pwr_f3/PWR
     RCC:
       address: 0x40021000
       block: rcc_f3/RCC
@@ -653,6 +655,7 @@ cores:
           reset:
             register: APB2RSTR
             field: SPI1RST
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -696,6 +699,7 @@ cores:
           reset:
             register: APB1RSTR
             field: SPI2RST
+      block: spi_v2/SPI
       pins:
       - pin: PB12
         signal: NSS
@@ -736,6 +740,7 @@ cores:
           reset:
             register: APB1RSTR
             field: SPI3RST
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -779,6 +784,7 @@ cores:
           reset:
             register: APB2RSTR
             field: SYSCFGRST
+      block: syscfg_f3/SYSCFG
     TIM1:
       address: 0x40012c00
       rcc:

--- a/data/chips/STM32F302K6.yaml
+++ b/data/chips/STM32F302K6.yaml
@@ -330,6 +330,7 @@ cores:
       block: exti_v1/EXTI
     FLASH:
       address: 0x40022000
+      block: flash_f3/FLASH
     GPIOA:
       address: 0x48000000
       rcc:
@@ -535,6 +536,7 @@ cores:
           reset:
             register: APB1RSTR
             field: PWRRST
+      block: pwr_f3/PWR
     RCC:
       address: 0x40021000
       block: rcc_f3/RCC
@@ -566,6 +568,7 @@ cores:
           reset:
             register: APB1RSTR
             field: SPI2RST
+      block: spi_v2/SPI
       pins:
       - pin: PA10
         signal: MISO
@@ -609,6 +612,7 @@ cores:
           reset:
             register: APB1RSTR
             field: SPI3RST
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -652,6 +656,7 @@ cores:
           reset:
             register: APB2RSTR
             field: SYSCFGRST
+      block: syscfg_f3/SYSCFG
     TIM1:
       address: 0x40012c00
       rcc:

--- a/data/chips/STM32F302K8.yaml
+++ b/data/chips/STM32F302K8.yaml
@@ -330,6 +330,7 @@ cores:
       block: exti_v1/EXTI
     FLASH:
       address: 0x40022000
+      block: flash_f3/FLASH
     GPIOA:
       address: 0x48000000
       rcc:
@@ -535,6 +536,7 @@ cores:
           reset:
             register: APB1RSTR
             field: PWRRST
+      block: pwr_f3/PWR
     RCC:
       address: 0x40021000
       block: rcc_f3/RCC
@@ -566,6 +568,7 @@ cores:
           reset:
             register: APB1RSTR
             field: SPI2RST
+      block: spi_v2/SPI
       pins:
       - pin: PA10
         signal: MISO
@@ -609,6 +612,7 @@ cores:
           reset:
             register: APB1RSTR
             field: SPI3RST
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -652,6 +656,7 @@ cores:
           reset:
             register: APB2RSTR
             field: SYSCFGRST
+      block: syscfg_f3/SYSCFG
     TIM1:
       address: 0x40012c00
       rcc:

--- a/data/chips/STM32F302R6.yaml
+++ b/data/chips/STM32F302R6.yaml
@@ -355,6 +355,7 @@ cores:
       block: exti_v1/EXTI
     FLASH:
       address: 0x40022000
+      block: flash_f3/FLASH
     GPIOA:
       address: 0x48000000
       rcc:
@@ -568,6 +569,7 @@ cores:
           reset:
             register: APB1RSTR
             field: PWRRST
+      block: pwr_f3/PWR
     RCC:
       address: 0x40021000
       block: rcc_f3/RCC
@@ -599,6 +601,7 @@ cores:
           reset:
             register: APB1RSTR
             field: SPI2RST
+      block: spi_v2/SPI
       pins:
       - pin: PA10
         signal: MISO
@@ -642,6 +645,7 @@ cores:
           reset:
             register: APB1RSTR
             field: SPI3RST
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -685,6 +689,7 @@ cores:
           reset:
             register: APB2RSTR
             field: SYSCFGRST
+      block: syscfg_f3/SYSCFG
     TIM1:
       address: 0x40012c00
       rcc:

--- a/data/chips/STM32F302R8.yaml
+++ b/data/chips/STM32F302R8.yaml
@@ -355,6 +355,7 @@ cores:
       block: exti_v1/EXTI
     FLASH:
       address: 0x40022000
+      block: flash_f3/FLASH
     GPIOA:
       address: 0x48000000
       rcc:
@@ -568,6 +569,7 @@ cores:
           reset:
             register: APB1RSTR
             field: PWRRST
+      block: pwr_f3/PWR
     RCC:
       address: 0x40021000
       block: rcc_f3/RCC
@@ -599,6 +601,7 @@ cores:
           reset:
             register: APB1RSTR
             field: SPI2RST
+      block: spi_v2/SPI
       pins:
       - pin: PA10
         signal: MISO
@@ -642,6 +645,7 @@ cores:
           reset:
             register: APB1RSTR
             field: SPI3RST
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -685,6 +689,7 @@ cores:
           reset:
             register: APB2RSTR
             field: SYSCFGRST
+      block: syscfg_f3/SYSCFG
     TIM1:
       address: 0x40012c00
       rcc:

--- a/data/chips/STM32F302RB.yaml
+++ b/data/chips/STM32F302RB.yaml
@@ -428,6 +428,7 @@ cores:
       block: exti_v1/EXTI
     FLASH:
       address: 0x40022000
+      block: flash_f3/FLASH
     GPIOA:
       address: 0x48000000
       rcc:
@@ -652,6 +653,7 @@ cores:
           reset:
             register: APB1RSTR
             field: PWRRST
+      block: pwr_f3/PWR
     RCC:
       address: 0x40021000
       block: rcc_f3/RCC
@@ -683,6 +685,7 @@ cores:
           reset:
             register: APB2RSTR
             field: SPI1RST
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -726,6 +729,7 @@ cores:
           reset:
             register: APB1RSTR
             field: SPI2RST
+      block: spi_v2/SPI
       pins:
       - pin: PB12
         signal: NSS
@@ -766,6 +770,7 @@ cores:
           reset:
             register: APB1RSTR
             field: SPI3RST
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -809,6 +814,7 @@ cores:
           reset:
             register: APB2RSTR
             field: SYSCFGRST
+      block: syscfg_f3/SYSCFG
     TIM1:
       address: 0x40012c00
       rcc:

--- a/data/chips/STM32F302RC.yaml
+++ b/data/chips/STM32F302RC.yaml
@@ -428,6 +428,7 @@ cores:
       block: exti_v1/EXTI
     FLASH:
       address: 0x40022000
+      block: flash_f3/FLASH
     GPIOA:
       address: 0x48000000
       rcc:
@@ -652,6 +653,7 @@ cores:
           reset:
             register: APB1RSTR
             field: PWRRST
+      block: pwr_f3/PWR
     RCC:
       address: 0x40021000
       block: rcc_f3/RCC
@@ -683,6 +685,7 @@ cores:
           reset:
             register: APB2RSTR
             field: SPI1RST
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -726,6 +729,7 @@ cores:
           reset:
             register: APB1RSTR
             field: SPI2RST
+      block: spi_v2/SPI
       pins:
       - pin: PB12
         signal: NSS
@@ -766,6 +770,7 @@ cores:
           reset:
             register: APB1RSTR
             field: SPI3RST
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -809,6 +814,7 @@ cores:
           reset:
             register: APB2RSTR
             field: SYSCFGRST
+      block: syscfg_f3/SYSCFG
     TIM1:
       address: 0x40012c00
       rcc:

--- a/data/chips/STM32F302RD.yaml
+++ b/data/chips/STM32F302RD.yaml
@@ -430,6 +430,7 @@ cores:
       block: exti_v1/EXTI
     FLASH:
       address: 0x40022000
+      block: flash_f3/FLASH
     GPIOA:
       address: 0x48000000
       rcc:
@@ -711,6 +712,7 @@ cores:
           reset:
             register: APB1RSTR
             field: PWRRST
+      block: pwr_f3/PWR
     RCC:
       address: 0x40021000
       block: rcc_f3/RCC
@@ -742,6 +744,7 @@ cores:
           reset:
             register: APB2RSTR
             field: SPI1RST
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -785,6 +788,7 @@ cores:
           reset:
             register: APB1RSTR
             field: SPI2RST
+      block: spi_v2/SPI
       pins:
       - pin: PA10
         signal: MISO
@@ -837,6 +841,7 @@ cores:
           reset:
             register: APB1RSTR
             field: SPI3RST
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -880,6 +885,7 @@ cores:
           reset:
             register: APB2RSTR
             field: SYSCFGRST
+      block: syscfg_f3/SYSCFG
     TIM1:
       address: 0x40012c00
       rcc:

--- a/data/chips/STM32F302RE.yaml
+++ b/data/chips/STM32F302RE.yaml
@@ -432,6 +432,7 @@ cores:
       block: exti_v1/EXTI
     FLASH:
       address: 0x40022000
+      block: flash_f3/FLASH
     GPIOA:
       address: 0x48000000
       rcc:
@@ -713,6 +714,7 @@ cores:
           reset:
             register: APB1RSTR
             field: PWRRST
+      block: pwr_f3/PWR
     RCC:
       address: 0x40021000
       block: rcc_f3/RCC
@@ -744,6 +746,7 @@ cores:
           reset:
             register: APB2RSTR
             field: SPI1RST
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -787,6 +790,7 @@ cores:
           reset:
             register: APB1RSTR
             field: SPI2RST
+      block: spi_v2/SPI
       pins:
       - pin: PA10
         signal: MISO
@@ -839,6 +843,7 @@ cores:
           reset:
             register: APB1RSTR
             field: SPI3RST
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -882,6 +887,7 @@ cores:
           reset:
             register: APB2RSTR
             field: SYSCFGRST
+      block: syscfg_f3/SYSCFG
     TIM1:
       address: 0x40012c00
       rcc:

--- a/data/chips/STM32F302VB.yaml
+++ b/data/chips/STM32F302VB.yaml
@@ -432,6 +432,7 @@ cores:
       block: exti_v1/EXTI
     FLASH:
       address: 0x40022000
+      block: flash_f3/FLASH
     GPIOA:
       address: 0x48000000
       rcc:
@@ -660,6 +661,7 @@ cores:
           reset:
             register: APB1RSTR
             field: PWRRST
+      block: pwr_f3/PWR
     RCC:
       address: 0x40021000
       block: rcc_f3/RCC
@@ -691,6 +693,7 @@ cores:
           reset:
             register: APB2RSTR
             field: SPI1RST
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -734,6 +737,7 @@ cores:
           reset:
             register: APB1RSTR
             field: SPI2RST
+      block: spi_v2/SPI
       pins:
       - pin: PB12
         signal: NSS
@@ -774,6 +778,7 @@ cores:
           reset:
             register: APB1RSTR
             field: SPI3RST
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -817,6 +822,7 @@ cores:
           reset:
             register: APB2RSTR
             field: SYSCFGRST
+      block: syscfg_f3/SYSCFG
     TIM1:
       address: 0x40012c00
       rcc:

--- a/data/chips/STM32F302VC.yaml
+++ b/data/chips/STM32F302VC.yaml
@@ -434,6 +434,7 @@ cores:
       block: exti_v1/EXTI
     FLASH:
       address: 0x40022000
+      block: flash_f3/FLASH
     GPIOA:
       address: 0x48000000
       rcc:
@@ -662,6 +663,7 @@ cores:
           reset:
             register: APB1RSTR
             field: PWRRST
+      block: pwr_f3/PWR
     RCC:
       address: 0x40021000
       block: rcc_f3/RCC
@@ -693,6 +695,7 @@ cores:
           reset:
             register: APB2RSTR
             field: SPI1RST
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -736,6 +739,7 @@ cores:
           reset:
             register: APB1RSTR
             field: SPI2RST
+      block: spi_v2/SPI
       pins:
       - pin: PB12
         signal: NSS
@@ -776,6 +780,7 @@ cores:
           reset:
             register: APB1RSTR
             field: SPI3RST
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -819,6 +824,7 @@ cores:
           reset:
             register: APB2RSTR
             field: SYSCFGRST
+      block: syscfg_f3/SYSCFG
     TIM1:
       address: 0x40012c00
       rcc:

--- a/data/chips/STM32F302VD.yaml
+++ b/data/chips/STM32F302VD.yaml
@@ -436,6 +436,7 @@ cores:
       block: exti_v1/EXTI
     FLASH:
       address: 0x40022000
+      block: flash_f3/FLASH
     FMC:
       address: 0x60000000
       rcc:
@@ -927,6 +928,7 @@ cores:
           reset:
             register: APB1RSTR
             field: PWRRST
+      block: pwr_f3/PWR
     RCC:
       address: 0x40021000
       block: rcc_f3/RCC
@@ -958,6 +960,7 @@ cores:
           reset:
             register: APB2RSTR
             field: SPI1RST
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -1001,6 +1004,7 @@ cores:
           reset:
             register: APB1RSTR
             field: SPI2RST
+      block: spi_v2/SPI
       pins:
       - pin: PA10
         signal: MISO
@@ -1053,6 +1057,7 @@ cores:
           reset:
             register: APB1RSTR
             field: SPI3RST
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -1096,6 +1101,7 @@ cores:
           reset:
             register: APB2RSTR
             field: SPI4RST
+      block: spi_v2/SPI
       pins:
       - pin: PE2
         signal: SCK
@@ -1142,6 +1148,7 @@ cores:
           reset:
             register: APB2RSTR
             field: SYSCFGRST
+      block: syscfg_f3/SYSCFG
     TIM1:
       address: 0x40012c00
       rcc:

--- a/data/chips/STM32F302VE.yaml
+++ b/data/chips/STM32F302VE.yaml
@@ -438,6 +438,7 @@ cores:
       block: exti_v1/EXTI
     FLASH:
       address: 0x40022000
+      block: flash_f3/FLASH
     FMC:
       address: 0x60000000
       rcc:
@@ -929,6 +930,7 @@ cores:
           reset:
             register: APB1RSTR
             field: PWRRST
+      block: pwr_f3/PWR
     RCC:
       address: 0x40021000
       block: rcc_f3/RCC
@@ -960,6 +962,7 @@ cores:
           reset:
             register: APB2RSTR
             field: SPI1RST
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -1003,6 +1006,7 @@ cores:
           reset:
             register: APB1RSTR
             field: SPI2RST
+      block: spi_v2/SPI
       pins:
       - pin: PA10
         signal: MISO
@@ -1055,6 +1059,7 @@ cores:
           reset:
             register: APB1RSTR
             field: SPI3RST
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -1098,6 +1103,7 @@ cores:
           reset:
             register: APB2RSTR
             field: SPI4RST
+      block: spi_v2/SPI
       pins:
       - pin: PE2
         signal: SCK
@@ -1144,6 +1150,7 @@ cores:
           reset:
             register: APB2RSTR
             field: SYSCFGRST
+      block: syscfg_f3/SYSCFG
     TIM1:
       address: 0x40012c00
       rcc:

--- a/data/chips/STM32F302ZD.yaml
+++ b/data/chips/STM32F302ZD.yaml
@@ -436,6 +436,7 @@ cores:
       block: exti_v1/EXTI
     FLASH:
       address: 0x40022000
+      block: flash_f3/FLASH
     FMC:
       address: 0x60000000
       rcc:
@@ -927,6 +928,7 @@ cores:
           reset:
             register: APB1RSTR
             field: PWRRST
+      block: pwr_f3/PWR
     RCC:
       address: 0x40021000
       block: rcc_f3/RCC
@@ -958,6 +960,7 @@ cores:
           reset:
             register: APB2RSTR
             field: SPI1RST
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -1001,6 +1004,7 @@ cores:
           reset:
             register: APB1RSTR
             field: SPI2RST
+      block: spi_v2/SPI
       pins:
       - pin: PA10
         signal: MISO
@@ -1053,6 +1057,7 @@ cores:
           reset:
             register: APB1RSTR
             field: SPI3RST
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -1096,6 +1101,7 @@ cores:
           reset:
             register: APB2RSTR
             field: SPI4RST
+      block: spi_v2/SPI
       pins:
       - pin: PE2
         signal: SCK
@@ -1142,6 +1148,7 @@ cores:
           reset:
             register: APB2RSTR
             field: SYSCFGRST
+      block: syscfg_f3/SYSCFG
     TIM1:
       address: 0x40012c00
       rcc:

--- a/data/chips/STM32F302ZE.yaml
+++ b/data/chips/STM32F302ZE.yaml
@@ -438,6 +438,7 @@ cores:
       block: exti_v1/EXTI
     FLASH:
       address: 0x40022000
+      block: flash_f3/FLASH
     FMC:
       address: 0x60000000
       rcc:
@@ -929,6 +930,7 @@ cores:
           reset:
             register: APB1RSTR
             field: PWRRST
+      block: pwr_f3/PWR
     RCC:
       address: 0x40021000
       block: rcc_f3/RCC
@@ -960,6 +962,7 @@ cores:
           reset:
             register: APB2RSTR
             field: SPI1RST
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -1003,6 +1006,7 @@ cores:
           reset:
             register: APB1RSTR
             field: SPI2RST
+      block: spi_v2/SPI
       pins:
       - pin: PA10
         signal: MISO
@@ -1055,6 +1059,7 @@ cores:
           reset:
             register: APB1RSTR
             field: SPI3RST
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -1098,6 +1103,7 @@ cores:
           reset:
             register: APB2RSTR
             field: SPI4RST
+      block: spi_v2/SPI
       pins:
       - pin: PE2
         signal: SCK
@@ -1144,6 +1150,7 @@ cores:
           reset:
             register: APB2RSTR
             field: SYSCFGRST
+      block: syscfg_f3/SYSCFG
     TIM1:
       address: 0x40012c00
       rcc:

--- a/data/chips/STM32F303C6.yaml
+++ b/data/chips/STM32F303C6.yaml
@@ -410,6 +410,7 @@ cores:
       block: exti_v1/EXTI
     FLASH:
       address: 0x40022000
+      block: flash_f3/FLASH
     GPIOA:
       address: 0x48000000
       rcc:
@@ -536,6 +537,7 @@ cores:
           reset:
             register: APB1RSTR
             field: PWRRST
+      block: pwr_f3/PWR
     RCC:
       address: 0x40021000
       block: rcc_f3/RCC
@@ -560,6 +562,7 @@ cores:
           reset:
             register: APB2RSTR
             field: SPI1RST
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -607,6 +610,7 @@ cores:
           reset:
             register: APB2RSTR
             field: SYSCFGRST
+      block: syscfg_f3/SYSCFG
     TIM1:
       address: 0x40012c00
       rcc:

--- a/data/chips/STM32F303C8.yaml
+++ b/data/chips/STM32F303C8.yaml
@@ -412,6 +412,7 @@ cores:
       block: exti_v1/EXTI
     FLASH:
       address: 0x40022000
+      block: flash_f3/FLASH
     GPIOA:
       address: 0x48000000
       rcc:
@@ -538,6 +539,7 @@ cores:
           reset:
             register: APB1RSTR
             field: PWRRST
+      block: pwr_f3/PWR
     RCC:
       address: 0x40021000
       block: rcc_f3/RCC
@@ -562,6 +564,7 @@ cores:
           reset:
             register: APB2RSTR
             field: SPI1RST
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -609,6 +612,7 @@ cores:
           reset:
             register: APB2RSTR
             field: SYSCFGRST
+      block: syscfg_f3/SYSCFG
     TIM1:
       address: 0x40012c00
       rcc:

--- a/data/chips/STM32F303CB.yaml
+++ b/data/chips/STM32F303CB.yaml
@@ -475,6 +475,7 @@ cores:
       block: exti_v1/EXTI
     FLASH:
       address: 0x40022000
+      block: flash_f3/FLASH
     GPIOA:
       address: 0x48000000
       rcc:
@@ -741,6 +742,7 @@ cores:
           reset:
             register: APB1RSTR
             field: PWRRST
+      block: pwr_f3/PWR
     RCC:
       address: 0x40021000
       block: rcc_f3/RCC
@@ -772,6 +774,7 @@ cores:
           reset:
             register: APB2RSTR
             field: SPI1RST
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -815,6 +818,7 @@ cores:
           reset:
             register: APB1RSTR
             field: SPI2RST
+      block: spi_v2/SPI
       pins:
       - pin: PB12
         signal: NSS
@@ -855,6 +859,7 @@ cores:
           reset:
             register: APB1RSTR
             field: SPI3RST
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -898,6 +903,7 @@ cores:
           reset:
             register: APB2RSTR
             field: SYSCFGRST
+      block: syscfg_f3/SYSCFG
     TIM1:
       address: 0x40012c00
       rcc:

--- a/data/chips/STM32F303CC.yaml
+++ b/data/chips/STM32F303CC.yaml
@@ -475,6 +475,7 @@ cores:
       block: exti_v1/EXTI
     FLASH:
       address: 0x40022000
+      block: flash_f3/FLASH
     GPIOA:
       address: 0x48000000
       rcc:
@@ -741,6 +742,7 @@ cores:
           reset:
             register: APB1RSTR
             field: PWRRST
+      block: pwr_f3/PWR
     RCC:
       address: 0x40021000
       block: rcc_f3/RCC
@@ -772,6 +774,7 @@ cores:
           reset:
             register: APB2RSTR
             field: SPI1RST
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -815,6 +818,7 @@ cores:
           reset:
             register: APB1RSTR
             field: SPI2RST
+      block: spi_v2/SPI
       pins:
       - pin: PB12
         signal: NSS
@@ -855,6 +859,7 @@ cores:
           reset:
             register: APB1RSTR
             field: SPI3RST
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -898,6 +903,7 @@ cores:
           reset:
             register: APB2RSTR
             field: SYSCFGRST
+      block: syscfg_f3/SYSCFG
     TIM1:
       address: 0x40012c00
       rcc:

--- a/data/chips/STM32F303K6.yaml
+++ b/data/chips/STM32F303K6.yaml
@@ -383,6 +383,7 @@ cores:
       block: exti_v1/EXTI
     FLASH:
       address: 0x40022000
+      block: flash_f3/FLASH
     GPIOA:
       address: 0x48000000
       rcc:
@@ -509,6 +510,7 @@ cores:
           reset:
             register: APB1RSTR
             field: PWRRST
+      block: pwr_f3/PWR
     RCC:
       address: 0x40021000
       block: rcc_f3/RCC
@@ -533,6 +535,7 @@ cores:
           reset:
             register: APB2RSTR
             field: SPI1RST
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -580,6 +583,7 @@ cores:
           reset:
             register: APB2RSTR
             field: SYSCFGRST
+      block: syscfg_f3/SYSCFG
     TIM1:
       address: 0x40012c00
       rcc:

--- a/data/chips/STM32F303K8.yaml
+++ b/data/chips/STM32F303K8.yaml
@@ -383,6 +383,7 @@ cores:
       block: exti_v1/EXTI
     FLASH:
       address: 0x40022000
+      block: flash_f3/FLASH
     GPIOA:
       address: 0x48000000
       rcc:
@@ -509,6 +510,7 @@ cores:
           reset:
             register: APB1RSTR
             field: PWRRST
+      block: pwr_f3/PWR
     RCC:
       address: 0x40021000
       block: rcc_f3/RCC
@@ -533,6 +535,7 @@ cores:
           reset:
             register: APB2RSTR
             field: SPI1RST
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -580,6 +583,7 @@ cores:
           reset:
             register: APB2RSTR
             field: SYSCFGRST
+      block: syscfg_f3/SYSCFG
     TIM1:
       address: 0x40012c00
       rcc:

--- a/data/chips/STM32F303R6.yaml
+++ b/data/chips/STM32F303R6.yaml
@@ -422,6 +422,7 @@ cores:
       block: exti_v1/EXTI
     FLASH:
       address: 0x40022000
+      block: flash_f3/FLASH
     GPIOA:
       address: 0x48000000
       rcc:
@@ -548,6 +549,7 @@ cores:
           reset:
             register: APB1RSTR
             field: PWRRST
+      block: pwr_f3/PWR
     RCC:
       address: 0x40021000
       block: rcc_f3/RCC
@@ -572,6 +574,7 @@ cores:
           reset:
             register: APB2RSTR
             field: SPI1RST
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -619,6 +622,7 @@ cores:
           reset:
             register: APB2RSTR
             field: SYSCFGRST
+      block: syscfg_f3/SYSCFG
     TIM1:
       address: 0x40012c00
       rcc:

--- a/data/chips/STM32F303R8.yaml
+++ b/data/chips/STM32F303R8.yaml
@@ -422,6 +422,7 @@ cores:
       block: exti_v1/EXTI
     FLASH:
       address: 0x40022000
+      block: flash_f3/FLASH
     GPIOA:
       address: 0x48000000
       rcc:
@@ -548,6 +549,7 @@ cores:
           reset:
             register: APB1RSTR
             field: PWRRST
+      block: pwr_f3/PWR
     RCC:
       address: 0x40021000
       block: rcc_f3/RCC
@@ -572,6 +574,7 @@ cores:
           reset:
             register: APB2RSTR
             field: SPI1RST
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -619,6 +622,7 @@ cores:
           reset:
             register: APB2RSTR
             field: SYSCFGRST
+      block: syscfg_f3/SYSCFG
     TIM1:
       address: 0x40012c00
       rcc:

--- a/data/chips/STM32F303RB.yaml
+++ b/data/chips/STM32F303RB.yaml
@@ -497,6 +497,7 @@ cores:
       block: exti_v1/EXTI
     FLASH:
       address: 0x40022000
+      block: flash_f3/FLASH
     GPIOA:
       address: 0x48000000
       rcc:
@@ -771,6 +772,7 @@ cores:
           reset:
             register: APB1RSTR
             field: PWRRST
+      block: pwr_f3/PWR
     RCC:
       address: 0x40021000
       block: rcc_f3/RCC
@@ -802,6 +804,7 @@ cores:
           reset:
             register: APB2RSTR
             field: SPI1RST
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -845,6 +848,7 @@ cores:
           reset:
             register: APB1RSTR
             field: SPI2RST
+      block: spi_v2/SPI
       pins:
       - pin: PB12
         signal: NSS
@@ -885,6 +889,7 @@ cores:
           reset:
             register: APB1RSTR
             field: SPI3RST
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -928,6 +933,7 @@ cores:
           reset:
             register: APB2RSTR
             field: SYSCFGRST
+      block: syscfg_f3/SYSCFG
     TIM1:
       address: 0x40012c00
       rcc:

--- a/data/chips/STM32F303RC.yaml
+++ b/data/chips/STM32F303RC.yaml
@@ -501,6 +501,7 @@ cores:
       block: exti_v1/EXTI
     FLASH:
       address: 0x40022000
+      block: flash_f3/FLASH
     GPIOA:
       address: 0x48000000
       rcc:
@@ -775,6 +776,7 @@ cores:
           reset:
             register: APB1RSTR
             field: PWRRST
+      block: pwr_f3/PWR
     RCC:
       address: 0x40021000
       block: rcc_f3/RCC
@@ -806,6 +808,7 @@ cores:
           reset:
             register: APB2RSTR
             field: SPI1RST
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -849,6 +852,7 @@ cores:
           reset:
             register: APB1RSTR
             field: SPI2RST
+      block: spi_v2/SPI
       pins:
       - pin: PB12
         signal: NSS
@@ -889,6 +893,7 @@ cores:
           reset:
             register: APB1RSTR
             field: SPI3RST
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -932,6 +937,7 @@ cores:
           reset:
             register: APB2RSTR
             field: SYSCFGRST
+      block: syscfg_f3/SYSCFG
     TIM1:
       address: 0x40012c00
       rcc:

--- a/data/chips/STM32F303RD.yaml
+++ b/data/chips/STM32F303RD.yaml
@@ -499,6 +499,7 @@ cores:
       block: exti_v1/EXTI
     FLASH:
       address: 0x40022000
+      block: flash_f3/FLASH
     GPIOA:
       address: 0x48000000
       rcc:
@@ -830,6 +831,7 @@ cores:
           reset:
             register: APB1RSTR
             field: PWRRST
+      block: pwr_f3/PWR
     RCC:
       address: 0x40021000
       block: rcc_f3/RCC
@@ -861,6 +863,7 @@ cores:
           reset:
             register: APB2RSTR
             field: SPI1RST
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -904,6 +907,7 @@ cores:
           reset:
             register: APB1RSTR
             field: SPI2RST
+      block: spi_v2/SPI
       pins:
       - pin: PA10
         signal: MISO
@@ -956,6 +960,7 @@ cores:
           reset:
             register: APB1RSTR
             field: SPI3RST
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -999,6 +1004,7 @@ cores:
           reset:
             register: APB2RSTR
             field: SYSCFGRST
+      block: syscfg_f3/SYSCFG
     TIM1:
       address: 0x40012c00
       rcc:

--- a/data/chips/STM32F303RE.yaml
+++ b/data/chips/STM32F303RE.yaml
@@ -501,6 +501,7 @@ cores:
       block: exti_v1/EXTI
     FLASH:
       address: 0x40022000
+      block: flash_f3/FLASH
     GPIOA:
       address: 0x48000000
       rcc:
@@ -832,6 +833,7 @@ cores:
           reset:
             register: APB1RSTR
             field: PWRRST
+      block: pwr_f3/PWR
     RCC:
       address: 0x40021000
       block: rcc_f3/RCC
@@ -863,6 +865,7 @@ cores:
           reset:
             register: APB2RSTR
             field: SPI1RST
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -906,6 +909,7 @@ cores:
           reset:
             register: APB1RSTR
             field: SPI2RST
+      block: spi_v2/SPI
       pins:
       - pin: PA10
         signal: MISO
@@ -958,6 +962,7 @@ cores:
           reset:
             register: APB1RSTR
             field: SPI3RST
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -1001,6 +1006,7 @@ cores:
           reset:
             register: APB2RSTR
             field: SYSCFGRST
+      block: syscfg_f3/SYSCFG
     TIM1:
       address: 0x40012c00
       rcc:

--- a/data/chips/STM32F303VB.yaml
+++ b/data/chips/STM32F303VB.yaml
@@ -545,6 +545,7 @@ cores:
       block: exti_v1/EXTI
     FLASH:
       address: 0x40022000
+      block: flash_f3/FLASH
     GPIOA:
       address: 0x48000000
       rcc:
@@ -831,6 +832,7 @@ cores:
           reset:
             register: APB1RSTR
             field: PWRRST
+      block: pwr_f3/PWR
     RCC:
       address: 0x40021000
       block: rcc_f3/RCC
@@ -862,6 +864,7 @@ cores:
           reset:
             register: APB2RSTR
             field: SPI1RST
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -905,6 +908,7 @@ cores:
           reset:
             register: APB1RSTR
             field: SPI2RST
+      block: spi_v2/SPI
       pins:
       - pin: PB12
         signal: NSS
@@ -945,6 +949,7 @@ cores:
           reset:
             register: APB1RSTR
             field: SPI3RST
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -988,6 +993,7 @@ cores:
           reset:
             register: APB2RSTR
             field: SYSCFGRST
+      block: syscfg_f3/SYSCFG
     TIM1:
       address: 0x40012c00
       rcc:

--- a/data/chips/STM32F303VC.yaml
+++ b/data/chips/STM32F303VC.yaml
@@ -547,6 +547,7 @@ cores:
       block: exti_v1/EXTI
     FLASH:
       address: 0x40022000
+      block: flash_f3/FLASH
     GPIOA:
       address: 0x48000000
       rcc:
@@ -833,6 +834,7 @@ cores:
           reset:
             register: APB1RSTR
             field: PWRRST
+      block: pwr_f3/PWR
     RCC:
       address: 0x40021000
       block: rcc_f3/RCC
@@ -864,6 +866,7 @@ cores:
           reset:
             register: APB2RSTR
             field: SPI1RST
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -907,6 +910,7 @@ cores:
           reset:
             register: APB1RSTR
             field: SPI2RST
+      block: spi_v2/SPI
       pins:
       - pin: PB12
         signal: NSS
@@ -947,6 +951,7 @@ cores:
           reset:
             register: APB1RSTR
             field: SPI3RST
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -990,6 +995,7 @@ cores:
           reset:
             register: APB2RSTR
             field: SYSCFGRST
+      block: syscfg_f3/SYSCFG
     TIM1:
       address: 0x40012c00
       rcc:

--- a/data/chips/STM32F303VD.yaml
+++ b/data/chips/STM32F303VD.yaml
@@ -549,6 +549,7 @@ cores:
       block: exti_v1/EXTI
     FLASH:
       address: 0x40022000
+      block: flash_f3/FLASH
     FMC:
       address: 0x60000000
       rcc:
@@ -1098,6 +1099,7 @@ cores:
           reset:
             register: APB1RSTR
             field: PWRRST
+      block: pwr_f3/PWR
     RCC:
       address: 0x40021000
       block: rcc_f3/RCC
@@ -1129,6 +1131,7 @@ cores:
           reset:
             register: APB2RSTR
             field: SPI1RST
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -1172,6 +1175,7 @@ cores:
           reset:
             register: APB1RSTR
             field: SPI2RST
+      block: spi_v2/SPI
       pins:
       - pin: PA10
         signal: MISO
@@ -1224,6 +1228,7 @@ cores:
           reset:
             register: APB1RSTR
             field: SPI3RST
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -1267,6 +1272,7 @@ cores:
           reset:
             register: APB2RSTR
             field: SPI4RST
+      block: spi_v2/SPI
       pins:
       - pin: PE2
         signal: SCK
@@ -1313,6 +1319,7 @@ cores:
           reset:
             register: APB2RSTR
             field: SYSCFGRST
+      block: syscfg_f3/SYSCFG
     TIM1:
       address: 0x40012c00
       rcc:

--- a/data/chips/STM32F303VE.yaml
+++ b/data/chips/STM32F303VE.yaml
@@ -553,6 +553,7 @@ cores:
       block: exti_v1/EXTI
     FLASH:
       address: 0x40022000
+      block: flash_f3/FLASH
     FMC:
       address: 0x60000000
       rcc:
@@ -1102,6 +1103,7 @@ cores:
           reset:
             register: APB1RSTR
             field: PWRRST
+      block: pwr_f3/PWR
     RCC:
       address: 0x40021000
       block: rcc_f3/RCC
@@ -1133,6 +1135,7 @@ cores:
           reset:
             register: APB2RSTR
             field: SPI1RST
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -1176,6 +1179,7 @@ cores:
           reset:
             register: APB1RSTR
             field: SPI2RST
+      block: spi_v2/SPI
       pins:
       - pin: PA10
         signal: MISO
@@ -1228,6 +1232,7 @@ cores:
           reset:
             register: APB1RSTR
             field: SPI3RST
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -1271,6 +1276,7 @@ cores:
           reset:
             register: APB2RSTR
             field: SPI4RST
+      block: spi_v2/SPI
       pins:
       - pin: PE2
         signal: SCK
@@ -1317,6 +1323,7 @@ cores:
           reset:
             register: APB2RSTR
             field: SYSCFGRST
+      block: syscfg_f3/SYSCFG
     TIM1:
       address: 0x40012c00
       rcc:

--- a/data/chips/STM32F303ZD.yaml
+++ b/data/chips/STM32F303ZD.yaml
@@ -549,6 +549,7 @@ cores:
       block: exti_v1/EXTI
     FLASH:
       address: 0x40022000
+      block: flash_f3/FLASH
     FMC:
       address: 0x60000000
       rcc:
@@ -1098,6 +1099,7 @@ cores:
           reset:
             register: APB1RSTR
             field: PWRRST
+      block: pwr_f3/PWR
     RCC:
       address: 0x40021000
       block: rcc_f3/RCC
@@ -1129,6 +1131,7 @@ cores:
           reset:
             register: APB2RSTR
             field: SPI1RST
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -1172,6 +1175,7 @@ cores:
           reset:
             register: APB1RSTR
             field: SPI2RST
+      block: spi_v2/SPI
       pins:
       - pin: PA10
         signal: MISO
@@ -1224,6 +1228,7 @@ cores:
           reset:
             register: APB1RSTR
             field: SPI3RST
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -1267,6 +1272,7 @@ cores:
           reset:
             register: APB2RSTR
             field: SPI4RST
+      block: spi_v2/SPI
       pins:
       - pin: PE2
         signal: SCK
@@ -1313,6 +1319,7 @@ cores:
           reset:
             register: APB2RSTR
             field: SYSCFGRST
+      block: syscfg_f3/SYSCFG
     TIM1:
       address: 0x40012c00
       rcc:

--- a/data/chips/STM32F303ZE.yaml
+++ b/data/chips/STM32F303ZE.yaml
@@ -551,6 +551,7 @@ cores:
       block: exti_v1/EXTI
     FLASH:
       address: 0x40022000
+      block: flash_f3/FLASH
     FMC:
       address: 0x60000000
       rcc:
@@ -1100,6 +1101,7 @@ cores:
           reset:
             register: APB1RSTR
             field: PWRRST
+      block: pwr_f3/PWR
     RCC:
       address: 0x40021000
       block: rcc_f3/RCC
@@ -1131,6 +1133,7 @@ cores:
           reset:
             register: APB2RSTR
             field: SPI1RST
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -1174,6 +1177,7 @@ cores:
           reset:
             register: APB1RSTR
             field: SPI2RST
+      block: spi_v2/SPI
       pins:
       - pin: PA10
         signal: MISO
@@ -1226,6 +1230,7 @@ cores:
           reset:
             register: APB1RSTR
             field: SPI3RST
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -1269,6 +1274,7 @@ cores:
           reset:
             register: APB2RSTR
             field: SPI4RST
+      block: spi_v2/SPI
       pins:
       - pin: PE2
         signal: SCK
@@ -1315,6 +1321,7 @@ cores:
           reset:
             register: APB2RSTR
             field: SYSCFGRST
+      block: syscfg_f3/SYSCFG
     TIM1:
       address: 0x40012c00
       rcc:

--- a/data/chips/STM32F318C8.yaml
+++ b/data/chips/STM32F318C8.yaml
@@ -311,6 +311,7 @@ cores:
       block: exti_v1/EXTI
     FLASH:
       address: 0x40022000
+      block: flash_f3/FLASH
     GPIOA:
       address: 0x48000000
       rcc:
@@ -520,6 +521,7 @@ cores:
           reset:
             register: APB1RSTR
             field: PWRRST
+      block: pwr_f3/PWR
     RCC:
       address: 0x40021000
       block: rcc_f3/RCC
@@ -551,6 +553,7 @@ cores:
           reset:
             register: APB1RSTR
             field: SPI2RST
+      block: spi_v2/SPI
       pins:
       - pin: PA10
         signal: MISO
@@ -594,6 +597,7 @@ cores:
           reset:
             register: APB1RSTR
             field: SPI3RST
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -637,6 +641,7 @@ cores:
           reset:
             register: APB2RSTR
             field: SYSCFGRST
+      block: syscfg_f3/SYSCFG
     TIM1:
       address: 0x40012c00
       rcc:

--- a/data/chips/STM32F318K8.yaml
+++ b/data/chips/STM32F318K8.yaml
@@ -292,6 +292,7 @@ cores:
       block: exti_v1/EXTI
     FLASH:
       address: 0x40022000
+      block: flash_f3/FLASH
     GPIOA:
       address: 0x48000000
       rcc:
@@ -497,6 +498,7 @@ cores:
           reset:
             register: APB1RSTR
             field: PWRRST
+      block: pwr_f3/PWR
     RCC:
       address: 0x40021000
       block: rcc_f3/RCC
@@ -528,6 +530,7 @@ cores:
           reset:
             register: APB1RSTR
             field: SPI2RST
+      block: spi_v2/SPI
       pins:
       - pin: PA10
         signal: MISO
@@ -571,6 +574,7 @@ cores:
           reset:
             register: APB1RSTR
             field: SPI3RST
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -614,6 +618,7 @@ cores:
           reset:
             register: APB2RSTR
             field: SYSCFGRST
+      block: syscfg_f3/SYSCFG
     TIM1:
       address: 0x40012c00
       rcc:

--- a/data/chips/STM32F328C8.yaml
+++ b/data/chips/STM32F328C8.yaml
@@ -384,6 +384,7 @@ cores:
       block: exti_v1/EXTI
     FLASH:
       address: 0x40022000
+      block: flash_f3/FLASH
     GPIOA:
       address: 0x48000000
       rcc:
@@ -510,6 +511,7 @@ cores:
           reset:
             register: APB1RSTR
             field: PWRRST
+      block: pwr_f3/PWR
     RCC:
       address: 0x40021000
       block: rcc_f3/RCC
@@ -534,6 +536,7 @@ cores:
           reset:
             register: APB2RSTR
             field: SPI1RST
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -581,6 +584,7 @@ cores:
           reset:
             register: APB2RSTR
             field: SYSCFGRST
+      block: syscfg_f3/SYSCFG
     TIM1:
       address: 0x40012c00
       rcc:

--- a/data/chips/STM32F334C4.yaml
+++ b/data/chips/STM32F334C4.yaml
@@ -410,6 +410,7 @@ cores:
       block: exti_v1/EXTI
     FLASH:
       address: 0x40022000
+      block: flash_f3/FLASH
     GPIOA:
       address: 0x48000000
       rcc:
@@ -655,6 +656,7 @@ cores:
           reset:
             register: APB1RSTR
             field: PWRRST
+      block: pwr_f3/PWR
     RCC:
       address: 0x40021000
       block: rcc_f3/RCC
@@ -679,6 +681,7 @@ cores:
           reset:
             register: APB2RSTR
             field: SPI1RST
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -726,6 +729,7 @@ cores:
           reset:
             register: APB2RSTR
             field: SYSCFGRST
+      block: syscfg_f3/SYSCFG
     TIM1:
       address: 0x40012c00
       rcc:

--- a/data/chips/STM32F334C6.yaml
+++ b/data/chips/STM32F334C6.yaml
@@ -410,6 +410,7 @@ cores:
       block: exti_v1/EXTI
     FLASH:
       address: 0x40022000
+      block: flash_f3/FLASH
     GPIOA:
       address: 0x48000000
       rcc:
@@ -655,6 +656,7 @@ cores:
           reset:
             register: APB1RSTR
             field: PWRRST
+      block: pwr_f3/PWR
     RCC:
       address: 0x40021000
       block: rcc_f3/RCC
@@ -679,6 +681,7 @@ cores:
           reset:
             register: APB2RSTR
             field: SPI1RST
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -726,6 +729,7 @@ cores:
           reset:
             register: APB2RSTR
             field: SYSCFGRST
+      block: syscfg_f3/SYSCFG
     TIM1:
       address: 0x40012c00
       rcc:

--- a/data/chips/STM32F334C8.yaml
+++ b/data/chips/STM32F334C8.yaml
@@ -412,6 +412,7 @@ cores:
       block: exti_v1/EXTI
     FLASH:
       address: 0x40022000
+      block: flash_f3/FLASH
     GPIOA:
       address: 0x48000000
       rcc:
@@ -657,6 +658,7 @@ cores:
           reset:
             register: APB1RSTR
             field: PWRRST
+      block: pwr_f3/PWR
     RCC:
       address: 0x40021000
       block: rcc_f3/RCC
@@ -681,6 +683,7 @@ cores:
           reset:
             register: APB2RSTR
             field: SPI1RST
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -728,6 +731,7 @@ cores:
           reset:
             register: APB2RSTR
             field: SYSCFGRST
+      block: syscfg_f3/SYSCFG
     TIM1:
       address: 0x40012c00
       rcc:

--- a/data/chips/STM32F334K4.yaml
+++ b/data/chips/STM32F334K4.yaml
@@ -383,6 +383,7 @@ cores:
       block: exti_v1/EXTI
     FLASH:
       address: 0x40022000
+      block: flash_f3/FLASH
     GPIOA:
       address: 0x48000000
       rcc:
@@ -628,6 +629,7 @@ cores:
           reset:
             register: APB1RSTR
             field: PWRRST
+      block: pwr_f3/PWR
     RCC:
       address: 0x40021000
       block: rcc_f3/RCC
@@ -652,6 +654,7 @@ cores:
           reset:
             register: APB2RSTR
             field: SPI1RST
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -699,6 +702,7 @@ cores:
           reset:
             register: APB2RSTR
             field: SYSCFGRST
+      block: syscfg_f3/SYSCFG
     TIM1:
       address: 0x40012c00
       rcc:

--- a/data/chips/STM32F334K6.yaml
+++ b/data/chips/STM32F334K6.yaml
@@ -383,6 +383,7 @@ cores:
       block: exti_v1/EXTI
     FLASH:
       address: 0x40022000
+      block: flash_f3/FLASH
     GPIOA:
       address: 0x48000000
       rcc:
@@ -628,6 +629,7 @@ cores:
           reset:
             register: APB1RSTR
             field: PWRRST
+      block: pwr_f3/PWR
     RCC:
       address: 0x40021000
       block: rcc_f3/RCC
@@ -652,6 +654,7 @@ cores:
           reset:
             register: APB2RSTR
             field: SPI1RST
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -699,6 +702,7 @@ cores:
           reset:
             register: APB2RSTR
             field: SYSCFGRST
+      block: syscfg_f3/SYSCFG
     TIM1:
       address: 0x40012c00
       rcc:

--- a/data/chips/STM32F334K8.yaml
+++ b/data/chips/STM32F334K8.yaml
@@ -383,6 +383,7 @@ cores:
       block: exti_v1/EXTI
     FLASH:
       address: 0x40022000
+      block: flash_f3/FLASH
     GPIOA:
       address: 0x48000000
       rcc:
@@ -628,6 +629,7 @@ cores:
           reset:
             register: APB1RSTR
             field: PWRRST
+      block: pwr_f3/PWR
     RCC:
       address: 0x40021000
       block: rcc_f3/RCC
@@ -652,6 +654,7 @@ cores:
           reset:
             register: APB2RSTR
             field: SPI1RST
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -699,6 +702,7 @@ cores:
           reset:
             register: APB2RSTR
             field: SYSCFGRST
+      block: syscfg_f3/SYSCFG
     TIM1:
       address: 0x40012c00
       rcc:

--- a/data/chips/STM32F334R6.yaml
+++ b/data/chips/STM32F334R6.yaml
@@ -422,6 +422,7 @@ cores:
       block: exti_v1/EXTI
     FLASH:
       address: 0x40022000
+      block: flash_f3/FLASH
     GPIOA:
       address: 0x48000000
       rcc:
@@ -667,6 +668,7 @@ cores:
           reset:
             register: APB1RSTR
             field: PWRRST
+      block: pwr_f3/PWR
     RCC:
       address: 0x40021000
       block: rcc_f3/RCC
@@ -691,6 +693,7 @@ cores:
           reset:
             register: APB2RSTR
             field: SPI1RST
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -738,6 +741,7 @@ cores:
           reset:
             register: APB2RSTR
             field: SYSCFGRST
+      block: syscfg_f3/SYSCFG
     TIM1:
       address: 0x40012c00
       rcc:

--- a/data/chips/STM32F334R8.yaml
+++ b/data/chips/STM32F334R8.yaml
@@ -422,6 +422,7 @@ cores:
       block: exti_v1/EXTI
     FLASH:
       address: 0x40022000
+      block: flash_f3/FLASH
     GPIOA:
       address: 0x48000000
       rcc:
@@ -667,6 +668,7 @@ cores:
           reset:
             register: APB1RSTR
             field: PWRRST
+      block: pwr_f3/PWR
     RCC:
       address: 0x40021000
       block: rcc_f3/RCC
@@ -691,6 +693,7 @@ cores:
           reset:
             register: APB2RSTR
             field: SPI1RST
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -738,6 +741,7 @@ cores:
           reset:
             register: APB2RSTR
             field: SYSCFGRST
+      block: syscfg_f3/SYSCFG
     TIM1:
       address: 0x40012c00
       rcc:

--- a/data/chips/STM32F358CC.yaml
+++ b/data/chips/STM32F358CC.yaml
@@ -447,6 +447,7 @@ cores:
       block: exti_v1/EXTI
     FLASH:
       address: 0x40022000
+      block: flash_f3/FLASH
     GPIOA:
       address: 0x48000000
       rcc:
@@ -709,6 +710,7 @@ cores:
           reset:
             register: APB1RSTR
             field: PWRRST
+      block: pwr_f3/PWR
     RCC:
       address: 0x40021000
       block: rcc_f3/RCC
@@ -740,6 +742,7 @@ cores:
           reset:
             register: APB2RSTR
             field: SPI1RST
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -783,6 +786,7 @@ cores:
           reset:
             register: APB1RSTR
             field: SPI2RST
+      block: spi_v2/SPI
       pins:
       - pin: PB12
         signal: NSS
@@ -823,6 +827,7 @@ cores:
           reset:
             register: APB1RSTR
             field: SPI3RST
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -866,6 +871,7 @@ cores:
           reset:
             register: APB2RSTR
             field: SYSCFGRST
+      block: syscfg_f3/SYSCFG
     TIM1:
       address: 0x40012c00
       rcc:

--- a/data/chips/STM32F358RC.yaml
+++ b/data/chips/STM32F358RC.yaml
@@ -469,6 +469,7 @@ cores:
       block: exti_v1/EXTI
     FLASH:
       address: 0x40022000
+      block: flash_f3/FLASH
     GPIOA:
       address: 0x48000000
       rcc:
@@ -739,6 +740,7 @@ cores:
           reset:
             register: APB1RSTR
             field: PWRRST
+      block: pwr_f3/PWR
     RCC:
       address: 0x40021000
       block: rcc_f3/RCC
@@ -770,6 +772,7 @@ cores:
           reset:
             register: APB2RSTR
             field: SPI1RST
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -813,6 +816,7 @@ cores:
           reset:
             register: APB1RSTR
             field: SPI2RST
+      block: spi_v2/SPI
       pins:
       - pin: PB12
         signal: NSS
@@ -853,6 +857,7 @@ cores:
           reset:
             register: APB1RSTR
             field: SPI3RST
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -896,6 +901,7 @@ cores:
           reset:
             register: APB2RSTR
             field: SYSCFGRST
+      block: syscfg_f3/SYSCFG
     TIM1:
       address: 0x40012c00
       rcc:

--- a/data/chips/STM32F358VC.yaml
+++ b/data/chips/STM32F358VC.yaml
@@ -517,6 +517,7 @@ cores:
       block: exti_v1/EXTI
     FLASH:
       address: 0x40022000
+      block: flash_f3/FLASH
     GPIOA:
       address: 0x48000000
       rcc:
@@ -799,6 +800,7 @@ cores:
           reset:
             register: APB1RSTR
             field: PWRRST
+      block: pwr_f3/PWR
     RCC:
       address: 0x40021000
       block: rcc_f3/RCC
@@ -830,6 +832,7 @@ cores:
           reset:
             register: APB2RSTR
             field: SPI1RST
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -873,6 +876,7 @@ cores:
           reset:
             register: APB1RSTR
             field: SPI2RST
+      block: spi_v2/SPI
       pins:
       - pin: PB12
         signal: NSS
@@ -913,6 +917,7 @@ cores:
           reset:
             register: APB1RSTR
             field: SPI3RST
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -956,6 +961,7 @@ cores:
           reset:
             register: APB2RSTR
             field: SYSCFGRST
+      block: syscfg_f3/SYSCFG
     TIM1:
       address: 0x40012c00
       rcc:

--- a/data/chips/STM32F373C8.yaml
+++ b/data/chips/STM32F373C8.yaml
@@ -423,6 +423,7 @@ cores:
       block: exti_v1/EXTI
     FLASH:
       address: 0x40022000
+      block: flash_f3/FLASH
     GPIOA:
       address: 0x48000000
       rcc:
@@ -596,6 +597,7 @@ cores:
           reset:
             register: APB1RSTR
             field: PWRRST
+      block: pwr_f3/PWR
     RCC:
       address: 0x40021000
       block: rcc_f3/RCC
@@ -675,6 +677,7 @@ cores:
           reset:
             register: APB2RSTR
             field: SPI1RST
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -745,6 +748,7 @@ cores:
           reset:
             register: APB1RSTR
             field: SPI2RST
+      block: spi_v2/SPI
       pins:
       - pin: PA8
         signal: SCK
@@ -812,6 +816,7 @@ cores:
           reset:
             register: APB1RSTR
             field: SPI3RST
+      block: spi_v2/SPI
       pins:
       - pin: PA1
         signal: SCK
@@ -864,6 +869,7 @@ cores:
           reset:
             register: APB2RSTR
             field: SYSCFGRST
+      block: syscfg_f3/SYSCFG
     TIM12:
       address: 0x40001800
       rcc:

--- a/data/chips/STM32F373CB.yaml
+++ b/data/chips/STM32F373CB.yaml
@@ -423,6 +423,7 @@ cores:
       block: exti_v1/EXTI
     FLASH:
       address: 0x40022000
+      block: flash_f3/FLASH
     GPIOA:
       address: 0x48000000
       rcc:
@@ -596,6 +597,7 @@ cores:
           reset:
             register: APB1RSTR
             field: PWRRST
+      block: pwr_f3/PWR
     RCC:
       address: 0x40021000
       block: rcc_f3/RCC
@@ -675,6 +677,7 @@ cores:
           reset:
             register: APB2RSTR
             field: SPI1RST
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -745,6 +748,7 @@ cores:
           reset:
             register: APB1RSTR
             field: SPI2RST
+      block: spi_v2/SPI
       pins:
       - pin: PA8
         signal: SCK
@@ -812,6 +816,7 @@ cores:
           reset:
             register: APB1RSTR
             field: SPI3RST
+      block: spi_v2/SPI
       pins:
       - pin: PA1
         signal: SCK
@@ -864,6 +869,7 @@ cores:
           reset:
             register: APB2RSTR
             field: SYSCFGRST
+      block: syscfg_f3/SYSCFG
     TIM12:
       address: 0x40001800
       rcc:

--- a/data/chips/STM32F373CC.yaml
+++ b/data/chips/STM32F373CC.yaml
@@ -423,6 +423,7 @@ cores:
       block: exti_v1/EXTI
     FLASH:
       address: 0x40022000
+      block: flash_f3/FLASH
     GPIOA:
       address: 0x48000000
       rcc:
@@ -596,6 +597,7 @@ cores:
           reset:
             register: APB1RSTR
             field: PWRRST
+      block: pwr_f3/PWR
     RCC:
       address: 0x40021000
       block: rcc_f3/RCC
@@ -675,6 +677,7 @@ cores:
           reset:
             register: APB2RSTR
             field: SPI1RST
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -745,6 +748,7 @@ cores:
           reset:
             register: APB1RSTR
             field: SPI2RST
+      block: spi_v2/SPI
       pins:
       - pin: PA8
         signal: SCK
@@ -812,6 +816,7 @@ cores:
           reset:
             register: APB1RSTR
             field: SPI3RST
+      block: spi_v2/SPI
       pins:
       - pin: PA1
         signal: SCK
@@ -864,6 +869,7 @@ cores:
           reset:
             register: APB2RSTR
             field: SYSCFGRST
+      block: syscfg_f3/SYSCFG
     TIM12:
       address: 0x40001800
       rcc:

--- a/data/chips/STM32F373R8.yaml
+++ b/data/chips/STM32F373R8.yaml
@@ -437,6 +437,7 @@ cores:
       block: exti_v1/EXTI
     FLASH:
       address: 0x40022000
+      block: flash_f3/FLASH
     GPIOA:
       address: 0x48000000
       rcc:
@@ -610,6 +611,7 @@ cores:
           reset:
             register: APB1RSTR
             field: PWRRST
+      block: pwr_f3/PWR
     RCC:
       address: 0x40021000
       block: rcc_f3/RCC
@@ -689,6 +691,7 @@ cores:
           reset:
             register: APB2RSTR
             field: SPI1RST
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -759,6 +762,7 @@ cores:
           reset:
             register: APB1RSTR
             field: SPI2RST
+      block: spi_v2/SPI
       pins:
       - pin: PA8
         signal: SCK
@@ -826,6 +830,7 @@ cores:
           reset:
             register: APB1RSTR
             field: SPI3RST
+      block: spi_v2/SPI
       pins:
       - pin: PA1
         signal: SCK
@@ -878,6 +883,7 @@ cores:
           reset:
             register: APB2RSTR
             field: SYSCFGRST
+      block: syscfg_f3/SYSCFG
     TIM12:
       address: 0x40001800
       rcc:

--- a/data/chips/STM32F373RB.yaml
+++ b/data/chips/STM32F373RB.yaml
@@ -437,6 +437,7 @@ cores:
       block: exti_v1/EXTI
     FLASH:
       address: 0x40022000
+      block: flash_f3/FLASH
     GPIOA:
       address: 0x48000000
       rcc:
@@ -610,6 +611,7 @@ cores:
           reset:
             register: APB1RSTR
             field: PWRRST
+      block: pwr_f3/PWR
     RCC:
       address: 0x40021000
       block: rcc_f3/RCC
@@ -689,6 +691,7 @@ cores:
           reset:
             register: APB2RSTR
             field: SPI1RST
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -759,6 +762,7 @@ cores:
           reset:
             register: APB1RSTR
             field: SPI2RST
+      block: spi_v2/SPI
       pins:
       - pin: PA8
         signal: SCK
@@ -826,6 +830,7 @@ cores:
           reset:
             register: APB1RSTR
             field: SPI3RST
+      block: spi_v2/SPI
       pins:
       - pin: PA1
         signal: SCK
@@ -878,6 +883,7 @@ cores:
           reset:
             register: APB2RSTR
             field: SYSCFGRST
+      block: syscfg_f3/SYSCFG
     TIM12:
       address: 0x40001800
       rcc:

--- a/data/chips/STM32F373RC.yaml
+++ b/data/chips/STM32F373RC.yaml
@@ -437,6 +437,7 @@ cores:
       block: exti_v1/EXTI
     FLASH:
       address: 0x40022000
+      block: flash_f3/FLASH
     GPIOA:
       address: 0x48000000
       rcc:
@@ -610,6 +611,7 @@ cores:
           reset:
             register: APB1RSTR
             field: PWRRST
+      block: pwr_f3/PWR
     RCC:
       address: 0x40021000
       block: rcc_f3/RCC
@@ -689,6 +691,7 @@ cores:
           reset:
             register: APB2RSTR
             field: SPI1RST
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -759,6 +762,7 @@ cores:
           reset:
             register: APB1RSTR
             field: SPI2RST
+      block: spi_v2/SPI
       pins:
       - pin: PA8
         signal: SCK
@@ -826,6 +830,7 @@ cores:
           reset:
             register: APB1RSTR
             field: SPI3RST
+      block: spi_v2/SPI
       pins:
       - pin: PA1
         signal: SCK
@@ -878,6 +883,7 @@ cores:
           reset:
             register: APB2RSTR
             field: SYSCFGRST
+      block: syscfg_f3/SYSCFG
     TIM12:
       address: 0x40001800
       rcc:

--- a/data/chips/STM32F373V8.yaml
+++ b/data/chips/STM32F373V8.yaml
@@ -439,6 +439,7 @@ cores:
       block: exti_v1/EXTI
     FLASH:
       address: 0x40022000
+      block: flash_f3/FLASH
     GPIOA:
       address: 0x48000000
       rcc:
@@ -612,6 +613,7 @@ cores:
           reset:
             register: APB1RSTR
             field: PWRRST
+      block: pwr_f3/PWR
     RCC:
       address: 0x40021000
       block: rcc_f3/RCC
@@ -691,6 +693,7 @@ cores:
           reset:
             register: APB2RSTR
             field: SPI1RST
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -761,6 +764,7 @@ cores:
           reset:
             register: APB1RSTR
             field: SPI2RST
+      block: spi_v2/SPI
       pins:
       - pin: PA8
         signal: SCK
@@ -828,6 +832,7 @@ cores:
           reset:
             register: APB1RSTR
             field: SPI3RST
+      block: spi_v2/SPI
       pins:
       - pin: PA1
         signal: SCK
@@ -880,6 +885,7 @@ cores:
           reset:
             register: APB2RSTR
             field: SYSCFGRST
+      block: syscfg_f3/SYSCFG
     TIM12:
       address: 0x40001800
       rcc:

--- a/data/chips/STM32F373VB.yaml
+++ b/data/chips/STM32F373VB.yaml
@@ -439,6 +439,7 @@ cores:
       block: exti_v1/EXTI
     FLASH:
       address: 0x40022000
+      block: flash_f3/FLASH
     GPIOA:
       address: 0x48000000
       rcc:
@@ -612,6 +613,7 @@ cores:
           reset:
             register: APB1RSTR
             field: PWRRST
+      block: pwr_f3/PWR
     RCC:
       address: 0x40021000
       block: rcc_f3/RCC
@@ -691,6 +693,7 @@ cores:
           reset:
             register: APB2RSTR
             field: SPI1RST
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -761,6 +764,7 @@ cores:
           reset:
             register: APB1RSTR
             field: SPI2RST
+      block: spi_v2/SPI
       pins:
       - pin: PA8
         signal: SCK
@@ -828,6 +832,7 @@ cores:
           reset:
             register: APB1RSTR
             field: SPI3RST
+      block: spi_v2/SPI
       pins:
       - pin: PA1
         signal: SCK
@@ -880,6 +885,7 @@ cores:
           reset:
             register: APB2RSTR
             field: SYSCFGRST
+      block: syscfg_f3/SYSCFG
     TIM12:
       address: 0x40001800
       rcc:

--- a/data/chips/STM32F373VC.yaml
+++ b/data/chips/STM32F373VC.yaml
@@ -439,6 +439,7 @@ cores:
       block: exti_v1/EXTI
     FLASH:
       address: 0x40022000
+      block: flash_f3/FLASH
     GPIOA:
       address: 0x48000000
       rcc:
@@ -612,6 +613,7 @@ cores:
           reset:
             register: APB1RSTR
             field: PWRRST
+      block: pwr_f3/PWR
     RCC:
       address: 0x40021000
       block: rcc_f3/RCC
@@ -691,6 +693,7 @@ cores:
           reset:
             register: APB2RSTR
             field: SPI1RST
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -761,6 +764,7 @@ cores:
           reset:
             register: APB1RSTR
             field: SPI2RST
+      block: spi_v2/SPI
       pins:
       - pin: PA8
         signal: SCK
@@ -828,6 +832,7 @@ cores:
           reset:
             register: APB1RSTR
             field: SPI3RST
+      block: spi_v2/SPI
       pins:
       - pin: PA1
         signal: SCK
@@ -880,6 +885,7 @@ cores:
           reset:
             register: APB2RSTR
             field: SYSCFGRST
+      block: syscfg_f3/SYSCFG
     TIM12:
       address: 0x40001800
       rcc:

--- a/data/chips/STM32F378CC.yaml
+++ b/data/chips/STM32F378CC.yaml
@@ -411,6 +411,7 @@ cores:
       block: exti_v1/EXTI
     FLASH:
       address: 0x40022000
+      block: flash_f3/FLASH
     GPIOA:
       address: 0x48000000
       rcc:
@@ -584,6 +585,7 @@ cores:
           reset:
             register: APB1RSTR
             field: PWRRST
+      block: pwr_f3/PWR
     RCC:
       address: 0x40021000
       block: rcc_f3/RCC
@@ -663,6 +665,7 @@ cores:
           reset:
             register: APB2RSTR
             field: SPI1RST
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -733,6 +736,7 @@ cores:
           reset:
             register: APB1RSTR
             field: SPI2RST
+      block: spi_v2/SPI
       pins:
       - pin: PA8
         signal: SCK
@@ -800,6 +804,7 @@ cores:
           reset:
             register: APB1RSTR
             field: SPI3RST
+      block: spi_v2/SPI
       pins:
       - pin: PA1
         signal: SCK
@@ -852,6 +857,7 @@ cores:
           reset:
             register: APB2RSTR
             field: SYSCFGRST
+      block: syscfg_f3/SYSCFG
     TIM12:
       address: 0x40001800
       rcc:

--- a/data/chips/STM32F378RC.yaml
+++ b/data/chips/STM32F378RC.yaml
@@ -427,6 +427,7 @@ cores:
       block: exti_v1/EXTI
     FLASH:
       address: 0x40022000
+      block: flash_f3/FLASH
     GPIOA:
       address: 0x48000000
       rcc:
@@ -600,6 +601,7 @@ cores:
           reset:
             register: APB1RSTR
             field: PWRRST
+      block: pwr_f3/PWR
     RCC:
       address: 0x40021000
       block: rcc_f3/RCC
@@ -679,6 +681,7 @@ cores:
           reset:
             register: APB2RSTR
             field: SPI1RST
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -749,6 +752,7 @@ cores:
           reset:
             register: APB1RSTR
             field: SPI2RST
+      block: spi_v2/SPI
       pins:
       - pin: PA8
         signal: SCK
@@ -816,6 +820,7 @@ cores:
           reset:
             register: APB1RSTR
             field: SPI3RST
+      block: spi_v2/SPI
       pins:
       - pin: PA1
         signal: SCK
@@ -868,6 +873,7 @@ cores:
           reset:
             register: APB2RSTR
             field: SYSCFGRST
+      block: syscfg_f3/SYSCFG
     TIM12:
       address: 0x40001800
       rcc:

--- a/data/chips/STM32F378VC.yaml
+++ b/data/chips/STM32F378VC.yaml
@@ -427,6 +427,7 @@ cores:
       block: exti_v1/EXTI
     FLASH:
       address: 0x40022000
+      block: flash_f3/FLASH
     GPIOA:
       address: 0x48000000
       rcc:
@@ -600,6 +601,7 @@ cores:
           reset:
             register: APB1RSTR
             field: PWRRST
+      block: pwr_f3/PWR
     RCC:
       address: 0x40021000
       block: rcc_f3/RCC
@@ -679,6 +681,7 @@ cores:
           reset:
             register: APB2RSTR
             field: SPI1RST
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -749,6 +752,7 @@ cores:
           reset:
             register: APB1RSTR
             field: SPI2RST
+      block: spi_v2/SPI
       pins:
       - pin: PA8
         signal: SCK
@@ -816,6 +820,7 @@ cores:
           reset:
             register: APB1RSTR
             field: SPI3RST
+      block: spi_v2/SPI
       pins:
       - pin: PA1
         signal: SCK
@@ -868,6 +873,7 @@ cores:
           reset:
             register: APB2RSTR
             field: SYSCFGRST
+      block: syscfg_f3/SYSCFG
     TIM12:
       address: 0x40001800
       rcc:

--- a/data/chips/STM32F398VE.yaml
+++ b/data/chips/STM32F398VE.yaml
@@ -525,6 +525,7 @@ cores:
       block: exti_v1/EXTI
     FLASH:
       address: 0x40022000
+      block: flash_f3/FLASH
     FMC:
       address: 0x60000000
       rcc:
@@ -1070,6 +1071,7 @@ cores:
           reset:
             register: APB1RSTR
             field: PWRRST
+      block: pwr_f3/PWR
     RCC:
       address: 0x40021000
       block: rcc_f3/RCC
@@ -1101,6 +1103,7 @@ cores:
           reset:
             register: APB2RSTR
             field: SPI1RST
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -1144,6 +1147,7 @@ cores:
           reset:
             register: APB1RSTR
             field: SPI2RST
+      block: spi_v2/SPI
       pins:
       - pin: PA10
         signal: MISO
@@ -1196,6 +1200,7 @@ cores:
           reset:
             register: APB1RSTR
             field: SPI3RST
+      block: spi_v2/SPI
       pins:
       - pin: PA4
         signal: NSS
@@ -1239,6 +1244,7 @@ cores:
           reset:
             register: APB2RSTR
             field: SPI4RST
+      block: spi_v2/SPI
       pins:
       - pin: PE2
         signal: SCK
@@ -1285,6 +1291,7 @@ cores:
           reset:
             register: APB2RSTR
             field: SYSCFGRST
+      block: syscfg_f3/SYSCFG
     TIM1:
       address: 0x40012c00
       rcc:

--- a/data/registers/flash_f3.yaml
+++ b/data/registers/flash_f3.yaml
@@ -1,0 +1,492 @@
+block/FLASH:
+  description: Flash
+  items:
+  - byte_offset: 0
+    description: Flash access control register
+    fieldset: ACR
+    name: ACR
+  - access: Write
+    byte_offset: 4
+    description: Flash key register
+    fieldset: KEYR
+    name: KEYR
+  - access: Write
+    byte_offset: 8
+    description: Flash option key register
+    fieldset: OPTKEYR
+    name: OPTKEYR
+  - byte_offset: 12
+    description: Flash status register
+    fieldset: SR
+    name: SR
+  - byte_offset: 16
+    description: Flash control register
+    fieldset: CR
+    name: CR
+  - access: Write
+    byte_offset: 20
+    description: Flash address register
+    fieldset: AR
+    name: AR
+  - access: Read
+    byte_offset: 28
+    description: Option byte register
+    fieldset: OBR
+    name: OBR
+  - access: Read
+    byte_offset: 32
+    description: Write protection register
+    fieldset: WRPR
+    name: WRPR
+enum/BSYR:
+  bit_size: 1
+  variants:
+  - description: No write/erase operation is in progress
+    name: Inactive
+    value: 0
+  - description: No write/erase operation is in progress
+    name: Active
+    value: 1
+enum/EOPIE:
+  bit_size: 1
+  variants:
+  - description: End of operation interrupt disabled
+    name: Disabled
+    value: 0
+  - description: End of operation interrupt enabled
+    name: Enabled
+    value: 1
+enum/EOPR:
+  bit_size: 1
+  variants:
+  - description: No EOP event occurred
+    name: NoEvent
+    value: 0
+  - description: An EOP event occurred
+    name: Event
+    value: 1
+enum/EOPW:
+  bit_size: 1
+  variants:
+  - description: Reset EOP event
+    name: Reset
+    value: 1
+enum/ERRIE:
+  bit_size: 1
+  variants:
+  - description: Error interrupt generation disabled
+    name: Disabled
+    value: 0
+  - description: Error interrupt generation enabled
+    name: Enabled
+    value: 1
+enum/HLFCYA:
+  bit_size: 1
+  variants:
+  - description: Half cycle is disabled
+    name: Disabled
+    value: 0
+  - description: Half cycle is enabled
+    name: Enabled
+    value: 1
+enum/LATENCY:
+  bit_size: 3
+  variants:
+  - description: 0 wait states, if 0 < HCLK <= 24 MHz
+    name: WS0
+    value: 0
+  - description: 1 wait state, if 24 < HCLK <= 48 MHz
+    name: WS1
+    value: 1
+  - description: 2 wait states, if 48 < HCLK <= 72 MHz
+    name: WS2
+    value: 2
+enum/LOCKR:
+  bit_size: 1
+  variants:
+  - description: FLASH_CR register is unlocked
+    name: Unlocked
+    value: 0
+  - description: FLASH_CR register is locked
+    name: Locked
+    value: 1
+enum/LOCKW:
+  bit_size: 1
+  variants:
+  - description: Lock the FLASH_CR register
+    name: Lock
+    value: 1
+enum/MER:
+  bit_size: 1
+  variants:
+  - description: Erase activated for all user sectors
+    name: MassErase
+    value: 1
+enum/OBL_LAUNCH:
+  bit_size: 1
+  variants:
+  - description: Force option byte loading inactive
+    name: Inactive
+    value: 0
+  - description: Force option byte loading active
+    name: Active
+    value: 1
+enum/OPTER:
+  bit_size: 1
+  variants:
+  - description: Erase option byte activated
+    name: OptionByteErase
+    value: 1
+enum/OPTERR:
+  bit_size: 1
+  variants:
+  - description: The loaded option byte and its complement do not match
+    name: OptionByteError
+    value: 1
+enum/OPTPG:
+  bit_size: 1
+  variants:
+  - description: Program option byte activated
+    name: OptionByteProgramming
+    value: 1
+enum/OPTWRE:
+  bit_size: 1
+  variants:
+  - description: Option byte write enabled
+    name: Disabled
+    value: 0
+  - description: Option byte write disabled
+    name: Enabled
+    value: 1
+enum/PER:
+  bit_size: 1
+  variants:
+  - description: Erase activated for selected page
+    name: PageErase
+    value: 1
+enum/PG:
+  bit_size: 1
+  variants:
+  - description: Flash programming activated
+    name: Program
+    value: 1
+enum/PGERRR:
+  bit_size: 1
+  variants:
+  - description: No programming error occurred
+    name: NoError
+    value: 0
+  - description: A programming error occurred
+    name: Error
+    value: 1
+enum/PGERRW:
+  bit_size: 1
+  variants:
+  - description: Reset programming error
+    name: Reset
+    value: 1
+enum/PRFTBE:
+  bit_size: 1
+  variants:
+  - description: Prefetch is disabled
+    name: Disabled
+    value: 0
+  - description: Prefetch is enabled
+    name: Enabled
+    value: 1
+enum/PRFTBS:
+  bit_size: 1
+  variants:
+  - description: Prefetch buffer is disabled
+    name: Disabled
+    value: 0
+  - description: Prefetch buffer is enabled
+    name: Enabled
+    value: 1
+enum/RDPRT:
+  bit_size: 2
+  variants:
+  - description: Level 0
+    name: Level0
+    value: 0
+  - description: Level 1
+    name: Level1
+    value: 1
+  - description: Level 2
+    name: Level2
+    value: 3
+enum/SDADC_VDD_MONITOR:
+  bit_size: 1
+  variants:
+  - description: VDDSD12 monitoring disabled
+    name: Disabled
+    value: 0
+  - description: VDDSD12 monitoring enabled
+    name: Enabled
+    value: 1
+enum/SRAM_PARITY_CHECK:
+  bit_size: 1
+  variants:
+  - description: RAM parity check disabled
+    name: Disabled
+    value: 0
+  - description: RAM parity check enabled
+    name: Enabled
+    value: 1
+enum/STRT:
+  bit_size: 1
+  variants:
+  - description: Trigger an erase operation
+    name: Start
+    value: 1
+enum/VDDA_MONITOR:
+  bit_size: 1
+  variants:
+  - description: VDDA power supply supervisor disabled
+    name: Disabled
+    value: 0
+  - description: VDDA power supply supervisor enabled
+    name: Enabled
+    value: 1
+enum/WDG_SW:
+  bit_size: 1
+  variants:
+  - description: Hardware watchdog
+    name: Hardware
+    value: 0
+  - description: Software watchdog
+    name: Software
+    value: 1
+enum/WRPRTERRR:
+  bit_size: 1
+  variants:
+  - description: No write protection error occurred
+    name: NoError
+    value: 0
+  - description: A write protection error occurred
+    name: Error
+    value: 1
+enum/WRPRTERRW:
+  bit_size: 1
+  variants:
+  - description: Reset write protection error
+    name: Reset
+    value: 1
+enum/nBOOT:
+  bit_size: 1
+  variants:
+  - description: Together with BOOT0, select the device boot mode
+    name: Disabled
+    value: 0
+  - description: Together with BOOT0, select the device boot mode
+    name: Enabled
+    value: 1
+enum/nRST_STDBY:
+  bit_size: 1
+  variants:
+  - description: Reset generated when entering Standby mode
+    name: Reset
+    value: 0
+  - description: No reset generated
+    name: NoReset
+    value: 1
+enum/nRST_STOP:
+  bit_size: 1
+  variants:
+  - description: Reset generated when entering Stop mode
+    name: Reset
+    value: 0
+  - description: No reset generated
+    name: NoReset
+    value: 1
+fieldset/ACR:
+  description: Flash access control register
+  fields:
+  - bit_offset: 0
+    bit_size: 3
+    description: LATENCY
+    enum: LATENCY
+    name: LATENCY
+  - bit_offset: 3
+    bit_size: 1
+    description: Flash half cycle access enable
+    enum: HLFCYA
+    name: HLFCYA
+  - bit_offset: 4
+    bit_size: 1
+    description: PRFTBE
+    enum: PRFTBE
+    name: PRFTBE
+  - bit_offset: 5
+    bit_size: 1
+    description: PRFTBS
+    enum: PRFTBS
+    name: PRFTBS
+fieldset/AR:
+  description: Flash address register
+  fields:
+  - bit_offset: 0
+    bit_size: 32
+    description: Flash address
+    name: FAR
+fieldset/CR:
+  description: Flash control register
+  fields:
+  - bit_offset: 0
+    bit_size: 1
+    description: Programming
+    enum: PG
+    name: PG
+  - bit_offset: 1
+    bit_size: 1
+    description: Page erase
+    enum: PER
+    name: PER
+  - bit_offset: 2
+    bit_size: 1
+    description: Mass erase
+    enum: MER
+    name: MER
+  - bit_offset: 4
+    bit_size: 1
+    description: Option byte programming
+    enum: OPTPG
+    name: OPTPG
+  - bit_offset: 5
+    bit_size: 1
+    description: Option byte erase
+    enum: OPTER
+    name: OPTER
+  - bit_offset: 6
+    bit_size: 1
+    description: Start
+    enum: STRT
+    name: STRT
+  - bit_offset: 7
+    bit_size: 1
+    description: Lock
+    enum_read: LOCKR
+    enum_write: LOCKW
+    name: LOCK
+  - bit_offset: 9
+    bit_size: 1
+    description: Option bytes write enable
+    enum: OPTWRE
+    name: OPTWRE
+  - bit_offset: 10
+    bit_size: 1
+    description: Error interrupt enable
+    enum: ERRIE
+    name: ERRIE
+  - bit_offset: 12
+    bit_size: 1
+    description: End of operation interrupt enable
+    enum: EOPIE
+    name: EOPIE
+  - bit_offset: 13
+    bit_size: 1
+    description: Force option byte loading
+    enum: OBL_LAUNCH
+    name: OBL_LAUNCH
+fieldset/KEYR:
+  description: Flash key register
+  fields:
+  - bit_offset: 0
+    bit_size: 32
+    description: Flash Key
+    name: FKEYR
+fieldset/OBR:
+  description: Option byte register
+  fields:
+  - bit_offset: 0
+    bit_size: 1
+    description: Option byte error
+    enum: OPTERR
+    name: OPTERR
+  - bit_offset: 1
+    bit_size: 2
+    description: Read protection Level status
+    enum: RDPRT
+    name: RDPRT
+  - bit_offset: 8
+    bit_size: 1
+    description: WDG_SW
+    enum: WDG_SW
+    name: WDG_SW
+  - bit_offset: 9
+    bit_size: 1
+    description: nRST_STOP
+    enum: nRST_STOP
+    name: nRST_STOP
+  - bit_offset: 10
+    bit_size: 1
+    description: nRST_STDBY
+    enum: nRST_STDBY
+    name: nRST_STDBY
+  - bit_offset: 12
+    bit_size: 1
+    description: BOOT1
+    enum: nBOOT
+    name: nBOOT1
+  - bit_offset: 13
+    bit_size: 1
+    description: VDDA_MONITOR
+    enum: VDDA_MONITOR
+    name: VDDA_MONITOR
+  - bit_offset: 14
+    bit_size: 1
+    description: SRAM_PARITY_CHECK
+    name: SRAM_PARITY_CHECK
+  - bit_offset: 15
+    bit_size: 1
+    description: SDADC12_VDD_MONITOR
+    enum: SDADC_VDD_MONITOR
+    name: SDADC12_VDD_MONITOR
+  - bit_offset: 16
+    bit_size: 8
+    description: Data0
+    name: Data0
+  - bit_offset: 24
+    bit_size: 8
+    description: Data1
+    name: Data1
+fieldset/OPTKEYR:
+  description: Flash option key register
+  fields:
+  - bit_offset: 0
+    bit_size: 32
+    description: Option byte key
+    name: OPTKEYR
+fieldset/SR:
+  description: Flash status register
+  fields:
+  - bit_offset: 0
+    bit_size: 1
+    description: Busy
+    enum_read: BSYR
+    name: BSY
+  - bit_offset: 2
+    bit_size: 1
+    description: Programming error
+    enum_read: PGERRR
+    enum_write: PGERRW
+    name: PGERR
+  - bit_offset: 4
+    bit_size: 1
+    description: Write protection error
+    enum_read: WRPRTERRR
+    enum_write: WRPRTERRW
+    name: WRPRTERR
+  - bit_offset: 5
+    bit_size: 1
+    description: End of operation
+    enum_read: EOPR
+    enum_write: EOPW
+    name: EOP
+fieldset/WRPR:
+  description: Write protection register
+  fields:
+  - bit_offset: 0
+    bit_size: 32
+    description: Write protect
+    name: WRP

--- a/data/registers/pwr_f3.yaml
+++ b/data/registers/pwr_f3.yaml
@@ -1,0 +1,85 @@
+block/PWR:
+  description: Power control
+  items:
+  - byte_offset: 0
+    description: power control register
+    fieldset: CR
+    name: CR
+  - byte_offset: 4
+    description: power control/status register
+    fieldset: CSR
+    name: CSR
+enum/PDDS:
+  bit_size: 1
+  variants:
+  - description: Enter Stop mode when the CPU enters deepsleep
+    name: STOP_MODE
+    value: 0
+  - description: Enter Standby mode when the CPU enters deepsleep
+    name: STANDBY_MODE
+    value: 1
+fieldset/CR:
+  description: power control register
+  fields:
+  - bit_offset: 0
+    bit_size: 1
+    description: Low-power deep sleep
+    name: LPDS
+  - bit_offset: 1
+    bit_size: 1
+    description: Power down deepsleep
+    enum: PDDS
+    name: PDDS
+  - bit_offset: 2
+    bit_size: 1
+    description: Clear wakeup flag
+    name: CWUF
+  - bit_offset: 3
+    bit_size: 1
+    description: Clear standby flag
+    name: CSBF
+  - bit_offset: 4
+    bit_size: 1
+    description: Power voltage detector enable
+    name: PVDE
+  - bit_offset: 5
+    bit_size: 3
+    description: PVD level selection
+    name: PLS
+  - bit_offset: 8
+    bit_size: 1
+    description: Disable backup domain write protection
+    name: DBP
+  - array:
+      len: 3
+      stride: 1
+    bit_offset: 9
+    bit_size: 1
+    description: ENable SD1 ADC
+    name: ENSD
+fieldset/CSR:
+  description: power control/status register
+  fields:
+  - bit_offset: 0
+    bit_size: 1
+    description: Wakeup flag
+    name: WUF
+  - bit_offset: 1
+    bit_size: 1
+    description: Standby flag
+    name: SBF
+  - bit_offset: 2
+    bit_size: 1
+    description: PVD output
+    name: PVDO
+  - bit_offset: 3
+    bit_size: 1
+    description: Internal voltage reference ready flag
+    name: VREFINTRDYF
+  - array:
+      len: 2
+      stride: 1
+    bit_offset: 8
+    bit_size: 1
+    description: Enable WKUP1 pin
+    name: EWUP

--- a/data/registers/rcc_f3.yaml
+++ b/data/registers/rcc_f3.yaml
@@ -609,11 +609,6 @@ fieldset/CFGR:
       bit_offset: 15
       bit_size: 2
       enum: PLLSRC
-    - name: PLLSRC
-      description: PLL entry clock source
-      bit_offset: 16
-      bit_size: 1
-      enum: PLLSRC
     - name: PLLXTPRE
       description: HSE divider for PLL entry
       bit_offset: 17
@@ -1274,14 +1269,17 @@ enum/PLLNODIV:
       description: PLL is not divided for MCO
       value: 1
 enum/PLLSRC:
-  bit_size: 1
+  bit_size: 2
   variants:
     - name: HSI_Div2
       description: HSI divided by 2 selected as PLL input clock
       value: 0
+    - name: HSI_Div_PREDIV
+      description: HSI divided by PREDIV selected as PLL input clock
+      value: 1
     - name: HSE_Div_PREDIV
       description: HSE divided by PREDIV selected as PLL input clock
-      value: 1
+      value: 2
 enum/PLLXTPRE:
   bit_size: 1
   variants:

--- a/data/registers/syscfg_f3.yaml
+++ b/data/registers/syscfg_f3.yaml
@@ -10,21 +10,12 @@ block/SYSCFG:
     fieldset: RCR
     name: RCR
   - byte_offset: 8
-    description: external interrupt configuration register 1
-    fieldset: EXTICR1
-    name: EXTICR1
-  - byte_offset: 12
-    description: external interrupt configuration register 2
-    fieldset: EXTICR2
-    name: EXTICR2
-  - byte_offset: 16
-    description: external interrupt configuration register 3
-    fieldset: EXTICR3
-    name: EXTICR3
-  - byte_offset: 20
-    description: external interrupt configuration register 4
-    fieldset: EXTICR4
-    name: EXTICR4
+    description: external interrupt configuration register
+    fieldset: EXTICR
+    name: EXTICR
+    array:
+      len: 4
+      stride: 4
   - byte_offset: 24
     description: configuration register 2
     fieldset: CFGR2
@@ -1210,98 +1201,16 @@ fieldset/CFGR4:
     description: Controls the Input trigger of ADC34 injected channel JEXT14
     enum: ADC34_JEXT14_RMP
     name: ADC34_JEXT14_RMP
-fieldset/EXTICR1:
-  description: external interrupt configuration register 1
+fieldset/EXTICR:
+  description: external interrupt configuration register
   fields:
   - bit_offset: 0
     bit_size: 4
-    description: EXTI 0 configuration bits
-    enum: EXTI0
-    name: EXTI0
-  - bit_offset: 4
-    bit_size: 4
-    description: EXTI 1 configuration bits
-    enum: EXTI1
-    name: EXTI1
-  - bit_offset: 8
-    bit_size: 4
-    description: EXTI 2 configuration bits
-    enum: EXTI2
-    name: EXTI2
-  - bit_offset: 12
-    bit_size: 4
-    description: EXTI 3 configuration bits
-    enum: EXTI3
-    name: EXTI3
-fieldset/EXTICR2:
-  description: external interrupt configuration register 2
-  fields:
-  - bit_offset: 0
-    bit_size: 4
-    description: EXTI 4 configuration bits
-    enum: EXTI4
-    name: EXTI4
-  - bit_offset: 4
-    bit_size: 4
-    description: EXTI 5 configuration bits
-    enum: EXTI5
-    name: EXTI5
-  - bit_offset: 8
-    bit_size: 4
-    description: EXTI 6 configuration bits
-    enum: EXTI6
-    name: EXTI6
-  - bit_offset: 12
-    bit_size: 4
-    description: EXTI 7 configuration bits
-    enum: EXTI7
-    name: EXTI7
-fieldset/EXTICR3:
-  description: external interrupt configuration register 3
-  fields:
-  - bit_offset: 0
-    bit_size: 4
-    description: EXTI 8 configuration bits
-    enum: EXTI8
-    name: EXTI8
-  - bit_offset: 4
-    bit_size: 4
-    description: EXTI 9 configuration bits
-    enum: EXTI9
-    name: EXTI9
-  - bit_offset: 8
-    bit_size: 4
-    description: EXTI 10 configuration bits
-    enum: EXTI10
-    name: EXTI10
-  - bit_offset: 12
-    bit_size: 4
-    description: EXTI 11 configuration bits
-    enum: EXTI11
-    name: EXTI11
-fieldset/EXTICR4:
-  description: external interrupt configuration register 4
-  fields:
-  - bit_offset: 0
-    bit_size: 4
-    description: EXTI 12 configuration bits
-    enum: EXTI12
-    name: EXTI12
-  - bit_offset: 4
-    bit_size: 4
-    description: EXTI 13 configuration bits
-    enum: EXTI13
-    name: EXTI13
-  - bit_offset: 8
-    bit_size: 4
-    description: EXTI 14 configuration bits
-    enum: EXTI14
-    name: EXTI14
-  - bit_offset: 12
-    bit_size: 4
-    description: EXTI 15 configuration bits
-    enum: EXTI15
-    name: EXTI15
+    description: EXTI x configuration
+    name: EXTI
+    array:
+      len: 4
+      stride: 4
 fieldset/RCR:
   description: CCM SRAM protection register
   fields:

--- a/data/registers/syscfg_f3.yaml
+++ b/data/registers/syscfg_f3.yaml
@@ -1,0 +1,1387 @@
+block/SYSCFG:
+  description: System configuration controller
+  items:
+  - byte_offset: 0
+    description: configuration register 1
+    fieldset: CFGR1
+    name: CFGR1
+  - byte_offset: 4
+    description: CCM SRAM protection register
+    fieldset: RCR
+    name: RCR
+  - byte_offset: 8
+    description: external interrupt configuration register 1
+    fieldset: EXTICR1
+    name: EXTICR1
+  - byte_offset: 12
+    description: external interrupt configuration register 2
+    fieldset: EXTICR2
+    name: EXTICR2
+  - byte_offset: 16
+    description: external interrupt configuration register 3
+    fieldset: EXTICR3
+    name: EXTICR3
+  - byte_offset: 20
+    description: external interrupt configuration register 4
+    fieldset: EXTICR4
+    name: EXTICR4
+  - byte_offset: 24
+    description: configuration register 2
+    fieldset: CFGR2
+    name: CFGR2
+  - byte_offset: 72
+    description: configuration register 4
+    fieldset: CFGR4
+    name: CFGR4
+  - byte_offset: 80
+    description: configuration register 3
+    fieldset: CFGR3
+    name: CFGR3
+enum/ADC12_EXT13_RMP:
+  bit_size: 1
+  variants:
+  - description: Trigger source is TIM6_TRGO
+    name: Tim6
+    value: 0
+  - description: Trigger source is TIM20_CC2
+    name: Tim20
+    value: 1
+enum/ADC12_EXT15_RMP:
+  bit_size: 1
+  variants:
+  - description: Trigger source is TIM3_CC4
+    name: Tim3
+    value: 0
+  - description: Trigger source is TIM20_CC3
+    name: Tim20
+    value: 1
+enum/ADC12_EXT2_RMP:
+  bit_size: 1
+  variants:
+  - description: Trigger source is TIM3_CC3
+    name: Tim1
+    value: 0
+  - description: rigger source is TIM20_TRGO
+    name: Tim20
+    value: 1
+enum/ADC12_EXT3_RMP:
+  bit_size: 1
+  variants:
+  - description: Trigger source is TIM2_CC2
+    name: Tim2
+    value: 0
+  - description: rigger source is TIM20_TRGO2
+    name: Tim20
+    value: 1
+enum/ADC12_EXT5_RMP:
+  bit_size: 1
+  variants:
+  - description: Trigger source is TIM4_CC4
+    name: Tim4
+    value: 0
+  - description: Trigger source is TIM20_CC1
+    name: Tim20
+    value: 1
+enum/ADC12_JEXT13_RMP:
+  bit_size: 1
+  variants:
+  - description: Trigger source is TIM3_CC1
+    name: Tim3
+    value: 0
+  - description: Trigger source is TIM20_CC4
+    name: Tim20
+    value: 1
+enum/ADC12_JEXT3_RMP:
+  bit_size: 1
+  variants:
+  - description: Trigger source is TIM2_CC1
+    name: Tim2
+    value: 0
+  - description: Trigger source is TIM20_TRGO
+    name: Tim20
+    value: 1
+enum/ADC12_JEXT6_RMP:
+  bit_size: 1
+  variants:
+  - description: Trigger source is EXTI line 15
+    name: Exti15
+    value: 0
+  - description: Trigger source is TIM20_TRGO2
+    name: Tim20
+    value: 1
+enum/ADC2_DMA_RMP:
+  bit_size: 1
+  variants:
+  - description: ADC2 mapped on DMA2
+    name: MapDma2
+    value: 0
+  - description: ADC2 mapped on DMA1 channel 2
+    name: MapDma1Ch2
+    value: 2
+  - description: ADC2 mapped on DMA1 channel 4
+    name: MapDma1Ch4
+    value: 3
+enum/ADC34_EXT15_RMP:
+  bit_size: 1
+  variants:
+  - description: Trigger source is TIM2_CC1
+    name: Tim2
+    value: 0
+  - description: Trigger source is TIM20_CC1
+    name: Tim20
+    value: 1
+enum/ADC34_EXT5_RMP:
+  bit_size: 1
+  variants:
+  - description: Trigger source is EXTI line 2 when reset at 0
+    name: Exti2
+    value: 0
+  - description: Trigger source is TIM20_TRGO
+    name: Tim20
+    value: 1
+enum/ADC34_EXT6_RMP:
+  bit_size: 1
+  variants:
+  - description: Trigger source is TIM4_CC1
+    name: Tim4
+    value: 0
+  - description: Trigger source is TIM20_TRGO2
+    name: Tim20
+    value: 1
+enum/ADC34_JEXT11_RMP:
+  bit_size: 1
+  variants:
+  - description: Trigger source is TIM1_CC3
+    name: Tim1
+    value: 0
+  - description: Trigger source is TIM20_TRGO2
+    name: Tim20
+    value: 1
+enum/ADC34_JEXT14_RMP:
+  bit_size: 1
+  variants:
+  - description: Trigger source is TIM7_TRGO
+    name: Tim7
+    value: 0
+  - description: Trigger source is TIM20_CC2
+    name: Tim20
+    value: 1
+enum/ADC34_JEXT5_RMP:
+  bit_size: 1
+  variants:
+  - description: Trigger source is TIM4_CC3
+    name: Tim4
+    value: 0
+  - description: Trigger source is TIM20_TRGO
+    name: Tim20
+    value: 1
+enum/BYP_ADDR_PAR:
+  bit_size: 1
+  variants:
+  - description: The ramload operation is performed taking into consideration bit
+      29 of the address when the parity is calculated
+    name: NoBypass
+    value: 0
+  - description: The ramload operation is performed without taking into consideration
+      bit 29 of the address when the parity is calculated
+    name: Bypass
+    value: 1
+enum/CFGR1_ADC2_DMA_RMP:
+  bit_size: 1
+  variants:
+  - description: ADC24 DMA requests mapped on DMA2 channels 1 and 2
+    name: NotRemapped
+    value: 0
+  - description: ADC24 DMA requests mapped on DMA2 channels 3 and 4
+    name: Remapped
+    value: 1
+enum/CFGR3_ADC2_DMA_RMP:
+  bit_size: 2
+  variants:
+  - description: ADC2 mapped on DMA2
+    name: MapDma2
+    value: 0
+  - description: ADC2 mapped on DMA1 channel 2
+    name: MapDma1Ch2
+    value: 2
+  - description: ADC2 mapped on DMA1 channel 4
+    name: MapDma1Ch4
+    value: 3
+enum/DAC1_TRIG3_RMP:
+  bit_size: 1
+  variants:
+  - description: DAC trigger is TIM15_TRGO
+    name: Tim15
+    value: 0
+  - description: DAC trigger is HRTIM1_DAC1_TRIG1
+    name: HrTim1
+    value: 1
+enum/DAC1_TRIG5_RMP:
+  bit_size: 1
+  variants:
+  - description: Not remapped
+    name: NotRemapped
+    value: 0
+  - description: DAC trigger is HRTIM1_DAC1_TRIG2
+    name: Remapped
+    value: 1
+enum/DAC1_TRIG_RMP:
+  bit_size: 1
+  variants:
+  - description: DAC trigger is TIM8_TRGO in STM32F303xB/C and STM32F358xC devices
+    name: NotRemapped
+    value: 0
+  - description: DAC trigger is TIM3_TRGO
+    name: Remapped
+    value: 1
+enum/DAC2_CH1_DMA_RMP:
+  bit_size: 1
+  variants:
+  - description: Not remapped
+    name: NotRemapped
+    value: 0
+  - description: DAC2_CH1 DMA requests mapped on DMA1 channel 5
+    name: Remapped
+    value: 1
+enum/DAC_TRIG_RMP:
+  bit_size: 1
+  variants:
+  - description: Not remapped
+    name: NotRemapped
+    value: 0
+  - description: DAC trigger is TIM3_TRGO
+    name: Remapped
+    value: 1
+enum/ENCODER_MODE:
+  bit_size: 2
+  variants:
+  - description: No redirection
+    name: NoRedirection
+    value: 0
+  - description: TIM2 IC1 and TIM2 IC2 are connected to TIM15 IC1 and TIM15 IC2 respectively
+    name: MapTim2Tim15
+    value: 1
+  - description: TIM3 IC1 and TIM3 IC2 are connected to TIM15 IC1 and TIM15 IC2 respectively
+    name: MapTim3Tim15
+    value: 2
+enum/EXTI0:
+  bit_size: 4
+  variants:
+  - description: Select PA0 as the source input for the EXTI0 external interrupt
+    name: PA0
+    value: 0
+  - description: Select PB0 as the source input for the EXTI0 external interrupt
+    name: PB0
+    value: 1
+  - description: Select PC0 as the source input for the EXTI0 external interrupt
+    name: PC0
+    value: 2
+  - description: Select PD0 as the source input for the EXTI0 external interrupt
+    name: PD0
+    value: 3
+  - description: Select PE0 as the source input for the EXTI0 external interrupt
+    name: PE0
+    value: 4
+  - description: Select PF0 as the source input for the EXTI0 external interrupt
+    name: PF0
+    value: 5
+enum/EXTI1:
+  bit_size: 4
+  variants:
+  - description: Select PA1 as the source input for the EXTI1 external interrupt
+    name: PA1
+    value: 0
+  - description: Select PB1 as the source input for the EXTI1 external interrupt
+    name: PB1
+    value: 1
+  - description: Select PC1 as the source input for the EXTI1 external interrupt
+    name: PC1
+    value: 2
+  - description: Select PD1 as the source input for the EXTI1 external interrupt
+    name: PD1
+    value: 3
+  - description: Select PE1 as the source input for the EXTI1 external interrupt
+    name: PE1
+    value: 4
+  - description: Select PF1 as the source input for the EXTI1 external interrupt
+    name: PF1
+    value: 5
+enum/EXTI10:
+  bit_size: 4
+  variants:
+  - description: Select PA10 as the source input for the EXTI10 external interrupt
+    name: PA10
+    value: 0
+  - description: Select PB10 as the source input for the EXTI10 external interrupt
+    name: PB10
+    value: 1
+  - description: Select PC10 as the source input for the EXTI10 external interrupt
+    name: PC10
+    value: 2
+  - description: Select PD10 as the source input for the EXTI10 external interrupt
+    name: PD10
+    value: 3
+  - description: Select PE10 as the source input for the EXTI10 external interrupt
+    name: PE10
+    value: 4
+  - description: Select PF10 as the source input for the EXTI10 external interrupt
+    name: PF10
+    value: 5
+enum/EXTI11:
+  bit_size: 4
+  variants:
+  - description: Select PA11 as the source input for the EXTI11 external interrupt
+    name: PA11
+    value: 0
+  - description: Select PB11 as the source input for the EXTI11 external interrupt
+    name: PB11
+    value: 1
+  - description: Select PC11 as the source input for the EXTI11 external interrupt
+    name: PC11
+    value: 2
+  - description: Select PD11 as the source input for the EXTI11 external interrupt
+    name: PD11
+    value: 3
+  - description: Select PE11 as the source input for the EXTI11 external interrupt
+    name: PE11
+    value: 4
+enum/EXTI12:
+  bit_size: 4
+  variants:
+  - description: Select PA12 as the source input for the EXTI12 external interrupt
+    name: PA12
+    value: 0
+  - description: Select PB12 as the source input for the EXTI12 external interrupt
+    name: PB12
+    value: 1
+  - description: Select PC12 as the source input for the EXTI12 external interrupt
+    name: PC12
+    value: 2
+  - description: Select PD12 as the source input for the EXTI12 external interrupt
+    name: PD12
+    value: 3
+  - description: Select PE12 as the source input for the EXTI12 external interrupt
+    name: PE12
+    value: 4
+enum/EXTI13:
+  bit_size: 4
+  variants:
+  - description: Select PA13 as the source input for the EXTI13 external interrupt
+    name: PA13
+    value: 0
+  - description: Select PB13 as the source input for the EXTI13 external interrupt
+    name: PB13
+    value: 1
+  - description: Select PC13 as the source input for the EXTI13 external interrupt
+    name: PC13
+    value: 2
+  - description: Select PD13 as the source input for the EXTI13 external interrupt
+    name: PD13
+    value: 3
+  - description: Select PE13 as the source input for the EXTI13 external interrupt
+    name: PE13
+    value: 4
+enum/EXTI14:
+  bit_size: 4
+  variants:
+  - description: Select PA14 as the source input for the EXTI14 external interrupt
+    name: PA14
+    value: 0
+  - description: Select PB14 as the source input for the EXTI14 external interrupt
+    name: PB14
+    value: 1
+  - description: Select PC14 as the source input for the EXTI14 external interrupt
+    name: PC14
+    value: 2
+  - description: Select PD14 as the source input for the EXTI14 external interrupt
+    name: PD14
+    value: 3
+  - description: Select PE14 as the source input for the EXTI14 external interrupt
+    name: PE14
+    value: 4
+enum/EXTI15:
+  bit_size: 4
+  variants:
+  - description: Select PA15 as the source input for the EXTI15 external interrupt
+    name: PA15
+    value: 0
+  - description: Select PB15 as the source input for the EXTI15 external interrupt
+    name: PB15
+    value: 1
+  - description: Select PC15 as the source input for the EXTI15 external interrupt
+    name: PC15
+    value: 2
+  - description: Select PD15 as the source input for the EXTI15 external interrupt
+    name: PD15
+    value: 3
+  - description: Select PE15 as the source input for the EXTI15 external interrupt
+    name: PE15
+    value: 4
+enum/EXTI2:
+  bit_size: 4
+  variants:
+  - description: Select PA2 as the source input for the EXTI2 external interrupt
+    name: PA2
+    value: 0
+  - description: Select PB2 as the source input for the EXTI2 external interrupt
+    name: PB2
+    value: 1
+  - description: Select PC2 as the source input for the EXTI2 external interrupt
+    name: PC2
+    value: 2
+  - description: Select PD2 as the source input for the EXTI2 external interrupt
+    name: PD2
+    value: 3
+  - description: Select PE2 as the source input for the EXTI2 external interrupt
+    name: PE2
+    value: 4
+  - description: Select PF2 as the source input for the EXTI2 external interrupt
+    name: PF2
+    value: 5
+enum/EXTI3:
+  bit_size: 4
+  variants:
+  - description: Select PA3 as the source input for the EXTI3 external interrupt
+    name: PA3
+    value: 0
+  - description: Select PB3 as the source input for the EXTI3 external interrupt
+    name: PB3
+    value: 1
+  - description: Select PC3 as the source input for the EXTI3 external interrupt
+    name: PC3
+    value: 2
+  - description: Select PD3 as the source input for the EXTI3 external interrupt
+    name: PD3
+    value: 3
+  - description: Select PE3 as the source input for the EXTI3 external interrupt
+    name: PE3
+    value: 4
+enum/EXTI4:
+  bit_size: 4
+  variants:
+  - description: Select PA4 as the source input for the EXTI4 external interrupt
+    name: PA4
+    value: 0
+  - description: Select PB4 as the source input for the EXTI4 external interrupt
+    name: PB4
+    value: 1
+  - description: Select PC4 as the source input for the EXTI4 external interrupt
+    name: PC4
+    value: 2
+  - description: Select PD4 as the source input for the EXTI4 external interrupt
+    name: PD4
+    value: 3
+  - description: Select PE4 as the source input for the EXTI4 external interrupt
+    name: PE4
+    value: 4
+  - description: Select PF4 as the source input for the EXTI4 external interrupt
+    name: PF4
+    value: 5
+enum/EXTI5:
+  bit_size: 4
+  variants:
+  - description: Select PA5 as the source input for the EXTI5 external interrupt
+    name: PA5
+    value: 0
+  - description: Select PB5 as the source input for the EXTI5 external interrupt
+    name: PB5
+    value: 1
+  - description: Select PC5 as the source input for the EXTI5 external interrupt
+    name: PC5
+    value: 2
+  - description: Select PD5 as the source input for the EXTI5 external interrupt
+    name: PD5
+    value: 3
+  - description: Select PE5 as the source input for the EXTI5 external interrupt
+    name: PE5
+    value: 4
+  - description: Select PF5 as the source input for the EXTI5 external interrupt
+    name: PF5
+    value: 5
+enum/EXTI6:
+  bit_size: 4
+  variants:
+  - description: Select PA6 as the source input for the EXTI6 external interrupt
+    name: PA6
+    value: 0
+  - description: Select PB6 as the source input for the EXTI6 external interrupt
+    name: PB6
+    value: 1
+  - description: Select PC6 as the source input for the EXTI6 external interrupt
+    name: PC6
+    value: 2
+  - description: Select PD6 as the source input for the EXTI6 external interrupt
+    name: PD6
+    value: 3
+  - description: Select PE6 as the source input for the EXTI6 external interrupt
+    name: PE6
+    value: 4
+  - description: Select PF6 as the source input for the EXTI6 external interrupt
+    name: PF6
+    value: 5
+enum/EXTI7:
+  bit_size: 4
+  variants:
+  - description: Select PA7 as the source input for the EXTI7 external interrupt
+    name: PA7
+    value: 0
+  - description: Select PB7 as the source input for the EXTI7 external interrupt
+    name: PB7
+    value: 1
+  - description: Select PC7 as the source input for the EXTI7 external interrupt
+    name: PC7
+    value: 2
+  - description: Select PD7 as the source input for the EXTI7 external interrupt
+    name: PD7
+    value: 3
+  - description: Select PE7 as the source input for the EXTI7 external interrupt
+    name: PE7
+    value: 4
+enum/EXTI8:
+  bit_size: 4
+  variants:
+  - description: Select PA8 as the source input for the EXTI8 external interrupt
+    name: PA8
+    value: 0
+  - description: Select PB8 as the source input for the EXTI8 external interrupt
+    name: PB8
+    value: 1
+  - description: Select PC8 as the source input for the EXTI8 external interrupt
+    name: PC8
+    value: 2
+  - description: Select PD8 as the source input for the EXTI8 external interrupt
+    name: PD8
+    value: 3
+  - description: Select PE8 as the source input for the EXTI8 external interrupt
+    name: PE8
+    value: 4
+enum/EXTI9:
+  bit_size: 4
+  variants:
+  - description: Select PA9 as the source input for the EXTI9 external interrupt
+    name: PA9
+    value: 0
+  - description: Select PB9 as the source input for the EXTI9 external interrupt
+    name: PB9
+    value: 1
+  - description: Select PC9 as the source input for the EXTI9 external interrupt
+    name: PC9
+    value: 2
+  - description: Select PD9 as the source input for the EXTI9 external interrupt
+    name: PD9
+    value: 3
+  - description: Select PE9 as the source input for the EXTI9 external interrupt
+    name: PE9
+    value: 4
+  - description: Select PF9 as the source input for the EXTI9 external interrupt
+    name: PF9
+    value: 5
+enum/FPU_IE0:
+  bit_size: 1
+  variants:
+  - description: Invalid operation interrupt disable
+    name: Disabled
+    value: 0
+  - description: Invalid operation interrupt enable
+    name: Enabled
+    value: 1
+enum/FPU_IE1:
+  bit_size: 1
+  variants:
+  - description: Devide-by-zero interrupt disable
+    name: Disabled
+    value: 0
+  - description: Devide-by-zero interrupt enable
+    name: Enabled
+    value: 1
+enum/FPU_IE2:
+  bit_size: 1
+  variants:
+  - description: Underflow interrupt disable
+    name: Disabled
+    value: 0
+  - description: Underflow interrupt enable
+    name: Enabled
+    value: 1
+enum/FPU_IE3:
+  bit_size: 1
+  variants:
+  - description: Overflow interrupt disable
+    name: Disabled
+    value: 0
+  - description: Overflow interrupt enable
+    name: Enabled
+    value: 1
+enum/FPU_IE4:
+  bit_size: 1
+  variants:
+  - description: Input denormal interrupt disable
+    name: Disabled
+    value: 0
+  - description: Input denormal interrupt enable
+    name: Enabled
+    value: 1
+enum/FPU_IE5:
+  bit_size: 1
+  variants:
+  - description: Inexact interrupt disable
+    name: Disabled
+    value: 0
+  - description: Inexact interrupt enable
+    name: Enabled
+    value: 1
+enum/I2C1_FMP:
+  bit_size: 1
+  variants:
+  - description: FM+ mode is controlled by I2C_Pxx_FMP bits only
+    name: Standard
+    value: 0
+  - description: FM+ mode is enabled on all I2C1 pins selected through selection through
+      IOPORT control registers AF selection bits
+    name: FMP
+    value: 1
+enum/I2C1_RX_DMA_RMP:
+  bit_size: 2
+  variants:
+  - description: I2C1_RX mapped on DMA1 CH7
+    name: MapDma1Ch7
+    value: 0
+  - description: I2C1_RX mapped on DMA1 CH3
+    name: MapDma1Ch3
+    value: 1
+  - description: I2C1_RX mapped on DMA1 CH5
+    name: MapDma1Ch5
+    value: 2
+enum/I2C1_TX_DMA_RMP:
+  bit_size: 2
+  variants:
+  - description: I2C1_TX mapped on DMA1 CH6
+    name: MapDma1Ch6
+    value: 0
+  - description: I2C1_TX mapped on DMA1 CH2
+    name: MapDma1Ch2
+    value: 1
+  - description: I2C1_TX mapped on DMA1 CH4
+    name: MapDma1Ch4
+    value: 2
+enum/I2C2_FMP:
+  bit_size: 1
+  variants:
+  - description: FM+ mode is controlled by I2C_Pxx_FMP bits only
+    name: Standard
+    value: 0
+  - description: FM+ mode is enabled on all I2C2 pins selected through selection through
+      IOPORT control registers AF selection bits
+    name: FMP
+    value: 1
+enum/I2C3_FMP:
+  bit_size: 1
+  variants:
+  - description: FM+ mode is controlled by I2C_Pxx_FMP bits only
+    name: Standard
+    value: 0
+  - description: FM+ mode is enabled on all I2C3 pins selected through selection trhough
+      IOPORT control registers AF selection bits
+    name: FMP
+    value: 1
+enum/I2C_PB6_FMP:
+  bit_size: 1
+  variants:
+  - description: PB6 pin operate in standard mode
+    name: Standard
+    value: 0
+  - description: I2C FM+ mode enabled on PB6 and the Speed control is bypassed
+    name: FMP
+    value: 1
+enum/I2C_PB7_FMP:
+  bit_size: 1
+  variants:
+  - description: PB7 pin operate in standard mode
+    name: Standard
+    value: 0
+  - description: I2C FM+ mode enabled on PB7 and the Speed control is bypassed
+    name: FMP
+    value: 1
+enum/I2C_PB8_FMP:
+  bit_size: 1
+  variants:
+  - description: PB8 pin operate in standard mode
+    name: Standard
+    value: 0
+  - description: I2C FM+ mode enabled on PB8 and the Speed control is bypassed
+    name: FMP
+    value: 1
+enum/I2C_PB9_FMP:
+  bit_size: 1
+  variants:
+  - description: PB9 pin operate in standard mode
+    name: Standard
+    value: 0
+  - description: I2C FM+ mode enabled on PB9 and the Speed control is bypassed
+    name: FMP
+    value: 1
+enum/LOCKUP_LOCK:
+  bit_size: 1
+  variants:
+  - description: Cortex-M4 LOCKUP output disconnected from TIM1/15/16/17 Break inputs
+      and HRTIM1 SYSFLT.
+    name: Disconnected
+    value: 0
+  - description: Cortex-M4 LOCKUP output connected to TIM1/15/16/17 and HRTIM1 SYSFLT
+      Break inputs
+    name: Connected
+    value: 1
+enum/MEM_MODE:
+  bit_size: 2
+  variants:
+  - description: Main Flash memory mapped at 0x0000_0000
+    name: MainFlash
+    value: 0
+  - description: System Flash memory mapped at 0x0000_0000
+    name: SystemFlash
+    value: 1
+  - description: Main Flash memory mapped at 0x0000_0000
+    name: MainFlash2
+    value: 2
+  - description: Embedded SRAM mapped at 0x0000_0000
+    name: SRAM
+    value: 3
+enum/PAGE0_WP:
+  bit_size: 1
+  variants:
+  - description: Write protection of pagex is disabled
+    name: Disabled
+    value: 0
+  - description: Write protection of pagex is enabled
+    name: Enabled
+    value: 1
+enum/PVD_LOCK:
+  bit_size: 1
+  variants:
+  - description: PVD interrupt disconnected from TIM15/16/17 Break input
+    name: Disconnected
+    value: 0
+  - description: PVD interrupt connected to TIM15/16/17 Break input
+    name: Connected
+    value: 1
+enum/SPI1_RX_DMA_RMP:
+  bit_size: 2
+  variants:
+  - description: SPI1_RX mapped on DMA1 CH2
+    name: MapDma1Ch3
+    value: 0
+  - description: SPI1_RX mapped on DMA1 CH4
+    name: MapDma1Ch5
+    value: 1
+  - description: SPI1_RX mapped on DMA1 CH6
+    name: MapDma1Ch7
+    value: 2
+enum/SPI1_TX_DMA_RMP:
+  bit_size: 2
+  variants:
+  - description: SPI1_TX mapped on DMA1 CH3
+    name: MapDma1Ch3
+    value: 0
+  - description: SPI1_TX mapped on DMA1 CH5
+    name: MapDma1Ch5
+    value: 1
+  - description: SPI1_TX mapped on DMA1 CH7
+    name: MapDma1Ch7
+    value: 2
+enum/SRAM_PARITY_LOCK:
+  bit_size: 1
+  variants:
+  - description: SRAM parity error signal disconnected from TIM1/15/16/17 and HRTIM1
+      SYSFLT Break inputs
+    name: Disconnected
+    value: 0
+  - description: SRAM parity error signal connected to TIM1/15/16/17 and HRTIM1 SYSFLT
+      Break inputs
+    name: Connected
+    value: 1
+enum/SRAM_PEFR:
+  bit_size: 1
+  variants:
+  - description: No SRAM parity error detected
+    name: NoParityError
+    value: 0
+  - description: SRAM parity error detected
+    name: ParityErrorDetected
+    value: 1
+enum/SRAM_PEFW:
+  bit_size: 1
+  variants:
+  - description: Clear SRAM parity error flag
+    name: Clear
+    value: 1
+enum/TIM16_DMA_RMP:
+  bit_size: 1
+  variants:
+  - description: TIM16_CH1 and TIM16_UP DMA requests mapped on DMA channel 3
+    name: NotRemapped
+    value: 0
+  - description: TIM16_CH1 and TIM16_UP DMA requests mapped on DMA channel 4
+    name: Remapped
+    value: 1
+enum/TIM17_DMA_RMP:
+  bit_size: 1
+  variants:
+  - description: TIM17_CH1 and TIM17_UP DMA requests mapped on DMA channel 1
+    name: NotRemapped
+    value: 0
+  - description: TIM17_CH1 and TIM17_UP DMA requests mapped on DMA channel 2
+    name: Remapped
+    value: 1
+enum/TIM18_DAC2_OUT1_DMA_RMP:
+  bit_size: 1
+  variants:
+  - description: TIM18 and DAC2_OUT1 DMA requests mapped on DMA2 channel 5
+    name: NotRemapped
+    value: 0
+  - description: TIM18 and DAC2_OUT1 DMA requests mapped on DMA1 channel 5
+    name: Remapped
+    value: 1
+enum/TIM1_ITR3_RMP:
+  bit_size: 1
+  variants:
+  - description: Not remapped
+    name: NotRemapped
+    value: 0
+  - description: TIM1_ITR3 = TIM17_OC
+    name: Remapped
+    value: 1
+enum/TIM6_DAC1_CH1_DMA_RMP:
+  bit_size: 1
+  variants:
+  - description: TIM6_UP and DAC_CH1 DMA requests mapped on DMA2 channel 3
+    name: NotRemapped
+    value: 0
+  - description: TIM6_UP and DAC_CH1 DMA requests mapped on DMA1 channel 3
+    name: Remapped
+    value: 1
+enum/TIM6_DAC1_DMA_RMP:
+  bit_size: 1
+  variants:
+  - description: TIM6_UP and DAC_CH1 DMA requests mapped on DMA2 channel 3
+    name: NotRemapped
+    value: 0
+  - description: TIM6_UP and DAC_CH1 DMA requests mapped on DMA1 channel 3
+    name: Remapped
+    value: 1
+enum/TIM6_DAC1_OUT1_DMA_RMP:
+  bit_size: 1
+  variants:
+  - description: TIM7 and DAC1_OUT1 DMA requests mapped on DMA2 channel 3
+    name: NotRemapped
+    value: 0
+  - description: TIM7 and DAC1_OUT1 DMA requests mapped on DMA1 channel 3
+    name: Remapped
+    value: 1
+enum/TIM7_DAC1_CH2_DMA_RMP:
+  bit_size: 1
+  variants:
+  - description: Not remapped
+    name: NotRemapped
+    value: 0
+  - description: TIM7_UP and DAC_CH2 DMA requests mapped on DMA1 channel 4
+    name: Remapped
+    value: 1
+enum/TIM7_DAC1_OUT2_DMA_RMP:
+  bit_size: 1
+  variants:
+  - description: TIM7 and DAC1_OUT2 DMA requests mapped on DMA2 channel 4
+    name: NotRemapped
+    value: 0
+  - description: TIM7 and DAC1_OUT2 DMA requests mapped on DMA1 channel 4
+    name: Remapped
+    value: 1
+enum/USB_IT_RMP:
+  bit_size: 1
+  variants:
+  - description: USB_HP, USB_LP and USB_WAKEUP interrupts are mapped on interrupt
+      lines 19, 20 and 42 respectively
+    name: NotRemapped
+    value: 0
+  - description: USB_HP, USB_LP and USB_WAKEUP interrupts are mapped on interrupt
+      lines 74, 75 and 76 respectively
+    name: Remapped
+    value: 1
+enum/VBAT_MON:
+  bit_size: 1
+  variants:
+  - description: Disable the power switch to not deliver VBAT voltage on ADC channel
+      18 input
+    name: Disable
+    value: 0
+  - description: Enable the power switch to deliver VBAT voltage on ADC channel 18
+      input
+    name: Enable
+    value: 1
+fieldset/CFGR1:
+  description: configuration register 1
+  fields:
+  - bit_offset: 0
+    bit_size: 2
+    description: Memory mapping selection bits
+    enum: MEM_MODE
+    name: MEM_MODE
+  - bit_offset: 5
+    bit_size: 1
+    description: USB interrupt remap
+    enum: USB_IT_RMP
+    name: USB_IT_RMP
+  - bit_offset: 6
+    bit_size: 1
+    description: Timer 1 ITR3 selection
+    enum: TIM1_ITR3_RMP
+    name: TIM1_ITR3_RMP
+  - bit_offset: 7
+    bit_size: 1
+    description: DAC trigger remap (when TSEL = 001)
+    enum: DAC_TRIG_RMP
+    name: DAC_TRIG_RMP
+  - bit_offset: 7
+    bit_size: 1
+    description: DAC trigger remap (when TSEL = 001)
+    enum: DAC1_TRIG_RMP
+    name: DAC1_TRIG_RMP
+  - bit_offset: 8
+    bit_size: 1
+    description: ADC24 DMA remapping bit
+    enum: ADC2_DMA_RMP
+    name: ADC2_DMA_RMP
+  - bit_offset: 11
+    bit_size: 1
+    description: TIM16 DMA request remapping bit
+    enum: TIM16_DMA_RMP
+    name: TIM16_DMA_RMP
+  - bit_offset: 12
+    bit_size: 1
+    description: TIM17 DMA request remapping bit
+    enum: TIM17_DMA_RMP
+    name: TIM17_DMA_RMP
+  - bit_offset: 13
+    bit_size: 1
+    description: TIM6 and DAC1 DMA request remapping bit
+    enum: TIM6_DAC1_CH1_DMA_RMP
+    name: TIM6_DAC1_CH1_DMA_RMP
+  - bit_offset: 13
+    bit_size: 1
+    description: TIM6 and DAC1 DMA request remapping bit
+    enum: TIM6_DAC1_DMA_RMP
+    name: TIM6_DAC1_DMA_RMP
+  - bit_offset: 13
+    bit_size: 1
+    description: TIM6 and DAC1 DMA request remapping bit
+    enum: TIM6_DAC1_OUT1_DMA_RMP
+    name: TIM6_DAC1_OUT1_DMA_RMP
+  - bit_offset: 14
+    bit_size: 1
+    description: TIM7 and DAC2 DMA request remapping bit
+    enum: TIM7_DAC1_CH2_DMA_RMP
+    name: TIM7_DAC1_CH2_DMA_RMP
+  - bit_offset: 14
+    bit_size: 1
+    description: TIM7 and DAC2 DMA request remapping bit
+    enum: TIM7_DAC1_OUT2_DMA_RMP
+    name: TIM7_DAC1_OUT2_DMA_RMP
+  - bit_offset: 15
+    bit_size: 1
+    description: DAC2 channel1 DMA remap
+    enum: DAC2_CH1_DMA_RMP
+    name: DAC2_CH1_DMA_RMP
+  - bit_offset: 15
+    bit_size: 1
+    description: TIM18 and DAC2_OUT1 DMA request remapping bit
+    enum: TIM18_DAC2_OUT1_DMA_RMP
+    name: TIM18_DAC2_OUT1_DMA_RMP
+  - bit_offset: 16
+    bit_size: 1
+    description: Fast Mode Plus (FM+) driving capability activation bits.
+    enum: I2C_PB6_FMP
+    name: I2C_PB6_FMP
+  - bit_offset: 17
+    bit_size: 1
+    description: Fast Mode Plus (FM+) driving capability activation bits.
+    enum: I2C_PB7_FMP
+    name: I2C_PB7_FMP
+  - bit_offset: 18
+    bit_size: 1
+    description: Fast Mode Plus (FM+) driving capability activation bits.
+    enum: I2C_PB8_FMP
+    name: I2C_PB8_FMP
+  - bit_offset: 19
+    bit_size: 1
+    description: Fast Mode Plus (FM+) driving capability activation bits.
+    enum: I2C_PB9_FMP
+    name: I2C_PB9_FMP
+  - bit_offset: 20
+    bit_size: 1
+    description: I2C1 Fast Mode Plus
+    enum: I2C1_FMP
+    name: I2C1_FMP
+  - bit_offset: 21
+    bit_size: 1
+    description: I2C2 Fast Mode Plus
+    enum: I2C2_FMP
+    name: I2C2_FMP
+  - bit_offset: 22
+    bit_size: 2
+    description: Encoder mode
+    enum: ENCODER_MODE
+    name: ENCODER_MODE
+  - bit_offset: 24
+    bit_size: 1
+    description: I2C3 Fast Mode Plus
+    enum: I2C3_FMP
+    name: I2C3_FMP
+  - bit_offset: 24
+    bit_size: 1
+    description: VBAT monitoring enable
+    enum: VBAT_MON
+    name: VBAT_MON
+  - bit_offset: 26
+    bit_size: 1
+    description: Invalid operation interrupt enable
+    enum: FPU_IE0
+    name: FPU_IE0
+  - bit_offset: 27
+    bit_size: 1
+    description: Devide-by-zero interrupt enable
+    enum: FPU_IE1
+    name: FPU_IE1
+  - bit_offset: 28
+    bit_size: 1
+    description: Underflow interrupt enable
+    enum: FPU_IE2
+    name: FPU_IE2
+  - bit_offset: 29
+    bit_size: 1
+    description: Overflow interrupt enable
+    enum: FPU_IE3
+    name: FPU_IE3
+  - bit_offset: 30
+    bit_size: 1
+    description: Input denormal interrupt enable
+    enum: FPU_IE4
+    name: FPU_IE4
+  - bit_offset: 31
+    bit_size: 1
+    description: Inexact interrupt enable
+    enum: FPU_IE5
+    name: FPU_IE5
+fieldset/CFGR2:
+  description: configuration register 2
+  fields:
+  - bit_offset: 0
+    bit_size: 1
+    description: Cortex-M0 LOCKUP bit enable bit
+    enum: LOCKUP_LOCK
+    name: LOCKUP_LOCK
+  - bit_offset: 1
+    bit_size: 1
+    description: SRAM parity lock bit
+    enum: SRAM_PARITY_LOCK
+    name: SRAM_PARITY_LOCK
+  - bit_offset: 2
+    bit_size: 1
+    description: PVD lock enable bit
+    enum: PVD_LOCK
+    name: PVD_LOCK
+  - bit_offset: 4
+    bit_size: 1
+    description: Bypass address bit 29 in parity calculation
+    enum: BYP_ADDR_PAR
+    name: BYP_ADDR_PAR
+  - bit_offset: 8
+    bit_size: 1
+    description: SRAM parity flag
+    enum_read: SRAM_PEFR
+    enum_write: SRAM_PEFW
+    name: SRAM_PEF
+fieldset/CFGR3:
+  description: configuration register 3
+  fields:
+  - bit_offset: 0
+    bit_size: 2
+    description: SPI1_RX DMA remapping bit
+    enum: SPI1_RX_DMA_RMP
+    name: SPI1_RX_DMA_RMP
+  - bit_offset: 2
+    bit_size: 2
+    description: SPI1_TX DMA remapping bit
+    enum: SPI1_TX_DMA_RMP
+    name: SPI1_TX_DMA_RMP
+  - bit_offset: 4
+    bit_size: 2
+    description: I2C1_RX DMA remapping bit
+    enum: I2C1_RX_DMA_RMP
+    name: I2C1_RX_DMA_RMP
+  - bit_offset: 6
+    bit_size: 2
+    description: I2C1_TX DMA remapping bit
+    enum: I2C1_TX_DMA_RMP
+    name: I2C1_TX_DMA_RMP
+  - bit_offset: 8
+    bit_size: 2
+    description: ADC2 DMA remapping bit
+    enum: ADC2_DMA_RMP
+    name: ADC2_DMA_RMP
+  - bit_offset: 16
+    bit_size: 1
+    description: DAC1_CH1 / DAC1_CH2 Trigger remap
+    enum: DAC1_TRIG3_RMP
+    name: DAC1_TRIG3_RMP
+  - bit_offset: 17
+    bit_size: 1
+    description: DAC1_CH1 / DAC1_CH2 Trigger remap
+    enum: DAC1_TRIG5_RMP
+    name: DAC1_TRIG5_RMP
+fieldset/CFGR4:
+  description: configuration register 4
+  fields:
+  - bit_offset: 0
+    bit_size: 1
+    description: Controls the Input trigger of ADC12 regular channel EXT2
+    enum: ADC12_EXT2_RMP
+    name: ADC12_EXT2_RMP
+  - bit_offset: 1
+    bit_size: 1
+    description: Controls the Input trigger of ADC12 regular channel EXT3
+    enum: ADC12_EXT3_RMP
+    name: ADC12_EXT3_RMP
+  - bit_offset: 2
+    bit_size: 1
+    description: Controls the Input trigger of ADC12 regular channel EXT5
+    enum: ADC12_EXT5_RMP
+    name: ADC12_EXT5_RMP
+  - bit_offset: 3
+    bit_size: 1
+    description: Controls the Input trigger of ADC12 regular channel EXT13
+    enum: ADC12_EXT13_RMP
+    name: ADC12_EXT13_RMP
+  - bit_offset: 4
+    bit_size: 1
+    description: Controls the Input trigger of ADC12 regular channel EXT15
+    enum: ADC12_EXT15_RMP
+    name: ADC12_EXT15_RMP
+  - bit_offset: 5
+    bit_size: 1
+    description: Controls the Input trigger of ADC12 injected channel JEXT3
+    enum: ADC12_JEXT3_RMP
+    name: ADC12_JEXT3_RMP
+  - bit_offset: 6
+    bit_size: 1
+    description: Controls the Input trigger of ADC12 injected channel JEXT6
+    enum: ADC12_JEXT6_RMP
+    name: ADC12_JEXT6_RMP
+  - bit_offset: 7
+    bit_size: 1
+    description: Controls the Input trigger of ADC12 injected channel JEXT13
+    enum: ADC12_JEXT13_RMP
+    name: ADC12_JEXT13_RMP
+  - bit_offset: 8
+    bit_size: 1
+    description: Controls the Input trigger of ADC34 regular channel EXT5
+    enum: ADC34_EXT5_RMP
+    name: ADC34_EXT5_RMP
+  - bit_offset: 9
+    bit_size: 1
+    description: Controls the Input trigger of ADC34 regular channel EXT6
+    enum: ADC34_EXT6_RMP
+    name: ADC34_EXT6_RMP
+  - bit_offset: 10
+    bit_size: 1
+    description: Controls the Input trigger of ADC34 regular channel EXT15
+    enum: ADC34_EXT15_RMP
+    name: ADC34_EXT15_RMP
+  - bit_offset: 11
+    bit_size: 1
+    description: Controls the Input trigger of ADC34 injected channel JEXT5
+    enum: ADC34_JEXT5_RMP
+    name: ADC34_JEXT5_RMP
+  - bit_offset: 12
+    bit_size: 1
+    description: Controls the Input trigger of ADC34 injected channel JEXT11
+    enum: ADC34_JEXT11_RMP
+    name: ADC34_JEXT11_RMP
+  - bit_offset: 13
+    bit_size: 1
+    description: Controls the Input trigger of ADC34 injected channel JEXT14
+    enum: ADC34_JEXT14_RMP
+    name: ADC34_JEXT14_RMP
+fieldset/EXTICR1:
+  description: external interrupt configuration register 1
+  fields:
+  - bit_offset: 0
+    bit_size: 4
+    description: EXTI 0 configuration bits
+    enum: EXTI0
+    name: EXTI0
+  - bit_offset: 4
+    bit_size: 4
+    description: EXTI 1 configuration bits
+    enum: EXTI1
+    name: EXTI1
+  - bit_offset: 8
+    bit_size: 4
+    description: EXTI 2 configuration bits
+    enum: EXTI2
+    name: EXTI2
+  - bit_offset: 12
+    bit_size: 4
+    description: EXTI 3 configuration bits
+    enum: EXTI3
+    name: EXTI3
+fieldset/EXTICR2:
+  description: external interrupt configuration register 2
+  fields:
+  - bit_offset: 0
+    bit_size: 4
+    description: EXTI 4 configuration bits
+    enum: EXTI4
+    name: EXTI4
+  - bit_offset: 4
+    bit_size: 4
+    description: EXTI 5 configuration bits
+    enum: EXTI5
+    name: EXTI5
+  - bit_offset: 8
+    bit_size: 4
+    description: EXTI 6 configuration bits
+    enum: EXTI6
+    name: EXTI6
+  - bit_offset: 12
+    bit_size: 4
+    description: EXTI 7 configuration bits
+    enum: EXTI7
+    name: EXTI7
+fieldset/EXTICR3:
+  description: external interrupt configuration register 3
+  fields:
+  - bit_offset: 0
+    bit_size: 4
+    description: EXTI 8 configuration bits
+    enum: EXTI8
+    name: EXTI8
+  - bit_offset: 4
+    bit_size: 4
+    description: EXTI 9 configuration bits
+    enum: EXTI9
+    name: EXTI9
+  - bit_offset: 8
+    bit_size: 4
+    description: EXTI 10 configuration bits
+    enum: EXTI10
+    name: EXTI10
+  - bit_offset: 12
+    bit_size: 4
+    description: EXTI 11 configuration bits
+    enum: EXTI11
+    name: EXTI11
+fieldset/EXTICR4:
+  description: external interrupt configuration register 4
+  fields:
+  - bit_offset: 0
+    bit_size: 4
+    description: EXTI 12 configuration bits
+    enum: EXTI12
+    name: EXTI12
+  - bit_offset: 4
+    bit_size: 4
+    description: EXTI 13 configuration bits
+    enum: EXTI13
+    name: EXTI13
+  - bit_offset: 8
+    bit_size: 4
+    description: EXTI 14 configuration bits
+    enum: EXTI14
+    name: EXTI14
+  - bit_offset: 12
+    bit_size: 4
+    description: EXTI 15 configuration bits
+    enum: EXTI15
+    name: EXTI15
+fieldset/RCR:
+  description: CCM SRAM protection register
+  fields:
+  - bit_offset: 0
+    bit_size: 1
+    description: CCM SRAM page write protection bit
+    enum: PAGE0_WP
+    name: PAGE0_WP
+  - bit_offset: 1
+    bit_size: 1
+    description: CCM SRAM page write protection bit
+    enum: PAGE0_WP
+    name: PAGE1_WP
+  - bit_offset: 2
+    bit_size: 1
+    description: CCM SRAM page write protection bit
+    enum: PAGE0_WP
+    name: PAGE2_WP
+  - bit_offset: 3
+    bit_size: 1
+    description: CCM SRAM page write protection bit
+    enum: PAGE0_WP
+    name: PAGE3_WP
+  - bit_offset: 4
+    bit_size: 1
+    description: CCM SRAM page write protection bit
+    enum: PAGE0_WP
+    name: PAGE4_WP
+  - bit_offset: 5
+    bit_size: 1
+    description: CCM SRAM page write protection bit
+    enum: PAGE0_WP
+    name: PAGE5_WP
+  - bit_offset: 6
+    bit_size: 1
+    description: CCM SRAM page write protection bit
+    enum: PAGE0_WP
+    name: PAGE6_WP
+  - bit_offset: 7
+    bit_size: 1
+    description: CCM SRAM page write protection bit
+    enum: PAGE0_WP
+    name: PAGE7_WP
+  - bit_offset: 8
+    bit_size: 1
+    description: CCM SRAM page write protection bit
+    enum: PAGE0_WP
+    name: PAGE8_WP
+  - bit_offset: 9
+    bit_size: 1
+    description: CCM SRAM page write protection bit
+    enum: PAGE0_WP
+    name: PAGE9_WP
+  - bit_offset: 10
+    bit_size: 1
+    description: CCM SRAM page write protection bit
+    enum: PAGE0_WP
+    name: PAGE10_WP
+  - bit_offset: 11
+    bit_size: 1
+    description: CCM SRAM page write protection bit
+    enum: PAGE0_WP
+    name: PAGE11_WP
+  - bit_offset: 12
+    bit_size: 1
+    description: CCM SRAM page write protection bit
+    enum: PAGE0_WP
+    name: PAGE12_WP
+  - bit_offset: 13
+    bit_size: 1
+    description: CCM SRAM page write protection bit
+    enum: PAGE0_WP
+    name: PAGE13_WP
+  - bit_offset: 14
+    bit_size: 1
+    description: CCM SRAM page write protection bit
+    enum: PAGE0_WP
+    name: PAGE14_WP
+  - bit_offset: 15
+    bit_size: 1
+    description: CCM SRAM page write protection bit
+    enum: PAGE0_WP
+    name: PAGE15_WP

--- a/stm32data/__main__.py
+++ b/stm32data/__main__.py
@@ -125,6 +125,7 @@ perimap = [
     ('.*:ADC_COMMON:aditf4_v3_0_WL', 'adccommon_v3/ADC_COMMON'),
     ('.*:DCMI:.*', 'dcmi_v1/DCMI'),
     ('STM32F0.*:SYSCFG:.*',  'syscfg_f0/SYSCFG'),
+    ('STM32F3.*:SYSCFG:.*',  'syscfg_f3/SYSCFG'),
     ('STM32F4.*:SYSCFG:.*',  'syscfg_f4/SYSCFG'),
     ('STM32F7.*:SYSCFG:.*',  'syscfg_f7/SYSCFG'),
     ('STM32L4.*:SYSCFG:.*',  'syscfg_l4/SYSCFG'),
@@ -173,6 +174,8 @@ perimap = [
     ('STM32WL5.*:RCC:.*', 'rcc_wl5/RCC'),
     ('STM32WLE.*:RCC:.*', 'rcc_wle/RCC'),
 
+    ('STM32F3.*:SPI[1234]:.*', 'spi_v2/SPI'),
+
     ('STM32F1.*:AFIO:.*', 'afio_f1/AFIO'),
 
     ('STM32L5.*:EXTI:.*', 'exti_l5/EXTI'),
@@ -190,6 +193,7 @@ perimap = [
     ('STM32G4.*:PWR:.*', 'pwr_g4/PWR'),
     ('STM32H7(42|43|53|50).*:PWR:.*', 'pwr_h7/PWR'),
     ('STM32H7.*:PWR:.*', 'pwr_h7smps/PWR'),
+    ('STM32F3.*:PWR:.*', 'pwr_f3/PWR'),
     ('STM32F4.*:PWR:.*', 'pwr_f4/PWR'),
     ('STM32F7.*:PWR:.*', 'pwr_f7/PWR'),
     ('STM32L1.*:PWR:.*', 'pwr_l1/PWR'),
@@ -198,6 +202,7 @@ perimap = [
     ('STM32H7.*:FLASH:.*', 'flash_h7/FLASH'),
     ('STM32F0.*:FLASH:.*', 'flash_f0/FLASH'),
     ('STM32F1.*:FLASH:.*', 'flash_f1/FLASH'),
+    ('STM32F3.*:FLASH:.*', 'flash_f3/FLASH'),
     ('STM32F4.*:FLASH:.*', 'flash_f4/FLASH'),
     ('STM32F7.*:FLASH:.*', 'flash_f7/FLASH'),
     ('STM32L4.*:FLASH:.*', 'flash_l4/FLASH'),


### PR DESCRIPTION
I am trying to get the examples in embassy repo working on an STM32F303VC MCU,
this PR adds the registers that are currently missing for F3 chips.

- [x] SYSCFG
- [x] PWR
- [x] FLASH
- [x] SPI