### PR TITLE
Assign correct register blocks for F3 Timers

### DIFF
--- a/data/chips/STM32F301C6.yaml
+++ b/data/chips/STM32F301C6.yaml
@@ -651,7 +651,7 @@ cores:
           reset:
             register: APB2RSTR
             field: TIM1RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_ADV
       pins:
       - pin: PA6
         signal: BKIN
@@ -905,7 +905,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM2RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_GP32
       pins:
       - pin: PA0
         signal: CH1
@@ -976,7 +976,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM6RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_BASIC
       interrupts: {}
       dma_channels:
         UP:

--- a/data/chips/STM32F301C8.yaml
+++ b/data/chips/STM32F301C8.yaml
@@ -657,7 +657,7 @@ cores:
           reset:
             register: APB2RSTR
             field: TIM1RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_ADV
       pins:
       - pin: PA6
         signal: BKIN
@@ -911,7 +911,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM2RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_GP32
       pins:
       - pin: PA0
         signal: CH1
@@ -982,7 +982,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM6RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_BASIC
       interrupts: {}
       dma_channels:
         UP:

--- a/data/chips/STM32F301K6.yaml
+++ b/data/chips/STM32F301K6.yaml
@@ -634,7 +634,7 @@ cores:
           reset:
             register: APB2RSTR
             field: TIM1RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_ADV
       pins:
       - pin: PA6
         signal: BKIN
@@ -888,7 +888,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM2RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_GP32
       pins:
       - pin: PA0
         signal: CH1
@@ -959,7 +959,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM6RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_BASIC
       interrupts: {}
       dma_channels:
         UP:

--- a/data/chips/STM32F301K8.yaml
+++ b/data/chips/STM32F301K8.yaml
@@ -638,7 +638,7 @@ cores:
           reset:
             register: APB2RSTR
             field: TIM1RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_ADV
       pins:
       - pin: PA6
         signal: BKIN
@@ -892,7 +892,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM2RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_GP32
       pins:
       - pin: PA0
         signal: CH1
@@ -963,7 +963,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM6RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_BASIC
       interrupts: {}
       dma_channels:
         UP:

--- a/data/chips/STM32F301R6.yaml
+++ b/data/chips/STM32F301R6.yaml
@@ -663,7 +663,7 @@ cores:
           reset:
             register: APB2RSTR
             field: TIM1RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_ADV
       pins:
       - pin: PA6
         signal: BKIN
@@ -917,7 +917,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM2RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_GP32
       pins:
       - pin: PA0
         signal: CH1
@@ -988,7 +988,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM6RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_BASIC
       interrupts: {}
       dma_channels:
         UP:

--- a/data/chips/STM32F301R8.yaml
+++ b/data/chips/STM32F301R8.yaml
@@ -667,7 +667,7 @@ cores:
           reset:
             register: APB2RSTR
             field: TIM1RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_ADV
       pins:
       - pin: PA6
         signal: BKIN
@@ -921,7 +921,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM2RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_GP32
       pins:
       - pin: PA0
         signal: CH1
@@ -992,7 +992,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM6RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_BASIC
       interrupts: {}
       dma_channels:
         UP:

--- a/data/chips/STM32F302C6.yaml
+++ b/data/chips/STM32F302C6.yaml
@@ -689,7 +689,7 @@ cores:
           reset:
             register: APB2RSTR
             field: TIM1RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_ADV
       pins:
       - pin: PA6
         signal: BKIN
@@ -943,7 +943,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM2RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_GP32
       pins:
       - pin: PA0
         signal: CH1
@@ -1014,7 +1014,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM6RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_BASIC
       interrupts: {}
       dma_channels:
         UP:

--- a/data/chips/STM32F302C8.yaml
+++ b/data/chips/STM32F302C8.yaml
@@ -691,7 +691,7 @@ cores:
           reset:
             register: APB2RSTR
             field: TIM1RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_ADV
       pins:
       - pin: PA6
         signal: BKIN
@@ -945,7 +945,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM2RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_GP32
       pins:
       - pin: PA0
         signal: CH1
@@ -1016,7 +1016,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM6RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_BASIC
       interrupts: {}
       dma_channels:
         UP:

--- a/data/chips/STM32F302CB.yaml
+++ b/data/chips/STM32F302CB.yaml
@@ -796,7 +796,7 @@ cores:
           reset:
             register: APB2RSTR
             field: TIM1RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_ADV
       pins:
       - pin: PA6
         signal: BKIN
@@ -1074,7 +1074,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM2RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_GP32
       pins:
       - pin: PA0
         signal: CH1
@@ -1315,7 +1315,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM6RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_BASIC
       interrupts: {}
       dma_channels:
         UP:

--- a/data/chips/STM32F302CC.yaml
+++ b/data/chips/STM32F302CC.yaml
@@ -796,7 +796,7 @@ cores:
           reset:
             register: APB2RSTR
             field: TIM1RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_ADV
       pins:
       - pin: PA6
         signal: BKIN
@@ -1074,7 +1074,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM2RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_GP32
       pins:
       - pin: PA0
         signal: CH1
@@ -1315,7 +1315,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM6RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_BASIC
       interrupts: {}
       dma_channels:
         UP:

--- a/data/chips/STM32F302K6.yaml
+++ b/data/chips/STM32F302K6.yaml
@@ -668,7 +668,7 @@ cores:
           reset:
             register: APB2RSTR
             field: TIM1RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_ADV
       pins:
       - pin: PA6
         signal: BKIN
