### PR TITLE
stm32f1xx adc support

### DIFF
--- a/data/chips/STM32F100C4.yaml
+++ b/data/chips/STM32F100C4.yaml
@@ -189,6 +189,7 @@ cores:
           reset:
             register: APB2RSTR
             field: ADC1RST
+      block: adc_f1/ADC
       pins:
       - pin: PA0
         signal: IN0

--- a/data/chips/STM32F100C6.yaml
+++ b/data/chips/STM32F100C6.yaml
@@ -189,6 +189,7 @@ cores:
           reset:
             register: APB2RSTR
             field: ADC1RST
+      block: adc_f1/ADC
       pins:
       - pin: PA0
         signal: IN0

--- a/data/chips/STM32F100C8.yaml
+++ b/data/chips/STM32F100C8.yaml
@@ -189,6 +189,7 @@ cores:
           reset:
             register: APB2RSTR
             field: ADC1RST
+      block: adc_f1/ADC
       pins:
       - pin: PA0
         signal: IN0

--- a/data/chips/STM32F100CB.yaml
+++ b/data/chips/STM32F100CB.yaml
@@ -189,6 +189,7 @@ cores:
           reset:
             register: APB2RSTR
             field: ADC1RST
+      block: adc_f1/ADC
       pins:
       - pin: PA0
         signal: IN0

--- a/data/chips/STM32F100R4.yaml
+++ b/data/chips/STM32F100R4.yaml
@@ -191,6 +191,7 @@ cores:
           reset:
             register: APB2RSTR
             field: ADC1RST
+      block: adc_f1/ADC
       pins:
       - pin: PC1
         signal: IN11

--- a/data/chips/STM32F100R6.yaml
+++ b/data/chips/STM32F100R6.yaml
@@ -191,6 +191,7 @@ cores:
           reset:
             register: APB2RSTR
             field: ADC1RST
+      block: adc_f1/ADC
       pins:
       - pin: PC1
         signal: IN11

--- a/data/chips/STM32F100R8.yaml
+++ b/data/chips/STM32F100R8.yaml
@@ -191,6 +191,7 @@ cores:
           reset:
             register: APB2RSTR
             field: ADC1RST
+      block: adc_f1/ADC
       pins:
       - pin: PC1
         signal: IN11

--- a/data/chips/STM32F100RB.yaml
+++ b/data/chips/STM32F100RB.yaml
@@ -191,6 +191,7 @@ cores:
           reset:
             register: APB2RSTR
             field: ADC1RST
+      block: adc_f1/ADC
       pins:
       - pin: PC1
         signal: IN11

--- a/data/chips/STM32F100RC.yaml
+++ b/data/chips/STM32F100RC.yaml
@@ -189,6 +189,7 @@ cores:
           reset:
             register: APB2RSTR
             field: ADC1RST
+      block: adc_f1/ADC
       pins:
       - pin: PC0
         signal: IN10

--- a/data/chips/STM32F100RD.yaml
+++ b/data/chips/STM32F100RD.yaml
@@ -189,6 +189,7 @@ cores:
           reset:
             register: APB2RSTR
             field: ADC1RST
+      block: adc_f1/ADC
       pins:
       - pin: PC0
         signal: IN10

--- a/data/chips/STM32F100RE.yaml
+++ b/data/chips/STM32F100RE.yaml
@@ -189,6 +189,7 @@ cores:
           reset:
             register: APB2RSTR
             field: ADC1RST
+      block: adc_f1/ADC
       pins:
       - pin: PC0
         signal: IN10

--- a/data/chips/STM32F100V8.yaml
+++ b/data/chips/STM32F100V8.yaml
@@ -189,6 +189,7 @@ cores:
           reset:
             register: APB2RSTR
             field: ADC1RST
+      block: adc_f1/ADC
       pins:
       - pin: PC0
         signal: IN10

--- a/data/chips/STM32F100VB.yaml
+++ b/data/chips/STM32F100VB.yaml
@@ -189,6 +189,7 @@ cores:
           reset:
             register: APB2RSTR
             field: ADC1RST
+      block: adc_f1/ADC
       pins:
       - pin: PC0
         signal: IN10

--- a/data/chips/STM32F100VC.yaml
+++ b/data/chips/STM32F100VC.yaml
@@ -189,6 +189,7 @@ cores:
           reset:
             register: APB2RSTR
             field: ADC1RST
+      block: adc_f1/ADC
       pins:
       - pin: PC0
         signal: IN10

--- a/data/chips/STM32F100VD.yaml
+++ b/data/chips/STM32F100VD.yaml
@@ -189,6 +189,7 @@ cores:
           reset:
             register: APB2RSTR
             field: ADC1RST
+      block: adc_f1/ADC
       pins:
       - pin: PC0
         signal: IN10

--- a/data/chips/STM32F100VE.yaml
+++ b/data/chips/STM32F100VE.yaml
@@ -189,6 +189,7 @@ cores:
           reset:
             register: APB2RSTR
             field: ADC1RST
+      block: adc_f1/ADC
       pins:
       - pin: PC0
         signal: IN10

--- a/data/chips/STM32F100ZC.yaml
+++ b/data/chips/STM32F100ZC.yaml
@@ -189,6 +189,7 @@ cores:
           reset:
             register: APB2RSTR
             field: ADC1RST
+      block: adc_f1/ADC
       pins:
       - pin: PC0
         signal: IN10

--- a/data/chips/STM32F100ZD.yaml
+++ b/data/chips/STM32F100ZD.yaml
@@ -189,6 +189,7 @@ cores:
           reset:
             register: APB2RSTR
             field: ADC1RST
+      block: adc_f1/ADC
       pins:
       - pin: PC0
         signal: IN10

--- a/data/chips/STM32F100ZE.yaml
+++ b/data/chips/STM32F100ZE.yaml
@@ -189,6 +189,7 @@ cores:
           reset:
             register: APB2RSTR
             field: ADC1RST
+      block: adc_f1/ADC
       pins:
       - pin: PC0
         signal: IN10

--- a/data/chips/STM32F101C4.yaml
+++ b/data/chips/STM32F101C4.yaml
@@ -193,6 +193,7 @@ cores:
           reset:
             register: APB2RSTR
             field: ADC1RST
+      block: adc_f1/ADC
       pins:
       - pin: PA0
         signal: IN0

--- a/data/chips/STM32F101C6.yaml
+++ b/data/chips/STM32F101C6.yaml
@@ -197,6 +197,7 @@ cores:
           reset:
             register: APB2RSTR
             field: ADC1RST
+      block: adc_f1/ADC
       pins:
       - pin: PA0
         signal: IN0

