### PR TITLE
Unify SPI LSBFirst enums.

### DIFF
--- a/data/registers/spi_v3.yaml
+++ b/data/registers/spi_v3.yaml
@@ -131,11 +131,11 @@ fieldset/CFG2:
       bit_offset: 22
       bit_size: 1
       enum: MASTER
-    - name: LSBFRST
+    - name: LSBFIRST
       description: Data frame format
       bit_offset: 23
       bit_size: 1
-      enum: LSBFRST
+      enum: LSBFIRST
     - name: CPHA
       description: Clock phase
       bit_offset: 24
@@ -556,7 +556,7 @@ enum/HDDIR:
     - name: Transmitter
       description: Transmitter in half duplex mode
       value: 1
-enum/LSBFRST:
+enum/LSBFIRST:
   bit_size: 1
   variants:
     - name: MSBFirst


### PR DESCRIPTION
This leaves out some of the cfg attributes needed for SPI setup, alongside the ugly conditional includes.