@@ -922,7 +922,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM2RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_GP32
       pins:
       - pin: PA0
         signal: CH1
@@ -993,7 +993,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM6RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_BASIC
       interrupts: {}
       dma_channels:
         UP:

--- a/data/chips/STM32F302K8.yaml
+++ b/data/chips/STM32F302K8.yaml
@@ -668,7 +668,7 @@ cores:
           reset:
             register: APB2RSTR
             field: TIM1RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_ADV
       pins:
       - pin: PA6
         signal: BKIN
@@ -922,7 +922,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM2RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_GP32
       pins:
       - pin: PA0
         signal: CH1
@@ -993,7 +993,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM6RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_BASIC
       interrupts: {}
       dma_channels:
         UP:

--- a/data/chips/STM32F302R6.yaml
+++ b/data/chips/STM32F302R6.yaml
@@ -701,7 +701,7 @@ cores:
           reset:
             register: APB2RSTR
             field: TIM1RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_ADV
       pins:
       - pin: PA6
         signal: BKIN
@@ -955,7 +955,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM2RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_GP32
       pins:
       - pin: PA0
         signal: CH1
@@ -1026,7 +1026,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM6RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_BASIC
       interrupts: {}
       dma_channels:
         UP:

--- a/data/chips/STM32F302R8.yaml
+++ b/data/chips/STM32F302R8.yaml
@@ -701,7 +701,7 @@ cores:
           reset:
             register: APB2RSTR
             field: TIM1RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_ADV
       pins:
       - pin: PA6
         signal: BKIN
@@ -955,7 +955,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM2RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_GP32
       pins:
       - pin: PA0
         signal: CH1
@@ -1026,7 +1026,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM6RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_BASIC
       interrupts: {}
       dma_channels:
         UP:

--- a/data/chips/STM32F302RB.yaml
+++ b/data/chips/STM32F302RB.yaml
@@ -826,7 +826,7 @@ cores:
           reset:
             register: APB2RSTR
             field: TIM1RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_ADV
       pins:
       - pin: PA6
         signal: BKIN
@@ -1104,7 +1104,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM2RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_GP32
       pins:
       - pin: PA0
         signal: CH1
@@ -1345,7 +1345,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM6RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_BASIC
       interrupts: {}
       dma_channels:
         UP:

--- a/data/chips/STM32F302RC.yaml
+++ b/data/chips/STM32F302RC.yaml
@@ -826,7 +826,7 @@ cores:
           reset:
             register: APB2RSTR
             field: TIM1RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_ADV
       pins:
       - pin: PA6
         signal: BKIN
@@ -1104,7 +1104,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM2RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_GP32
       pins:
       - pin: PA0
         signal: CH1
@@ -1345,7 +1345,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM6RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_BASIC
       interrupts: {}
       dma_channels:
         UP:

--- a/data/chips/STM32F302RD.yaml
+++ b/data/chips/STM32F302RD.yaml
@@ -897,7 +897,7 @@ cores:
           reset:
             register: APB2RSTR
             field: TIM1RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_ADV
       pins:
       - pin: PA6
         signal: BKIN
@@ -1193,7 +1193,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM2RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_GP32
       pins:
       - pin: PA0
         signal: CH1
@@ -1434,7 +1434,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM6RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_BASIC
       interrupts: {}
       dma_channels:
         UP:

--- a/data/chips/STM32F302RE.yaml
+++ b/data/chips/STM32F302RE.yaml
@@ -899,7 +899,7 @@ cores:
           reset:
             register: APB2RSTR
             field: TIM1RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_ADV
       pins:
       - pin: PA6
         signal: BKIN
@@ -1195,7 +1195,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM2RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_GP32
       pins:
       - pin: PA0
         signal: CH1
@@ -1436,7 +1436,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM6RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_BASIC
       interrupts: {}
       dma_channels:
         UP:

--- a/data/chips/STM32F302VB.yaml
+++ b/data/chips/STM32F302VB.yaml
@@ -834,7 +834,7 @@ cores:
           reset:
             register: APB2RSTR
             field: TIM1RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_ADV
       pins:
       - pin: PA6
         signal: BKIN
@@ -1112,7 +1112,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM2RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_GP32
       pins:
       - pin: PA0
         signal: CH1
@@ -1353,7 +1353,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM6RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_BASIC
       interrupts: {}
       dma_channels:
         UP:

--- a/data/chips/STM32F302VC.yaml
+++ b/data/chips/STM32F302VC.yaml
@@ -836,7 +836,7 @@ cores:
           reset:
             register: APB2RSTR
             field: TIM1RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_ADV
       pins:
       - pin: PA6
         signal: BKIN
@@ -1114,7 +1114,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM2RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_GP32
       pins:
       - pin: PA0
         signal: CH1
@@ -1355,7 +1355,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM6RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_BASIC
       interrupts: {}
       dma_channels:
         UP:

--- a/data/chips/STM32F302VD.yaml
+++ b/data/chips/STM32F302VD.yaml
@@ -1160,7 +1160,7 @@ cores:
           reset:
             register: APB2RSTR
             field: TIM1RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_ADV
       pins:
       - pin: PA6
         signal: BKIN
@@ -1456,7 +1456,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM2RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_GP32
       pins:
       - pin: PA0
         signal: CH1
@@ -1697,7 +1697,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM6RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_BASIC
       interrupts: {}
       dma_channels:
         UP:

--- a/data/chips/STM32F302VE.yaml
+++ b/data/chips/STM32F302VE.yaml
@@ -1162,7 +1162,7 @@ cores:
           reset:
             register: APB2RSTR
             field: TIM1RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_ADV
       pins:
       - pin: PA6
         signal: BKIN