--- a/data/chips/STM32F101C8.yaml
+++ b/data/chips/STM32F101C8.yaml
@@ -199,6 +199,7 @@ cores:
           reset:
             register: APB2RSTR
             field: ADC1RST
+      block: adc_f1/ADC
       pins:
       - pin: PA0
         signal: IN0

--- a/data/chips/STM32F101CB.yaml
+++ b/data/chips/STM32F101CB.yaml
@@ -195,6 +195,7 @@ cores:
           reset:
             register: APB2RSTR
             field: ADC1RST
+      block: adc_f1/ADC
       pins:
       - pin: PA0
         signal: IN0

--- a/data/chips/STM32F101R4.yaml
+++ b/data/chips/STM32F101R4.yaml
@@ -197,6 +197,7 @@ cores:
           reset:
             register: APB2RSTR
             field: ADC1RST
+      block: adc_f1/ADC
       pins:
       - pin: PC0
         signal: IN10

--- a/data/chips/STM32F101R6.yaml
+++ b/data/chips/STM32F101R6.yaml
@@ -201,6 +201,7 @@ cores:
           reset:
             register: APB2RSTR
             field: ADC1RST
+      block: adc_f1/ADC
       pins:
       - pin: PC0
         signal: IN10

--- a/data/chips/STM32F101R8.yaml
+++ b/data/chips/STM32F101R8.yaml
@@ -201,6 +201,7 @@ cores:
           reset:
             register: APB2RSTR
             field: ADC1RST
+      block: adc_f1/ADC
       pins:
       - pin: PC0
         signal: IN10

--- a/data/chips/STM32F101RB.yaml
+++ b/data/chips/STM32F101RB.yaml
@@ -203,6 +203,7 @@ cores:
           reset:
             register: APB2RSTR
             field: ADC1RST
+      block: adc_f1/ADC
       pins:
       - pin: PC0
         signal: IN10

--- a/data/chips/STM32F101RC.yaml
+++ b/data/chips/STM32F101RC.yaml
@@ -205,6 +205,7 @@ cores:
           reset:
             register: APB2RSTR
             field: ADC1RST
+      block: adc_f1/ADC
       pins:
       - pin: PC0
         signal: IN10

--- a/data/chips/STM32F101RD.yaml
+++ b/data/chips/STM32F101RD.yaml
@@ -205,6 +205,7 @@ cores:
           reset:
             register: APB2RSTR
             field: ADC1RST
+      block: adc_f1/ADC
       pins:
       - pin: PC0
         signal: IN10

--- a/data/chips/STM32F101RE.yaml
+++ b/data/chips/STM32F101RE.yaml
@@ -205,6 +205,7 @@ cores:
           reset:
             register: APB2RSTR
             field: ADC1RST
+      block: adc_f1/ADC
       pins:
       - pin: PC0
         signal: IN10

--- a/data/chips/STM32F101RF.yaml
+++ b/data/chips/STM32F101RF.yaml
@@ -209,6 +209,7 @@ cores:
           reset:
             register: APB2RSTR
             field: ADC1RST
+      block: adc_f1/ADC
       pins:
       - pin: PC0
         signal: IN10

--- a/data/chips/STM32F101RG.yaml
+++ b/data/chips/STM32F101RG.yaml
@@ -197,6 +197,7 @@ cores:
           reset:
             register: APB2RSTR
             field: ADC1RST
+      block: adc_f1/ADC
       pins:
       - pin: PC0
         signal: IN10

--- a/data/chips/STM32F101T4.yaml
+++ b/data/chips/STM32F101T4.yaml
@@ -193,6 +193,7 @@ cores:
           reset:
             register: APB2RSTR
             field: ADC1RST
+      block: adc_f1/ADC
       pins:
       - pin: PA0
         signal: IN0

--- a/data/chips/STM32F101T6.yaml
+++ b/data/chips/STM32F101T6.yaml
@@ -193,6 +193,7 @@ cores:
           reset:
             register: APB2RSTR
             field: ADC1RST
+      block: adc_f1/ADC
       pins:
       - pin: PA0
         signal: IN0

--- a/data/chips/STM32F101T8.yaml
+++ b/data/chips/STM32F101T8.yaml
@@ -197,6 +197,7 @@ cores:
           reset:
             register: APB2RSTR
             field: ADC1RST
+      block: adc_f1/ADC
       pins:
       - pin: PA0
         signal: IN0

--- a/data/chips/STM32F101TB.yaml
+++ b/data/chips/STM32F101TB.yaml
@@ -189,6 +189,7 @@ cores:
           reset:
             register: APB2RSTR
             field: ADC1RST
+      block: adc_f1/ADC
       pins:
       - pin: PA0
         signal: IN0

--- a/data/chips/STM32F101V8.yaml
+++ b/data/chips/STM32F101V8.yaml
@@ -197,6 +197,7 @@ cores:
           reset:
             register: APB2RSTR
             field: ADC1RST
+      block: adc_f1/ADC
       pins:
       - pin: PC0
         signal: IN10

--- a/data/chips/STM32F101VB.yaml
+++ b/data/chips/STM32F101VB.yaml
@@ -197,6 +197,7 @@ cores:
           reset:
             register: APB2RSTR
             field: ADC1RST
+      block: adc_f1/ADC
       pins:
       - pin: PC0
         signal: IN10

--- a/data/chips/STM32F101VC.yaml
+++ b/data/chips/STM32F101VC.yaml
@@ -201,6 +201,7 @@ cores:
           reset:
             register: APB2RSTR
             field: ADC1RST
+      block: adc_f1/ADC
       pins:
       - pin: PC0
         signal: IN10

--- a/data/chips/STM32F101VD.yaml
+++ b/data/chips/STM32F101VD.yaml
@@ -201,6 +201,7 @@ cores:
           reset:
             register: APB2RSTR
             field: ADC1RST
+      block: adc_f1/ADC
       pins:
       - pin: PC0
         signal: IN10

--- a/data/chips/STM32F101VE.yaml
+++ b/data/chips/STM32F101VE.yaml
@@ -197,6 +197,7 @@ cores:
           reset:
             register: APB2RSTR
             field: ADC1RST
+      block: adc_f1/ADC
       pins:
       - pin: PC0
         signal: IN10

--- a/data/chips/STM32F101VF.yaml
+++ b/data/chips/STM32F101VF.yaml
@@ -193,6 +193,7 @@ cores:
           reset:
             register: APB2RSTR
             field: ADC1RST
+      block: adc_f1/ADC
       pins:
       - pin: PC0
         signal: IN10

--- a/data/chips/STM32F101VG.yaml
+++ b/data/chips/STM32F101VG.yaml
@@ -193,6 +193,7 @@ cores:
           reset:
             register: APB2RSTR
             field: ADC1RST
+      block: adc_f1/ADC
       pins:
       - pin: PC0
         signal: IN10

--- a/data/chips/STM32F101ZC.yaml
+++ b/data/chips/STM32F101ZC.yaml
@@ -197,6 +197,7 @@ cores:
           reset:
             register: APB2RSTR
             field: ADC1RST
+      block: adc_f1/ADC
       pins:
       - pin: PC0
         signal: IN10

--- a/data/chips/STM32F101ZD.yaml
+++ b/data/chips/STM32F101ZD.yaml
@@ -197,6 +197,7 @@ cores:
           reset:
             register: APB2RSTR
             field: ADC1RST
+      block: adc_f1/ADC
       pins:
       - pin: PC0
         signal: IN10

--- a/data/chips/STM32F101ZE.yaml
+++ b/data/chips/STM32F101ZE.yaml
@@ -197,6 +197,7 @@ cores:
           reset:
             register: APB2RSTR
             field: ADC1RST
+      block: adc_f1/ADC
       pins:
       - pin: PC0
         signal: IN10

--- a/data/chips/STM32F101ZF.yaml
+++ b/data/chips/STM32F101ZF.yaml
@@ -177,6 +177,7 @@ cores:
           reset:
             register: APB2RSTR
             field: ADC1RST
+      block: adc_f1/ADC
       pins:
       - pin: PC0
         signal: IN10

--- a/data/chips/STM32F101ZG.yaml
+++ b/data/chips/STM32F101ZG.yaml
@@ -193,6 +193,7 @@ cores:
           reset:
             register: APB2RSTR
             field: ADC1RST
+      block: adc_f1/ADC
       pins:
       - pin: PC0
         signal: IN10

--- a/data/chips/STM32F102C4.yaml
+++ b/data/chips/STM32F102C4.yaml
@@ -193,6 +193,7 @@ cores:
           reset:
             register: APB2RSTR
             field: ADC1RST
+      block: adc_f1/ADC
       pins:
       - pin: PA0
         signal: IN0

--- a/data/chips/STM32F102C6.yaml
+++ b/data/chips/STM32F102C6.yaml
@@ -193,6 +193,7 @@ cores:
           reset:
             register: APB2RSTR
             field: ADC1RST
+      block: adc_f1/ADC
       pins:
       - pin: PA0
         signal: IN0

--- a/data/chips/STM32F102C8.yaml
+++ b/data/chips/STM32F102C8.yaml
@@ -193,6 +193,7 @@ cores:
           reset:
             register: APB2RSTR
             field: ADC1RST
+      block: adc_f1/ADC
       pins:
       - pin: PA0
         signal: IN0

--- a/data/chips/STM32F102CB.yaml
+++ b/data/chips/STM32F102CB.yaml
@@ -193,6 +193,7 @@ cores:
           reset:
             register: APB2RSTR
             field: ADC1RST
+      block: adc_f1/ADC
       pins:
       - pin: PA0
         signal: IN0

--- a/data/chips/STM32F102R4.yaml
+++ b/data/chips/STM32F102R4.yaml
@@ -193,6 +193,7 @@ cores:
           reset:
             register: APB2RSTR
             field: ADC1RST
+      block: adc_f1/ADC
       pins:
       - pin: PC0
         signal: IN10

--- a/data/chips/STM32F102R6.yaml
+++ b/data/chips/STM32F102R6.yaml
@@ -193,6 +193,7 @@ cores:
           reset:
             register: APB2RSTR
             field: ADC1RST
+      block: adc_f1/ADC
       pins:
       - pin: PC0
         signal: IN10

--- a/data/chips/STM32F102R8.yaml
+++ b/data/chips/STM32F102R8.yaml
@@ -193,6 +193,7 @@ cores:
           reset:
             register: APB2RSTR
             field: ADC1RST
+      block: adc_f1/ADC
       pins:
       - pin: PC0
         signal: IN10

--- a/data/chips/STM32F102RB.yaml
+++ b/data/chips/STM32F102RB.yaml
@@ -193,6 +193,7 @@ cores:
           reset:
             register: APB2RSTR
             field: ADC1RST
+      block: adc_f1/ADC
       pins:
       - pin: PC0
         signal: IN10

--- a/data/chips/STM32F103C4.yaml
+++ b/data/chips/STM32F103C4.yaml
@@ -193,6 +193,7 @@ cores:
           reset:
             register: APB2RSTR
             field: ADC1RST
+      block: adc_f1/ADC
       pins:
       - pin: PA0
         signal: IN0
@@ -229,6 +230,7 @@ cores:
           reset:
             register: APB2RSTR
             field: ADC2RST
+      block: adc_f1/ADC
       pins:
       - pin: PA0
         signal: IN0

--- a/data/chips/STM32F103C6.yaml
+++ b/data/chips/STM32F103C6.yaml
@@ -199,6 +199,7 @@ cores:
           reset:
             register: APB2RSTR
             field: ADC1RST
+      block: adc_f1/ADC
       pins:
       - pin: PA0
         signal: IN0
@@ -235,6 +236,7 @@ cores:
           reset:
             register: APB2RSTR
             field: ADC2RST
+      block: adc_f1/ADC
       pins:
       - pin: PA0
         signal: IN0

--- a/data/chips/STM32F103C8.yaml
+++ b/data/chips/STM32F103C8.yaml
@@ -197,6 +197,7 @@ cores:
           reset:
             register: APB2RSTR
             field: ADC1RST
+      block: adc_f1/ADC
       pins:
       - pin: PA0
         signal: IN0
@@ -233,6 +234,7 @@ cores:
           reset:
             register: APB2RSTR
             field: ADC2RST
+      block: adc_f1/ADC
       pins:
       - pin: PA0
         signal: IN0

--- a/data/chips/STM32F103CB.yaml
+++ b/data/chips/STM32F103CB.yaml
@@ -195,6 +195,7 @@ cores:
           reset:
             register: APB2RSTR
             field: ADC1RST
+      block: adc_f1/ADC
       pins:
       - pin: PA0
         signal: IN0
@@ -231,6 +232,7 @@ cores:
           reset:
             register: APB2RSTR
             field: ADC2RST
+      block: adc_f1/ADC
       pins:
       - pin: PA0
         signal: IN0

--- a/data/chips/STM32F103R4.yaml
+++ b/data/chips/STM32F103R4.yaml
@@ -195,6 +195,7 @@ cores:
           reset:
             register: APB2RSTR
             field: ADC1RST