@@ -1458,7 +1458,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM2RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_GP32
       pins:
       - pin: PA0
         signal: CH1
@@ -1699,7 +1699,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM6RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_BASIC
       interrupts: {}
       dma_channels:
         UP:

--- a/data/chips/STM32F302ZD.yaml
+++ b/data/chips/STM32F302ZD.yaml
@@ -1160,7 +1160,7 @@ cores:
           reset:
             register: APB2RSTR
             field: TIM1RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_ADV
       pins:
       - pin: PA6
         signal: BKIN
@@ -1456,7 +1456,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM2RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_GP32
       pins:
       - pin: PA0
         signal: CH1
@@ -1697,7 +1697,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM6RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_BASIC
       interrupts: {}
       dma_channels:
         UP:

--- a/data/chips/STM32F302ZE.yaml
+++ b/data/chips/STM32F302ZE.yaml
@@ -1162,7 +1162,7 @@ cores:
           reset:
             register: APB2RSTR
             field: TIM1RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_ADV
       pins:
       - pin: PA6
         signal: BKIN
@@ -1458,7 +1458,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM2RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_GP32
       pins:
       - pin: PA0
         signal: CH1
@@ -1699,7 +1699,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM6RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_BASIC
       interrupts: {}
       dma_channels:
         UP:

--- a/data/chips/STM32F303C6.yaml
+++ b/data/chips/STM32F303C6.yaml
@@ -622,7 +622,7 @@ cores:
           reset:
             register: APB2RSTR
             field: TIM1RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_ADV
       pins:
       - pin: PA6
         signal: BKIN
@@ -876,7 +876,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM2RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_GP32
       pins:
       - pin: PA0
         signal: CH1
@@ -1018,7 +1018,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM6RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_BASIC
       interrupts: {}
       dma_channels:
         UP:
@@ -1034,7 +1034,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM7RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_BASIC
       interrupts: {}
       dma_channels:
         UP:

--- a/data/chips/STM32F303C8.yaml
+++ b/data/chips/STM32F303C8.yaml
@@ -624,7 +624,7 @@ cores:
           reset:
             register: APB2RSTR
             field: TIM1RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_ADV
       pins:
       - pin: PA6
         signal: BKIN
@@ -878,7 +878,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM2RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_GP32
       pins:
       - pin: PA0
         signal: CH1
@@ -1020,7 +1020,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM6RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_BASIC
       interrupts: {}
       dma_channels:
         UP:
@@ -1036,7 +1036,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM7RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_BASIC
       interrupts: {}
       dma_channels:
         UP:

--- a/data/chips/STM32F303CB.yaml
+++ b/data/chips/STM32F303CB.yaml
@@ -915,7 +915,7 @@ cores:
           reset:
             register: APB2RSTR
             field: TIM1RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_ADV
       pins:
       - pin: PA6
         signal: BKIN
@@ -1193,7 +1193,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM2RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_GP32
       pins:
       - pin: PA0
         signal: CH1
@@ -1434,7 +1434,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM6RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_BASIC
       interrupts: {}
       dma_channels:
         UP:
@@ -1451,7 +1451,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM7RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_BASIC
       interrupts:
         BRK: TIM7
         COM: TIM7
@@ -1472,7 +1472,7 @@ cores:
           reset:
             register: APB2RSTR
             field: TIM8RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_ADV
       pins:
       - pin: PA0
         signal: BKIN

--- a/data/chips/STM32F303CC.yaml
+++ b/data/chips/STM32F303CC.yaml
@@ -915,7 +915,7 @@ cores:
           reset:
             register: APB2RSTR
             field: TIM1RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_ADV
       pins:
       - pin: PA6
         signal: BKIN
@@ -1193,7 +1193,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM2RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_GP32
       pins:
       - pin: PA0
         signal: CH1
@@ -1434,7 +1434,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM6RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_BASIC
       interrupts: {}
       dma_channels:
         UP:
@@ -1451,7 +1451,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM7RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_BASIC
       interrupts:
         BRK: TIM7
         COM: TIM7
@@ -1472,7 +1472,7 @@ cores:
           reset:
             register: APB2RSTR
             field: TIM8RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_ADV
       pins:
       - pin: PA0
         signal: BKIN

--- a/data/chips/STM32F303K6.yaml
+++ b/data/chips/STM32F303K6.yaml
@@ -595,7 +595,7 @@ cores:
           reset:
             register: APB2RSTR
             field: TIM1RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_ADV
       pins:
       - pin: PA6
         signal: BKIN
@@ -849,7 +849,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM2RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_GP32
       pins:
       - pin: PA0
         signal: CH1
@@ -991,7 +991,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM6RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_BASIC
       interrupts: {}
       dma_channels:
         UP:
@@ -1007,7 +1007,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM7RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_BASIC
       interrupts: {}
       dma_channels:
         UP:

--- a/data/chips/STM32F303K8.yaml
+++ b/data/chips/STM32F303K8.yaml
@@ -595,7 +595,7 @@ cores:
           reset:
             register: APB2RSTR
             field: TIM1RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_ADV
       pins:
       - pin: PA6
         signal: BKIN
@@ -849,7 +849,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM2RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_GP32
       pins:
       - pin: PA0
         signal: CH1
@@ -991,7 +991,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM6RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_BASIC
       interrupts: {}
       dma_channels:
         UP:
@@ -1007,7 +1007,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM7RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_BASIC
       interrupts: {}
       dma_channels:
         UP:

--- a/data/chips/STM32F303R6.yaml
+++ b/data/chips/STM32F303R6.yaml
@@ -634,7 +634,7 @@ cores:
           reset:
             register: APB2RSTR
             field: TIM1RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_ADV
       pins:
       - pin: PA6
         signal: BKIN
@@ -888,7 +888,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM2RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_GP32
       pins:
       - pin: PA0
         signal: CH1
@@ -1030,7 +1030,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM6RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_BASIC
       interrupts: {}
       dma_channels:
         UP:
@@ -1046,7 +1046,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM7RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_BASIC
       interrupts: {}
       dma_channels:
         UP:

--- a/data/chips/STM32F303R8.yaml
+++ b/data/chips/STM32F303R8.yaml
@@ -634,7 +634,7 @@ cores:
           reset:
             register: APB2RSTR
             field: TIM1RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_ADV
       pins:
       - pin: PA6
         signal: BKIN
@@ -888,7 +888,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM2RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_GP32
       pins:
       - pin: PA0
         signal: CH1
@@ -1030,7 +1030,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM6RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_BASIC
       interrupts: {}
       dma_channels:
         UP:
@@ -1046,7 +1046,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM7RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_BASIC
       interrupts: {}
       dma_channels:
         UP:

--- a/data/chips/STM32F303RB.yaml
+++ b/data/chips/STM32F303RB.yaml
@@ -945,7 +945,7 @@ cores:
           reset:
             register: APB2RSTR
             field: TIM1RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_ADV
       pins:
       - pin: PA6
         signal: BKIN
@@ -1223,7 +1223,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM2RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_GP32
       pins:
       - pin: PA0
         signal: CH1
@@ -1464,7 +1464,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM6RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_BASIC
       interrupts: {}
       dma_channels:
         UP:
@@ -1481,7 +1481,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM7RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_BASIC
       interrupts:
         BRK: TIM7
         COM: TIM7
@@ -1502,7 +1502,7 @@ cores:
           reset:
             register: APB2RSTR
             field: TIM8RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_ADV
       pins:
       - pin: PA0
         signal: BKIN

--- a/data/chips/STM32F303RC.yaml
+++ b/data/chips/STM32F303RC.yaml
@@ -949,7 +949,7 @@ cores:
           reset:
             register: APB2RSTR
             field: TIM1RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_ADV
       pins:
       - pin: PA6
         signal: BKIN
@@ -1227,7 +1227,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM2RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_GP32
       pins:
       - pin: PA0
         signal: CH1
@@ -1468,7 +1468,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM6RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_BASIC
       interrupts: {}
       dma_channels:
         UP:
@@ -1485,7 +1485,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM7RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_BASIC
       interrupts:
         BRK: TIM7
         COM: TIM7
@@ -1506,7 +1506,7 @@ cores:
           reset:
             register: APB2RSTR
             field: TIM8RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_ADV
       pins:
       - pin: PA0
         signal: BKIN

--- a/data/chips/STM32F303RD.yaml
+++ b/data/chips/STM32F303RD.yaml
@@ -1016,7 +1016,7 @@ cores:
           reset:
             register: APB2RSTR
             field: TIM1RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_ADV
       pins:
       - pin: PA6
         signal: BKIN
@@ -1312,7 +1312,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM2RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_GP32
       pins:
       - pin: PA0
         signal: CH1
@@ -1553,7 +1553,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM6RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_BASIC
       interrupts: {}
       dma_channels:
         UP:
@@ -1570,7 +1570,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM7RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_BASIC
       interrupts:
         BRK: TIM7
         COM: TIM7
@@ -1591,7 +1591,7 @@ cores:
           reset:
             register: APB2RSTR
             field: TIM8RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_ADV
       pins:
       - pin: PA0
         signal: BKIN

--- a/data/chips/STM32F303RE.yaml
+++ b/data/chips/STM32F303RE.yaml
@@ -1018,7 +1018,7 @@ cores:
           reset:
             register: APB2RSTR
             field: TIM1RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_ADV
       pins:
       - pin: PA6
         signal: BKIN
@@ -1314,7 +1314,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM2RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_GP32
       pins:
       - pin: PA0
         signal: CH1
@@ -1555,7 +1555,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM6RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_BASIC
       interrupts: {}
       dma_channels:
         UP:
@@ -1572,7 +1572,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM7RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_BASIC
       interrupts:
         BRK: TIM7
         COM: TIM7
@@ -1593,7 +1593,7 @@ cores:
           reset:
             register: APB2RSTR
             field: TIM8RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_ADV
       pins:
       - pin: PA0
         signal: BKIN

--- a/data/chips/STM32F303VB.yaml
+++ b/data/chips/STM32F303VB.yaml
@@ -1005,7 +1005,7 @@ cores:
           reset:
             register: APB2RSTR
             field: TIM1RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_ADV
       pins:
       - pin: PA6
         signal: BKIN
@@ -1283,7 +1283,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM2RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_GP32
       pins:
       - pin: PA0
         signal: CH1
@@ -1524,7 +1524,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM6RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_BASIC
       interrupts: {}
       dma_channels:
         UP:
@@ -1541,7 +1541,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM7RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_BASIC
       interrupts:
         BRK: TIM7
         COM: TIM7
@@ -1562,7 +1562,7 @@ cores:
           reset:
             register: APB2RSTR
             field: TIM8RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_ADV
       pins:
       - pin: PA0
         signal: BKIN