+      block: adc_f1/ADC
       pins:
       - pin: PC1
         signal: IN11
@@ -243,6 +244,7 @@ cores:
           reset:
             register: APB2RSTR
             field: ADC2RST
+      block: adc_f1/ADC
       pins:
       - pin: PC1
         signal: IN11

--- a/data/chips/STM32F103R6.yaml
+++ b/data/chips/STM32F103R6.yaml
@@ -199,6 +199,7 @@ cores:
           reset:
             register: APB2RSTR
             field: ADC1RST
+      block: adc_f1/ADC
       pins:
       - pin: PC1
         signal: IN11
@@ -247,6 +248,7 @@ cores:
           reset:
             register: APB2RSTR
             field: ADC2RST
+      block: adc_f1/ADC
       pins:
       - pin: PC1
         signal: IN11

--- a/data/chips/STM32F103R8.yaml
+++ b/data/chips/STM32F103R8.yaml
@@ -199,6 +199,7 @@ cores:
           reset:
             register: APB2RSTR
             field: ADC1RST
+      block: adc_f1/ADC
       pins:
       - pin: PC1
         signal: IN11
@@ -247,6 +248,7 @@ cores:
           reset:
             register: APB2RSTR
             field: ADC2RST
+      block: adc_f1/ADC
       pins:
       - pin: PC1
         signal: IN11

--- a/data/chips/STM32F103RB.yaml
+++ b/data/chips/STM32F103RB.yaml
@@ -199,6 +199,7 @@ cores:
           reset:
             register: APB2RSTR
             field: ADC1RST
+      block: adc_f1/ADC
       pins:
       - pin: PC1
         signal: IN11
@@ -247,6 +248,7 @@ cores:
           reset:
             register: APB2RSTR
             field: ADC2RST
+      block: adc_f1/ADC
       pins:
       - pin: PC1
         signal: IN11

--- a/data/chips/STM32F103RC.yaml
+++ b/data/chips/STM32F103RC.yaml
@@ -199,6 +199,7 @@ cores:
           reset:
             register: APB2RSTR
             field: ADC1RST
+      block: adc_f1/ADC
       pins:
       - pin: PC0
         signal: IN10
@@ -247,6 +248,7 @@ cores:
           reset:
             register: APB2RSTR
             field: ADC2RST
+      block: adc_f1/ADC
       pins:
       - pin: PC0
         signal: IN10
@@ -293,6 +295,7 @@ cores:
           reset:
             register: APB2RSTR
             field: ADC3RST
+      block: adc_f1/ADC
       pins:
       - pin: PC0
         signal: IN10

--- a/data/chips/STM32F103RD.yaml
+++ b/data/chips/STM32F103RD.yaml
@@ -199,6 +199,7 @@ cores:
           reset:
             register: APB2RSTR
             field: ADC1RST
+      block: adc_f1/ADC
       pins:
       - pin: PC0
         signal: IN10
@@ -247,6 +248,7 @@ cores:
           reset:
             register: APB2RSTR
             field: ADC2RST
+      block: adc_f1/ADC
       pins:
       - pin: PC0
         signal: IN10
@@ -293,6 +295,7 @@ cores:
           reset:
             register: APB2RSTR
             field: ADC3RST
+      block: adc_f1/ADC
       pins:
       - pin: PC0
         signal: IN10

--- a/data/chips/STM32F103RE.yaml
+++ b/data/chips/STM32F103RE.yaml
@@ -199,6 +199,7 @@ cores:
           reset:
             register: APB2RSTR
             field: ADC1RST
+      block: adc_f1/ADC
       pins:
       - pin: PC0
         signal: IN10
@@ -247,6 +248,7 @@ cores:
           reset:
             register: APB2RSTR
             field: ADC2RST
+      block: adc_f1/ADC
       pins:
       - pin: PC0
         signal: IN10
@@ -293,6 +295,7 @@ cores:
           reset:
             register: APB2RSTR
             field: ADC3RST
+      block: adc_f1/ADC
       pins:
       - pin: PC0
         signal: IN10

--- a/data/chips/STM32F103RF.yaml
+++ b/data/chips/STM32F103RF.yaml
@@ -193,6 +193,7 @@ cores:
           reset:
             register: APB2RSTR
             field: ADC1RST
+      block: adc_f1/ADC
       pins:
       - pin: PC0
         signal: IN10
@@ -241,6 +242,7 @@ cores:
           reset:
             register: APB2RSTR
             field: ADC2RST
+      block: adc_f1/ADC
       pins:
       - pin: PC0
         signal: IN10
@@ -287,6 +289,7 @@ cores:
           reset:
             register: APB2RSTR
             field: ADC3RST
+      block: adc_f1/ADC
       pins:
       - pin: PC0
         signal: IN10

--- a/data/chips/STM32F103RG.yaml
+++ b/data/chips/STM32F103RG.yaml
@@ -193,6 +193,7 @@ cores:
           reset:
             register: APB2RSTR
             field: ADC1RST
+      block: adc_f1/ADC
       pins:
       - pin: PC0
         signal: IN10
@@ -241,6 +242,7 @@ cores:
           reset:
             register: APB2RSTR
             field: ADC2RST
+      block: adc_f1/ADC
       pins:
       - pin: PC0
         signal: IN10
@@ -287,6 +289,7 @@ cores:
           reset:
             register: APB2RSTR
             field: ADC3RST
+      block: adc_f1/ADC
       pins:
       - pin: PC0
         signal: IN10

--- a/data/chips/STM32F103T4.yaml
+++ b/data/chips/STM32F103T4.yaml
@@ -193,6 +193,7 @@ cores:
           reset:
             register: APB2RSTR
             field: ADC1RST
+      block: adc_f1/ADC
       pins:
       - pin: PA0
         signal: IN0
@@ -229,6 +230,7 @@ cores:
           reset:
             register: APB2RSTR
             field: ADC2RST
+      block: adc_f1/ADC
       pins:
       - pin: PA0
         signal: IN0

--- a/data/chips/STM32F103T6.yaml
+++ b/data/chips/STM32F103T6.yaml
@@ -193,6 +193,7 @@ cores:
           reset:
             register: APB2RSTR
             field: ADC1RST
+      block: adc_f1/ADC
       pins:
       - pin: PA0
         signal: IN0
@@ -229,6 +230,7 @@ cores:
           reset:
             register: APB2RSTR
             field: ADC2RST
+      block: adc_f1/ADC
       pins:
       - pin: PA0
         signal: IN0

--- a/data/chips/STM32F103T8.yaml
+++ b/data/chips/STM32F103T8.yaml
@@ -193,6 +193,7 @@ cores:
           reset:
             register: APB2RSTR
             field: ADC1RST
+      block: adc_f1/ADC
       pins:
       - pin: PA0
         signal: IN0
@@ -229,6 +230,7 @@ cores:
           reset:
             register: APB2RSTR
             field: ADC2RST
+      block: adc_f1/ADC
       pins:
       - pin: PA0
         signal: IN0

--- a/data/chips/STM32F103TB.yaml
+++ b/data/chips/STM32F103TB.yaml
@@ -189,6 +189,7 @@ cores:
           reset:
             register: APB2RSTR
             field: ADC1RST
+      block: adc_f1/ADC
       pins:
       - pin: PA0
         signal: IN0
@@ -225,6 +226,7 @@ cores:
           reset:
             register: APB2RSTR
             field: ADC2RST
+      block: adc_f1/ADC
       pins:
       - pin: PA0
         signal: IN0

--- a/data/chips/STM32F103V8.yaml
+++ b/data/chips/STM32F103V8.yaml
@@ -199,6 +199,7 @@ cores:
           reset:
             register: APB2RSTR
             field: ADC1RST
+      block: adc_f1/ADC
       pins:
       - pin: PC2
         signal: IN12
@@ -247,6 +248,7 @@ cores:
           reset:
             register: APB2RSTR
             field: ADC2RST
+      block: adc_f1/ADC
       pins:
       - pin: PC2
         signal: IN12

--- a/data/chips/STM32F103VB.yaml
+++ b/data/chips/STM32F103VB.yaml
@@ -201,6 +201,7 @@ cores:
           reset:
             register: APB2RSTR
             field: ADC1RST
+      block: adc_f1/ADC
       pins:
       - pin: PC2
         signal: IN12
@@ -249,6 +250,7 @@ cores:
           reset:
             register: APB2RSTR
             field: ADC2RST
+      block: adc_f1/ADC
       pins:
       - pin: PC2
         signal: IN12

--- a/data/chips/STM32F103VC.yaml
+++ b/data/chips/STM32F103VC.yaml
@@ -199,6 +199,7 @@ cores:
           reset:
             register: APB2RSTR
             field: ADC1RST
+      block: adc_f1/ADC
       pins:
       - pin: PC2
         signal: IN12
@@ -247,6 +248,7 @@ cores:
           reset:
             register: APB2RSTR
             field: ADC2RST
+      block: adc_f1/ADC
       pins:
       - pin: PC2
         signal: IN12
@@ -293,6 +295,7 @@ cores:
           reset:
             register: APB2RSTR
             field: ADC3RST
+      block: adc_f1/ADC
       pins:
       - pin: PC2
         signal: IN12

--- a/data/chips/STM32F103VD.yaml
+++ b/data/chips/STM32F103VD.yaml
@@ -199,6 +199,7 @@ cores:
           reset:
             register: APB2RSTR
             field: ADC1RST
+      block: adc_f1/ADC
       pins:
       - pin: PC2
         signal: IN12
@@ -247,6 +248,7 @@ cores:
           reset:
             register: APB2RSTR
             field: ADC2RST
+      block: adc_f1/ADC
       pins:
       - pin: PC2
         signal: IN12
@@ -293,6 +295,7 @@ cores:
           reset:
             register: APB2RSTR
             field: ADC3RST
+      block: adc_f1/ADC
       pins:
       - pin: PC2
         signal: IN12

--- a/data/chips/STM32F103VE.yaml
+++ b/data/chips/STM32F103VE.yaml
@@ -199,6 +199,7 @@ cores:
           reset:
             register: APB2RSTR
             field: ADC1RST
+      block: adc_f1/ADC
       pins:
       - pin: PC2
         signal: IN12
@@ -247,6 +248,7 @@ cores:
           reset:
             register: APB2RSTR
             field: ADC2RST
+      block: adc_f1/ADC
       pins:
       - pin: PC2
         signal: IN12
@@ -293,6 +295,7 @@ cores:
           reset:
             register: APB2RSTR
             field: ADC3RST
+      block: adc_f1/ADC
       pins:
       - pin: PC2
         signal: IN12

--- a/data/chips/STM32F103VF.yaml
+++ b/data/chips/STM32F103VF.yaml
@@ -193,6 +193,7 @@ cores:
           reset:
             register: APB2RSTR
             field: ADC1RST
+      block: adc_f1/ADC
       pins:
       - pin: PC0
         signal: IN10
@@ -241,6 +242,7 @@ cores:
           reset:
             register: APB2RSTR
             field: ADC2RST
+      block: adc_f1/ADC
       pins:
       - pin: PC0
         signal: IN10
@@ -287,6 +289,7 @@ cores:
           reset:
             register: APB2RSTR
             field: ADC3RST
+      block: adc_f1/ADC
       pins:
       - pin: PC0
         signal: IN10

--- a/data/chips/STM32F103VG.yaml
+++ b/data/chips/STM32F103VG.yaml
@@ -193,6 +193,7 @@ cores:
           reset:
             register: APB2RSTR
             field: ADC1RST
+      block: adc_f1/ADC
       pins:
       - pin: PC0
         signal: IN10
@@ -241,6 +242,7 @@ cores:
           reset:
             register: APB2RSTR
             field: ADC2RST
+      block: adc_f1/ADC
       pins:
       - pin: PC0
         signal: IN10
@@ -287,6 +289,7 @@ cores:
           reset:
             register: APB2RSTR
             field: ADC3RST
+      block: adc_f1/ADC
       pins:
       - pin: PC0
         signal: IN10

--- a/data/chips/STM32F103ZC.yaml
+++ b/data/chips/STM32F103ZC.yaml
@@ -199,6 +199,7 @@ cores:
           reset:
             register: APB2RSTR
             field: ADC1RST
+      block: adc_f1/ADC
       pins:
       - pin: PC0
         signal: IN10
@@ -247,6 +248,7 @@ cores:
           reset:
             register: APB2RSTR
             field: ADC2RST
+      block: adc_f1/ADC
       pins:
       - pin: PC0
         signal: IN10
@@ -293,6 +295,7 @@ cores:
           reset:
             register: APB2RSTR
             field: ADC3RST
+      block: adc_f1/ADC
       pins:
       - pin: PF7
         signal: IN5

--- a/data/chips/STM32F103ZD.yaml
+++ b/data/chips/STM32F103ZD.yaml
@@ -199,6 +199,7 @@ cores:
           reset:
             register: APB2RSTR
             field: ADC1RST
+      block: adc_f1/ADC
       pins:
       - pin: PC0
         signal: IN10