--- a/data/chips/STM32F303VC.yaml
+++ b/data/chips/STM32F303VC.yaml
@@ -1007,7 +1007,7 @@ cores:
           reset:
             register: APB2RSTR
             field: TIM1RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_ADV
       pins:
       - pin: PA6
         signal: BKIN
@@ -1285,7 +1285,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM2RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_GP32
       pins:
       - pin: PA0
         signal: CH1
@@ -1526,7 +1526,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM6RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_BASIC
       interrupts: {}
       dma_channels:
         UP:
@@ -1543,7 +1543,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM7RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_BASIC
       interrupts:
         BRK: TIM7
         COM: TIM7
@@ -1564,7 +1564,7 @@ cores:
           reset:
             register: APB2RSTR
             field: TIM8RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_ADV
       pins:
       - pin: PA0
         signal: BKIN

--- a/data/chips/STM32F303VD.yaml
+++ b/data/chips/STM32F303VD.yaml
@@ -1331,7 +1331,7 @@ cores:
           reset:
             register: APB2RSTR
             field: TIM1RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_ADV
       pins:
       - pin: PA6
         signal: BKIN
@@ -1627,7 +1627,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM2RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_GP32
       pins:
       - pin: PA0
         signal: CH1
@@ -1713,7 +1713,7 @@ cores:
           reset:
             register: APB2RSTR
             field: TIM20RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_ADV
       pins:
       - pin: PE0
         signal: ETR
@@ -1985,7 +1985,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM6RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_BASIC
       interrupts: {}
       dma_channels:
         UP:
@@ -2002,7 +2002,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM7RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_BASIC
       interrupts:
         BRK: TIM7
         COM: TIM7
@@ -2023,7 +2023,7 @@ cores:
           reset:
             register: APB2RSTR
             field: TIM8RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_ADV
       pins:
       - pin: PA0
         signal: BKIN

--- a/data/chips/STM32F303VE.yaml
+++ b/data/chips/STM32F303VE.yaml
@@ -1335,7 +1335,7 @@ cores:
           reset:
             register: APB2RSTR
             field: TIM1RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_ADV
       pins:
       - pin: PA6
         signal: BKIN
@@ -1631,7 +1631,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM2RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_GP32
       pins:
       - pin: PA0
         signal: CH1
@@ -1717,7 +1717,7 @@ cores:
           reset:
             register: APB2RSTR
             field: TIM20RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_ADV
       pins:
       - pin: PE0
         signal: ETR
@@ -1989,7 +1989,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM6RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_BASIC
       interrupts: {}
       dma_channels:
         UP:
@@ -2006,7 +2006,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM7RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_BASIC
       interrupts:
         BRK: TIM7
         COM: TIM7
@@ -2027,7 +2027,7 @@ cores:
           reset:
             register: APB2RSTR
             field: TIM8RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_ADV
       pins:
       - pin: PA0
         signal: BKIN

--- a/data/chips/STM32F303ZD.yaml
+++ b/data/chips/STM32F303ZD.yaml
@@ -1331,7 +1331,7 @@ cores:
           reset:
             register: APB2RSTR
             field: TIM1RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_ADV
       pins:
       - pin: PA6
         signal: BKIN
@@ -1627,7 +1627,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM2RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_GP32
       pins:
       - pin: PA0
         signal: CH1
@@ -1713,7 +1713,7 @@ cores:
           reset:
             register: APB2RSTR
             field: TIM20RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_ADV
       pins:
       - pin: PE0
         signal: ETR
@@ -1985,7 +1985,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM6RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_BASIC
       interrupts: {}
       dma_channels:
         UP:
@@ -2002,7 +2002,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM7RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_BASIC
       interrupts:
         BRK: TIM7
         COM: TIM7
@@ -2023,7 +2023,7 @@ cores:
           reset:
             register: APB2RSTR
             field: TIM8RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_ADV
       pins:
       - pin: PA0
         signal: BKIN

--- a/data/chips/STM32F303ZE.yaml
+++ b/data/chips/STM32F303ZE.yaml
@@ -1333,7 +1333,7 @@ cores:
           reset:
             register: APB2RSTR
             field: TIM1RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_ADV
       pins:
       - pin: PA6
         signal: BKIN
@@ -1629,7 +1629,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM2RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_GP32
       pins:
       - pin: PA0
         signal: CH1
@@ -1715,7 +1715,7 @@ cores:
           reset:
             register: APB2RSTR
             field: TIM20RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_ADV
       pins:
       - pin: PE0
         signal: ETR
@@ -1987,7 +1987,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM6RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_BASIC
       interrupts: {}
       dma_channels:
         UP:
@@ -2004,7 +2004,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM7RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_BASIC
       interrupts:
         BRK: TIM7
         COM: TIM7
@@ -2025,7 +2025,7 @@ cores:
           reset:
             register: APB2RSTR
             field: TIM8RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_ADV
       pins:
       - pin: PA0
         signal: BKIN

--- a/data/chips/STM32F318C8.yaml
+++ b/data/chips/STM32F318C8.yaml
@@ -653,7 +653,7 @@ cores:
           reset:
             register: APB2RSTR
             field: TIM1RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_ADV
       pins:
       - pin: PA6
         signal: BKIN
@@ -907,7 +907,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM2RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_GP32
       pins:
       - pin: PA0
         signal: CH1
@@ -978,7 +978,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM6RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_BASIC
       interrupts: {}
       dma_channels:
         UP:

--- a/data/chips/STM32F318K8.yaml
+++ b/data/chips/STM32F318K8.yaml
@@ -630,7 +630,7 @@ cores:
           reset:
             register: APB2RSTR
             field: TIM1RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_ADV
       pins:
       - pin: PA6
         signal: BKIN
@@ -884,7 +884,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM2RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_GP32
       pins:
       - pin: PA0
         signal: CH1
@@ -955,7 +955,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM6RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_BASIC
       interrupts: {}
       dma_channels:
         UP:

--- a/data/chips/STM32F328C8.yaml
+++ b/data/chips/STM32F328C8.yaml
@@ -596,7 +596,7 @@ cores:
           reset:
             register: APB2RSTR
             field: TIM1RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_ADV
       pins:
       - pin: PA6
         signal: BKIN
@@ -850,7 +850,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM2RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_GP32
       pins:
       - pin: PA0
         signal: CH1
@@ -992,7 +992,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM6RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_BASIC
       interrupts: {}
       dma_channels:
         UP:
@@ -1008,7 +1008,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM7RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_BASIC
       interrupts: {}
       dma_channels:
         UP:

--- a/data/chips/STM32F334C4.yaml
+++ b/data/chips/STM32F334C4.yaml
@@ -741,7 +741,7 @@ cores:
           reset:
             register: APB2RSTR
             field: TIM1RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_ADV
       pins:
       - pin: PA6
         signal: BKIN
@@ -995,7 +995,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM2RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_GP32
       pins:
       - pin: PA0
         signal: CH1
@@ -1137,7 +1137,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM6RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_BASIC
       interrupts: {}
       dma_channels:
         UP:
@@ -1153,7 +1153,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM7RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_BASIC
       interrupts: {}
       dma_channels:
         UP:

--- a/data/chips/STM32F334C6.yaml
+++ b/data/chips/STM32F334C6.yaml
@@ -741,7 +741,7 @@ cores:
           reset:
             register: APB2RSTR
             field: TIM1RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_ADV
       pins:
       - pin: PA6
         signal: BKIN
@@ -995,7 +995,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM2RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_GP32
       pins:
       - pin: PA0
         signal: CH1
@@ -1137,7 +1137,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM6RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_BASIC
       interrupts: {}
       dma_channels:
         UP:
@@ -1153,7 +1153,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM7RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_BASIC
       interrupts: {}
       dma_channels:
         UP:

--- a/data/chips/STM32F334C8.yaml
+++ b/data/chips/STM32F334C8.yaml
@@ -743,7 +743,7 @@ cores:
           reset:
             register: APB2RSTR
             field: TIM1RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_ADV
       pins:
       - pin: PA6
         signal: BKIN
@@ -997,7 +997,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM2RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_GP32
       pins:
       - pin: PA0
         signal: CH1
@@ -1139,7 +1139,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM6RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_BASIC
       interrupts: {}
       dma_channels:
         UP:
@@ -1155,7 +1155,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM7RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_BASIC
       interrupts: {}
       dma_channels:
         UP:

--- a/data/chips/STM32F334K4.yaml
+++ b/data/chips/STM32F334K4.yaml
@@ -714,7 +714,7 @@ cores:
           reset:
             register: APB2RSTR
             field: TIM1RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_ADV
       pins:
       - pin: PA6
         signal: BKIN
@@ -968,7 +968,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM2RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_GP32
       pins:
       - pin: PA0
         signal: CH1
@@ -1110,7 +1110,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM6RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_BASIC
       interrupts: {}
       dma_channels:
         UP:
@@ -1126,7 +1126,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM7RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_BASIC
       interrupts: {}
       dma_channels:
         UP:

--- a/data/chips/STM32F334K6.yaml
+++ b/data/chips/STM32F334K6.yaml
@@ -714,7 +714,7 @@ cores:
           reset:
             register: APB2RSTR
             field: TIM1RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_ADV
       pins:
       - pin: PA6
         signal: BKIN
@@ -968,7 +968,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM2RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_GP32
       pins:
       - pin: PA0
         signal: CH1
@@ -1110,7 +1110,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM6RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_BASIC
       interrupts: {}
       dma_channels:
         UP:
@@ -1126,7 +1126,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM7RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_BASIC
       interrupts: {}
       dma_channels:
         UP:

--- a/data/chips/STM32F334K8.yaml
+++ b/data/chips/STM32F334K8.yaml
@@ -714,7 +714,7 @@ cores:
           reset:
             register: APB2RSTR
             field: TIM1RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_ADV
       pins:
       - pin: PA6
         signal: BKIN
@@ -968,7 +968,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM2RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_GP32
       pins:
       - pin: PA0
         signal: CH1
@@ -1110,7 +1110,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM6RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_BASIC
       interrupts: {}
       dma_channels:
         UP:
@@ -1126,7 +1126,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM7RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_BASIC
       interrupts: {}
       dma_channels:
         UP:

--- a/data/chips/STM32F334R6.yaml
+++ b/data/chips/STM32F334R6.yaml
@@ -753,7 +753,7 @@ cores:
           reset:
             register: APB2RSTR
             field: TIM1RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_ADV
       pins:
       - pin: PA6
         signal: BKIN
@@ -1007,7 +1007,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM2RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_GP32
       pins:
       - pin: PA0
         signal: CH1
@@ -1149,7 +1149,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM6RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_BASIC
       interrupts: {}
       dma_channels:
         UP:
@@ -1165,7 +1165,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM7RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_BASIC
       interrupts: {}
       dma_channels:
         UP:

--- a/data/chips/STM32F334R8.yaml
+++ b/data/chips/STM32F334R8.yaml
@@ -753,7 +753,7 @@ cores:
           reset:
             register: APB2RSTR
             field: TIM1RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_ADV
       pins:
       - pin: PA6
         signal: BKIN
@@ -1007,7 +1007,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM2RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_GP32
       pins:
       - pin: PA0
         signal: CH1
@@ -1149,7 +1149,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM6RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_BASIC
       interrupts: {}
       dma_channels:
         UP:
@@ -1165,7 +1165,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM7RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_BASIC
       interrupts: {}
       dma_channels:
         UP:

--- a/data/chips/STM32F358CC.yaml
+++ b/data/chips/STM32F358CC.yaml
@@ -883,7 +883,7 @@ cores:
           reset:
             register: APB2RSTR
             field: TIM1RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_ADV
       pins:
       - pin: PA6
         signal: BKIN
@@ -1161,7 +1161,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM2RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_GP32
       pins:
       - pin: PA0
         signal: CH1
@@ -1402,7 +1402,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM6RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_BASIC
       interrupts: {}
       dma_channels:
         UP:
@@ -1419,7 +1419,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM7RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_BASIC
       interrupts:
         BRK: TIM7
         COM: TIM7
@@ -1440,7 +1440,7 @@ cores:
           reset:
             register: APB2RSTR
             field: TIM8RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_ADV
       pins:
       - pin: PA0
         signal: BKIN

--- a/data/chips/STM32F358RC.yaml
+++ b/data/chips/STM32F358RC.yaml
@@ -913,7 +913,7 @@ cores:
           reset:
             register: APB2RSTR
             field: TIM1RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_ADV
       pins:
       - pin: PA6
         signal: BKIN
@@ -1191,7 +1191,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM2RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_GP32
       pins:
       - pin: PA0
         signal: CH1
@@ -1432,7 +1432,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM6RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_BASIC
       interrupts: {}
       dma_channels:
         UP:
@@ -1449,7 +1449,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM7RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_BASIC
       interrupts:
         BRK: TIM7
         COM: TIM7
@@ -1470,7 +1470,7 @@ cores:
           reset:
             register: APB2RSTR
             field: TIM8RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_ADV
       pins:
       - pin: PA0
         signal: BKIN

--- a/data/chips/STM32F358VC.yaml
+++ b/data/chips/STM32F358VC.yaml
@@ -973,7 +973,7 @@ cores:
           reset:
             register: APB2RSTR
             field: TIM1RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_ADV
       pins:
       - pin: PA6
         signal: BKIN
@@ -1251,7 +1251,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM2RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_GP32
       pins:
       - pin: PA0
         signal: CH1
@@ -1492,7 +1492,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM6RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_BASIC
       interrupts: {}
       dma_channels:
         UP:
@@ -1509,7 +1509,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM7RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_BASIC
       interrupts:
         BRK: TIM7
         COM: TIM7
@@ -1530,7 +1530,7 @@ cores:
           reset:
             register: APB2RSTR
             field: TIM8RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_ADV
       pins:
       - pin: PA0
         signal: BKIN

--- a/data/chips/STM32F373C8.yaml
+++ b/data/chips/STM32F373C8.yaml
@@ -1213,7 +1213,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM2RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_GP32
       pins:
       - pin: PA0
         signal: CH1
@@ -1506,7 +1506,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM6RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_BASIC
       interrupts: {}
       dma_channels:
         UP:
@@ -1523,7 +1523,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM7RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_BASIC
       interrupts:
         BRK: TIM7
         COM: TIM7

--- a/data/chips/STM32F373CB.yaml
+++ b/data/chips/STM32F373CB.yaml
@@ -1213,7 +1213,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM2RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_GP32
       pins:
       - pin: PA0
         signal: CH1
@@ -1506,7 +1506,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM6RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_BASIC
       interrupts: {}
       dma_channels:
         UP:
@@ -1523,7 +1523,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM7RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_BASIC
       interrupts:
         BRK: TIM7
         COM: TIM7

--- a/data/chips/STM32F373CC.yaml
+++ b/data/chips/STM32F373CC.yaml
@@ -1213,7 +1213,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM2RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_GP32
       pins:
       - pin: PA0
         signal: CH1
@@ -1506,7 +1506,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM6RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_BASIC
       interrupts: {}
       dma_channels:
         UP:
@@ -1523,7 +1523,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM7RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_BASIC
       interrupts:
         BRK: TIM7
         COM: TIM7

--- a/data/chips/STM32F373R8.yaml
+++ b/data/chips/STM32F373R8.yaml
@@ -1227,7 +1227,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM2RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_GP32
       pins:
       - pin: PA0
         signal: CH1
@@ -1520,7 +1520,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM6RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_BASIC
       interrupts: {}
       dma_channels:
         UP:
@@ -1537,7 +1537,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM7RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_BASIC
       interrupts:
         BRK: TIM7
         COM: TIM7

--- a/data/chips/STM32F373RB.yaml
+++ b/data/chips/STM32F373RB.yaml
@@ -1227,7 +1227,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM2RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_GP32
       pins:
       - pin: PA0
         signal: CH1
@@ -1520,7 +1520,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM6RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_BASIC
       interrupts: {}
       dma_channels:
         UP:
@@ -1537,7 +1537,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM7RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_BASIC
       interrupts:
         BRK: TIM7
         COM: TIM7

--- a/data/chips/STM32F373RC.yaml
+++ b/data/chips/STM32F373RC.yaml
@@ -1227,7 +1227,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM2RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_GP32
       pins:
       - pin: PA0
         signal: CH1