@@ -247,6 +248,7 @@ cores:
           reset:
             register: APB2RSTR
             field: ADC2RST
+      block: adc_f1/ADC
       pins:
       - pin: PC0
         signal: IN10
@@ -293,6 +295,7 @@ cores:
           reset:
             register: APB2RSTR
             field: ADC3RST
+      block: adc_f1/ADC
       pins:
       - pin: PF7
         signal: IN5

--- a/data/chips/STM32F103ZE.yaml
+++ b/data/chips/STM32F103ZE.yaml
@@ -199,6 +199,7 @@ cores:
           reset:
             register: APB2RSTR
             field: ADC1RST
+      block: adc_f1/ADC
       pins:
       - pin: PC0
         signal: IN10
@@ -247,6 +248,7 @@ cores:
           reset:
             register: APB2RSTR
             field: ADC2RST
+      block: adc_f1/ADC
       pins:
       - pin: PC0
         signal: IN10
@@ -293,6 +295,7 @@ cores:
           reset:
             register: APB2RSTR
             field: ADC3RST
+      block: adc_f1/ADC
       pins:
       - pin: PF7
         signal: IN5

--- a/data/chips/STM32F103ZF.yaml
+++ b/data/chips/STM32F103ZF.yaml
@@ -195,6 +195,7 @@ cores:
           reset:
             register: APB2RSTR
             field: ADC1RST
+      block: adc_f1/ADC
       pins:
       - pin: PC0
         signal: IN10
@@ -243,6 +244,7 @@ cores:
           reset:
             register: APB2RSTR
             field: ADC2RST
+      block: adc_f1/ADC
       pins:
       - pin: PC0
         signal: IN10
@@ -289,6 +291,7 @@ cores:
           reset:
             register: APB2RSTR
             field: ADC3RST
+      block: adc_f1/ADC
       pins:
       - pin: PF7
         signal: IN5

--- a/data/chips/STM32F103ZG.yaml
+++ b/data/chips/STM32F103ZG.yaml
@@ -195,6 +195,7 @@ cores:
           reset:
             register: APB2RSTR
             field: ADC1RST
+      block: adc_f1/ADC
       pins:
       - pin: PC0
         signal: IN10
@@ -243,6 +244,7 @@ cores:
           reset:
             register: APB2RSTR
             field: ADC2RST
+      block: adc_f1/ADC
       pins:
       - pin: PC0
         signal: IN10
@@ -289,6 +291,7 @@ cores:
           reset:
             register: APB2RSTR
             field: ADC3RST
+      block: adc_f1/ADC
       pins:
       - pin: PF7
         signal: IN5

--- a/data/chips/STM32F105R8.yaml
+++ b/data/chips/STM32F105R8.yaml
@@ -193,6 +193,7 @@ cores:
           reset:
             register: APB2RSTR
             field: ADC1RST
+      block: adc_f1/ADC
       pins:
       - pin: PC0
         signal: IN10
@@ -241,6 +242,7 @@ cores:
           reset:
             register: APB2RSTR
             field: ADC2RST
+      block: adc_f1/ADC
       pins:
       - pin: PC0
         signal: IN10

--- a/data/chips/STM32F105RB.yaml
+++ b/data/chips/STM32F105RB.yaml
@@ -193,6 +193,7 @@ cores:
           reset:
             register: APB2RSTR
             field: ADC1RST
+      block: adc_f1/ADC
       pins:
       - pin: PC0
         signal: IN10
@@ -241,6 +242,7 @@ cores:
           reset:
             register: APB2RSTR
             field: ADC2RST
+      block: adc_f1/ADC
       pins:
       - pin: PC0
         signal: IN10

--- a/data/chips/STM32F105RC.yaml
+++ b/data/chips/STM32F105RC.yaml
@@ -193,6 +193,7 @@ cores:
           reset:
             register: APB2RSTR
             field: ADC1RST
+      block: adc_f1/ADC
       pins:
       - pin: PC0
         signal: IN10
@@ -241,6 +242,7 @@ cores:
           reset:
             register: APB2RSTR
             field: ADC2RST
+      block: adc_f1/ADC
       pins:
       - pin: PC0
         signal: IN10

--- a/data/chips/STM32F105V8.yaml
+++ b/data/chips/STM32F105V8.yaml
@@ -195,6 +195,7 @@ cores:
           reset:
             register: APB2RSTR
             field: ADC1RST
+      block: adc_f1/ADC
       pins:
       - pin: PC2
         signal: IN12
@@ -243,6 +244,7 @@ cores:
           reset:
             register: APB2RSTR
             field: ADC2RST
+      block: adc_f1/ADC
       pins:
       - pin: PC2
         signal: IN12

--- a/data/chips/STM32F105VB.yaml
+++ b/data/chips/STM32F105VB.yaml
@@ -195,6 +195,7 @@ cores:
           reset:
             register: APB2RSTR
             field: ADC1RST
+      block: adc_f1/ADC
       pins:
       - pin: PC2
         signal: IN12
@@ -243,6 +244,7 @@ cores:
           reset:
             register: APB2RSTR
             field: ADC2RST
+      block: adc_f1/ADC
       pins:
       - pin: PC2
         signal: IN12

--- a/data/chips/STM32F105VC.yaml
+++ b/data/chips/STM32F105VC.yaml
@@ -193,6 +193,7 @@ cores:
           reset:
             register: APB2RSTR
             field: ADC1RST
+      block: adc_f1/ADC
       pins:
       - pin: PC2
         signal: IN12
@@ -241,6 +242,7 @@ cores:
           reset:
             register: APB2RSTR
             field: ADC2RST
+      block: adc_f1/ADC
       pins:
       - pin: PC2
         signal: IN12

--- a/data/chips/STM32F107RB.yaml
+++ b/data/chips/STM32F107RB.yaml
@@ -193,6 +193,7 @@ cores:
           reset:
             register: APB2RSTR
             field: ADC1RST
+      block: adc_f1/ADC
       pins:
       - pin: PC0
         signal: IN10
@@ -241,6 +242,7 @@ cores:
           reset:
             register: APB2RSTR
             field: ADC2RST
+      block: adc_f1/ADC
       pins:
       - pin: PC0
         signal: IN10

--- a/data/chips/STM32F107RC.yaml
+++ b/data/chips/STM32F107RC.yaml
@@ -193,6 +193,7 @@ cores:
           reset:
             register: APB2RSTR
             field: ADC1RST
+      block: adc_f1/ADC
       pins:
       - pin: PC0
         signal: IN10
@@ -241,6 +242,7 @@ cores:
           reset:
             register: APB2RSTR
             field: ADC2RST
+      block: adc_f1/ADC
       pins:
       - pin: PC0
         signal: IN10

--- a/data/chips/STM32F107VB.yaml
+++ b/data/chips/STM32F107VB.yaml
@@ -193,6 +193,7 @@ cores:
           reset:
             register: APB2RSTR
             field: ADC1RST
+      block: adc_f1/ADC
       pins:
       - pin: PC0
         signal: IN10
@@ -241,6 +242,7 @@ cores:
           reset:
             register: APB2RSTR
             field: ADC2RST
+      block: adc_f1/ADC
       pins:
       - pin: PC0
         signal: IN10

--- a/data/chips/STM32F107VC.yaml
+++ b/data/chips/STM32F107VC.yaml
@@ -195,6 +195,7 @@ cores:
           reset:
             register: APB2RSTR
             field: ADC1RST
+      block: adc_f1/ADC
       pins:
       - pin: PC0
         signal: IN10
@@ -243,6 +244,7 @@ cores:
           reset:
             register: APB2RSTR
             field: ADC2RST
+      block: adc_f1/ADC
       pins:
       - pin: PC0
         signal: IN10

--- a/data/registers/adc_f1.yaml
+++ b/data/registers/adc_f1.yaml
@@ -1,0 +1,402 @@
+---
+block/ADC:
+  description: Analog-to-digital converter
+  items:
+    - name: SR
+      description: status register
+      byte_offset: 0
+      fieldset: SR
+    - name: CR1
+      description: control register 1
+      byte_offset: 4
+      fieldset: CR1
+    - name: CR2
+      description: control register 2
+      byte_offset: 8
+      fieldset: CR2
+    - name: SMPR1
+      description: sample time register 1
+      byte_offset: 12
+      fieldset: SMPR1
+    - name: SMPR2
+      description: sample time register 2
+      byte_offset: 16
+      fieldset: SMPR2
+    - name: JOFR
+      description: injected channel data offset register x
+      array:
+        len: 4
+        stride: 4
+      byte_offset: 20
+      fieldset: JOFR
+    - name: HTR
+      description: watchdog higher threshold register
+      byte_offset: 36
+      fieldset: HTR
+    - name: LTR
+      description: watchdog lower threshold register
+      byte_offset: 40
+      fieldset: LTR
+    - name: SQR1
+      description: regular sequence register 1
+      byte_offset: 44
+      fieldset: SQR1
+    - name: SQR2
+      description: regular sequence register 2
+      byte_offset: 48
+      fieldset: SQR2
+    - name: SQR3
+      description: regular sequence register 3
+      byte_offset: 52
+      fieldset: SQR3
+    - name: JSQR
+      description: injected sequence register
+      byte_offset: 56
+      fieldset: JSQR
+    - name: JDR
+      description: injected data register x
+      array:
+        len: 4
+        stride: 4
+      byte_offset: 60
+      access: Read
+      fieldset: JDR
+    - name: DR
+      description: regular data register
+      byte_offset: 76
+      access: Read
+      fieldset: DR
+fieldset/CR1:
+  description: control register 1
+  fields:
+    - name: AWDCH
+      description: Analog watchdog channel select bits
+      bit_offset: 0
+      bit_size: 5
+    - name: EOCIE
+      description: Interrupt enable for EOC
+      bit_offset: 5
+      bit_size: 1
+    - name: AWDIE
+      description: Analog watchdog interrupt enable
+      bit_offset: 6
+      bit_size: 1
+    - name: JEOCIE
+      description: Interrupt enable for injected channels
+      bit_offset: 7
+      bit_size: 1
+    - name: SCAN
+      description: Scan mode
+      bit_offset: 8
+      bit_size: 1
+    - name: AWDSGL
+      description: Enable the watchdog on a single channel in scan mode
+      bit_offset: 9
+      bit_size: 1
+    - name: JAUTO
+      description: Automatic injected group conversion
+      bit_offset: 10
+      bit_size: 1
+    - name: DISCEN
+      description: Discontinuous mode on regular channels
+      bit_offset: 11
+      bit_size: 1
+    - name: JDISCEN
+      description: Discontinuous mode on injected channels
+      bit_offset: 12
+      bit_size: 1
+    - name: DISCNUM
+      description: Discontinuous mode channel count
+      bit_offset: 13
+      bit_size: 3
+    - name: DUALMOD
+      description: Dual mode selection
+      bit_offset: 16
+      bit_size: 4
+      enum: DUALMOD
+    - name: JAWDEN
+      description: Analog watchdog enable on injected channels
+      bit_offset: 22
+      bit_size: 1
+    - name: AWDEN
+      description: Analog watchdog enable on regular channels
+      bit_offset: 23
+      bit_size: 1
+fieldset/CR2:
+  description: control register 2
+  fields:
+    - name: ADON
+      description: A/D Converter ON / OFF
+      bit_offset: 0
+      bit_size: 1
+    - name: CONT
+      description: Continuous conversion
+      bit_offset: 1
+      bit_size: 1
+    - name: CAL
+      description: A/D Calibration
+      bit_offset: 2
+      bit_size: 1
+    - name: RSTCAL
+      description: Reset calibration
+      bit_offset: 3
+      bit_size: 1
+    - name: DMA
+      description: Direct memory access mode (for single ADC mode)
+      bit_offset: 8
+      bit_size: 1
+    - name: ALIGN
+      description: Data alignment
+      bit_offset: 11
+      bit_size: 1
+    - name: JEXTSEL
+      description: External event select for injected group
+      bit_offset: 12
+      bit_size: 3
+      enum: EXTSEL
+    - name: JEXTTRIG
+      description: External trigger conversion mode for injected channels
+      bit_offset: 15
+      bit_size: 1
+    - name: EXTSEL
+      description: External event select for regular group
+      bit_offset: 17
+      bit_size: 3
+      enum: EXTSEL
+    - name: EXTTRIG
+      description: External trigger conversion mode for regular channels
+      bit_offset: 20
+      bit_size: 1
+    - name: JSWSTART
+      description: Start conversion of injected channels
+      bit_offset: 21
+      bit_size: 1
+      enum_write: JSWSTARTW
+    - name: SWSTART
+      description: Start conversion of regular channels
+      bit_offset: 22
+      bit_size: 1
+      enum_write: SWSTARTW
+    - name: TSVREFE
+      description: Temperature sensor and VREFINT enable
+      bit_offset: 23
+      bit_size: 1
+fieldset/DR:
+  description: regular data register
+  fields:
+    - name: DATA
+      description: Regular data
+      bit_offset: 0
+      bit_size: 16
+    - name: ADC2DATA
+      description: ADC2 data
+      bit_offset: 16
+      bit_size: 16
+fieldset/HTR:
+  description: watchdog higher threshold register
+  fields:
+    - name: HT
+      description: Analog watchdog higher threshold
+      bit_offset: 0
+      bit_size: 12
+fieldset/JDR:
+  description: injected data register x
+  fields:
+    - name: JDATA
+      description: Injected data
+      bit_offset: 0
+      bit_size: 16
+fieldset/JOFR:
+  description: injected channel data offset register x
+  fields:
+    - name: JOFFSET
+      description: Data offset for injected channel x
+      bit_offset: 0
+      bit_size: 12
+fieldset/JSQR:
+  description: injected sequence register
+  fields:
+    - name: JSQ
+      description: 1st conversion in injected sequence
+      bit_offset: 0
+      bit_size: 5
+      array:
+        len: 4
+        stride: 5
+    - name: JL
+      description: Injected sequence length
+      bit_offset: 20
+      bit_size: 2
+fieldset/LTR:
+  description: watchdog lower threshold register
+  fields:
+    - name: LT
+      description: Analog watchdog lower threshold
+      bit_offset: 0
+      bit_size: 12
+fieldset/SMPR1:
+  description: sample time register 1
+  fields:
+    - name: SMP
+      description: Channel x sample time selection
+      bit_offset: 0
+      bit_size: 3
+      array:
+        len: 8
+        stride: 3
+      enum: SAMPLE_TIME
+fieldset/SMPR2:
+  description: sample time register 2
+  fields:
+    - name: SMP
+      description: Channel 0 sampling time selection
+      bit_offset: 0
+      bit_size: 3
+      array:
+        len: 10
+        stride: 3
+      enum: SAMPLE_TIME
+fieldset/SQR1:
+  description: regular sequence register 1
+  fields:
+    - name: SQ
+      description: 13th to 16th conversion in regular sequence
+      bit_offset: 0
+      bit_size: 5
+      array:
+        len: 4
+        stride: 5
+    - name: L
+      description: Regular channel sequence length
+      bit_offset: 20
+      bit_size: 4
+fieldset/SQR2:
+  description: regular sequence register 2
+  fields:
+    - name: SQ
+      description: 7th to 12th conversion in regular sequence
+      bit_offset: 0
+      bit_size: 5
+      array:
+        len: 6
+        stride: 5
+fieldset/SQR3:
+  description: regular sequence register 3
+  fields:
+    - name: SQ
+      description: 1st to 6th conversion in regular sequence
+      bit_offset: 0
+      bit_size: 5
+      array:
+        len: 6
+        stride: 5
+fieldset/SR:
+  description: status register
+  fields:
+    - name: AWD
+      description: Analog watchdog flag
+      bit_offset: 0
+      bit_size: 1
+    - name: EOC
+      description: Regular channel end of conversion
+      bit_offset: 1
+      bit_size: 1
+    - name: JEOC
+      description: Injected channel end of conversion
+      bit_offset: 2
+      bit_size: 1
+    - name: JSTRT
+      description: Injected channel start flag
+      bit_offset: 3
+      bit_size: 1
+    - name: STRT
+      description: Regular channel start flag
+      bit_offset: 4
+      bit_size: 1
+enum/DUALMOD:
+  bit_size: 4
+  variants:
+    - name: Independent
+      description: Independent mode.
+      value: 0
+    - name: RegularInjected
+      description: Combined regular simultaneous + injected simultaneous mode
+      value: 1
+    - name: RegularAlternateTrigger
+      description: Combined regular simultaneous + alternate trigger mode
+      value: 2
+    - name: InjectedFastInterleaved
+      description: Combined injected simultaneous + fast interleaved mode
+      value: 3
+    - name: InjectedSlowInterleaved
+      description: Combined injected simultaneous + slow Interleaved mode
+      value: 4
+    - name: Injected
+      description: Injected simultaneous mode only
+      value: 5
+    - name: Regular
+      description: Regular simultaneous mode only
+      value: 6
+    - name: FastInterleaved
+      description: Fast interleaved mode only
+      value: 7
+    - name: SlowInterleaved
+      description: Slow interleaved mode only
+      value: 8
+    - name: AlternateTrigger
+      description: Alternate trigger mode only
+      value: 9
+enum/EXTSEL:
+  bit_size: 3
+  variants:
+    - name: TIM1TRGO
+      description: Timer 1 TRGO event
+      value: 0
+    - name: TIM1CC4
+      description: Timer 1 CC4 event
+      value: 1
+    - name: TIM2TRGO
+      description: Timer 2 TRGO event
+      value: 2
+    - name: TIM2CC1
+      description: Timer 2 CC1 event
+      value: 3
+    - name: TIM3CC4
+      description: Timer 3 CC4 event
+      value: 4
+    - name: TIM4TRGO
+      description: Timer 4 TRGO event
+      value: 5
+    - name: TIM8CC4
+      description: EXTI line 15/Timer 8 CC4 event
+      value: 6
+    - name: SWSTART
+      description: SWSTART
+      value: 7
+enum/SAMPLE_TIME:
+  bit_size: 3
+  variants:
+    - name: Cycles1_5
+      description: 1.5 cycles
+      value: 0
+    - name: Cycles7_5
+      description: 7.5 cycles
+      value: 1
+    - name: Cycles13_5
+      description: 13.5 cycles
+      value: 2
+    - name: Cycles28_5
+      description: 28.5 cycles
+      value: 3
+    - name: Cycles41_5
+      description: 41.5 cycles
+      value: 4
+    - name: Cycles55_5
+      description: 55.5 cycles
+      value: 5
+    - name: Cycles71_5
+      description: 71.5 cycles
+      value: 6
+    - name: Cycles239_5
+      description: 239.5 cycles
+      value: 7

--- a/stm32data/__main__.py
+++ b/stm32data/__main__.py
@@ -116,6 +116,7 @@ perimap = [
     ('.*:DAC:dacif_v1_1', 'dac_v1/DAC'),
     ('.*:DAC:dacif_v2_0', 'dac_v2/DAC'),
     ('.*:DAC:dacif_v3_0', 'dac_v2/DAC'),
+    ('.*:ADC:aditf_v2_5F1', 'adc_f1/ADC'),
     ('.*:ADC:aditf2_v1_1', 'adc_v2/ADC'),
     ('.*:ADC:aditf5_v2_0', 'adc_v3/ADC'),
     ('STM32G0.*:ADC:.*', 'adc_g0/ADC'),


### PR DESCRIPTION
Add the various bit need to support ADC on a stm32f1xx (tested on a blue pill).