@@ -1520,7 +1520,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM6RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_BASIC
       interrupts: {}
       dma_channels:
         UP:
@@ -1537,7 +1537,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM7RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_BASIC
       interrupts:
         BRK: TIM7
         COM: TIM7

--- a/data/chips/STM32F373V8.yaml
+++ b/data/chips/STM32F373V8.yaml
@@ -1229,7 +1229,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM2RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_GP32
       pins:
       - pin: PA0
         signal: CH1
@@ -1522,7 +1522,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM6RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_BASIC
       interrupts: {}
       dma_channels:
         UP:
@@ -1539,7 +1539,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM7RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_BASIC
       interrupts:
         BRK: TIM7
         COM: TIM7

--- a/data/chips/STM32F373VB.yaml
+++ b/data/chips/STM32F373VB.yaml
@@ -1229,7 +1229,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM2RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_GP32
       pins:
       - pin: PA0
         signal: CH1
@@ -1522,7 +1522,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM6RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_BASIC
       interrupts: {}
       dma_channels:
         UP:
@@ -1539,7 +1539,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM7RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_BASIC
       interrupts:
         BRK: TIM7
         COM: TIM7

--- a/data/chips/STM32F373VC.yaml
+++ b/data/chips/STM32F373VC.yaml
@@ -1229,7 +1229,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM2RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_GP32
       pins:
       - pin: PA0
         signal: CH1
@@ -1522,7 +1522,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM6RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_BASIC
       interrupts: {}
       dma_channels:
         UP:
@@ -1539,7 +1539,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM7RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_BASIC
       interrupts:
         BRK: TIM7
         COM: TIM7

--- a/data/chips/STM32F378CC.yaml
+++ b/data/chips/STM32F378CC.yaml
@@ -1201,7 +1201,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM2RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_GP32
       pins:
       - pin: PA0
         signal: CH1
@@ -1494,7 +1494,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM6RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_BASIC
       interrupts: {}
       dma_channels:
         UP:
@@ -1511,7 +1511,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM7RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_BASIC
       interrupts:
         BRK: TIM7
         COM: TIM7

--- a/data/chips/STM32F378RC.yaml
+++ b/data/chips/STM32F378RC.yaml
@@ -1217,7 +1217,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM2RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_GP32
       pins:
       - pin: PA0
         signal: CH1
@@ -1510,7 +1510,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM6RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_BASIC
       interrupts: {}
       dma_channels:
         UP:
@@ -1527,7 +1527,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM7RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_BASIC
       interrupts:
         BRK: TIM7
         COM: TIM7

--- a/data/chips/STM32F378VC.yaml
+++ b/data/chips/STM32F378VC.yaml
@@ -1217,7 +1217,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM2RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_GP32
       pins:
       - pin: PA0
         signal: CH1
@@ -1510,7 +1510,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM6RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_BASIC
       interrupts: {}
       dma_channels:
         UP:
@@ -1527,7 +1527,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM7RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_BASIC
       interrupts:
         BRK: TIM7
         COM: TIM7

--- a/data/chips/STM32F398VE.yaml
+++ b/data/chips/STM32F398VE.yaml
@@ -1303,7 +1303,7 @@ cores:
           reset:
             register: APB2RSTR
             field: TIM1RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_ADV
       pins:
       - pin: PA6
         signal: BKIN
@@ -1599,7 +1599,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM2RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_GP32
       pins:
       - pin: PA0
         signal: CH1
@@ -1685,7 +1685,7 @@ cores:
           reset:
             register: APB2RSTR
             field: TIM20RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_ADV
       pins:
       - pin: PE0
         signal: ETR
@@ -1957,7 +1957,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM6RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_BASIC
       interrupts: {}
       dma_channels:
         UP:
@@ -1974,7 +1974,7 @@ cores:
           reset:
             register: APB1RSTR
             field: TIM7RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_BASIC
       interrupts:
         BRK: TIM7
         COM: TIM7
@@ -1995,7 +1995,7 @@ cores:
           reset:
             register: APB2RSTR
             field: TIM8RST
-      block: timer_v1/TIM_GP16
+      block: timer_v1/TIM_ADV
       pins:
       - pin: PA0
         signal: BKIN

--- a/stm32data/__main__.py
+++ b/stm32data/__main__.py
@@ -220,6 +220,11 @@ perimap = [
     ('STM32H7.*:TIM6:.*', 'timer_v1/TIM_BASIC'),
     ('STM32H7.*:TIM7:.*', 'timer_v1/TIM_BASIC'),
     ('STM32H7.*:TIM8:.*', 'timer_v1/TIM_ADV'),
+
+    ('STM32F3.*:TIM(6|7){1}:.*', 'timer_v1/TIM_BASIC'),
+    ('STM32F3.*:TIM(3|4|15|16|17){1}:.*', 'timer_v1/TIM_GP16'),
+    ('STM32F3.*:TIM2:.*', 'timer_v1/TIM_GP32'),
+    ('STM32F3.*:TIM(1|8|20){1}:.*', 'timer_v1/TIM_ADV'),
     
     ('STM32F7.*:TIM1:.*', 'timer_v1/TIM_ADV'),
     ('STM32F7.*:TIM8:.*', 'timer_v1/TIM_ADV'),


### PR DESCRIPTION
Previously all `TIMx` registers in F3 chips were assigned to `timer_v1/TIM_GP16`, this PR maps `TIMx` registers to their correct register blocks.