### PR TITLE
Fix missing USB OTG pins

### DIFF
--- a/data/chips/STM32F105R8.yaml
+++ b/data/chips/STM32F105R8.yaml
@@ -1084,6 +1084,26 @@ cores:
         - channel: DMA1_CH2
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB
+        registers:
+          enable:
+            register: AHBENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHBRSTR
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+      - pin: PA11
+        signal: DM
+      - pin: PA12
+        signal: DP
       interrupts:
         GLOBAL: OTG_FS_WKUP
     WWDG:

--- a/data/chips/STM32F105RB.yaml
+++ b/data/chips/STM32F105RB.yaml
@@ -1084,6 +1084,26 @@ cores:
         - channel: DMA1_CH2
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB
+        registers:
+          enable:
+            register: AHBENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHBRSTR
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+      - pin: PA11
+        signal: DM
+      - pin: PA12
+        signal: DP
       interrupts:
         GLOBAL: OTG_FS_WKUP
     WWDG:

--- a/data/chips/STM32F105RC.yaml
+++ b/data/chips/STM32F105RC.yaml
@@ -1084,6 +1084,26 @@ cores:
         - channel: DMA1_CH2
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB
+        registers:
+          enable:
+            register: AHBENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHBRSTR
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+      - pin: PA11
+        signal: DM
+      - pin: PA12
+        signal: DP
       interrupts:
         GLOBAL: OTG_FS_WKUP
     WWDG:

--- a/data/chips/STM32F105V8.yaml
+++ b/data/chips/STM32F105V8.yaml
@@ -1134,6 +1134,26 @@ cores:
         - channel: DMA1_CH2
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB
+        registers:
+          enable:
+            register: AHBENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHBRSTR
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+      - pin: PA11
+        signal: DM
+      - pin: PA12
+        signal: DP
       interrupts:
         GLOBAL: OTG_FS_WKUP
     WWDG:

--- a/data/chips/STM32F105VB.yaml
+++ b/data/chips/STM32F105VB.yaml
@@ -1134,6 +1134,26 @@ cores:
         - channel: DMA1_CH2
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB
+        registers:
+          enable:
+            register: AHBENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHBRSTR
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+      - pin: PA11
+        signal: DM
+      - pin: PA12
+        signal: DP
       interrupts:
         GLOBAL: OTG_FS_WKUP
     WWDG:

--- a/data/chips/STM32F105VC.yaml
+++ b/data/chips/STM32F105VC.yaml
@@ -1132,6 +1132,26 @@ cores:
         - channel: DMA1_CH2
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB
+        registers:
+          enable:
+            register: AHBENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHBRSTR
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+      - pin: PA11
+        signal: DM
+      - pin: PA12
+        signal: DP
       interrupts:
         GLOBAL: OTG_FS_WKUP
     WWDG:

--- a/data/chips/STM32F107RB.yaml
+++ b/data/chips/STM32F107RB.yaml
@@ -1102,6 +1102,26 @@ cores:
         - channel: DMA1_CH2
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB
+        registers:
+          enable:
+            register: AHBENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHBRSTR
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+      - pin: PA11
+        signal: DM
+      - pin: PA12
+        signal: DP
       interrupts:
         GLOBAL: OTG_FS_WKUP
     WWDG:

--- a/data/chips/STM32F107RC.yaml
+++ b/data/chips/STM32F107RC.yaml
@@ -1102,6 +1102,26 @@ cores:
         - channel: DMA1_CH2
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB
+        registers:
+          enable:
+            register: AHBENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHBRSTR
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+      - pin: PA11
+        signal: DM
+      - pin: PA12
+        signal: DP
       interrupts:
         GLOBAL: OTG_FS_WKUP
     WWDG:

--- a/data/chips/STM32F107VB.yaml
+++ b/data/chips/STM32F107VB.yaml
@@ -1162,6 +1162,26 @@ cores:
         - channel: DMA1_CH2
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB
+        registers:
+          enable:
+            register: AHBENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHBRSTR
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+      - pin: PA11
+        signal: DM
+      - pin: PA12
+        signal: DP
       interrupts:
         GLOBAL: OTG_FS_WKUP
     WWDG:

--- a/data/chips/STM32F107VC.yaml
+++ b/data/chips/STM32F107VC.yaml
@@ -1164,6 +1164,26 @@ cores:
         - channel: DMA1_CH2
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB
+        registers:
+          enable:
+            register: AHBENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHBRSTR
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+      - pin: PA11
+        signal: DM
+      - pin: PA12
+        signal: DP
       interrupts:
         GLOBAL: OTG_FS_WKUP
     WWDG:

--- a/data/chips/STM32F205RB.yaml
+++ b/data/chips/STM32F205RB.yaml
@@ -1771,12 +1771,97 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
       block: otgfs_v1/OTG_FS
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
       address: 0x40040000
+      rcc:
+        clock: AHB1
+        registers:
+          enable:
+            register: AHB1ENR
+            field: USB_OTG_HSEN
+          reset:
+            register: AHB1RSTR
+            field: USB_OTG_HSRST
       block: otghs_v1/OTG_HS
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+        af: 12
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F205RC.yaml
+++ b/data/chips/STM32F205RC.yaml
@@ -1771,12 +1771,97 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
       block: otgfs_v1/OTG_FS
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
       address: 0x40040000
+      rcc:
+        clock: AHB1
+        registers:
+          enable:
+            register: AHB1ENR
+            field: USB_OTG_HSEN
+          reset:
+            register: AHB1RSTR
+            field: USB_OTG_HSRST
       block: otghs_v1/OTG_HS
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+        af: 12
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F205RE.yaml
+++ b/data/chips/STM32F205RE.yaml
@@ -1773,12 +1773,97 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
       block: otgfs_v1/OTG_FS
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
       address: 0x40040000
+      rcc:
+        clock: AHB1
+        registers:
+          enable:
+            register: AHB1ENR
+            field: USB_OTG_HSEN
+          reset:
+            register: AHB1RSTR
+            field: USB_OTG_HSRST
       block: otghs_v1/OTG_HS
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+        af: 12
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F205RF.yaml
+++ b/data/chips/STM32F205RF.yaml
@@ -1771,12 +1771,97 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
       block: otgfs_v1/OTG_FS
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
       address: 0x40040000
+      rcc:
+        clock: AHB1
+        registers:
+          enable:
+            register: AHB1ENR
+            field: USB_OTG_HSEN
+          reset:
+            register: AHB1RSTR
+            field: USB_OTG_HSRST
       block: otghs_v1/OTG_HS
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+        af: 12
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F205RG.yaml
+++ b/data/chips/STM32F205RG.yaml
@@ -1775,12 +1775,97 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
       block: otgfs_v1/OTG_FS
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
       address: 0x40040000
+      rcc:
+        clock: AHB1
+        registers:
+          enable:
+            register: AHB1ENR
+            field: USB_OTG_HSEN
+          reset:
+            register: AHB1RSTR
+            field: USB_OTG_HSRST
       block: otghs_v1/OTG_HS
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+        af: 12
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F205VB.yaml
+++ b/data/chips/STM32F205VB.yaml
@@ -1855,12 +1855,97 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
       block: otgfs_v1/OTG_FS
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
       address: 0x40040000
+      rcc:
+        clock: AHB1
+        registers:
+          enable:
+            register: AHB1ENR
+            field: USB_OTG_HSEN
+          reset:
+            register: AHB1RSTR
+            field: USB_OTG_HSRST
       block: otghs_v1/OTG_HS
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+        af: 12
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F205VC.yaml
+++ b/data/chips/STM32F205VC.yaml
@@ -1855,12 +1855,97 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
       block: otgfs_v1/OTG_FS
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
       address: 0x40040000
+      rcc:
+        clock: AHB1
+        registers:
+          enable:
+            register: AHB1ENR
+            field: USB_OTG_HSEN
+          reset:
+            register: AHB1RSTR
+            field: USB_OTG_HSRST
       block: otghs_v1/OTG_HS
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+        af: 12
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F205VE.yaml
+++ b/data/chips/STM32F205VE.yaml
@@ -1855,12 +1855,97 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
       block: otgfs_v1/OTG_FS
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
       address: 0x40040000
+      rcc:
+        clock: AHB1
+        registers:
+          enable:
+            register: AHB1ENR
+            field: USB_OTG_HSEN
+          reset:
+            register: AHB1RSTR
+            field: USB_OTG_HSRST
       block: otghs_v1/OTG_HS
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+        af: 12
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F205VF.yaml
+++ b/data/chips/STM32F205VF.yaml
@@ -1855,12 +1855,97 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
       block: otgfs_v1/OTG_FS
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
       address: 0x40040000
+      rcc:
+        clock: AHB1
+        registers:
+          enable:
+            register: AHB1ENR
+            field: USB_OTG_HSEN
+          reset:
+            register: AHB1RSTR
+            field: USB_OTG_HSRST
       block: otghs_v1/OTG_HS
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+        af: 12
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F205VG.yaml
+++ b/data/chips/STM32F205VG.yaml
@@ -1855,12 +1855,97 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
       block: otgfs_v1/OTG_FS
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
       address: 0x40040000
+      rcc:
+        clock: AHB1
+        registers:
+          enable:
+            register: AHB1ENR
+            field: USB_OTG_HSEN
+          reset:
+            register: AHB1RSTR
+            field: USB_OTG_HSRST
       block: otghs_v1/OTG_HS
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+        af: 12
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F205ZC.yaml
+++ b/data/chips/STM32F205ZC.yaml
@@ -1913,12 +1913,97 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
       block: otgfs_v1/OTG_FS
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
       address: 0x40040000
+      rcc:
+        clock: AHB1
+        registers:
+          enable:
+            register: AHB1ENR
+            field: USB_OTG_HSEN
+          reset:
+            register: AHB1RSTR
+            field: USB_OTG_HSRST
       block: otghs_v1/OTG_HS
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+        af: 12
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F205ZE.yaml
+++ b/data/chips/STM32F205ZE.yaml
@@ -1913,12 +1913,97 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
       block: otgfs_v1/OTG_FS
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
       address: 0x40040000
+      rcc:
+        clock: AHB1
+        registers:
+          enable:
+            register: AHB1ENR
+            field: USB_OTG_HSEN
+          reset:
+            register: AHB1RSTR
+            field: USB_OTG_HSRST
       block: otghs_v1/OTG_HS
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+        af: 12
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F205ZF.yaml
+++ b/data/chips/STM32F205ZF.yaml
@@ -1913,12 +1913,97 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
       block: otgfs_v1/OTG_FS
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
       address: 0x40040000
+      rcc:
+        clock: AHB1
+        registers:
+          enable:
+            register: AHB1ENR
+            field: USB_OTG_HSEN
+          reset:
+            register: AHB1RSTR
+            field: USB_OTG_HSRST
       block: otghs_v1/OTG_HS
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+        af: 12
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F205ZG.yaml
+++ b/data/chips/STM32F205ZG.yaml
@@ -1913,12 +1913,97 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
       block: otgfs_v1/OTG_FS
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
       address: 0x40040000
+      rcc:
+        clock: AHB1
+        registers:
+          enable:
+            register: AHB1ENR
+            field: USB_OTG_HSEN
+          reset:
+            register: AHB1RSTR
+            field: USB_OTG_HSRST
       block: otghs_v1/OTG_HS
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+        af: 12
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F207IC.yaml
+++ b/data/chips/STM32F207IC.yaml
@@ -2232,12 +2232,103 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
       block: otgfs_v1/OTG_FS
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
       address: 0x40040000
+      rcc:
+        clock: AHB1
+        registers:
+          enable:
+            register: AHB1ENR
+            field: USB_OTG_HSEN
+          reset:
+            register: AHB1RSTR
+            field: USB_OTG_HSRST
       block: otghs_v1/OTG_HS
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+        af: 12
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
+      - pin: PH4
+        signal: ULPI_NXT
+        af: 10
+      - pin: PI11
+        signal: ULPI_DIR
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F207IE.yaml
+++ b/data/chips/STM32F207IE.yaml
@@ -2232,12 +2232,103 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
       block: otgfs_v1/OTG_FS
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
       address: 0x40040000
+      rcc:
+        clock: AHB1
+        registers:
+          enable:
+            register: AHB1ENR
+            field: USB_OTG_HSEN
+          reset:
+            register: AHB1RSTR
+            field: USB_OTG_HSRST
       block: otghs_v1/OTG_HS
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+        af: 12
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
+      - pin: PH4
+        signal: ULPI_NXT
+        af: 10
+      - pin: PI11
+        signal: ULPI_DIR
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F207IF.yaml
+++ b/data/chips/STM32F207IF.yaml
@@ -2232,12 +2232,103 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
       block: otgfs_v1/OTG_FS
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
       address: 0x40040000
+      rcc:
+        clock: AHB1
+        registers:
+          enable:
+            register: AHB1ENR
+            field: USB_OTG_HSEN
+          reset:
+            register: AHB1RSTR
+            field: USB_OTG_HSRST
       block: otghs_v1/OTG_HS
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+        af: 12
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
+      - pin: PH4
+        signal: ULPI_NXT
+        af: 10
+      - pin: PI11
+        signal: ULPI_DIR
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F207IG.yaml
+++ b/data/chips/STM32F207IG.yaml
@@ -2232,12 +2232,103 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
       block: otgfs_v1/OTG_FS
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
       address: 0x40040000
+      rcc:
+        clock: AHB1
+        registers:
+          enable:
+            register: AHB1ENR
+            field: USB_OTG_HSEN
+          reset:
+            register: AHB1RSTR
+            field: USB_OTG_HSRST
       block: otghs_v1/OTG_HS
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+        af: 12
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
+      - pin: PH4
+        signal: ULPI_NXT
+        af: 10
+      - pin: PI11
+        signal: ULPI_DIR
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F207VC.yaml
+++ b/data/chips/STM32F207VC.yaml
@@ -2010,12 +2010,97 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
       block: otgfs_v1/OTG_FS
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
       address: 0x40040000
+      rcc:
+        clock: AHB1
+        registers:
+          enable:
+            register: AHB1ENR
+            field: USB_OTG_HSEN
+          reset:
+            register: AHB1RSTR
+            field: USB_OTG_HSRST
       block: otghs_v1/OTG_HS
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+        af: 12
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F207VE.yaml
+++ b/data/chips/STM32F207VE.yaml
@@ -2010,12 +2010,97 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
       block: otgfs_v1/OTG_FS
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
       address: 0x40040000
+      rcc:
+        clock: AHB1
+        registers:
+          enable:
+            register: AHB1ENR
+            field: USB_OTG_HSEN
+          reset:
+            register: AHB1RSTR
+            field: USB_OTG_HSRST
       block: otghs_v1/OTG_HS
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+        af: 12
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F207VF.yaml
+++ b/data/chips/STM32F207VF.yaml
@@ -2010,12 +2010,97 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
       block: otgfs_v1/OTG_FS
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
       address: 0x40040000
+      rcc:
+        clock: AHB1
+        registers:
+          enable:
+            register: AHB1ENR
+            field: USB_OTG_HSEN
+          reset:
+            register: AHB1RSTR
+            field: USB_OTG_HSRST
       block: otghs_v1/OTG_HS
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+        af: 12
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F207VG.yaml
+++ b/data/chips/STM32F207VG.yaml
@@ -2010,12 +2010,97 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
       block: otgfs_v1/OTG_FS
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
       address: 0x40040000
+      rcc:
+        clock: AHB1
+        registers:
+          enable:
+            register: AHB1ENR
+            field: USB_OTG_HSEN
+          reset:
+            register: AHB1RSTR
+            field: USB_OTG_HSRST
       block: otghs_v1/OTG_HS
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+        af: 12
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F207ZC.yaml
+++ b/data/chips/STM32F207ZC.yaml
@@ -2086,12 +2086,97 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
       block: otgfs_v1/OTG_FS
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
       address: 0x40040000
+      rcc:
+        clock: AHB1
+        registers:
+          enable:
+            register: AHB1ENR
+            field: USB_OTG_HSEN
+          reset:
+            register: AHB1RSTR
+            field: USB_OTG_HSRST
       block: otghs_v1/OTG_HS
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+        af: 12
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F207ZE.yaml
+++ b/data/chips/STM32F207ZE.yaml
@@ -2086,12 +2086,97 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
       block: otgfs_v1/OTG_FS
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
       address: 0x40040000
+      rcc:
+        clock: AHB1
+        registers:
+          enable:
+            register: AHB1ENR
+            field: USB_OTG_HSEN
+          reset:
+            register: AHB1RSTR
+            field: USB_OTG_HSRST
       block: otghs_v1/OTG_HS
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+        af: 12
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F207ZF.yaml
+++ b/data/chips/STM32F207ZF.yaml
@@ -2086,12 +2086,97 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
       block: otgfs_v1/OTG_FS
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
       address: 0x40040000
+      rcc:
+        clock: AHB1
+        registers:
+          enable:
+            register: AHB1ENR
+            field: USB_OTG_HSEN
+          reset:
+            register: AHB1RSTR
+            field: USB_OTG_HSRST
       block: otghs_v1/OTG_HS
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+        af: 12
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F207ZG.yaml
+++ b/data/chips/STM32F207ZG.yaml
@@ -2086,12 +2086,97 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
       block: otgfs_v1/OTG_FS
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
       address: 0x40040000
+      rcc:
+        clock: AHB1
+        registers:
+          enable:
+            register: AHB1ENR
+            field: USB_OTG_HSEN
+          reset:
+            register: AHB1RSTR
+            field: USB_OTG_HSRST
       block: otghs_v1/OTG_HS
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+        af: 12
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F215RE.yaml
+++ b/data/chips/STM32F215RE.yaml
@@ -1805,12 +1805,97 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
       block: otgfs_v1/OTG_FS
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
       address: 0x40040000
+      rcc:
+        clock: AHB1
+        registers:
+          enable:
+            register: AHB1ENR
+            field: USB_OTG_HSEN
+          reset:
+            register: AHB1RSTR
+            field: USB_OTG_HSRST
       block: otghs_v1/OTG_HS
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+        af: 12
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F215RG.yaml
+++ b/data/chips/STM32F215RG.yaml
@@ -1805,12 +1805,97 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
       block: otgfs_v1/OTG_FS
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
       address: 0x40040000
+      rcc:
+        clock: AHB1
+        registers:
+          enable:
+            register: AHB1ENR
+            field: USB_OTG_HSEN
+          reset:
+            register: AHB1RSTR
+            field: USB_OTG_HSRST
       block: otghs_v1/OTG_HS
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+        af: 12
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F215VE.yaml
+++ b/data/chips/STM32F215VE.yaml
@@ -1889,12 +1889,97 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
       block: otgfs_v1/OTG_FS
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
       address: 0x40040000
+      rcc:
+        clock: AHB1
+        registers:
+          enable:
+            register: AHB1ENR
+            field: USB_OTG_HSEN
+          reset:
+            register: AHB1RSTR
+            field: USB_OTG_HSRST
       block: otghs_v1/OTG_HS
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+        af: 12
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F215VG.yaml
+++ b/data/chips/STM32F215VG.yaml
@@ -1889,12 +1889,97 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
       block: otgfs_v1/OTG_FS
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
       address: 0x40040000
+      rcc:
+        clock: AHB1
+        registers:
+          enable:
+            register: AHB1ENR
+            field: USB_OTG_HSEN
+          reset:
+            register: AHB1RSTR
+            field: USB_OTG_HSRST
       block: otghs_v1/OTG_HS
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+        af: 12
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F215ZE.yaml
+++ b/data/chips/STM32F215ZE.yaml
@@ -1947,12 +1947,97 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
       block: otgfs_v1/OTG_FS
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
       address: 0x40040000
+      rcc:
+        clock: AHB1
+        registers:
+          enable:
+            register: AHB1ENR
+            field: USB_OTG_HSEN
+          reset:
+            register: AHB1RSTR
+            field: USB_OTG_HSRST
       block: otghs_v1/OTG_HS
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+        af: 12
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F215ZG.yaml
+++ b/data/chips/STM32F215ZG.yaml
@@ -1947,12 +1947,97 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
       block: otgfs_v1/OTG_FS
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
       address: 0x40040000
+      rcc:
+        clock: AHB1
+        registers:
+          enable:
+            register: AHB1ENR
+            field: USB_OTG_HSEN
+          reset:
+            register: AHB1RSTR
+            field: USB_OTG_HSRST
       block: otghs_v1/OTG_HS
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+        af: 12
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F217IE.yaml
+++ b/data/chips/STM32F217IE.yaml
@@ -2266,12 +2266,103 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
       block: otgfs_v1/OTG_FS
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
       address: 0x40040000
+      rcc:
+        clock: AHB1
+        registers:
+          enable:
+            register: AHB1ENR
+            field: USB_OTG_HSEN
+          reset:
+            register: AHB1RSTR
+            field: USB_OTG_HSRST
       block: otghs_v1/OTG_HS
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+        af: 12
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
+      - pin: PH4
+        signal: ULPI_NXT
+        af: 10
+      - pin: PI11
+        signal: ULPI_DIR
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F217IG.yaml
+++ b/data/chips/STM32F217IG.yaml
@@ -2266,12 +2266,103 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
       block: otgfs_v1/OTG_FS
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
       address: 0x40040000
+      rcc:
+        clock: AHB1
+        registers:
+          enable:
+            register: AHB1ENR
+            field: USB_OTG_HSEN
+          reset:
+            register: AHB1RSTR
+            field: USB_OTG_HSRST
       block: otghs_v1/OTG_HS
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+        af: 12
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
+      - pin: PH4
+        signal: ULPI_NXT
+        af: 10
+      - pin: PI11
+        signal: ULPI_DIR
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F217VE.yaml
+++ b/data/chips/STM32F217VE.yaml
@@ -2044,12 +2044,97 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
       block: otgfs_v1/OTG_FS
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
       address: 0x40040000
+      rcc:
+        clock: AHB1
+        registers:
+          enable:
+            register: AHB1ENR
+            field: USB_OTG_HSEN
+          reset:
+            register: AHB1RSTR
+            field: USB_OTG_HSRST
       block: otghs_v1/OTG_HS
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+        af: 12
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F217VG.yaml
+++ b/data/chips/STM32F217VG.yaml
@@ -2044,12 +2044,97 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
       block: otgfs_v1/OTG_FS
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
       address: 0x40040000
+      rcc:
+        clock: AHB1
+        registers:
+          enable:
+            register: AHB1ENR
+            field: USB_OTG_HSEN
+          reset:
+            register: AHB1RSTR
+            field: USB_OTG_HSRST
       block: otghs_v1/OTG_HS
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+        af: 12
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F217ZE.yaml
+++ b/data/chips/STM32F217ZE.yaml
@@ -2120,12 +2120,97 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
       block: otgfs_v1/OTG_FS
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
       address: 0x40040000
+      rcc:
+        clock: AHB1
+        registers:
+          enable:
+            register: AHB1ENR
+            field: USB_OTG_HSEN
+          reset:
+            register: AHB1RSTR
+            field: USB_OTG_HSRST
       block: otghs_v1/OTG_HS
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+        af: 12
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F217ZG.yaml
+++ b/data/chips/STM32F217ZG.yaml
@@ -2120,12 +2120,97 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
       block: otgfs_v1/OTG_FS
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
       address: 0x40040000
+      rcc:
+        clock: AHB1
+        registers:
+          enable:
+            register: AHB1ENR
+            field: USB_OTG_HSEN
+          reset:
+            register: AHB1RSTR
+            field: USB_OTG_HSRST
       block: otghs_v1/OTG_HS
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+        af: 12
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F401CB.yaml
+++ b/data/chips/STM32F401CB.yaml
@@ -1167,7 +1167,31 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
       block: otgfs_v1/OTG_FS
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     WWDG:

--- a/data/chips/STM32F401CC.yaml
+++ b/data/chips/STM32F401CC.yaml
@@ -1169,7 +1169,31 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
       block: otgfs_v1/OTG_FS
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     WWDG:

--- a/data/chips/STM32F401CD.yaml
+++ b/data/chips/STM32F401CD.yaml
@@ -1167,7 +1167,31 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
       block: otgfs_v1/OTG_FS
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     WWDG:

--- a/data/chips/STM32F401CE.yaml
+++ b/data/chips/STM32F401CE.yaml
@@ -1167,7 +1167,31 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
       block: otgfs_v1/OTG_FS
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     WWDG:

--- a/data/chips/STM32F401RB.yaml
+++ b/data/chips/STM32F401RB.yaml
@@ -1282,7 +1282,31 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
       block: otgfs_v1/OTG_FS
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     WWDG:

--- a/data/chips/STM32F401RC.yaml
+++ b/data/chips/STM32F401RC.yaml
@@ -1282,7 +1282,31 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
       block: otgfs_v1/OTG_FS
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     WWDG:

--- a/data/chips/STM32F401RD.yaml
+++ b/data/chips/STM32F401RD.yaml
@@ -1282,7 +1282,31 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
       block: otgfs_v1/OTG_FS
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     WWDG:

--- a/data/chips/STM32F401RE.yaml
+++ b/data/chips/STM32F401RE.yaml
@@ -1282,7 +1282,31 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
       block: otgfs_v1/OTG_FS
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     WWDG:

--- a/data/chips/STM32F401VB.yaml
+++ b/data/chips/STM32F401VB.yaml
@@ -1409,7 +1409,31 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
       block: otgfs_v1/OTG_FS
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     WWDG:

--- a/data/chips/STM32F401VC.yaml
+++ b/data/chips/STM32F401VC.yaml
@@ -1409,7 +1409,31 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
       block: otgfs_v1/OTG_FS
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     WWDG:

--- a/data/chips/STM32F401VD.yaml
+++ b/data/chips/STM32F401VD.yaml
@@ -1409,7 +1409,31 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
       block: otgfs_v1/OTG_FS
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     WWDG:

--- a/data/chips/STM32F401VE.yaml
+++ b/data/chips/STM32F401VE.yaml
@@ -1409,7 +1409,31 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
       block: otgfs_v1/OTG_FS
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     WWDG:

--- a/data/chips/STM32F405OE.yaml
+++ b/data/chips/STM32F405OE.yaml
@@ -1855,12 +1855,96 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
       block: otgfs_v1/OTG_FS
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
       address: 0x40040000
+      rcc:
+        clock: AHB1
+        registers:
+          enable:
+            register: AHB1ENR
+            field: USB_OTG_HSEN
+          reset:
+            register: AHB1RSTR
+            field: USB_OTG_HSRST
       block: otghs_v1/OTG_HS
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F405OG.yaml
+++ b/data/chips/STM32F405OG.yaml
@@ -1855,12 +1855,96 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
       block: otgfs_v1/OTG_FS
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
       address: 0x40040000
+      rcc:
+        clock: AHB1
+        registers:
+          enable:
+            register: AHB1ENR
+            field: USB_OTG_HSEN
+          reset:
+            register: AHB1RSTR
+            field: USB_OTG_HSRST
       block: otghs_v1/OTG_HS
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F405RG.yaml
+++ b/data/chips/STM32F405RG.yaml
@@ -1791,12 +1791,96 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
       block: otgfs_v1/OTG_FS
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
       address: 0x40040000
+      rcc:
+        clock: AHB1
+        registers:
+          enable:
+            register: AHB1ENR
+            field: USB_OTG_HSEN
+          reset:
+            register: AHB1RSTR
+            field: USB_OTG_HSRST
       block: otghs_v1/OTG_HS
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F405VG.yaml
+++ b/data/chips/STM32F405VG.yaml
@@ -1875,12 +1875,96 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
       block: otgfs_v1/OTG_FS
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
       address: 0x40040000
+      rcc:
+        clock: AHB1
+        registers:
+          enable:
+            register: AHB1ENR
+            field: USB_OTG_HSEN
+          reset:
+            register: AHB1RSTR
+            field: USB_OTG_HSRST
       block: otghs_v1/OTG_HS
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F405ZG.yaml
+++ b/data/chips/STM32F405ZG.yaml
@@ -1933,12 +1933,96 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
       block: otgfs_v1/OTG_FS
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
       address: 0x40040000
+      rcc:
+        clock: AHB1
+        registers:
+          enable:
+            register: AHB1ENR
+            field: USB_OTG_HSEN
+          reset:
+            register: AHB1RSTR
+            field: USB_OTG_HSRST
       block: otghs_v1/OTG_HS
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F407IE.yaml
+++ b/data/chips/STM32F407IE.yaml
@@ -2260,12 +2260,102 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
       block: otgfs_v1/OTG_FS
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
       address: 0x40040000
+      rcc:
+        clock: AHB1
+        registers:
+          enable:
+            register: AHB1ENR
+            field: USB_OTG_HSEN
+          reset:
+            register: AHB1RSTR
+            field: USB_OTG_HSRST
       block: otghs_v1/OTG_HS
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
+      - pin: PH4
+        signal: ULPI_NXT
+        af: 10
+      - pin: PI11
+        signal: ULPI_DIR
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F407IG.yaml
+++ b/data/chips/STM32F407IG.yaml
@@ -2260,12 +2260,102 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
       block: otgfs_v1/OTG_FS
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
       address: 0x40040000
+      rcc:
+        clock: AHB1
+        registers:
+          enable:
+            register: AHB1ENR
+            field: USB_OTG_HSEN
+          reset:
+            register: AHB1RSTR
+            field: USB_OTG_HSRST
       block: otghs_v1/OTG_HS
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
+      - pin: PH4
+        signal: ULPI_NXT
+        af: 10
+      - pin: PI11
+        signal: ULPI_DIR
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F407VE.yaml
+++ b/data/chips/STM32F407VE.yaml
@@ -2038,12 +2038,96 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
       block: otgfs_v1/OTG_FS
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
       address: 0x40040000
+      rcc:
+        clock: AHB1
+        registers:
+          enable:
+            register: AHB1ENR
+            field: USB_OTG_HSEN
+          reset:
+            register: AHB1RSTR
+            field: USB_OTG_HSRST
       block: otghs_v1/OTG_HS
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F407VG.yaml
+++ b/data/chips/STM32F407VG.yaml
@@ -2038,12 +2038,96 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
       block: otgfs_v1/OTG_FS
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
       address: 0x40040000
+      rcc:
+        clock: AHB1
+        registers:
+          enable:
+            register: AHB1ENR
+            field: USB_OTG_HSEN
+          reset:
+            register: AHB1RSTR
+            field: USB_OTG_HSRST
       block: otghs_v1/OTG_HS
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F407ZE.yaml
+++ b/data/chips/STM32F407ZE.yaml
@@ -2114,12 +2114,96 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
       block: otgfs_v1/OTG_FS
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
       address: 0x40040000
+      rcc:
+        clock: AHB1
+        registers:
+          enable:
+            register: AHB1ENR
+            field: USB_OTG_HSEN
+          reset:
+            register: AHB1RSTR
+            field: USB_OTG_HSRST
       block: otghs_v1/OTG_HS
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F407ZG.yaml
+++ b/data/chips/STM32F407ZG.yaml
@@ -2114,12 +2114,96 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
       block: otgfs_v1/OTG_FS
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
       address: 0x40040000
+      rcc:
+        clock: AHB1
+        registers:
+          enable:
+            register: AHB1ENR
+            field: USB_OTG_HSEN
+          reset:
+            register: AHB1RSTR
+            field: USB_OTG_HSRST
       block: otghs_v1/OTG_HS
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F411CC.yaml
+++ b/data/chips/STM32F411CC.yaml
@@ -1330,7 +1330,32 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
       block: otgfs_v1/OTG_FS
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+        af: 10
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     WWDG:

--- a/data/chips/STM32F411CE.yaml
+++ b/data/chips/STM32F411CE.yaml
@@ -1334,7 +1334,32 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
       block: otgfs_v1/OTG_FS
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+        af: 10
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     WWDG:

--- a/data/chips/STM32F411RC.yaml
+++ b/data/chips/STM32F411RC.yaml
@@ -1412,7 +1412,32 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
       block: otgfs_v1/OTG_FS
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+        af: 10
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     WWDG:

--- a/data/chips/STM32F411RE.yaml
+++ b/data/chips/STM32F411RE.yaml
@@ -1416,7 +1416,32 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
       block: otgfs_v1/OTG_FS
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+        af: 10
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     WWDG:

--- a/data/chips/STM32F411VC.yaml
+++ b/data/chips/STM32F411VC.yaml
@@ -1537,7 +1537,32 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
       block: otgfs_v1/OTG_FS
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+        af: 10
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     WWDG:

--- a/data/chips/STM32F411VE.yaml
+++ b/data/chips/STM32F411VE.yaml
@@ -1541,7 +1541,32 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
       block: otgfs_v1/OTG_FS
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+        af: 10
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     WWDG:

--- a/data/chips/STM32F412CE.yaml
+++ b/data/chips/STM32F412CE.yaml
@@ -1679,6 +1679,31 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+        af: 10
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     WWDG:

--- a/data/chips/STM32F412CG.yaml
+++ b/data/chips/STM32F412CG.yaml
@@ -1679,6 +1679,31 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+        af: 10
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     WWDG:

--- a/data/chips/STM32F412RE.yaml
+++ b/data/chips/STM32F412RE.yaml
@@ -1873,6 +1873,31 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+        af: 10
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     WWDG:

--- a/data/chips/STM32F412RG.yaml
+++ b/data/chips/STM32F412RG.yaml
@@ -1873,6 +1873,31 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+        af: 10
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     WWDG:

--- a/data/chips/STM32F412VE.yaml
+++ b/data/chips/STM32F412VE.yaml
@@ -2099,6 +2099,31 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+        af: 10
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     WWDG:

--- a/data/chips/STM32F412VG.yaml
+++ b/data/chips/STM32F412VG.yaml
@@ -2099,6 +2099,31 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+        af: 10
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     WWDG:

--- a/data/chips/STM32F412ZE.yaml
+++ b/data/chips/STM32F412ZE.yaml
@@ -2228,6 +2228,31 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+        af: 10
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     WWDG:

--- a/data/chips/STM32F412ZG.yaml
+++ b/data/chips/STM32F412ZG.yaml
@@ -2228,6 +2228,31 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+        af: 10
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     WWDG:

--- a/data/chips/STM32F413CG.yaml
+++ b/data/chips/STM32F413CG.yaml
@@ -2008,6 +2008,31 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+        af: 10
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     WWDG:

--- a/data/chips/STM32F413CH.yaml
+++ b/data/chips/STM32F413CH.yaml
@@ -2008,6 +2008,31 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+        af: 10
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     WWDG:

--- a/data/chips/STM32F413MG.yaml
+++ b/data/chips/STM32F413MG.yaml
@@ -2378,6 +2378,31 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+        af: 10
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     WWDG:

--- a/data/chips/STM32F413MH.yaml
+++ b/data/chips/STM32F413MH.yaml
@@ -2378,6 +2378,31 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+        af: 10
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     WWDG:

--- a/data/chips/STM32F413RG.yaml
+++ b/data/chips/STM32F413RG.yaml
@@ -2288,6 +2288,31 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+        af: 10
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     WWDG:

--- a/data/chips/STM32F413RH.yaml
+++ b/data/chips/STM32F413RH.yaml
@@ -2288,6 +2288,31 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+        af: 10
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     WWDG:

--- a/data/chips/STM32F413VG.yaml
+++ b/data/chips/STM32F413VG.yaml
@@ -2666,6 +2666,31 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+        af: 10
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     WWDG:

--- a/data/chips/STM32F413VH.yaml
+++ b/data/chips/STM32F413VH.yaml
@@ -2666,6 +2666,31 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+        af: 10
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     WWDG:

--- a/data/chips/STM32F413ZG.yaml
+++ b/data/chips/STM32F413ZG.yaml
@@ -2807,6 +2807,31 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+        af: 10
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     WWDG:

--- a/data/chips/STM32F413ZH.yaml
+++ b/data/chips/STM32F413ZH.yaml
@@ -2807,6 +2807,31 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+        af: 10
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     WWDG:

--- a/data/chips/STM32F415OG.yaml
+++ b/data/chips/STM32F415OG.yaml
@@ -1889,12 +1889,96 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
       block: otgfs_v1/OTG_FS
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
       address: 0x40040000
+      rcc:
+        clock: AHB1
+        registers:
+          enable:
+            register: AHB1ENR
+            field: USB_OTG_HSEN
+          reset:
+            register: AHB1RSTR
+            field: USB_OTG_HSRST
       block: otghs_v1/OTG_HS
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F415RG.yaml
+++ b/data/chips/STM32F415RG.yaml
@@ -1825,12 +1825,96 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
       block: otgfs_v1/OTG_FS
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
       address: 0x40040000
+      rcc:
+        clock: AHB1
+        registers:
+          enable:
+            register: AHB1ENR
+            field: USB_OTG_HSEN
+          reset:
+            register: AHB1RSTR
+            field: USB_OTG_HSRST
       block: otghs_v1/OTG_HS
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F415VG.yaml
+++ b/data/chips/STM32F415VG.yaml
@@ -1909,12 +1909,96 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
       block: otgfs_v1/OTG_FS
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
       address: 0x40040000
+      rcc:
+        clock: AHB1
+        registers:
+          enable:
+            register: AHB1ENR
+            field: USB_OTG_HSEN
+          reset:
+            register: AHB1RSTR
+            field: USB_OTG_HSRST
       block: otghs_v1/OTG_HS
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F415ZG.yaml
+++ b/data/chips/STM32F415ZG.yaml
@@ -1967,12 +1967,96 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
       block: otgfs_v1/OTG_FS
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
       address: 0x40040000
+      rcc:
+        clock: AHB1
+        registers:
+          enable:
+            register: AHB1ENR
+            field: USB_OTG_HSEN
+          reset:
+            register: AHB1RSTR
+            field: USB_OTG_HSRST
       block: otghs_v1/OTG_HS
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F417IE.yaml
+++ b/data/chips/STM32F417IE.yaml
@@ -2294,12 +2294,102 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
       block: otgfs_v1/OTG_FS
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
       address: 0x40040000
+      rcc:
+        clock: AHB1
+        registers:
+          enable:
+            register: AHB1ENR
+            field: USB_OTG_HSEN
+          reset:
+            register: AHB1RSTR
+            field: USB_OTG_HSRST
       block: otghs_v1/OTG_HS
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
+      - pin: PH4
+        signal: ULPI_NXT
+        af: 10
+      - pin: PI11
+        signal: ULPI_DIR
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F417IG.yaml
+++ b/data/chips/STM32F417IG.yaml
@@ -2294,12 +2294,102 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
       block: otgfs_v1/OTG_FS
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
       address: 0x40040000
+      rcc:
+        clock: AHB1
+        registers:
+          enable:
+            register: AHB1ENR
+            field: USB_OTG_HSEN
+          reset:
+            register: AHB1RSTR
+            field: USB_OTG_HSRST
       block: otghs_v1/OTG_HS
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
+      - pin: PH4
+        signal: ULPI_NXT
+        af: 10
+      - pin: PI11
+        signal: ULPI_DIR
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F417VE.yaml
+++ b/data/chips/STM32F417VE.yaml
@@ -2072,12 +2072,96 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
       block: otgfs_v1/OTG_FS
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
       address: 0x40040000
+      rcc:
+        clock: AHB1
+        registers:
+          enable:
+            register: AHB1ENR
+            field: USB_OTG_HSEN
+          reset:
+            register: AHB1RSTR
+            field: USB_OTG_HSRST
       block: otghs_v1/OTG_HS
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F417VG.yaml
+++ b/data/chips/STM32F417VG.yaml
@@ -2072,12 +2072,96 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
       block: otgfs_v1/OTG_FS
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
       address: 0x40040000
+      rcc:
+        clock: AHB1
+        registers:
+          enable:
+            register: AHB1ENR
+            field: USB_OTG_HSEN
+          reset:
+            register: AHB1RSTR
+            field: USB_OTG_HSRST
       block: otghs_v1/OTG_HS
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F417ZE.yaml
+++ b/data/chips/STM32F417ZE.yaml
@@ -2148,12 +2148,96 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
       block: otgfs_v1/OTG_FS
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
       address: 0x40040000
+      rcc:
+        clock: AHB1
+        registers:
+          enable:
+            register: AHB1ENR
+            field: USB_OTG_HSEN
+          reset:
+            register: AHB1RSTR
+            field: USB_OTG_HSRST
       block: otghs_v1/OTG_HS
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F417ZG.yaml
+++ b/data/chips/STM32F417ZG.yaml
@@ -2148,12 +2148,96 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
       block: otgfs_v1/OTG_FS
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
       address: 0x40040000
+      rcc:
+        clock: AHB1
+        registers:
+          enable:
+            register: AHB1ENR
+            field: USB_OTG_HSEN
+          reset:
+            register: AHB1RSTR
+            field: USB_OTG_HSRST
       block: otghs_v1/OTG_HS
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F423CH.yaml
+++ b/data/chips/STM32F423CH.yaml
@@ -2019,6 +2019,31 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+        af: 10
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     WWDG:

--- a/data/chips/STM32F423MH.yaml
+++ b/data/chips/STM32F423MH.yaml
@@ -2389,6 +2389,31 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+        af: 10
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     WWDG:

--- a/data/chips/STM32F423RH.yaml
+++ b/data/chips/STM32F423RH.yaml
@@ -2299,6 +2299,31 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+        af: 10
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     WWDG:

--- a/data/chips/STM32F423VH.yaml
+++ b/data/chips/STM32F423VH.yaml
@@ -2677,6 +2677,31 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+        af: 10
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     WWDG:

--- a/data/chips/STM32F423ZH.yaml
+++ b/data/chips/STM32F423ZH.yaml
@@ -2818,6 +2818,31 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+        af: 10
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     WWDG:

--- a/data/chips/STM32F427AG.yaml
+++ b/data/chips/STM32F427AG.yaml
@@ -2788,12 +2788,99 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
       block: otgfs_v1/OTG_FS
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
       address: 0x40040000
+      rcc:
+        clock: AHB1
+        registers:
+          enable:
+            register: AHB1ENR
+            field: USB_OTG_HSEN
+          reset:
+            register: AHB1RSTR
+            field: USB_OTG_HSRST
       block: otghs_v1/OTG_HS
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
+      - pin: PH4
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F427AI.yaml
+++ b/data/chips/STM32F427AI.yaml
@@ -2788,12 +2788,99 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
       block: otgfs_v1/OTG_FS
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
       address: 0x40040000
+      rcc:
+        clock: AHB1
+        registers:
+          enable:
+            register: AHB1ENR
+            field: USB_OTG_HSEN
+          reset:
+            register: AHB1RSTR
+            field: USB_OTG_HSRST
       block: otghs_v1/OTG_HS
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
+      - pin: PH4
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F427IG.yaml
+++ b/data/chips/STM32F427IG.yaml
@@ -2941,12 +2941,102 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
       block: otgfs_v1/OTG_FS
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
       address: 0x40040000
+      rcc:
+        clock: AHB1
+        registers:
+          enable:
+            register: AHB1ENR
+            field: USB_OTG_HSEN
+          reset:
+            register: AHB1RSTR
+            field: USB_OTG_HSRST
       block: otghs_v1/OTG_HS
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
+      - pin: PH4
+        signal: ULPI_NXT
+        af: 10
+      - pin: PI11
+        signal: ULPI_DIR
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F427II.yaml
+++ b/data/chips/STM32F427II.yaml
@@ -2941,12 +2941,102 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
       block: otgfs_v1/OTG_FS
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
       address: 0x40040000
+      rcc:
+        clock: AHB1
+        registers:
+          enable:
+            register: AHB1ENR
+            field: USB_OTG_HSEN
+          reset:
+            register: AHB1RSTR
+            field: USB_OTG_HSRST
       block: otghs_v1/OTG_HS
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
+      - pin: PH4
+        signal: ULPI_NXT
+        af: 10
+      - pin: PI11
+        signal: ULPI_DIR
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F427VG.yaml
+++ b/data/chips/STM32F427VG.yaml
@@ -2417,12 +2417,96 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
       block: otgfs_v1/OTG_FS
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
       address: 0x40040000
+      rcc:
+        clock: AHB1
+        registers:
+          enable:
+            register: AHB1ENR
+            field: USB_OTG_HSEN
+          reset:
+            register: AHB1RSTR
+            field: USB_OTG_HSRST
       block: otghs_v1/OTG_HS
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F427VI.yaml
+++ b/data/chips/STM32F427VI.yaml
@@ -2417,12 +2417,96 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
       block: otgfs_v1/OTG_FS
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
       address: 0x40040000
+      rcc:
+        clock: AHB1
+        registers:
+          enable:
+            register: AHB1ENR
+            field: USB_OTG_HSEN
+          reset:
+            register: AHB1RSTR
+            field: USB_OTG_HSRST
       block: otghs_v1/OTG_HS
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F427ZG.yaml
+++ b/data/chips/STM32F427ZG.yaml
@@ -2712,12 +2712,96 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
       block: otgfs_v1/OTG_FS
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
       address: 0x40040000
+      rcc:
+        clock: AHB1
+        registers:
+          enable:
+            register: AHB1ENR
+            field: USB_OTG_HSEN
+          reset:
+            register: AHB1RSTR
+            field: USB_OTG_HSRST
       block: otghs_v1/OTG_HS
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F427ZI.yaml
+++ b/data/chips/STM32F427ZI.yaml
@@ -2712,12 +2712,96 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
       block: otgfs_v1/OTG_FS
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
       address: 0x40040000
+      rcc:
+        clock: AHB1
+        registers:
+          enable:
+            register: AHB1ENR
+            field: USB_OTG_HSEN
+          reset:
+            register: AHB1RSTR
+            field: USB_OTG_HSRST
       block: otghs_v1/OTG_HS
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F429AG.yaml
+++ b/data/chips/STM32F429AG.yaml
@@ -2969,12 +2969,99 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
       block: otgfs_v1/OTG_FS
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
       address: 0x40040000
+      rcc:
+        clock: AHB1
+        registers:
+          enable:
+            register: AHB1ENR
+            field: USB_OTG_HSEN
+          reset:
+            register: AHB1RSTR
+            field: USB_OTG_HSRST
       block: otghs_v1/OTG_HS
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
+      - pin: PH4
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F429AI.yaml
+++ b/data/chips/STM32F429AI.yaml
@@ -2969,12 +2969,99 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
       block: otgfs_v1/OTG_FS
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
       address: 0x40040000
+      rcc:
+        clock: AHB1
+        registers:
+          enable:
+            register: AHB1ENR
+            field: USB_OTG_HSEN
+          reset:
+            register: AHB1RSTR
+            field: USB_OTG_HSRST
       block: otghs_v1/OTG_HS
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
+      - pin: PH4
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F429BE.yaml
+++ b/data/chips/STM32F429BE.yaml
@@ -3196,12 +3196,102 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
       block: otgfs_v1/OTG_FS
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
       address: 0x40040000
+      rcc:
+        clock: AHB1
+        registers:
+          enable:
+            register: AHB1ENR
+            field: USB_OTG_HSEN
+          reset:
+            register: AHB1RSTR
+            field: USB_OTG_HSRST
       block: otghs_v1/OTG_HS
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
+      - pin: PH4
+        signal: ULPI_NXT
+        af: 10
+      - pin: PI11
+        signal: ULPI_DIR
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F429BG.yaml
+++ b/data/chips/STM32F429BG.yaml
@@ -3200,12 +3200,102 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
       block: otgfs_v1/OTG_FS
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
       address: 0x40040000
+      rcc:
+        clock: AHB1
+        registers:
+          enable:
+            register: AHB1ENR
+            field: USB_OTG_HSEN
+          reset:
+            register: AHB1RSTR
+            field: USB_OTG_HSRST
       block: otghs_v1/OTG_HS
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
+      - pin: PH4
+        signal: ULPI_NXT
+        af: 10
+      - pin: PI11
+        signal: ULPI_DIR
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F429BI.yaml
+++ b/data/chips/STM32F429BI.yaml
@@ -3200,12 +3200,102 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
       block: otgfs_v1/OTG_FS
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
       address: 0x40040000
+      rcc:
+        clock: AHB1
+        registers:
+          enable:
+            register: AHB1ENR
+            field: USB_OTG_HSEN
+          reset:
+            register: AHB1RSTR
+            field: USB_OTG_HSRST
       block: otghs_v1/OTG_HS
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
+      - pin: PH4
+        signal: ULPI_NXT
+        af: 10
+      - pin: PI11
+        signal: ULPI_DIR
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F429IE.yaml
+++ b/data/chips/STM32F429IE.yaml
@@ -3114,12 +3114,102 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
       block: otgfs_v1/OTG_FS
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
       address: 0x40040000
+      rcc:
+        clock: AHB1
+        registers:
+          enable:
+            register: AHB1ENR
+            field: USB_OTG_HSEN
+          reset:
+            register: AHB1RSTR
+            field: USB_OTG_HSRST
       block: otghs_v1/OTG_HS
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
+      - pin: PH4
+        signal: ULPI_NXT
+        af: 10
+      - pin: PI11
+        signal: ULPI_DIR
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F429IG.yaml
+++ b/data/chips/STM32F429IG.yaml
@@ -3122,12 +3122,102 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
       block: otgfs_v1/OTG_FS
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
       address: 0x40040000
+      rcc:
+        clock: AHB1
+        registers:
+          enable:
+            register: AHB1ENR
+            field: USB_OTG_HSEN
+          reset:
+            register: AHB1RSTR
+            field: USB_OTG_HSRST
       block: otghs_v1/OTG_HS
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
+      - pin: PH4
+        signal: ULPI_NXT
+        af: 10
+      - pin: PI11
+        signal: ULPI_DIR
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F429II.yaml
+++ b/data/chips/STM32F429II.yaml
@@ -3122,12 +3122,102 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
       block: otgfs_v1/OTG_FS
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
       address: 0x40040000
+      rcc:
+        clock: AHB1
+        registers:
+          enable:
+            register: AHB1ENR
+            field: USB_OTG_HSEN
+          reset:
+            register: AHB1RSTR
+            field: USB_OTG_HSRST
       block: otghs_v1/OTG_HS
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
+      - pin: PH4
+        signal: ULPI_NXT
+        af: 10
+      - pin: PI11
+        signal: ULPI_DIR
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F429NE.yaml
+++ b/data/chips/STM32F429NE.yaml
@@ -3196,12 +3196,102 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
       block: otgfs_v1/OTG_FS
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
       address: 0x40040000
+      rcc:
+        clock: AHB1
+        registers:
+          enable:
+            register: AHB1ENR
+            field: USB_OTG_HSEN
+          reset:
+            register: AHB1RSTR
+            field: USB_OTG_HSRST
       block: otghs_v1/OTG_HS
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
+      - pin: PH4
+        signal: ULPI_NXT
+        af: 10
+      - pin: PI11
+        signal: ULPI_DIR
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F429NG.yaml
+++ b/data/chips/STM32F429NG.yaml
@@ -3200,12 +3200,102 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
       block: otgfs_v1/OTG_FS
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
       address: 0x40040000
+      rcc:
+        clock: AHB1
+        registers:
+          enable:
+            register: AHB1ENR
+            field: USB_OTG_HSEN
+          reset:
+            register: AHB1RSTR
+            field: USB_OTG_HSRST
       block: otghs_v1/OTG_HS
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
+      - pin: PH4
+        signal: ULPI_NXT
+        af: 10
+      - pin: PI11
+        signal: ULPI_DIR
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F429NI.yaml
+++ b/data/chips/STM32F429NI.yaml
@@ -3200,12 +3200,102 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
       block: otgfs_v1/OTG_FS
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
       address: 0x40040000
+      rcc:
+        clock: AHB1
+        registers:
+          enable:
+            register: AHB1ENR
+            field: USB_OTG_HSEN
+          reset:
+            register: AHB1RSTR
+            field: USB_OTG_HSRST
       block: otghs_v1/OTG_HS
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
+      - pin: PH4
+        signal: ULPI_NXT
+        af: 10
+      - pin: PI11
+        signal: ULPI_DIR
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F429VE.yaml
+++ b/data/chips/STM32F429VE.yaml
@@ -2494,12 +2494,96 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
       block: otgfs_v1/OTG_FS
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
       address: 0x40040000
+      rcc:
+        clock: AHB1
+        registers:
+          enable:
+            register: AHB1ENR
+            field: USB_OTG_HSEN
+          reset:
+            register: AHB1RSTR
+            field: USB_OTG_HSRST
       block: otghs_v1/OTG_HS
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F429VG.yaml
+++ b/data/chips/STM32F429VG.yaml
@@ -2498,12 +2498,96 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
       block: otgfs_v1/OTG_FS
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
       address: 0x40040000
+      rcc:
+        clock: AHB1
+        registers:
+          enable:
+            register: AHB1ENR
+            field: USB_OTG_HSEN
+          reset:
+            register: AHB1RSTR
+            field: USB_OTG_HSRST
       block: otghs_v1/OTG_HS
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F429VI.yaml
+++ b/data/chips/STM32F429VI.yaml
@@ -2498,12 +2498,96 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
       block: otgfs_v1/OTG_FS
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
       address: 0x40040000
+      rcc:
+        clock: AHB1
+        registers:
+          enable:
+            register: AHB1ENR
+            field: USB_OTG_HSEN
+          reset:
+            register: AHB1RSTR
+            field: USB_OTG_HSRST
       block: otghs_v1/OTG_HS
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F429ZE.yaml
+++ b/data/chips/STM32F429ZE.yaml
@@ -2828,12 +2828,96 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
       block: otgfs_v1/OTG_FS
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
       address: 0x40040000
+      rcc:
+        clock: AHB1
+        registers:
+          enable:
+            register: AHB1ENR
+            field: USB_OTG_HSEN
+          reset:
+            register: AHB1RSTR
+            field: USB_OTG_HSRST
       block: otghs_v1/OTG_HS
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F429ZG.yaml
+++ b/data/chips/STM32F429ZG.yaml
@@ -2834,12 +2834,96 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
       block: otgfs_v1/OTG_FS
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
       address: 0x40040000
+      rcc:
+        clock: AHB1
+        registers:
+          enable:
+            register: AHB1ENR
+            field: USB_OTG_HSEN
+          reset:
+            register: AHB1RSTR
+            field: USB_OTG_HSRST
       block: otghs_v1/OTG_HS
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F429ZI.yaml
+++ b/data/chips/STM32F429ZI.yaml
@@ -2834,12 +2834,96 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
       block: otgfs_v1/OTG_FS
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
       address: 0x40040000
+      rcc:
+        clock: AHB1
+        registers:
+          enable:
+            register: AHB1ENR
+            field: USB_OTG_HSEN
+          reset:
+            register: AHB1RSTR
+            field: USB_OTG_HSRST
       block: otghs_v1/OTG_HS
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F437AI.yaml
+++ b/data/chips/STM32F437AI.yaml
@@ -2821,12 +2821,99 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
       block: otgfs_v1/OTG_FS
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
       address: 0x40040000
+      rcc:
+        clock: AHB1
+        registers:
+          enable:
+            register: AHB1ENR
+            field: USB_OTG_HSEN
+          reset:
+            register: AHB1RSTR
+            field: USB_OTG_HSRST
       block: otghs_v1/OTG_HS
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
+      - pin: PH4
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F437IG.yaml
+++ b/data/chips/STM32F437IG.yaml
@@ -2974,12 +2974,102 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
       block: otgfs_v1/OTG_FS
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
       address: 0x40040000
+      rcc:
+        clock: AHB1
+        registers:
+          enable:
+            register: AHB1ENR
+            field: USB_OTG_HSEN
+          reset:
+            register: AHB1RSTR
+            field: USB_OTG_HSRST
       block: otghs_v1/OTG_HS
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
+      - pin: PH4
+        signal: ULPI_NXT
+        af: 10
+      - pin: PI11
+        signal: ULPI_DIR
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F437II.yaml
+++ b/data/chips/STM32F437II.yaml
@@ -2974,12 +2974,102 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
       block: otgfs_v1/OTG_FS
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
       address: 0x40040000
+      rcc:
+        clock: AHB1
+        registers:
+          enable:
+            register: AHB1ENR
+            field: USB_OTG_HSEN
+          reset:
+            register: AHB1RSTR
+            field: USB_OTG_HSRST
       block: otghs_v1/OTG_HS
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
+      - pin: PH4
+        signal: ULPI_NXT
+        af: 10
+      - pin: PI11
+        signal: ULPI_DIR
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F437VG.yaml
+++ b/data/chips/STM32F437VG.yaml
@@ -2450,12 +2450,96 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
       block: otgfs_v1/OTG_FS
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
       address: 0x40040000
+      rcc:
+        clock: AHB1
+        registers:
+          enable:
+            register: AHB1ENR
+            field: USB_OTG_HSEN
+          reset:
+            register: AHB1RSTR
+            field: USB_OTG_HSRST
       block: otghs_v1/OTG_HS
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F437VI.yaml
+++ b/data/chips/STM32F437VI.yaml
@@ -2450,12 +2450,96 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
       block: otgfs_v1/OTG_FS
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
       address: 0x40040000
+      rcc:
+        clock: AHB1
+        registers:
+          enable:
+            register: AHB1ENR
+            field: USB_OTG_HSEN
+          reset:
+            register: AHB1RSTR
+            field: USB_OTG_HSRST
       block: otghs_v1/OTG_HS
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F437ZG.yaml
+++ b/data/chips/STM32F437ZG.yaml
@@ -2745,12 +2745,96 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
       block: otgfs_v1/OTG_FS
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
       address: 0x40040000
+      rcc:
+        clock: AHB1
+        registers:
+          enable:
+            register: AHB1ENR
+            field: USB_OTG_HSEN
+          reset:
+            register: AHB1RSTR
+            field: USB_OTG_HSRST
       block: otghs_v1/OTG_HS
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F437ZI.yaml
+++ b/data/chips/STM32F437ZI.yaml
@@ -2745,12 +2745,96 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
       block: otgfs_v1/OTG_FS
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
       address: 0x40040000
+      rcc:
+        clock: AHB1
+        registers:
+          enable:
+            register: AHB1ENR
+            field: USB_OTG_HSEN
+          reset:
+            register: AHB1RSTR
+            field: USB_OTG_HSRST
       block: otghs_v1/OTG_HS
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F439AI.yaml
+++ b/data/chips/STM32F439AI.yaml
@@ -3002,12 +3002,99 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
       block: otgfs_v1/OTG_FS
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
       address: 0x40040000
+      rcc:
+        clock: AHB1
+        registers:
+          enable:
+            register: AHB1ENR
+            field: USB_OTG_HSEN
+          reset:
+            register: AHB1RSTR
+            field: USB_OTG_HSRST
       block: otghs_v1/OTG_HS
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
+      - pin: PH4
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F439BG.yaml
+++ b/data/chips/STM32F439BG.yaml
@@ -3233,12 +3233,102 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
       block: otgfs_v1/OTG_FS
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
       address: 0x40040000
+      rcc:
+        clock: AHB1
+        registers:
+          enable:
+            register: AHB1ENR
+            field: USB_OTG_HSEN
+          reset:
+            register: AHB1RSTR
+            field: USB_OTG_HSRST
       block: otghs_v1/OTG_HS
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
+      - pin: PH4
+        signal: ULPI_NXT
+        af: 10
+      - pin: PI11
+        signal: ULPI_DIR
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F439BI.yaml
+++ b/data/chips/STM32F439BI.yaml
@@ -3233,12 +3233,102 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
       block: otgfs_v1/OTG_FS
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
       address: 0x40040000
+      rcc:
+        clock: AHB1
+        registers:
+          enable:
+            register: AHB1ENR
+            field: USB_OTG_HSEN
+          reset:
+            register: AHB1RSTR
+            field: USB_OTG_HSRST
       block: otghs_v1/OTG_HS
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
+      - pin: PH4
+        signal: ULPI_NXT
+        af: 10
+      - pin: PI11
+        signal: ULPI_DIR
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F439IG.yaml
+++ b/data/chips/STM32F439IG.yaml
@@ -3155,12 +3155,102 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
       block: otgfs_v1/OTG_FS
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
       address: 0x40040000
+      rcc:
+        clock: AHB1
+        registers:
+          enable:
+            register: AHB1ENR
+            field: USB_OTG_HSEN
+          reset:
+            register: AHB1RSTR
+            field: USB_OTG_HSRST
       block: otghs_v1/OTG_HS
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
+      - pin: PH4
+        signal: ULPI_NXT
+        af: 10
+      - pin: PI11
+        signal: ULPI_DIR
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F439II.yaml
+++ b/data/chips/STM32F439II.yaml
@@ -3155,12 +3155,102 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
       block: otgfs_v1/OTG_FS
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
       address: 0x40040000
+      rcc:
+        clock: AHB1
+        registers:
+          enable:
+            register: AHB1ENR
+            field: USB_OTG_HSEN
+          reset:
+            register: AHB1RSTR
+            field: USB_OTG_HSRST
       block: otghs_v1/OTG_HS
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
+      - pin: PH4
+        signal: ULPI_NXT
+        af: 10
+      - pin: PI11
+        signal: ULPI_DIR
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F439NG.yaml
+++ b/data/chips/STM32F439NG.yaml
@@ -3233,12 +3233,102 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
       block: otgfs_v1/OTG_FS
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
       address: 0x40040000
+      rcc:
+        clock: AHB1
+        registers:
+          enable:
+            register: AHB1ENR
+            field: USB_OTG_HSEN
+          reset:
+            register: AHB1RSTR
+            field: USB_OTG_HSRST
       block: otghs_v1/OTG_HS
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
+      - pin: PH4
+        signal: ULPI_NXT
+        af: 10
+      - pin: PI11
+        signal: ULPI_DIR
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F439NI.yaml
+++ b/data/chips/STM32F439NI.yaml
@@ -3233,12 +3233,102 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
       block: otgfs_v1/OTG_FS
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
       address: 0x40040000
+      rcc:
+        clock: AHB1
+        registers:
+          enable:
+            register: AHB1ENR
+            field: USB_OTG_HSEN
+          reset:
+            register: AHB1RSTR
+            field: USB_OTG_HSRST
       block: otghs_v1/OTG_HS
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
+      - pin: PH4
+        signal: ULPI_NXT
+        af: 10
+      - pin: PI11
+        signal: ULPI_DIR
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F439VG.yaml
+++ b/data/chips/STM32F439VG.yaml
@@ -2531,12 +2531,96 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
       block: otgfs_v1/OTG_FS
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
       address: 0x40040000
+      rcc:
+        clock: AHB1
+        registers:
+          enable:
+            register: AHB1ENR
+            field: USB_OTG_HSEN
+          reset:
+            register: AHB1RSTR
+            field: USB_OTG_HSRST
       block: otghs_v1/OTG_HS
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F439VI.yaml
+++ b/data/chips/STM32F439VI.yaml
@@ -2531,12 +2531,96 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
       block: otgfs_v1/OTG_FS
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
       address: 0x40040000
+      rcc:
+        clock: AHB1
+        registers:
+          enable:
+            register: AHB1ENR
+            field: USB_OTG_HSEN
+          reset:
+            register: AHB1RSTR
+            field: USB_OTG_HSRST
       block: otghs_v1/OTG_HS
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F439ZG.yaml
+++ b/data/chips/STM32F439ZG.yaml
@@ -2867,12 +2867,96 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
       block: otgfs_v1/OTG_FS
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
       address: 0x40040000
+      rcc:
+        clock: AHB1
+        registers:
+          enable:
+            register: AHB1ENR
+            field: USB_OTG_HSEN
+          reset:
+            register: AHB1RSTR
+            field: USB_OTG_HSRST
       block: otghs_v1/OTG_HS
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F439ZI.yaml
+++ b/data/chips/STM32F439ZI.yaml
@@ -2867,12 +2867,96 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
       block: otgfs_v1/OTG_FS
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
       address: 0x40040000
+      rcc:
+        clock: AHB1
+        registers:
+          enable:
+            register: AHB1ENR
+            field: USB_OTG_HSEN
+          reset:
+            register: AHB1RSTR
+            field: USB_OTG_HSRST
       block: otghs_v1/OTG_HS
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F446MC.yaml
+++ b/data/chips/STM32F446MC.yaml
@@ -2184,12 +2184,96 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
       block: otgfs_v1/OTG_FS
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
       address: 0x40040000
+      rcc:
+        clock: AHB1
+        registers:
+          enable:
+            register: AHB1ENR
+            field: USB_OTG_HSEN
+          reset:
+            register: AHB1RSTR
+            field: USB_OTG_HSRST
       block: otghs_v1/OTG_HS
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB2
+        signal: ULPI_D4
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F446ME.yaml
+++ b/data/chips/STM32F446ME.yaml
@@ -2184,12 +2184,96 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
       block: otgfs_v1/OTG_FS
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
       address: 0x40040000
+      rcc:
+        clock: AHB1
+        registers:
+          enable:
+            register: AHB1ENR
+            field: USB_OTG_HSEN
+          reset:
+            register: AHB1RSTR
+            field: USB_OTG_HSRST
       block: otghs_v1/OTG_HS
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB2
+        signal: ULPI_D4
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F446RC.yaml
+++ b/data/chips/STM32F446RC.yaml
@@ -2024,12 +2024,96 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
       block: otgfs_v1/OTG_FS
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
       address: 0x40040000
+      rcc:
+        clock: AHB1
+        registers:
+          enable:
+            register: AHB1ENR
+            field: USB_OTG_HSEN
+          reset:
+            register: AHB1RSTR
+            field: USB_OTG_HSRST
       block: otghs_v1/OTG_HS
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB2
+        signal: ULPI_D4
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F446RE.yaml
+++ b/data/chips/STM32F446RE.yaml
@@ -2024,12 +2024,96 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
       block: otgfs_v1/OTG_FS
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
       address: 0x40040000
+      rcc:
+        clock: AHB1
+        registers:
+          enable:
+            register: AHB1ENR
+            field: USB_OTG_HSEN
+          reset:
+            register: AHB1RSTR
+            field: USB_OTG_HSRST
       block: otghs_v1/OTG_HS
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB2
+        signal: ULPI_D4
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F446VC.yaml
+++ b/data/chips/STM32F446VC.yaml
@@ -2508,12 +2508,96 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
       block: otgfs_v1/OTG_FS
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
       address: 0x40040000
+      rcc:
+        clock: AHB1
+        registers:
+          enable:
+            register: AHB1ENR
+            field: USB_OTG_HSEN
+          reset:
+            register: AHB1RSTR
+            field: USB_OTG_HSRST
       block: otghs_v1/OTG_HS
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB2
+        signal: ULPI_D4
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F446VE.yaml
+++ b/data/chips/STM32F446VE.yaml
@@ -2508,12 +2508,96 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
       block: otgfs_v1/OTG_FS
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
       address: 0x40040000
+      rcc:
+        clock: AHB1
+        registers:
+          enable:
+            register: AHB1ENR
+            field: USB_OTG_HSEN
+          reset:
+            register: AHB1RSTR
+            field: USB_OTG_HSRST
       block: otghs_v1/OTG_HS
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB2
+        signal: ULPI_D4
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F446ZC.yaml
+++ b/data/chips/STM32F446ZC.yaml
@@ -2769,12 +2769,96 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
       block: otgfs_v1/OTG_FS
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
       address: 0x40040000
+      rcc:
+        clock: AHB1
+        registers:
+          enable:
+            register: AHB1ENR
+            field: USB_OTG_HSEN
+          reset:
+            register: AHB1RSTR
+            field: USB_OTG_HSRST
       block: otghs_v1/OTG_HS
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB2
+        signal: ULPI_D4
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F446ZE.yaml
+++ b/data/chips/STM32F446ZE.yaml
@@ -2769,12 +2769,96 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
       block: otgfs_v1/OTG_FS
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
       address: 0x40040000
+      rcc:
+        clock: AHB1
+        registers:
+          enable:
+            register: AHB1ENR
+            field: USB_OTG_HSEN
+          reset:
+            register: AHB1RSTR
+            field: USB_OTG_HSRST
       block: otghs_v1/OTG_HS
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB2
+        signal: ULPI_D4
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F469AE.yaml
+++ b/data/chips/STM32F469AE.yaml
@@ -2955,10 +2955,94 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
       address: 0x40040000
+      rcc:
+        clock: AHB1
+        registers:
+          enable:
+            register: AHB1ENR
+            field: USB_OTG_HSEN
+          reset:
+            register: AHB1RSTR
+            field: USB_OTG_HSRST
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PH4
+        signal: ULPI_NXT
+        af: 10
+      - pin: PI11
+        signal: ULPI_DIR
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F469AG.yaml
+++ b/data/chips/STM32F469AG.yaml
@@ -2955,10 +2955,94 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
       address: 0x40040000
+      rcc:
+        clock: AHB1
+        registers:
+          enable:
+            register: AHB1ENR
+            field: USB_OTG_HSEN
+          reset:
+            register: AHB1RSTR
+            field: USB_OTG_HSRST
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PH4
+        signal: ULPI_NXT
+        af: 10
+      - pin: PI11
+        signal: ULPI_DIR
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F469AI.yaml
+++ b/data/chips/STM32F469AI.yaml
@@ -2955,10 +2955,94 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
       address: 0x40040000
+      rcc:
+        clock: AHB1
+        registers:
+          enable:
+            register: AHB1ENR
+            field: USB_OTG_HSEN
+          reset:
+            register: AHB1RSTR
+            field: USB_OTG_HSRST
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PH4
+        signal: ULPI_NXT
+        af: 10
+      - pin: PI11
+        signal: ULPI_DIR
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F469BE.yaml
+++ b/data/chips/STM32F469BE.yaml
@@ -3294,10 +3294,100 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
       address: 0x40040000
+      rcc:
+        clock: AHB1
+        registers:
+          enable:
+            register: AHB1ENR
+            field: USB_OTG_HSEN
+          reset:
+            register: AHB1RSTR
+            field: USB_OTG_HSRST
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
+      - pin: PH4
+        signal: ULPI_NXT
+        af: 10
+      - pin: PI11
+        signal: ULPI_DIR
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F469BG.yaml
+++ b/data/chips/STM32F469BG.yaml
@@ -3294,10 +3294,100 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
       address: 0x40040000
+      rcc:
+        clock: AHB1
+        registers:
+          enable:
+            register: AHB1ENR
+            field: USB_OTG_HSEN
+          reset:
+            register: AHB1RSTR
+            field: USB_OTG_HSRST
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
+      - pin: PH4
+        signal: ULPI_NXT
+        af: 10
+      - pin: PI11
+        signal: ULPI_DIR
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F469BI.yaml
+++ b/data/chips/STM32F469BI.yaml
@@ -3294,10 +3294,100 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
       address: 0x40040000
+      rcc:
+        clock: AHB1
+        registers:
+          enable:
+            register: AHB1ENR
+            field: USB_OTG_HSEN
+          reset:
+            register: AHB1RSTR
+            field: USB_OTG_HSRST
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
+      - pin: PH4
+        signal: ULPI_NXT
+        af: 10
+      - pin: PI11
+        signal: ULPI_DIR
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F469IE.yaml
+++ b/data/chips/STM32F469IE.yaml
@@ -3113,10 +3113,100 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
       address: 0x40040000
+      rcc:
+        clock: AHB1
+        registers:
+          enable:
+            register: AHB1ENR
+            field: USB_OTG_HSEN
+          reset:
+            register: AHB1RSTR
+            field: USB_OTG_HSRST
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
+      - pin: PH4
+        signal: ULPI_NXT
+        af: 10
+      - pin: PI11
+        signal: ULPI_DIR
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F469IG.yaml
+++ b/data/chips/STM32F469IG.yaml
@@ -3113,10 +3113,100 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
       address: 0x40040000
+      rcc:
+        clock: AHB1
+        registers:
+          enable:
+            register: AHB1ENR
+            field: USB_OTG_HSEN
+          reset:
+            register: AHB1RSTR
+            field: USB_OTG_HSRST
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
+      - pin: PH4
+        signal: ULPI_NXT
+        af: 10
+      - pin: PI11
+        signal: ULPI_DIR
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F469II.yaml
+++ b/data/chips/STM32F469II.yaml
@@ -3113,10 +3113,100 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
       address: 0x40040000
+      rcc:
+        clock: AHB1
+        registers:
+          enable:
+            register: AHB1ENR
+            field: USB_OTG_HSEN
+          reset:
+            register: AHB1RSTR
+            field: USB_OTG_HSRST
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
+      - pin: PH4
+        signal: ULPI_NXT
+        af: 10
+      - pin: PI11
+        signal: ULPI_DIR
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F469NE.yaml
+++ b/data/chips/STM32F469NE.yaml
@@ -3294,10 +3294,100 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
       address: 0x40040000
+      rcc:
+        clock: AHB1
+        registers:
+          enable:
+            register: AHB1ENR
+            field: USB_OTG_HSEN
+          reset:
+            register: AHB1RSTR
+            field: USB_OTG_HSRST
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
+      - pin: PH4
+        signal: ULPI_NXT
+        af: 10
+      - pin: PI11
+        signal: ULPI_DIR
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F469NG.yaml
+++ b/data/chips/STM32F469NG.yaml
@@ -3294,10 +3294,100 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
       address: 0x40040000
+      rcc:
+        clock: AHB1
+        registers:
+          enable:
+            register: AHB1ENR
+            field: USB_OTG_HSEN
+          reset:
+            register: AHB1RSTR
+            field: USB_OTG_HSRST
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
+      - pin: PH4
+        signal: ULPI_NXT
+        af: 10
+      - pin: PI11
+        signal: ULPI_DIR
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F469NI.yaml
+++ b/data/chips/STM32F469NI.yaml
@@ -3294,10 +3294,100 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
       address: 0x40040000
+      rcc:
+        clock: AHB1
+        registers:
+          enable:
+            register: AHB1ENR
+            field: USB_OTG_HSEN
+          reset:
+            register: AHB1RSTR
+            field: USB_OTG_HSRST
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
+      - pin: PH4
+        signal: ULPI_NXT
+        af: 10
+      - pin: PI11
+        signal: ULPI_DIR
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F469VE.yaml
+++ b/data/chips/STM32F469VE.yaml
@@ -2377,10 +2377,94 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
       address: 0x40040000
+      rcc:
+        clock: AHB1
+        registers:
+          enable:
+            register: AHB1ENR
+            field: USB_OTG_HSEN
+          reset:
+            register: AHB1RSTR
+            field: USB_OTG_HSRST
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F469VG.yaml
+++ b/data/chips/STM32F469VG.yaml
@@ -2377,10 +2377,94 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
       address: 0x40040000
+      rcc:
+        clock: AHB1
+        registers:
+          enable:
+            register: AHB1ENR
+            field: USB_OTG_HSEN
+          reset:
+            register: AHB1RSTR
+            field: USB_OTG_HSRST
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F469VI.yaml
+++ b/data/chips/STM32F469VI.yaml
@@ -2377,10 +2377,94 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
       address: 0x40040000
+      rcc:
+        clock: AHB1
+        registers:
+          enable:
+            register: AHB1ENR
+            field: USB_OTG_HSEN
+          reset:
+            register: AHB1RSTR
+            field: USB_OTG_HSRST
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F469ZE.yaml
+++ b/data/chips/STM32F469ZE.yaml
@@ -2681,10 +2681,94 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
       address: 0x40040000
+      rcc:
+        clock: AHB1
+        registers:
+          enable:
+            register: AHB1ENR
+            field: USB_OTG_HSEN
+          reset:
+            register: AHB1RSTR
+            field: USB_OTG_HSRST
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F469ZG.yaml
+++ b/data/chips/STM32F469ZG.yaml
@@ -2681,10 +2681,94 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
       address: 0x40040000
+      rcc:
+        clock: AHB1
+        registers:
+          enable:
+            register: AHB1ENR
+            field: USB_OTG_HSEN
+          reset:
+            register: AHB1RSTR
+            field: USB_OTG_HSRST
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F469ZI.yaml
+++ b/data/chips/STM32F469ZI.yaml
@@ -2681,10 +2681,94 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
       address: 0x40040000
+      rcc:
+        clock: AHB1
+        registers:
+          enable:
+            register: AHB1ENR
+            field: USB_OTG_HSEN
+          reset:
+            register: AHB1RSTR
+            field: USB_OTG_HSRST
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F479AG.yaml
+++ b/data/chips/STM32F479AG.yaml
@@ -2986,10 +2986,94 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
       address: 0x40040000
+      rcc:
+        clock: AHB1
+        registers:
+          enable:
+            register: AHB1ENR
+            field: USB_OTG_HSEN
+          reset:
+            register: AHB1RSTR
+            field: USB_OTG_HSRST
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PH4
+        signal: ULPI_NXT
+        af: 10
+      - pin: PI11
+        signal: ULPI_DIR
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F479AI.yaml
+++ b/data/chips/STM32F479AI.yaml
@@ -2986,10 +2986,94 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
       address: 0x40040000
+      rcc:
+        clock: AHB1
+        registers:
+          enable:
+            register: AHB1ENR
+            field: USB_OTG_HSEN
+          reset:
+            register: AHB1RSTR
+            field: USB_OTG_HSRST
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PH4
+        signal: ULPI_NXT
+        af: 10
+      - pin: PI11
+        signal: ULPI_DIR
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F479BG.yaml
+++ b/data/chips/STM32F479BG.yaml
@@ -3325,10 +3325,100 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
       address: 0x40040000
+      rcc:
+        clock: AHB1
+        registers:
+          enable:
+            register: AHB1ENR
+            field: USB_OTG_HSEN
+          reset:
+            register: AHB1RSTR
+            field: USB_OTG_HSRST
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
+      - pin: PH4
+        signal: ULPI_NXT
+        af: 10
+      - pin: PI11
+        signal: ULPI_DIR
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F479BI.yaml
+++ b/data/chips/STM32F479BI.yaml
@@ -3325,10 +3325,100 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
       address: 0x40040000
+      rcc:
+        clock: AHB1
+        registers:
+          enable:
+            register: AHB1ENR
+            field: USB_OTG_HSEN
+          reset:
+            register: AHB1RSTR
+            field: USB_OTG_HSRST
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
+      - pin: PH4
+        signal: ULPI_NXT
+        af: 10
+      - pin: PI11
+        signal: ULPI_DIR
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F479IG.yaml
+++ b/data/chips/STM32F479IG.yaml
@@ -3144,10 +3144,100 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
       address: 0x40040000
+      rcc:
+        clock: AHB1
+        registers:
+          enable:
+            register: AHB1ENR
+            field: USB_OTG_HSEN
+          reset:
+            register: AHB1RSTR
+            field: USB_OTG_HSRST
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
+      - pin: PH4
+        signal: ULPI_NXT
+        af: 10
+      - pin: PI11
+        signal: ULPI_DIR
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F479II.yaml
+++ b/data/chips/STM32F479II.yaml
@@ -3144,10 +3144,100 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
       address: 0x40040000
+      rcc:
+        clock: AHB1
+        registers:
+          enable:
+            register: AHB1ENR
+            field: USB_OTG_HSEN
+          reset:
+            register: AHB1RSTR
+            field: USB_OTG_HSRST
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
+      - pin: PH4
+        signal: ULPI_NXT
+        af: 10
+      - pin: PI11
+        signal: ULPI_DIR
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F479NG.yaml
+++ b/data/chips/STM32F479NG.yaml
@@ -3325,10 +3325,100 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
       address: 0x40040000
+      rcc:
+        clock: AHB1
+        registers:
+          enable:
+            register: AHB1ENR
+            field: USB_OTG_HSEN
+          reset:
+            register: AHB1RSTR
+            field: USB_OTG_HSRST
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
+      - pin: PH4
+        signal: ULPI_NXT
+        af: 10
+      - pin: PI11
+        signal: ULPI_DIR
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F479NI.yaml
+++ b/data/chips/STM32F479NI.yaml
@@ -3325,10 +3325,100 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
       address: 0x40040000
+      rcc:
+        clock: AHB1
+        registers:
+          enable:
+            register: AHB1ENR
+            field: USB_OTG_HSEN
+          reset:
+            register: AHB1RSTR
+            field: USB_OTG_HSRST
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
+      - pin: PH4
+        signal: ULPI_NXT
+        af: 10
+      - pin: PI11
+        signal: ULPI_DIR
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F479VG.yaml
+++ b/data/chips/STM32F479VG.yaml
@@ -2408,10 +2408,94 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
       address: 0x40040000
+      rcc:
+        clock: AHB1
+        registers:
+          enable:
+            register: AHB1ENR
+            field: USB_OTG_HSEN
+          reset:
+            register: AHB1RSTR
+            field: USB_OTG_HSRST
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F479VI.yaml
+++ b/data/chips/STM32F479VI.yaml
@@ -2408,10 +2408,94 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
       address: 0x40040000
+      rcc:
+        clock: AHB1
+        registers:
+          enable:
+            register: AHB1ENR
+            field: USB_OTG_HSEN
+          reset:
+            register: AHB1RSTR
+            field: USB_OTG_HSRST
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F479ZG.yaml
+++ b/data/chips/STM32F479ZG.yaml
@@ -2712,10 +2712,94 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
       address: 0x40040000
+      rcc:
+        clock: AHB1
+        registers:
+          enable:
+            register: AHB1ENR
+            field: USB_OTG_HSEN
+          reset:
+            register: AHB1RSTR
+            field: USB_OTG_HSRST
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F479ZI.yaml
+++ b/data/chips/STM32F479ZI.yaml
@@ -2712,10 +2712,94 @@ cores:
           request: 5
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
       address: 0x40040000
+      rcc:
+        clock: AHB1
+        registers:
+          enable:
+            register: AHB1ENR
+            field: USB_OTG_HSEN
+          reset:
+            register: AHB1RSTR
+            field: USB_OTG_HSRST
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F722IC.yaml
+++ b/data/chips/STM32F722IC.yaml
@@ -2972,6 +2972,21 @@ cores:
           reset:
             register: AHB2RSTR
             field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
@@ -2985,6 +3000,63 @@ cores:
           reset:
             register: AHB1RSTR
             field: USB_OTG_HSRST
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
+      - pin: PH4
+        signal: ULPI_NXT
+        af: 10
+      - pin: PI11
+        signal: ULPI_DIR
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F722IE.yaml
+++ b/data/chips/STM32F722IE.yaml
@@ -2972,6 +2972,21 @@ cores:
           reset:
             register: AHB2RSTR
             field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
@@ -2985,6 +3000,63 @@ cores:
           reset:
             register: AHB1RSTR
             field: USB_OTG_HSRST
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
+      - pin: PH4
+        signal: ULPI_NXT
+        af: 10
+      - pin: PI11
+        signal: ULPI_DIR
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F722RC.yaml
+++ b/data/chips/STM32F722RC.yaml
@@ -1926,6 +1926,21 @@ cores:
           reset:
             register: AHB2RSTR
             field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
@@ -1939,6 +1954,57 @@ cores:
           reset:
             register: AHB1RSTR
             field: USB_OTG_HSRST
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F722RE.yaml
+++ b/data/chips/STM32F722RE.yaml
@@ -1926,6 +1926,21 @@ cores:
           reset:
             register: AHB2RSTR
             field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
@@ -1939,6 +1954,57 @@ cores:
           reset:
             register: AHB1RSTR
             field: USB_OTG_HSRST
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F722VC.yaml
+++ b/data/chips/STM32F722VC.yaml
@@ -2498,6 +2498,21 @@ cores:
           reset:
             register: AHB2RSTR
             field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
@@ -2511,6 +2526,57 @@ cores:
           reset:
             register: AHB1RSTR
             field: USB_OTG_HSRST
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F722VE.yaml
+++ b/data/chips/STM32F722VE.yaml
@@ -2498,6 +2498,21 @@ cores:
           reset:
             register: AHB2RSTR
             field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
@@ -2511,6 +2526,57 @@ cores:
           reset:
             register: AHB1RSTR
             field: USB_OTG_HSRST
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F722ZC.yaml
+++ b/data/chips/STM32F722ZC.yaml
@@ -2765,6 +2765,21 @@ cores:
           reset:
             register: AHB2RSTR
             field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
@@ -2778,6 +2793,57 @@ cores:
           reset:
             register: AHB1RSTR
             field: USB_OTG_HSRST
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F722ZE.yaml
+++ b/data/chips/STM32F722ZE.yaml
@@ -2765,6 +2765,21 @@ cores:
           reset:
             register: AHB2RSTR
             field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
@@ -2778,6 +2793,57 @@ cores:
           reset:
             register: AHB1RSTR
             field: USB_OTG_HSRST
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F723IC.yaml
+++ b/data/chips/STM32F723IC.yaml
@@ -2927,6 +2927,21 @@ cores:
           reset:
             register: AHB2RSTR
             field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
@@ -2940,6 +2955,21 @@ cores:
           reset:
             register: AHB1RSTR
             field: USB_OTG_HSRST
+      pins:
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F723IE.yaml
+++ b/data/chips/STM32F723IE.yaml
@@ -2927,6 +2927,21 @@ cores:
           reset:
             register: AHB2RSTR
             field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
@@ -2940,6 +2955,21 @@ cores:
           reset:
             register: AHB1RSTR
             field: USB_OTG_HSRST
+      pins:
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F723VC.yaml
+++ b/data/chips/STM32F723VC.yaml
@@ -2361,6 +2361,21 @@ cores:
           reset:
             register: AHB2RSTR
             field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
@@ -2374,6 +2389,21 @@ cores:
           reset:
             register: AHB1RSTR
             field: USB_OTG_HSRST
+      pins:
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F723VE.yaml
+++ b/data/chips/STM32F723VE.yaml
@@ -2361,6 +2361,21 @@ cores:
           reset:
             register: AHB2RSTR
             field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
@@ -2374,6 +2389,21 @@ cores:
           reset:
             register: AHB1RSTR
             field: USB_OTG_HSRST
+      pins:
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F723ZC.yaml
+++ b/data/chips/STM32F723ZC.yaml
@@ -2704,6 +2704,21 @@ cores:
           reset:
             register: AHB2RSTR
             field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
@@ -2717,6 +2732,21 @@ cores:
           reset:
             register: AHB1RSTR
             field: USB_OTG_HSRST
+      pins:
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F723ZE.yaml
+++ b/data/chips/STM32F723ZE.yaml
@@ -2704,6 +2704,21 @@ cores:
           reset:
             register: AHB2RSTR
             field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
@@ -2717,6 +2732,21 @@ cores:
           reset:
             register: AHB1RSTR
             field: USB_OTG_HSRST
+      pins:
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F730I8.yaml
+++ b/data/chips/STM32F730I8.yaml
@@ -2937,6 +2937,21 @@ cores:
           reset:
             register: AHB2RSTR
             field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
@@ -2950,6 +2965,21 @@ cores:
           reset:
             register: AHB1RSTR
             field: USB_OTG_HSRST
+      pins:
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F730R8.yaml
+++ b/data/chips/STM32F730R8.yaml
@@ -1938,6 +1938,21 @@ cores:
           reset:
             register: AHB2RSTR
             field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
@@ -1951,6 +1966,57 @@ cores:
           reset:
             register: AHB1RSTR
             field: USB_OTG_HSRST
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F730V8.yaml
+++ b/data/chips/STM32F730V8.yaml
@@ -2510,6 +2510,21 @@ cores:
           reset:
             register: AHB2RSTR
             field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
@@ -2523,6 +2538,57 @@ cores:
           reset:
             register: AHB1RSTR
             field: USB_OTG_HSRST
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F730Z8.yaml
+++ b/data/chips/STM32F730Z8.yaml
@@ -2714,6 +2714,21 @@ cores:
           reset:
             register: AHB2RSTR
             field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
@@ -2727,6 +2742,21 @@ cores:
           reset:
             register: AHB1RSTR
             field: USB_OTG_HSRST
+      pins:
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F732IE.yaml
+++ b/data/chips/STM32F732IE.yaml
@@ -2992,6 +2992,21 @@ cores:
           reset:
             register: AHB2RSTR
             field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
@@ -3005,6 +3020,63 @@ cores:
           reset:
             register: AHB1RSTR
             field: USB_OTG_HSRST
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
+      - pin: PH4
+        signal: ULPI_NXT
+        af: 10
+      - pin: PI11
+        signal: ULPI_DIR
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F732RE.yaml
+++ b/data/chips/STM32F732RE.yaml
@@ -1946,6 +1946,21 @@ cores:
           reset:
             register: AHB2RSTR
             field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
@@ -1959,6 +1974,57 @@ cores:
           reset:
             register: AHB1RSTR
             field: USB_OTG_HSRST
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F732VE.yaml
+++ b/data/chips/STM32F732VE.yaml
@@ -2518,6 +2518,21 @@ cores:
           reset:
             register: AHB2RSTR
             field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
@@ -2531,6 +2546,57 @@ cores:
           reset:
             register: AHB1RSTR
             field: USB_OTG_HSRST
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F732ZE.yaml
+++ b/data/chips/STM32F732ZE.yaml
@@ -2785,6 +2785,21 @@ cores:
           reset:
             register: AHB2RSTR
             field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
@@ -2798,6 +2813,57 @@ cores:
           reset:
             register: AHB1RSTR
             field: USB_OTG_HSRST
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F733IE.yaml
+++ b/data/chips/STM32F733IE.yaml
@@ -2947,6 +2947,21 @@ cores:
           reset:
             register: AHB2RSTR
             field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
@@ -2960,6 +2975,21 @@ cores:
           reset:
             register: AHB1RSTR
             field: USB_OTG_HSRST
+      pins:
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F733VE.yaml
+++ b/data/chips/STM32F733VE.yaml
@@ -2381,6 +2381,21 @@ cores:
           reset:
             register: AHB2RSTR
             field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
@@ -2394,6 +2409,21 @@ cores:
           reset:
             register: AHB1RSTR
             field: USB_OTG_HSRST
+      pins:
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F733ZE.yaml
+++ b/data/chips/STM32F733ZE.yaml
@@ -2724,6 +2724,21 @@ cores:
           reset:
             register: AHB2RSTR
             field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
@@ -2737,6 +2752,21 @@ cores:
           reset:
             register: AHB1RSTR
             field: USB_OTG_HSRST
+      pins:
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F745IE.yaml
+++ b/data/chips/STM32F745IE.yaml
@@ -3391,6 +3391,21 @@ cores:
           reset:
             register: AHB2RSTR
             field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
@@ -3404,6 +3419,63 @@ cores:
           reset:
             register: AHB1RSTR
             field: USB_OTG_HSRST
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
+      - pin: PH4
+        signal: ULPI_NXT
+        af: 10
+      - pin: PI11
+        signal: ULPI_DIR
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F745IG.yaml
+++ b/data/chips/STM32F745IG.yaml
@@ -3391,6 +3391,21 @@ cores:
           reset:
             register: AHB2RSTR
             field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
@@ -3404,6 +3419,63 @@ cores:
           reset:
             register: AHB1RSTR
             field: USB_OTG_HSRST
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
+      - pin: PH4
+        signal: ULPI_NXT
+        af: 10
+      - pin: PI11
+        signal: ULPI_DIR
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F745VE.yaml
+++ b/data/chips/STM32F745VE.yaml
@@ -2778,6 +2778,21 @@ cores:
           reset:
             register: AHB2RSTR
             field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
@@ -2791,6 +2806,57 @@ cores:
           reset:
             register: AHB1RSTR
             field: USB_OTG_HSRST
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F745VG.yaml
+++ b/data/chips/STM32F745VG.yaml
@@ -2778,6 +2778,21 @@ cores:
           reset:
             register: AHB2RSTR
             field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
@@ -2791,6 +2806,57 @@ cores:
           reset:
             register: AHB1RSTR
             field: USB_OTG_HSRST
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F745ZE.yaml
+++ b/data/chips/STM32F745ZE.yaml
@@ -3121,6 +3121,21 @@ cores:
           reset:
             register: AHB2RSTR
             field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
@@ -3134,6 +3149,57 @@ cores:
           reset:
             register: AHB1RSTR
             field: USB_OTG_HSRST
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F745ZG.yaml
+++ b/data/chips/STM32F745ZG.yaml
@@ -3121,6 +3121,21 @@ cores:
           reset:
             register: AHB2RSTR
             field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
@@ -3134,6 +3149,57 @@ cores:
           reset:
             register: AHB1RSTR
             field: USB_OTG_HSRST
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F746BE.yaml
+++ b/data/chips/STM32F746BE.yaml
@@ -3668,6 +3668,21 @@ cores:
           reset:
             register: AHB2RSTR
             field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
@@ -3681,6 +3696,63 @@ cores:
           reset:
             register: AHB1RSTR
             field: USB_OTG_HSRST
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
+      - pin: PH4
+        signal: ULPI_NXT
+        af: 10
+      - pin: PI11
+        signal: ULPI_DIR
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F746BG.yaml
+++ b/data/chips/STM32F746BG.yaml
@@ -3668,6 +3668,21 @@ cores:
           reset:
             register: AHB2RSTR
             field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
@@ -3681,6 +3696,63 @@ cores:
           reset:
             register: AHB1RSTR
             field: USB_OTG_HSRST
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
+      - pin: PH4
+        signal: ULPI_NXT
+        af: 10
+      - pin: PI11
+        signal: ULPI_DIR
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F746IE.yaml
+++ b/data/chips/STM32F746IE.yaml
@@ -3586,6 +3586,21 @@ cores:
           reset:
             register: AHB2RSTR
             field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
@@ -3599,6 +3614,63 @@ cores:
           reset:
             register: AHB1RSTR
             field: USB_OTG_HSRST
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
+      - pin: PH4
+        signal: ULPI_NXT
+        af: 10
+      - pin: PI11
+        signal: ULPI_DIR
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F746IG.yaml
+++ b/data/chips/STM32F746IG.yaml
@@ -3586,6 +3586,21 @@ cores:
           reset:
             register: AHB2RSTR
             field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
@@ -3599,6 +3614,63 @@ cores:
           reset:
             register: AHB1RSTR
             field: USB_OTG_HSRST
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
+      - pin: PH4
+        signal: ULPI_NXT
+        af: 10
+      - pin: PI11
+        signal: ULPI_DIR
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F746NE.yaml
+++ b/data/chips/STM32F746NE.yaml
@@ -3668,6 +3668,21 @@ cores:
           reset:
             register: AHB2RSTR
             field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
@@ -3681,6 +3696,63 @@ cores:
           reset:
             register: AHB1RSTR
             field: USB_OTG_HSRST
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
+      - pin: PH4
+        signal: ULPI_NXT
+        af: 10
+      - pin: PI11
+        signal: ULPI_DIR
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F746NG.yaml
+++ b/data/chips/STM32F746NG.yaml
@@ -3668,6 +3668,21 @@ cores:
           reset:
             register: AHB2RSTR
             field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
@@ -3681,6 +3696,63 @@ cores:
           reset:
             register: AHB1RSTR
             field: USB_OTG_HSRST
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
+      - pin: PH4
+        signal: ULPI_NXT
+        af: 10
+      - pin: PI11
+        signal: ULPI_DIR
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F746VE.yaml
+++ b/data/chips/STM32F746VE.yaml
@@ -2886,6 +2886,21 @@ cores:
           reset:
             register: AHB2RSTR
             field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
@@ -2899,6 +2914,57 @@ cores:
           reset:
             register: AHB1RSTR
             field: USB_OTG_HSRST
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F746VG.yaml
+++ b/data/chips/STM32F746VG.yaml
@@ -2886,6 +2886,21 @@ cores:
           reset:
             register: AHB2RSTR
             field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
@@ -2899,6 +2914,57 @@ cores:
           reset:
             register: AHB1RSTR
             field: USB_OTG_HSRST
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F746ZE.yaml
+++ b/data/chips/STM32F746ZE.yaml
@@ -3261,6 +3261,21 @@ cores:
           reset:
             register: AHB2RSTR
             field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
@@ -3274,6 +3289,57 @@ cores:
           reset:
             register: AHB1RSTR
             field: USB_OTG_HSRST
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F746ZG.yaml
+++ b/data/chips/STM32F746ZG.yaml
@@ -3261,6 +3261,21 @@ cores:
           reset:
             register: AHB2RSTR
             field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
@@ -3274,6 +3289,57 @@ cores:
           reset:
             register: AHB1RSTR
             field: USB_OTG_HSRST
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F750N8.yaml
+++ b/data/chips/STM32F750N8.yaml
@@ -3686,6 +3686,21 @@ cores:
           reset:
             register: AHB2RSTR
             field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
@@ -3699,6 +3714,63 @@ cores:
           reset:
             register: AHB1RSTR
             field: USB_OTG_HSRST
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
+      - pin: PH4
+        signal: ULPI_NXT
+        af: 10
+      - pin: PI11
+        signal: ULPI_DIR
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F750V8.yaml
+++ b/data/chips/STM32F750V8.yaml
@@ -2902,6 +2902,21 @@ cores:
           reset:
             register: AHB2RSTR
             field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
@@ -2915,6 +2930,57 @@ cores:
           reset:
             register: AHB1RSTR
             field: USB_OTG_HSRST
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F750Z8.yaml
+++ b/data/chips/STM32F750Z8.yaml
@@ -3277,6 +3277,21 @@ cores:
           reset:
             register: AHB2RSTR
             field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
@@ -3290,6 +3305,57 @@ cores:
           reset:
             register: AHB1RSTR
             field: USB_OTG_HSRST
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F756BG.yaml
+++ b/data/chips/STM32F756BG.yaml
@@ -3702,6 +3702,21 @@ cores:
           reset:
             register: AHB2RSTR
             field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
@@ -3715,6 +3730,63 @@ cores:
           reset:
             register: AHB1RSTR
             field: USB_OTG_HSRST
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
+      - pin: PH4
+        signal: ULPI_NXT
+        af: 10
+      - pin: PI11
+        signal: ULPI_DIR
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F756IG.yaml
+++ b/data/chips/STM32F756IG.yaml
@@ -3620,6 +3620,21 @@ cores:
           reset:
             register: AHB2RSTR
             field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
@@ -3633,6 +3648,63 @@ cores:
           reset:
             register: AHB1RSTR
             field: USB_OTG_HSRST
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
+      - pin: PH4
+        signal: ULPI_NXT
+        af: 10
+      - pin: PI11
+        signal: ULPI_DIR
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F756NG.yaml
+++ b/data/chips/STM32F756NG.yaml
@@ -3702,6 +3702,21 @@ cores:
           reset:
             register: AHB2RSTR
             field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
@@ -3715,6 +3730,63 @@ cores:
           reset:
             register: AHB1RSTR
             field: USB_OTG_HSRST
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
+      - pin: PH4
+        signal: ULPI_NXT
+        af: 10
+      - pin: PI11
+        signal: ULPI_DIR
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F756VG.yaml
+++ b/data/chips/STM32F756VG.yaml
@@ -2920,6 +2920,21 @@ cores:
           reset:
             register: AHB2RSTR
             field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
@@ -2933,6 +2948,57 @@ cores:
           reset:
             register: AHB1RSTR
             field: USB_OTG_HSRST
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F756ZG.yaml
+++ b/data/chips/STM32F756ZG.yaml
@@ -3295,6 +3295,21 @@ cores:
           reset:
             register: AHB2RSTR
             field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
@@ -3308,6 +3323,57 @@ cores:
           reset:
             register: AHB1RSTR
             field: USB_OTG_HSRST
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F765BG.yaml
+++ b/data/chips/STM32F765BG.yaml
@@ -3853,6 +3853,21 @@ cores:
             register: AHB2RSTR
             field: USB_OTG_FSRST
       block: otgfs_v1/OTG_FS
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
@@ -3867,6 +3882,63 @@ cores:
             register: AHB1RSTR
             field: USB_OTG_HSRST
       block: otghs_v1/OTG_HS
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
+      - pin: PH4
+        signal: ULPI_NXT
+        af: 10
+      - pin: PI11
+        signal: ULPI_DIR
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F765BI.yaml
+++ b/data/chips/STM32F765BI.yaml
@@ -3857,6 +3857,21 @@ cores:
             register: AHB2RSTR
             field: USB_OTG_FSRST
       block: otgfs_v1/OTG_FS
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
@@ -3871,6 +3886,63 @@ cores:
             register: AHB1RSTR
             field: USB_OTG_HSRST
       block: otghs_v1/OTG_HS
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
+      - pin: PH4
+        signal: ULPI_NXT
+        af: 10
+      - pin: PI11
+        signal: ULPI_DIR
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F765IG.yaml
+++ b/data/chips/STM32F765IG.yaml
@@ -3859,6 +3859,21 @@ cores:
             register: AHB2RSTR
             field: USB_OTG_FSRST
       block: otgfs_v1/OTG_FS
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
@@ -3873,6 +3888,63 @@ cores:
             register: AHB1RSTR
             field: USB_OTG_HSRST
       block: otghs_v1/OTG_HS
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
+      - pin: PH4
+        signal: ULPI_NXT
+        af: 10
+      - pin: PI11
+        signal: ULPI_DIR
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F765II.yaml
+++ b/data/chips/STM32F765II.yaml
@@ -3859,6 +3859,21 @@ cores:
             register: AHB2RSTR
             field: USB_OTG_FSRST
       block: otgfs_v1/OTG_FS
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
@@ -3873,6 +3888,63 @@ cores:
             register: AHB1RSTR
             field: USB_OTG_HSRST
       block: otghs_v1/OTG_HS
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
+      - pin: PH4
+        signal: ULPI_NXT
+        af: 10
+      - pin: PI11
+        signal: ULPI_DIR
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F765NG.yaml
+++ b/data/chips/STM32F765NG.yaml
@@ -3857,6 +3857,21 @@ cores:
             register: AHB2RSTR
             field: USB_OTG_FSRST
       block: otgfs_v1/OTG_FS
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
@@ -3871,6 +3886,63 @@ cores:
             register: AHB1RSTR
             field: USB_OTG_HSRST
       block: otghs_v1/OTG_HS
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
+      - pin: PH4
+        signal: ULPI_NXT
+        af: 10
+      - pin: PI11
+        signal: ULPI_DIR
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F765NI.yaml
+++ b/data/chips/STM32F765NI.yaml
@@ -3857,6 +3857,21 @@ cores:
             register: AHB2RSTR
             field: USB_OTG_FSRST
       block: otgfs_v1/OTG_FS
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
@@ -3871,6 +3886,63 @@ cores:
             register: AHB1RSTR
             field: USB_OTG_HSRST
       block: otghs_v1/OTG_HS
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
+      - pin: PH4
+        signal: ULPI_NXT
+        af: 10
+      - pin: PI11
+        signal: ULPI_DIR
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F765VG.yaml
+++ b/data/chips/STM32F765VG.yaml
@@ -3220,6 +3220,21 @@ cores:
             register: AHB2RSTR
             field: USB_OTG_FSRST
       block: otgfs_v1/OTG_FS
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
@@ -3234,6 +3249,57 @@ cores:
             register: AHB1RSTR
             field: USB_OTG_HSRST
       block: otghs_v1/OTG_HS
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F765VI.yaml
+++ b/data/chips/STM32F765VI.yaml
@@ -3220,6 +3220,21 @@ cores:
             register: AHB2RSTR
             field: USB_OTG_FSRST
       block: otgfs_v1/OTG_FS
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
@@ -3234,6 +3249,57 @@ cores:
             register: AHB1RSTR
             field: USB_OTG_HSRST
       block: otghs_v1/OTG_HS
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F765ZG.yaml
+++ b/data/chips/STM32F765ZG.yaml
@@ -3577,6 +3577,21 @@ cores:
             register: AHB2RSTR
             field: USB_OTG_FSRST
       block: otgfs_v1/OTG_FS
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
@@ -3591,6 +3606,57 @@ cores:
             register: AHB1RSTR
             field: USB_OTG_HSRST
       block: otghs_v1/OTG_HS
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F765ZI.yaml
+++ b/data/chips/STM32F765ZI.yaml
@@ -3577,6 +3577,21 @@ cores:
             register: AHB2RSTR
             field: USB_OTG_FSRST
       block: otgfs_v1/OTG_FS
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
@@ -3591,6 +3606,57 @@ cores:
             register: AHB1RSTR
             field: USB_OTG_HSRST
       block: otghs_v1/OTG_HS
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F767BG.yaml
+++ b/data/chips/STM32F767BG.yaml
@@ -4213,6 +4213,21 @@ cores:
             register: AHB2RSTR
             field: USB_OTG_FSRST
       block: otgfs_v1/OTG_FS
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
@@ -4227,6 +4242,63 @@ cores:
             register: AHB1RSTR
             field: USB_OTG_HSRST
       block: otghs_v1/OTG_HS
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
+      - pin: PH4
+        signal: ULPI_NXT
+        af: 10
+      - pin: PI11
+        signal: ULPI_DIR
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F767BI.yaml
+++ b/data/chips/STM32F767BI.yaml
@@ -4213,6 +4213,21 @@ cores:
             register: AHB2RSTR
             field: USB_OTG_FSRST
       block: otgfs_v1/OTG_FS
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
@@ -4227,6 +4242,63 @@ cores:
             register: AHB1RSTR
             field: USB_OTG_HSRST
       block: otghs_v1/OTG_HS
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
+      - pin: PH4
+        signal: ULPI_NXT
+        af: 10
+      - pin: PI11
+        signal: ULPI_DIR
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F767IG.yaml
+++ b/data/chips/STM32F767IG.yaml
@@ -4119,6 +4119,21 @@ cores:
             register: AHB2RSTR
             field: USB_OTG_FSRST
       block: otgfs_v1/OTG_FS
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
@@ -4133,6 +4148,63 @@ cores:
             register: AHB1RSTR
             field: USB_OTG_HSRST
       block: otghs_v1/OTG_HS
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
+      - pin: PH4
+        signal: ULPI_NXT
+        af: 10
+      - pin: PI11
+        signal: ULPI_DIR
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F767II.yaml
+++ b/data/chips/STM32F767II.yaml
@@ -4119,6 +4119,21 @@ cores:
             register: AHB2RSTR
             field: USB_OTG_FSRST
       block: otgfs_v1/OTG_FS
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
@@ -4133,6 +4148,63 @@ cores:
             register: AHB1RSTR
             field: USB_OTG_HSRST
       block: otghs_v1/OTG_HS
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
+      - pin: PH4
+        signal: ULPI_NXT
+        af: 10
+      - pin: PI11
+        signal: ULPI_DIR
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F767NG.yaml
+++ b/data/chips/STM32F767NG.yaml
@@ -4213,6 +4213,21 @@ cores:
             register: AHB2RSTR
             field: USB_OTG_FSRST
       block: otgfs_v1/OTG_FS
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
@@ -4227,6 +4242,63 @@ cores:
             register: AHB1RSTR
             field: USB_OTG_HSRST
       block: otghs_v1/OTG_HS
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
+      - pin: PH4
+        signal: ULPI_NXT
+        af: 10
+      - pin: PI11
+        signal: ULPI_DIR
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F767NI.yaml
+++ b/data/chips/STM32F767NI.yaml
@@ -4213,6 +4213,21 @@ cores:
             register: AHB2RSTR
             field: USB_OTG_FSRST
       block: otgfs_v1/OTG_FS
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
@@ -4227,6 +4242,63 @@ cores:
             register: AHB1RSTR
             field: USB_OTG_HSRST
       block: otghs_v1/OTG_HS
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
+      - pin: PH4
+        signal: ULPI_NXT
+        af: 10
+      - pin: PI11
+        signal: ULPI_DIR
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F767VG.yaml
+++ b/data/chips/STM32F767VG.yaml
@@ -3381,6 +3381,21 @@ cores:
             register: AHB2RSTR
             field: USB_OTG_FSRST
       block: otgfs_v1/OTG_FS
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
@@ -3395,6 +3410,57 @@ cores:
             register: AHB1RSTR
             field: USB_OTG_HSRST
       block: otghs_v1/OTG_HS
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F767VI.yaml
+++ b/data/chips/STM32F767VI.yaml
@@ -3381,6 +3381,21 @@ cores:
             register: AHB2RSTR
             field: USB_OTG_FSRST
       block: otgfs_v1/OTG_FS
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
@@ -3395,6 +3410,57 @@ cores:
             register: AHB1RSTR
             field: USB_OTG_HSRST
       block: otghs_v1/OTG_HS
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F767ZG.yaml
+++ b/data/chips/STM32F767ZG.yaml
@@ -3771,6 +3771,21 @@ cores:
             register: AHB2RSTR
             field: USB_OTG_FSRST
       block: otgfs_v1/OTG_FS
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
@@ -3785,6 +3800,57 @@ cores:
             register: AHB1RSTR
             field: USB_OTG_HSRST
       block: otghs_v1/OTG_HS
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F767ZI.yaml
+++ b/data/chips/STM32F767ZI.yaml
@@ -3771,6 +3771,21 @@ cores:
             register: AHB2RSTR
             field: USB_OTG_FSRST
       block: otgfs_v1/OTG_FS
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
@@ -3785,6 +3800,57 @@ cores:
             register: AHB1RSTR
             field: USB_OTG_HSRST
       block: otghs_v1/OTG_HS
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F768AI.yaml
+++ b/data/chips/STM32F768AI.yaml
@@ -3615,6 +3615,21 @@ cores:
             register: AHB2RSTR
             field: USB_OTG_FSRST
       block: otgfs_v1/OTG_FS
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
@@ -3629,6 +3644,57 @@ cores:
             register: AHB1RSTR
             field: USB_OTG_HSRST
       block: otghs_v1/OTG_HS
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PH4
+        signal: ULPI_NXT
+        af: 10
+      - pin: PI11
+        signal: ULPI_DIR
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F769AG.yaml
+++ b/data/chips/STM32F769AG.yaml
@@ -3615,6 +3615,21 @@ cores:
             register: AHB2RSTR
             field: USB_OTG_FSRST
       block: otgfs_v1/OTG_FS
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
@@ -3629,6 +3644,57 @@ cores:
             register: AHB1RSTR
             field: USB_OTG_HSRST
       block: otghs_v1/OTG_HS
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PH4
+        signal: ULPI_NXT
+        af: 10
+      - pin: PI11
+        signal: ULPI_DIR
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F769AI.yaml
+++ b/data/chips/STM32F769AI.yaml
@@ -3807,6 +3807,21 @@ cores:
             register: AHB2RSTR
             field: USB_OTG_FSRST
       block: otgfs_v1/OTG_FS
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
@@ -3821,6 +3836,57 @@ cores:
             register: AHB1RSTR
             field: USB_OTG_HSRST
       block: otghs_v1/OTG_HS
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PH4
+        signal: ULPI_NXT
+        af: 10
+      - pin: PI11
+        signal: ULPI_DIR
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F769BG.yaml
+++ b/data/chips/STM32F769BG.yaml
@@ -4194,6 +4194,21 @@ cores:
             register: AHB2RSTR
             field: USB_OTG_FSRST
       block: otgfs_v1/OTG_FS
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
@@ -4208,6 +4223,63 @@ cores:
             register: AHB1RSTR
             field: USB_OTG_HSRST
       block: otghs_v1/OTG_HS
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
+      - pin: PH4
+        signal: ULPI_NXT
+        af: 10
+      - pin: PI11
+        signal: ULPI_DIR
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F769BI.yaml
+++ b/data/chips/STM32F769BI.yaml
@@ -4194,6 +4194,21 @@ cores:
             register: AHB2RSTR
             field: USB_OTG_FSRST
       block: otgfs_v1/OTG_FS
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
@@ -4208,6 +4223,63 @@ cores:
             register: AHB1RSTR
             field: USB_OTG_HSRST
       block: otghs_v1/OTG_HS
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
+      - pin: PH4
+        signal: ULPI_NXT
+        af: 10
+      - pin: PI11
+        signal: ULPI_DIR
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F769IG.yaml
+++ b/data/chips/STM32F769IG.yaml
@@ -3993,6 +3993,21 @@ cores:
             register: AHB2RSTR
             field: USB_OTG_FSRST
       block: otgfs_v1/OTG_FS
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
@@ -4007,6 +4022,63 @@ cores:
             register: AHB1RSTR
             field: USB_OTG_HSRST
       block: otghs_v1/OTG_HS
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
+      - pin: PH4
+        signal: ULPI_NXT
+        af: 10
+      - pin: PI11
+        signal: ULPI_DIR
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F769II.yaml
+++ b/data/chips/STM32F769II.yaml
@@ -3993,6 +3993,21 @@ cores:
             register: AHB2RSTR
             field: USB_OTG_FSRST
       block: otgfs_v1/OTG_FS
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
@@ -4007,6 +4022,63 @@ cores:
             register: AHB1RSTR
             field: USB_OTG_HSRST
       block: otghs_v1/OTG_HS
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
+      - pin: PH4
+        signal: ULPI_NXT
+        af: 10
+      - pin: PI11
+        signal: ULPI_DIR
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F769NG.yaml
+++ b/data/chips/STM32F769NG.yaml
@@ -4194,6 +4194,21 @@ cores:
             register: AHB2RSTR
             field: USB_OTG_FSRST
       block: otgfs_v1/OTG_FS
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
@@ -4208,6 +4223,63 @@ cores:
             register: AHB1RSTR
             field: USB_OTG_HSRST
       block: otghs_v1/OTG_HS
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
+      - pin: PH4
+        signal: ULPI_NXT
+        af: 10
+      - pin: PI11
+        signal: ULPI_DIR
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F769NI.yaml
+++ b/data/chips/STM32F769NI.yaml
@@ -4194,6 +4194,21 @@ cores:
             register: AHB2RSTR
             field: USB_OTG_FSRST
       block: otgfs_v1/OTG_FS
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
@@ -4208,6 +4223,63 @@ cores:
             register: AHB1RSTR
             field: USB_OTG_HSRST
       block: otghs_v1/OTG_HS
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
+      - pin: PH4
+        signal: ULPI_NXT
+        af: 10
+      - pin: PI11
+        signal: ULPI_DIR
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F777BI.yaml
+++ b/data/chips/STM32F777BI.yaml
@@ -4251,6 +4251,21 @@ cores:
             register: AHB2RSTR
             field: USB_OTG_FSRST
       block: otgfs_v1/OTG_FS
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
@@ -4265,6 +4280,63 @@ cores:
             register: AHB1RSTR
             field: USB_OTG_HSRST
       block: otghs_v1/OTG_HS
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
+      - pin: PH4
+        signal: ULPI_NXT
+        af: 10
+      - pin: PI11
+        signal: ULPI_DIR
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F777II.yaml
+++ b/data/chips/STM32F777II.yaml
@@ -4157,6 +4157,21 @@ cores:
             register: AHB2RSTR
             field: USB_OTG_FSRST
       block: otgfs_v1/OTG_FS
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
@@ -4171,6 +4186,63 @@ cores:
             register: AHB1RSTR
             field: USB_OTG_HSRST
       block: otghs_v1/OTG_HS
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
+      - pin: PH4
+        signal: ULPI_NXT
+        af: 10
+      - pin: PI11
+        signal: ULPI_DIR
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F777NI.yaml
+++ b/data/chips/STM32F777NI.yaml
@@ -4251,6 +4251,21 @@ cores:
             register: AHB2RSTR
             field: USB_OTG_FSRST
       block: otgfs_v1/OTG_FS
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
@@ -4265,6 +4280,63 @@ cores:
             register: AHB1RSTR
             field: USB_OTG_HSRST
       block: otghs_v1/OTG_HS
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
+      - pin: PH4
+        signal: ULPI_NXT
+        af: 10
+      - pin: PI11
+        signal: ULPI_DIR
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F777VI.yaml
+++ b/data/chips/STM32F777VI.yaml
@@ -3419,6 +3419,21 @@ cores:
             register: AHB2RSTR
             field: USB_OTG_FSRST
       block: otgfs_v1/OTG_FS
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
@@ -3433,6 +3448,57 @@ cores:
             register: AHB1RSTR
             field: USB_OTG_HSRST
       block: otghs_v1/OTG_HS
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F777ZI.yaml
+++ b/data/chips/STM32F777ZI.yaml
@@ -3809,6 +3809,21 @@ cores:
             register: AHB2RSTR
             field: USB_OTG_FSRST
       block: otgfs_v1/OTG_FS
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
@@ -3823,6 +3838,57 @@ cores:
             register: AHB1RSTR
             field: USB_OTG_HSRST
       block: otghs_v1/OTG_HS
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F778AI.yaml
+++ b/data/chips/STM32F778AI.yaml
@@ -3837,6 +3837,21 @@ cores:
             register: AHB2RSTR
             field: USB_OTG_FSRST
       block: otgfs_v1/OTG_FS
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
@@ -3851,6 +3866,57 @@ cores:
             register: AHB1RSTR
             field: USB_OTG_HSRST
       block: otghs_v1/OTG_HS
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PH4
+        signal: ULPI_NXT
+        af: 10
+      - pin: PI11
+        signal: ULPI_DIR
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F779AI.yaml
+++ b/data/chips/STM32F779AI.yaml
@@ -3841,6 +3841,21 @@ cores:
             register: AHB2RSTR
             field: USB_OTG_FSRST
       block: otgfs_v1/OTG_FS
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
@@ -3855,6 +3870,57 @@ cores:
             register: AHB1RSTR
             field: USB_OTG_HSRST
       block: otghs_v1/OTG_HS
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PH4
+        signal: ULPI_NXT
+        af: 10
+      - pin: PI11
+        signal: ULPI_DIR
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F779BI.yaml
+++ b/data/chips/STM32F779BI.yaml
@@ -4228,6 +4228,21 @@ cores:
             register: AHB2RSTR
             field: USB_OTG_FSRST
       block: otgfs_v1/OTG_FS
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
@@ -4242,6 +4257,63 @@ cores:
             register: AHB1RSTR
             field: USB_OTG_HSRST
       block: otghs_v1/OTG_HS
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
+      - pin: PH4
+        signal: ULPI_NXT
+        af: 10
+      - pin: PI11
+        signal: ULPI_DIR
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F779II.yaml
+++ b/data/chips/STM32F779II.yaml
@@ -4027,6 +4027,21 @@ cores:
             register: AHB2RSTR
             field: USB_OTG_FSRST
       block: otgfs_v1/OTG_FS
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
@@ -4041,6 +4056,63 @@ cores:
             register: AHB1RSTR
             field: USB_OTG_HSRST
       block: otghs_v1/OTG_HS
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
+      - pin: PH4
+        signal: ULPI_NXT
+        af: 10
+      - pin: PI11
+        signal: ULPI_DIR
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32F779NI.yaml
+++ b/data/chips/STM32F779NI.yaml
@@ -4228,6 +4228,21 @@ cores:
             register: AHB2RSTR
             field: USB_OTG_FSRST
       block: otgfs_v1/OTG_FS
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_WKUP
     USB_OTG_HS:
@@ -4242,6 +4257,63 @@ cores:
             register: AHB1RSTR
             field: USB_OTG_HSRST
       block: otghs_v1/OTG_HS
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
+      - pin: PH4
+        signal: ULPI_NXT
+        af: 10
+      - pin: PI11
+        signal: ULPI_DIR
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     WWDG:

--- a/data/chips/STM32H723VE.yaml
+++ b/data/chips/STM32H723VE.yaml
@@ -4116,6 +4116,55 @@ cores:
           request: 72
     USB_OTG_HS:
       address: 0x40040000
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+      - pin: PA12
+        signal: DP
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     VREFBUF:

--- a/data/chips/STM32H723VG.yaml
+++ b/data/chips/STM32H723VG.yaml
@@ -4116,6 +4116,55 @@ cores:
           request: 72
     USB_OTG_HS:
       address: 0x40040000
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+      - pin: PA12
+        signal: DP
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     VREFBUF:

--- a/data/chips/STM32H723ZE.yaml
+++ b/data/chips/STM32H723ZE.yaml
@@ -4767,6 +4767,55 @@ cores:
           request: 72
     USB_OTG_HS:
       address: 0x40040000
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+      - pin: PA12
+        signal: DP
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     VREFBUF:

--- a/data/chips/STM32H723ZG.yaml
+++ b/data/chips/STM32H723ZG.yaml
@@ -4767,6 +4767,55 @@ cores:
           request: 72
     USB_OTG_HS:
       address: 0x40040000
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+      - pin: PA12
+        signal: DP
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     VREFBUF:

--- a/data/chips/STM32H725AE.yaml
+++ b/data/chips/STM32H725AE.yaml
@@ -4844,6 +4844,55 @@ cores:
           request: 72
     USB_OTG_HS:
       address: 0x40040000
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+      - pin: PA12
+        signal: DP
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     VREFBUF:

--- a/data/chips/STM32H725AG.yaml
+++ b/data/chips/STM32H725AG.yaml
@@ -4848,6 +4848,55 @@ cores:
           request: 72
     USB_OTG_HS:
       address: 0x40040000
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+      - pin: PA12
+        signal: DP
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     VREFBUF:

--- a/data/chips/STM32H725IE.yaml
+++ b/data/chips/STM32H725IE.yaml
@@ -5104,6 +5104,58 @@ cores:
           request: 72
     USB_OTG_HS:
       address: 0x40040000
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+      - pin: PA12
+        signal: DP
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
+      - pin: PH4
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     VREFBUF:

--- a/data/chips/STM32H725IG.yaml
+++ b/data/chips/STM32H725IG.yaml
@@ -5108,6 +5108,58 @@ cores:
           request: 72
     USB_OTG_HS:
       address: 0x40040000
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+      - pin: PA12
+        signal: DP
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
+      - pin: PH4
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     VREFBUF:

--- a/data/chips/STM32H725RE.yaml
+++ b/data/chips/STM32H725RE.yaml
@@ -2875,6 +2875,46 @@ cores:
           request: 46
     USB_OTG_HS:
       address: 0x40040000
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+      - pin: PA12
+        signal: DP
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     VREFBUF:

--- a/data/chips/STM32H725RG.yaml
+++ b/data/chips/STM32H725RG.yaml
@@ -2879,6 +2879,46 @@ cores:
           request: 46
     USB_OTG_HS:
       address: 0x40040000
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+      - pin: PA12
+        signal: DP
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     VREFBUF:

--- a/data/chips/STM32H725VE.yaml
+++ b/data/chips/STM32H725VE.yaml
@@ -3934,6 +3934,55 @@ cores:
           request: 72
     USB_OTG_HS:
       address: 0x40040000
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+      - pin: PA12
+        signal: DP
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     VREFBUF:

--- a/data/chips/STM32H725VG.yaml
+++ b/data/chips/STM32H725VG.yaml
@@ -3971,6 +3971,55 @@ cores:
           request: 72
     USB_OTG_HS:
       address: 0x40040000
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+      - pin: PA12
+        signal: DP
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     VREFBUF:

--- a/data/chips/STM32H725ZE.yaml
+++ b/data/chips/STM32H725ZE.yaml
@@ -4565,6 +4565,55 @@ cores:
           request: 72
     USB_OTG_HS:
       address: 0x40040000
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+      - pin: PA12
+        signal: DP
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     VREFBUF:

--- a/data/chips/STM32H725ZG.yaml
+++ b/data/chips/STM32H725ZG.yaml
@@ -4569,6 +4569,55 @@ cores:
           request: 72
     USB_OTG_HS:
       address: 0x40040000
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+      - pin: PA12
+        signal: DP
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     VREFBUF:

--- a/data/chips/STM32H730AB.yaml
+++ b/data/chips/STM32H730AB.yaml
@@ -4767,6 +4767,49 @@ cores:
           request: 72
     USB_OTG_HS:
       address: 0x40040000
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+      - pin: PA12
+        signal: DP
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     VREFBUF:

--- a/data/chips/STM32H730IB.yaml
+++ b/data/chips/STM32H730IB.yaml
@@ -5108,6 +5108,52 @@ cores:
           request: 72
     USB_OTG_HS:
       address: 0x40040000
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+      - pin: PA12
+        signal: DP
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PH4
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     VREFBUF:

--- a/data/chips/STM32H730VB.yaml
+++ b/data/chips/STM32H730VB.yaml
@@ -4116,6 +4116,49 @@ cores:
           request: 72
     USB_OTG_HS:
       address: 0x40040000
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+      - pin: PA12
+        signal: DP
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     VREFBUF:

--- a/data/chips/STM32H730ZB.yaml
+++ b/data/chips/STM32H730ZB.yaml
@@ -4767,6 +4767,49 @@ cores:
           request: 72
     USB_OTG_HS:
       address: 0x40040000
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+      - pin: PA12
+        signal: DP
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     VREFBUF:

--- a/data/chips/STM32H733VG.yaml
+++ b/data/chips/STM32H733VG.yaml
@@ -4159,6 +4159,55 @@ cores:
           request: 72
     USB_OTG_HS:
       address: 0x40040000
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+      - pin: PA12
+        signal: DP
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     VREFBUF:

--- a/data/chips/STM32H733ZG.yaml
+++ b/data/chips/STM32H733ZG.yaml
@@ -4810,6 +4810,55 @@ cores:
           request: 72
     USB_OTG_HS:
       address: 0x40040000
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+      - pin: PA12
+        signal: DP
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     VREFBUF:

--- a/data/chips/STM32H735AG.yaml
+++ b/data/chips/STM32H735AG.yaml
@@ -4891,6 +4891,55 @@ cores:
           request: 72
     USB_OTG_HS:
       address: 0x40040000
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+      - pin: PA12
+        signal: DP
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     VREFBUF:

--- a/data/chips/STM32H735IG.yaml
+++ b/data/chips/STM32H735IG.yaml
@@ -5151,6 +5151,58 @@ cores:
           request: 72
     USB_OTG_HS:
       address: 0x40040000
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+      - pin: PA12
+        signal: DP
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
+      - pin: PH4
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     VREFBUF:

--- a/data/chips/STM32H735RG.yaml
+++ b/data/chips/STM32H735RG.yaml
@@ -2922,6 +2922,46 @@ cores:
           request: 46
     USB_OTG_HS:
       address: 0x40040000
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+      - pin: PA12
+        signal: DP
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     VREFBUF:

--- a/data/chips/STM32H735VG.yaml
+++ b/data/chips/STM32H735VG.yaml
@@ -4039,6 +4039,55 @@ cores:
           request: 72
     USB_OTG_HS:
       address: 0x40040000
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+      - pin: PA12
+        signal: DP
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     VREFBUF:

--- a/data/chips/STM32H735ZG.yaml
+++ b/data/chips/STM32H735ZG.yaml
@@ -4612,6 +4612,55 @@ cores:
           request: 72
     USB_OTG_HS:
       address: 0x40040000
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+      - pin: PA12
+        signal: DP
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     VREFBUF:

--- a/data/chips/STM32H742AG.yaml
+++ b/data/chips/STM32H742AG.yaml
@@ -4107,10 +4107,82 @@ cores:
           request: 72
     USB_OTG_FS:
       address: 0x40080000
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_EP1_OUT
     USB_OTG_HS:
       address: 0x40040000
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
+      - pin: PH4
+        signal: ULPI_NXT
+        af: 10
+      - pin: PI11
+        signal: ULPI_DIR
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     VREFBUF:

--- a/data/chips/STM32H742AI.yaml
+++ b/data/chips/STM32H742AI.yaml
@@ -4107,10 +4107,82 @@ cores:
           request: 72
     USB_OTG_FS:
       address: 0x40080000
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_EP1_OUT
     USB_OTG_HS:
       address: 0x40040000
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
+      - pin: PH4
+        signal: ULPI_NXT
+        af: 10
+      - pin: PI11
+        signal: ULPI_DIR
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     VREFBUF:

--- a/data/chips/STM32H742BG.yaml
+++ b/data/chips/STM32H742BG.yaml
@@ -4327,10 +4327,82 @@ cores:
           request: 72
     USB_OTG_FS:
       address: 0x40080000
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_EP1_OUT
     USB_OTG_HS:
       address: 0x40040000
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
+      - pin: PH4
+        signal: ULPI_NXT
+        af: 10
+      - pin: PI11
+        signal: ULPI_DIR
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     VREFBUF:

--- a/data/chips/STM32H742BI.yaml
+++ b/data/chips/STM32H742BI.yaml
@@ -4327,10 +4327,82 @@ cores:
           request: 72
     USB_OTG_FS:
       address: 0x40080000
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_EP1_OUT
     USB_OTG_HS:
       address: 0x40040000
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
+      - pin: PH4
+        signal: ULPI_NXT
+        af: 10
+      - pin: PI11
+        signal: ULPI_DIR
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     VREFBUF:

--- a/data/chips/STM32H742IG.yaml
+++ b/data/chips/STM32H742IG.yaml
@@ -4251,10 +4251,82 @@ cores:
           request: 72
     USB_OTG_FS:
       address: 0x40080000
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_EP1_OUT
     USB_OTG_HS:
       address: 0x40040000
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
+      - pin: PH4
+        signal: ULPI_NXT
+        af: 10
+      - pin: PI11
+        signal: ULPI_DIR
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     VREFBUF:

--- a/data/chips/STM32H742II.yaml
+++ b/data/chips/STM32H742II.yaml
@@ -4251,10 +4251,82 @@ cores:
           request: 72
     USB_OTG_FS:
       address: 0x40080000
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_EP1_OUT
     USB_OTG_HS:
       address: 0x40040000
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
+      - pin: PH4
+        signal: ULPI_NXT
+        af: 10
+      - pin: PI11
+        signal: ULPI_DIR
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     VREFBUF:

--- a/data/chips/STM32H742VG.yaml
+++ b/data/chips/STM32H742VG.yaml
@@ -3506,10 +3506,76 @@ cores:
           request: 72
     USB_OTG_FS:
       address: 0x40080000
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_EP1_OUT
     USB_OTG_HS:
       address: 0x40040000
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     VREFBUF:

--- a/data/chips/STM32H742VI.yaml
+++ b/data/chips/STM32H742VI.yaml
@@ -3506,10 +3506,76 @@ cores:
           request: 72
     USB_OTG_FS:
       address: 0x40080000
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_EP1_OUT
     USB_OTG_HS:
       address: 0x40040000
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     VREFBUF:

--- a/data/chips/STM32H742XG.yaml
+++ b/data/chips/STM32H742XG.yaml
@@ -4333,10 +4333,82 @@ cores:
           request: 72
     USB_OTG_FS:
       address: 0x40080000
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_EP1_OUT
     USB_OTG_HS:
       address: 0x40040000
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
+      - pin: PH4
+        signal: ULPI_NXT
+        af: 10
+      - pin: PI11
+        signal: ULPI_DIR
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     VREFBUF:

--- a/data/chips/STM32H742XI.yaml
+++ b/data/chips/STM32H742XI.yaml
@@ -4333,10 +4333,82 @@ cores:
           request: 72
     USB_OTG_FS:
       address: 0x40080000
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_EP1_OUT
     USB_OTG_HS:
       address: 0x40040000
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
+      - pin: PH4
+        signal: ULPI_NXT
+        af: 10
+      - pin: PI11
+        signal: ULPI_DIR
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     VREFBUF:

--- a/data/chips/STM32H742ZG.yaml
+++ b/data/chips/STM32H742ZG.yaml
@@ -3938,10 +3938,76 @@ cores:
           request: 72
     USB_OTG_FS:
       address: 0x40080000
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_EP1_OUT
     USB_OTG_HS:
       address: 0x40040000
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     VREFBUF:

--- a/data/chips/STM32H742ZI.yaml
+++ b/data/chips/STM32H742ZI.yaml
@@ -3938,10 +3938,76 @@ cores:
           request: 72
     USB_OTG_FS:
       address: 0x40080000
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_EP1_OUT
     USB_OTG_HS:
       address: 0x40040000
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     VREFBUF:

--- a/data/chips/STM32H743AG.yaml
+++ b/data/chips/STM32H743AG.yaml
@@ -4358,10 +4358,82 @@ cores:
           request: 72
     USB_OTG_FS:
       address: 0x40080000
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_EP1_OUT
     USB_OTG_HS:
       address: 0x40040000
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
+      - pin: PH4
+        signal: ULPI_NXT
+        af: 10
+      - pin: PI11
+        signal: ULPI_DIR
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     VREFBUF:

--- a/data/chips/STM32H743AI.yaml
+++ b/data/chips/STM32H743AI.yaml
@@ -4358,10 +4358,82 @@ cores:
           request: 72
     USB_OTG_FS:
       address: 0x40080000
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_EP1_OUT
     USB_OTG_HS:
       address: 0x40040000
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
+      - pin: PH4
+        signal: ULPI_NXT
+        af: 10
+      - pin: PI11
+        signal: ULPI_DIR
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     VREFBUF:

--- a/data/chips/STM32H743BG.yaml
+++ b/data/chips/STM32H743BG.yaml
@@ -4686,10 +4686,82 @@ cores:
           request: 72
     USB_OTG_FS:
       address: 0x40080000
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_EP1_OUT
     USB_OTG_HS:
       address: 0x40040000
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
+      - pin: PH4
+        signal: ULPI_NXT
+        af: 10
+      - pin: PI11
+        signal: ULPI_DIR
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     VREFBUF:

--- a/data/chips/STM32H743BI.yaml
+++ b/data/chips/STM32H743BI.yaml
@@ -4686,10 +4686,82 @@ cores:
           request: 72
     USB_OTG_FS:
       address: 0x40080000
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_EP1_OUT
     USB_OTG_HS:
       address: 0x40040000
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
+      - pin: PH4
+        signal: ULPI_NXT
+        af: 10
+      - pin: PI11
+        signal: ULPI_DIR
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     VREFBUF:

--- a/data/chips/STM32H743IG.yaml
+++ b/data/chips/STM32H743IG.yaml
@@ -4514,10 +4514,82 @@ cores:
           request: 72
     USB_OTG_FS:
       address: 0x40080000
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_EP1_OUT
     USB_OTG_HS:
       address: 0x40040000
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
+      - pin: PH4
+        signal: ULPI_NXT
+        af: 10
+      - pin: PI11
+        signal: ULPI_DIR
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     VREFBUF:

--- a/data/chips/STM32H743II.yaml
+++ b/data/chips/STM32H743II.yaml
@@ -4514,10 +4514,82 @@ cores:
           request: 72
     USB_OTG_FS:
       address: 0x40080000
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_EP1_OUT
     USB_OTG_HS:
       address: 0x40040000
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
+      - pin: PH4
+        signal: ULPI_NXT
+        af: 10
+      - pin: PI11
+        signal: ULPI_DIR
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     VREFBUF:

--- a/data/chips/STM32H743VG.yaml
+++ b/data/chips/STM32H743VG.yaml
@@ -3670,10 +3670,76 @@ cores:
           request: 72
     USB_OTG_FS:
       address: 0x40080000
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_EP1_OUT
     USB_OTG_HS:
       address: 0x40040000
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     VREFBUF:

--- a/data/chips/STM32H743VI.yaml
+++ b/data/chips/STM32H743VI.yaml
@@ -3670,10 +3670,76 @@ cores:
           request: 72
     USB_OTG_FS:
       address: 0x40080000
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_EP1_OUT
     USB_OTG_HS:
       address: 0x40040000
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     VREFBUF:

--- a/data/chips/STM32H743XG.yaml
+++ b/data/chips/STM32H743XG.yaml
@@ -4692,10 +4692,82 @@ cores:
           request: 72
     USB_OTG_FS:
       address: 0x40080000
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_EP1_OUT
     USB_OTG_HS:
       address: 0x40040000
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
+      - pin: PH4
+        signal: ULPI_NXT
+        af: 10
+      - pin: PI11
+        signal: ULPI_DIR
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     VREFBUF:

--- a/data/chips/STM32H743XI.yaml
+++ b/data/chips/STM32H743XI.yaml
@@ -4692,10 +4692,82 @@ cores:
           request: 72
     USB_OTG_FS:
       address: 0x40080000
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_EP1_OUT
     USB_OTG_HS:
       address: 0x40040000
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
+      - pin: PH4
+        signal: ULPI_NXT
+        af: 10
+      - pin: PI11
+        signal: ULPI_DIR
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     VREFBUF:

--- a/data/chips/STM32H743ZG.yaml
+++ b/data/chips/STM32H743ZG.yaml
@@ -4135,10 +4135,76 @@ cores:
           request: 72
     USB_OTG_FS:
       address: 0x40080000
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_EP1_OUT
     USB_OTG_HS:
       address: 0x40040000
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     VREFBUF:

--- a/data/chips/STM32H743ZI.yaml
+++ b/data/chips/STM32H743ZI.yaml
@@ -4135,10 +4135,76 @@ cores:
           request: 72
     USB_OTG_FS:
       address: 0x40080000
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_EP1_OUT
     USB_OTG_HS:
       address: 0x40040000
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     VREFBUF:

--- a/data/chips/STM32H745BG.yaml
+++ b/data/chips/STM32H745BG.yaml
@@ -4716,10 +4716,82 @@ cores:
           request: 72
     USB_OTG_FS:
       address: 0x40080000
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_EP1_OUT
     USB_OTG_HS:
       address: 0x40040000
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
+      - pin: PH4
+        signal: ULPI_NXT
+        af: 10
+      - pin: PI11
+        signal: ULPI_DIR
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     VREFBUF:
@@ -8700,10 +8772,82 @@ cores:
         - *id175
     USB_OTG_FS:
       address: 0x40080000
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_EP1_OUT
     USB_OTG_HS:
       address: 0x40040000
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
+      - pin: PH4
+        signal: ULPI_NXT
+        af: 10
+      - pin: PI11
+        signal: ULPI_DIR
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     VREFBUF:

--- a/data/chips/STM32H745BI.yaml
+++ b/data/chips/STM32H745BI.yaml
@@ -4716,10 +4716,82 @@ cores:
           request: 72
     USB_OTG_FS:
       address: 0x40080000
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_EP1_OUT
     USB_OTG_HS:
       address: 0x40040000
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
+      - pin: PH4
+        signal: ULPI_NXT
+        af: 10
+      - pin: PI11
+        signal: ULPI_DIR
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     VREFBUF:
@@ -8700,10 +8772,82 @@ cores:
         - *id175
     USB_OTG_FS:
       address: 0x40080000
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_EP1_OUT
     USB_OTG_HS:
       address: 0x40040000
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
+      - pin: PH4
+        signal: ULPI_NXT
+        af: 10
+      - pin: PI11
+        signal: ULPI_DIR
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     VREFBUF:

--- a/data/chips/STM32H745IG.yaml
+++ b/data/chips/STM32H745IG.yaml
@@ -4541,10 +4541,79 @@ cores:
           request: 72
     USB_OTG_FS:
       address: 0x40080000
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_EP1_OUT
     USB_OTG_HS:
       address: 0x40040000
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
+      - pin: PH4
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     VREFBUF:
@@ -8348,10 +8417,79 @@ cores:
         - *id175
     USB_OTG_FS:
       address: 0x40080000
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_EP1_OUT
     USB_OTG_HS:
       address: 0x40040000
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
+      - pin: PH4
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     VREFBUF:

--- a/data/chips/STM32H745II.yaml
+++ b/data/chips/STM32H745II.yaml
@@ -4541,10 +4541,79 @@ cores:
           request: 72
     USB_OTG_FS:
       address: 0x40080000
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_EP1_OUT
     USB_OTG_HS:
       address: 0x40040000
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
+      - pin: PH4
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     VREFBUF:
@@ -8348,10 +8417,79 @@ cores:
         - *id175
     USB_OTG_FS:
       address: 0x40080000
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_EP1_OUT
     USB_OTG_HS:
       address: 0x40040000
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
+      - pin: PH4
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     VREFBUF:

--- a/data/chips/STM32H745XG.yaml
+++ b/data/chips/STM32H745XG.yaml
@@ -4785,10 +4785,82 @@ cores:
           request: 72
     USB_OTG_FS:
       address: 0x40080000
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_EP1_OUT
     USB_OTG_HS:
       address: 0x40040000
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
+      - pin: PH4
+        signal: ULPI_NXT
+        af: 10
+      - pin: PI11
+        signal: ULPI_DIR
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     VREFBUF:
@@ -8838,10 +8910,82 @@ cores:
         - *id175
     USB_OTG_FS:
       address: 0x40080000
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_EP1_OUT
     USB_OTG_HS:
       address: 0x40040000
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
+      - pin: PH4
+        signal: ULPI_NXT
+        af: 10
+      - pin: PI11
+        signal: ULPI_DIR
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     VREFBUF:

--- a/data/chips/STM32H745XI.yaml
+++ b/data/chips/STM32H745XI.yaml
@@ -4785,10 +4785,82 @@ cores:
           request: 72
     USB_OTG_FS:
       address: 0x40080000
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_EP1_OUT
     USB_OTG_HS:
       address: 0x40040000
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
+      - pin: PH4
+        signal: ULPI_NXT
+        af: 10
+      - pin: PI11
+        signal: ULPI_DIR
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     VREFBUF:
@@ -8838,10 +8910,82 @@ cores:
         - *id175
     USB_OTG_FS:
       address: 0x40080000
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_EP1_OUT
     USB_OTG_HS:
       address: 0x40040000
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
+      - pin: PH4
+        signal: ULPI_NXT
+        af: 10
+      - pin: PI11
+        signal: ULPI_DIR
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     VREFBUF:

--- a/data/chips/STM32H745ZG.yaml
+++ b/data/chips/STM32H745ZG.yaml
@@ -4105,10 +4105,76 @@ cores:
           request: 72
     USB_OTG_FS:
       address: 0x40080000
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_EP1_OUT
     USB_OTG_HS:
       address: 0x40040000
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     VREFBUF:
@@ -7478,10 +7544,76 @@ cores:
         - *id175
     USB_OTG_FS:
       address: 0x40080000
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_EP1_OUT
     USB_OTG_HS:
       address: 0x40040000
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     VREFBUF:

--- a/data/chips/STM32H745ZI.yaml
+++ b/data/chips/STM32H745ZI.yaml
@@ -4105,10 +4105,76 @@ cores:
           request: 72
     USB_OTG_FS:
       address: 0x40080000
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_EP1_OUT
     USB_OTG_HS:
       address: 0x40040000
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     VREFBUF:
@@ -7478,10 +7544,76 @@ cores:
         - *id175
     USB_OTG_FS:
       address: 0x40080000
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_EP1_OUT
     USB_OTG_HS:
       address: 0x40040000
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     VREFBUF:

--- a/data/chips/STM32H747AG.yaml
+++ b/data/chips/STM32H747AG.yaml
@@ -4232,10 +4232,76 @@ cores:
           request: 72
     USB_OTG_FS:
       address: 0x40080000
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_EP1_OUT
     USB_OTG_HS:
       address: 0x40040000
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     VREFBUF:
@@ -7729,10 +7795,76 @@ cores:
         - *id175
     USB_OTG_FS:
       address: 0x40080000
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_EP1_OUT
     USB_OTG_HS:
       address: 0x40040000
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     VREFBUF:

--- a/data/chips/STM32H747AI.yaml
+++ b/data/chips/STM32H747AI.yaml
@@ -4232,10 +4232,76 @@ cores:
           request: 72
     USB_OTG_FS:
       address: 0x40080000
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_EP1_OUT
     USB_OTG_HS:
       address: 0x40040000
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     VREFBUF:
@@ -7729,10 +7795,76 @@ cores:
         - *id175
     USB_OTG_FS:
       address: 0x40080000
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_EP1_OUT
     USB_OTG_HS:
       address: 0x40040000
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     VREFBUF:

--- a/data/chips/STM32H747BG.yaml
+++ b/data/chips/STM32H747BG.yaml
@@ -4615,10 +4615,82 @@ cores:
           request: 72
     USB_OTG_FS:
       address: 0x40080000
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_EP1_OUT
     USB_OTG_HS:
       address: 0x40040000
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
+      - pin: PH4
+        signal: ULPI_NXT
+        af: 10
+      - pin: PI11
+        signal: ULPI_DIR
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     VREFBUF:
@@ -8495,10 +8567,82 @@ cores:
         - *id175
     USB_OTG_FS:
       address: 0x40080000
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_EP1_OUT
     USB_OTG_HS:
       address: 0x40040000
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
+      - pin: PH4
+        signal: ULPI_NXT
+        af: 10
+      - pin: PI11
+        signal: ULPI_DIR
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     VREFBUF:

--- a/data/chips/STM32H747BI.yaml
+++ b/data/chips/STM32H747BI.yaml
@@ -4615,10 +4615,82 @@ cores:
           request: 72
     USB_OTG_FS:
       address: 0x40080000
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_EP1_OUT
     USB_OTG_HS:
       address: 0x40040000
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
+      - pin: PH4
+        signal: ULPI_NXT
+        af: 10
+      - pin: PI11
+        signal: ULPI_DIR
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     VREFBUF:
@@ -8495,10 +8567,82 @@ cores:
         - *id175
     USB_OTG_FS:
       address: 0x40080000
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_EP1_OUT
     USB_OTG_HS:
       address: 0x40040000
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
+      - pin: PH4
+        signal: ULPI_NXT
+        af: 10
+      - pin: PI11
+        signal: ULPI_DIR
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     VREFBUF:

--- a/data/chips/STM32H747IG.yaml
+++ b/data/chips/STM32H747IG.yaml
@@ -4232,10 +4232,76 @@ cores:
           request: 72
     USB_OTG_FS:
       address: 0x40080000
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_EP1_OUT
     USB_OTG_HS:
       address: 0x40040000
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     VREFBUF:
@@ -7729,10 +7795,76 @@ cores:
         - *id175
     USB_OTG_FS:
       address: 0x40080000
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_EP1_OUT
     USB_OTG_HS:
       address: 0x40040000
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     VREFBUF:

--- a/data/chips/STM32H747II.yaml
+++ b/data/chips/STM32H747II.yaml
@@ -4232,10 +4232,76 @@ cores:
           request: 72
     USB_OTG_FS:
       address: 0x40080000
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_EP1_OUT
     USB_OTG_HS:
       address: 0x40040000
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     VREFBUF:
@@ -7729,10 +7795,76 @@ cores:
         - *id175
     USB_OTG_FS:
       address: 0x40080000
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_EP1_OUT
     USB_OTG_HS:
       address: 0x40040000
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     VREFBUF:

--- a/data/chips/STM32H747XG.yaml
+++ b/data/chips/STM32H747XG.yaml
@@ -4789,10 +4789,82 @@ cores:
           request: 72
     USB_OTG_FS:
       address: 0x40080000
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_EP1_OUT
     USB_OTG_HS:
       address: 0x40040000
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
+      - pin: PH4
+        signal: ULPI_NXT
+        af: 10
+      - pin: PI11
+        signal: ULPI_DIR
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     VREFBUF:
@@ -8843,10 +8915,82 @@ cores:
         - *id175
     USB_OTG_FS:
       address: 0x40080000
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_EP1_OUT
     USB_OTG_HS:
       address: 0x40040000
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
+      - pin: PH4
+        signal: ULPI_NXT
+        af: 10
+      - pin: PI11
+        signal: ULPI_DIR
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     VREFBUF:

--- a/data/chips/STM32H747XI.yaml
+++ b/data/chips/STM32H747XI.yaml
@@ -4789,10 +4789,82 @@ cores:
           request: 72
     USB_OTG_FS:
       address: 0x40080000
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_EP1_OUT
     USB_OTG_HS:
       address: 0x40040000
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
+      - pin: PH4
+        signal: ULPI_NXT
+        af: 10
+      - pin: PI11
+        signal: ULPI_DIR
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     VREFBUF:
@@ -8843,10 +8915,82 @@ cores:
         - *id175
     USB_OTG_FS:
       address: 0x40080000
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_EP1_OUT
     USB_OTG_HS:
       address: 0x40040000
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
+      - pin: PH4
+        signal: ULPI_NXT
+        af: 10
+      - pin: PI11
+        signal: ULPI_DIR
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     VREFBUF:

--- a/data/chips/STM32H747ZI.yaml
+++ b/data/chips/STM32H747ZI.yaml
@@ -3937,10 +3937,76 @@ cores:
           request: 72
     USB_OTG_FS:
       address: 0x40080000
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_EP1_OUT
     USB_OTG_HS:
       address: 0x40040000
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     VREFBUF:
@@ -7151,10 +7217,76 @@ cores:
         - *id172
     USB_OTG_FS:
       address: 0x40080000
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_EP1_OUT
     USB_OTG_HS:
       address: 0x40040000
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     VREFBUF:

--- a/data/chips/STM32H750IB.yaml
+++ b/data/chips/STM32H750IB.yaml
@@ -4534,10 +4534,82 @@ cores:
           request: 72
     USB_OTG_FS:
       address: 0x40080000
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_EP1_OUT
     USB_OTG_HS:
       address: 0x40040000
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
+      - pin: PH4
+        signal: ULPI_NXT
+        af: 10
+      - pin: PI11
+        signal: ULPI_DIR
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     VREFBUF:

--- a/data/chips/STM32H750VB.yaml
+++ b/data/chips/STM32H750VB.yaml
@@ -3688,10 +3688,76 @@ cores:
           request: 72
     USB_OTG_FS:
       address: 0x40080000
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_EP1_OUT
     USB_OTG_HS:
       address: 0x40040000
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     VREFBUF:

--- a/data/chips/STM32H750XB.yaml
+++ b/data/chips/STM32H750XB.yaml
@@ -4712,10 +4712,82 @@ cores:
           request: 72
     USB_OTG_FS:
       address: 0x40080000
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_EP1_OUT
     USB_OTG_HS:
       address: 0x40040000
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
+      - pin: PH4
+        signal: ULPI_NXT
+        af: 10
+      - pin: PI11
+        signal: ULPI_DIR
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     VREFBUF:

--- a/data/chips/STM32H750ZB.yaml
+++ b/data/chips/STM32H750ZB.yaml
@@ -4147,10 +4147,76 @@ cores:
           request: 72
     USB_OTG_FS:
       address: 0x40080000
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_EP1_OUT
     USB_OTG_HS:
       address: 0x40040000
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     VREFBUF:

--- a/data/chips/STM32H753AI.yaml
+++ b/data/chips/STM32H753AI.yaml
@@ -4390,10 +4390,82 @@ cores:
           request: 72
     USB_OTG_FS:
       address: 0x40080000
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_EP1_OUT
     USB_OTG_HS:
       address: 0x40040000
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
+      - pin: PH4
+        signal: ULPI_NXT
+        af: 10
+      - pin: PI11
+        signal: ULPI_DIR
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     VREFBUF:

--- a/data/chips/STM32H753BI.yaml
+++ b/data/chips/STM32H753BI.yaml
@@ -4718,10 +4718,82 @@ cores:
           request: 72
     USB_OTG_FS:
       address: 0x40080000
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_EP1_OUT
     USB_OTG_HS:
       address: 0x40040000
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
+      - pin: PH4
+        signal: ULPI_NXT
+        af: 10
+      - pin: PI11
+        signal: ULPI_DIR
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     VREFBUF:

--- a/data/chips/STM32H753II.yaml
+++ b/data/chips/STM32H753II.yaml
@@ -4546,10 +4546,82 @@ cores:
           request: 72
     USB_OTG_FS:
       address: 0x40080000
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_EP1_OUT
     USB_OTG_HS:
       address: 0x40040000
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
+      - pin: PH4
+        signal: ULPI_NXT
+        af: 10
+      - pin: PI11
+        signal: ULPI_DIR
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     VREFBUF:

--- a/data/chips/STM32H753VI.yaml
+++ b/data/chips/STM32H753VI.yaml
@@ -3702,10 +3702,76 @@ cores:
           request: 72
     USB_OTG_FS:
       address: 0x40080000
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_EP1_OUT
     USB_OTG_HS:
       address: 0x40040000
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     VREFBUF:

--- a/data/chips/STM32H753XI.yaml
+++ b/data/chips/STM32H753XI.yaml
@@ -4724,10 +4724,82 @@ cores:
           request: 72
     USB_OTG_FS:
       address: 0x40080000
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_EP1_OUT
     USB_OTG_HS:
       address: 0x40040000
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
+      - pin: PH4
+        signal: ULPI_NXT
+        af: 10
+      - pin: PI11
+        signal: ULPI_DIR
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     VREFBUF:

--- a/data/chips/STM32H753ZI.yaml
+++ b/data/chips/STM32H753ZI.yaml
@@ -4167,10 +4167,76 @@ cores:
           request: 72
     USB_OTG_FS:
       address: 0x40080000
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_EP1_OUT
     USB_OTG_HS:
       address: 0x40040000
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     VREFBUF:

--- a/data/chips/STM32H755BI.yaml
+++ b/data/chips/STM32H755BI.yaml
@@ -4751,10 +4751,82 @@ cores:
           request: 72
     USB_OTG_FS:
       address: 0x40080000
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_EP1_OUT
     USB_OTG_HS:
       address: 0x40040000
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
+      - pin: PH4
+        signal: ULPI_NXT
+        af: 10
+      - pin: PI11
+        signal: ULPI_DIR
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     VREFBUF:
@@ -8753,10 +8825,82 @@ cores:
         - *id179
     USB_OTG_FS:
       address: 0x40080000
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_EP1_OUT
     USB_OTG_HS:
       address: 0x40040000
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
+      - pin: PH4
+        signal: ULPI_NXT
+        af: 10
+      - pin: PI11
+        signal: ULPI_DIR
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     VREFBUF:

--- a/data/chips/STM32H755II.yaml
+++ b/data/chips/STM32H755II.yaml
@@ -4576,10 +4576,79 @@ cores:
           request: 72
     USB_OTG_FS:
       address: 0x40080000
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_EP1_OUT
     USB_OTG_HS:
       address: 0x40040000
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
+      - pin: PH4
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     VREFBUF:
@@ -8401,10 +8470,79 @@ cores:
         - *id179
     USB_OTG_FS:
       address: 0x40080000
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_EP1_OUT
     USB_OTG_HS:
       address: 0x40040000
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
+      - pin: PH4
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     VREFBUF:

--- a/data/chips/STM32H755XI.yaml
+++ b/data/chips/STM32H755XI.yaml
@@ -4820,10 +4820,82 @@ cores:
           request: 72
     USB_OTG_FS:
       address: 0x40080000
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_EP1_OUT
     USB_OTG_HS:
       address: 0x40040000
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
+      - pin: PH4
+        signal: ULPI_NXT
+        af: 10
+      - pin: PI11
+        signal: ULPI_DIR
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     VREFBUF:
@@ -8891,10 +8963,82 @@ cores:
         - *id179
     USB_OTG_FS:
       address: 0x40080000
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_EP1_OUT
     USB_OTG_HS:
       address: 0x40040000
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
+      - pin: PH4
+        signal: ULPI_NXT
+        af: 10
+      - pin: PI11
+        signal: ULPI_DIR
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     VREFBUF:

--- a/data/chips/STM32H755ZI.yaml
+++ b/data/chips/STM32H755ZI.yaml
@@ -4140,10 +4140,76 @@ cores:
           request: 72
     USB_OTG_FS:
       address: 0x40080000
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_EP1_OUT
     USB_OTG_HS:
       address: 0x40040000
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     VREFBUF:
@@ -7531,10 +7597,76 @@ cores:
         - *id179
     USB_OTG_FS:
       address: 0x40080000
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_EP1_OUT
     USB_OTG_HS:
       address: 0x40040000
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     VREFBUF:

--- a/data/chips/STM32H757AI.yaml
+++ b/data/chips/STM32H757AI.yaml
@@ -4267,10 +4267,76 @@ cores:
           request: 72
     USB_OTG_FS:
       address: 0x40080000
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_EP1_OUT
     USB_OTG_HS:
       address: 0x40040000
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     VREFBUF:
@@ -7782,10 +7848,76 @@ cores:
         - *id179
     USB_OTG_FS:
       address: 0x40080000
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_EP1_OUT
     USB_OTG_HS:
       address: 0x40040000
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     VREFBUF:

--- a/data/chips/STM32H757BI.yaml
+++ b/data/chips/STM32H757BI.yaml
@@ -4650,10 +4650,82 @@ cores:
           request: 72
     USB_OTG_FS:
       address: 0x40080000
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_EP1_OUT
     USB_OTG_HS:
       address: 0x40040000
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
+      - pin: PH4
+        signal: ULPI_NXT
+        af: 10
+      - pin: PI11
+        signal: ULPI_DIR
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     VREFBUF:
@@ -8548,10 +8620,82 @@ cores:
         - *id179
     USB_OTG_FS:
       address: 0x40080000
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_EP1_OUT
     USB_OTG_HS:
       address: 0x40040000
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
+      - pin: PH4
+        signal: ULPI_NXT
+        af: 10
+      - pin: PI11
+        signal: ULPI_DIR
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     VREFBUF:

--- a/data/chips/STM32H757II.yaml
+++ b/data/chips/STM32H757II.yaml
@@ -4267,10 +4267,76 @@ cores:
           request: 72
     USB_OTG_FS:
       address: 0x40080000
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_EP1_OUT
     USB_OTG_HS:
       address: 0x40040000
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     VREFBUF:
@@ -7782,10 +7848,76 @@ cores:
         - *id179
     USB_OTG_FS:
       address: 0x40080000
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_EP1_OUT
     USB_OTG_HS:
       address: 0x40040000
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     VREFBUF:

--- a/data/chips/STM32H757XI.yaml
+++ b/data/chips/STM32H757XI.yaml
@@ -4824,10 +4824,82 @@ cores:
           request: 72
     USB_OTG_FS:
       address: 0x40080000
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_EP1_OUT
     USB_OTG_HS:
       address: 0x40040000
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
+      - pin: PH4
+        signal: ULPI_NXT
+        af: 10
+      - pin: PI11
+        signal: ULPI_DIR
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     VREFBUF:
@@ -8896,10 +8968,82 @@ cores:
         - *id179
     USB_OTG_FS:
       address: 0x40080000
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_EP1_OUT
     USB_OTG_HS:
       address: 0x40040000
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
+      - pin: PH4
+        signal: ULPI_NXT
+        af: 10
+      - pin: PI11
+        signal: ULPI_DIR
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     VREFBUF:

--- a/data/chips/STM32H757ZI.yaml
+++ b/data/chips/STM32H757ZI.yaml
@@ -3972,10 +3972,76 @@ cores:
           request: 72
     USB_OTG_FS:
       address: 0x40080000
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_EP1_OUT
     USB_OTG_HS:
       address: 0x40040000
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     VREFBUF:
@@ -7204,10 +7270,76 @@ cores:
         - *id176
     USB_OTG_FS:
       address: 0x40080000
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
       interrupts:
         GLOBAL: OTG_FS_EP1_OUT
     USB_OTG_HS:
       address: 0x40040000
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA4
+        signal: SOF
+        af: 12
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ID
+        af: 12
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PB13
+        signal: VBUS
+      - pin: PB14
+        signal: DM
+        af: 12
+      - pin: PB15
+        signal: DP
+        af: 12
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     VREFBUF:

--- a/data/chips/STM32H7A3AG.yaml
+++ b/data/chips/STM32H7A3AG.yaml
@@ -4412,6 +4412,55 @@ cores:
           request: 72
     USB_OTG_HS:
       address: 0x40040000
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+      - pin: PA12
+        signal: DP
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     VREFBUF:

--- a/data/chips/STM32H7A3AI.yaml
+++ b/data/chips/STM32H7A3AI.yaml
@@ -4412,6 +4412,55 @@ cores:
           request: 72
     USB_OTG_HS:
       address: 0x40040000
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+      - pin: PA12
+        signal: DP
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     VREFBUF:

--- a/data/chips/STM32H7A3IG.yaml
+++ b/data/chips/STM32H7A3IG.yaml
@@ -4813,6 +4813,61 @@ cores:
           request: 72
     USB_OTG_HS:
       address: 0x40040000
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+      - pin: PA12
+        signal: DP
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
+      - pin: PH4
+        signal: ULPI_NXT
+        af: 10
+      - pin: PI11
+        signal: ULPI_DIR
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     VREFBUF:

--- a/data/chips/STM32H7A3II.yaml
+++ b/data/chips/STM32H7A3II.yaml
@@ -4813,6 +4813,61 @@ cores:
           request: 72
     USB_OTG_HS:
       address: 0x40040000
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+      - pin: PA12
+        signal: DP
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
+      - pin: PH4
+        signal: ULPI_NXT
+        af: 10
+      - pin: PI11
+        signal: ULPI_DIR
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     VREFBUF:

--- a/data/chips/STM32H7A3LG.yaml
+++ b/data/chips/STM32H7A3LG.yaml
@@ -4926,6 +4926,61 @@ cores:
           request: 72
     USB_OTG_HS:
       address: 0x40040000
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+      - pin: PA12
+        signal: DP
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
+      - pin: PH4
+        signal: ULPI_NXT
+        af: 10
+      - pin: PI11
+        signal: ULPI_DIR
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     VREFBUF:

--- a/data/chips/STM32H7A3LI.yaml
+++ b/data/chips/STM32H7A3LI.yaml
@@ -4930,6 +4930,61 @@ cores:
           request: 72
     USB_OTG_HS:
       address: 0x40040000
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+      - pin: PA12
+        signal: DP
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
+      - pin: PH4
+        signal: ULPI_NXT
+        af: 10
+      - pin: PI11
+        signal: ULPI_DIR
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     VREFBUF:

--- a/data/chips/STM32H7A3NG.yaml
+++ b/data/chips/STM32H7A3NG.yaml
@@ -4924,6 +4924,61 @@ cores:
           request: 72
     USB_OTG_HS:
       address: 0x40040000
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+      - pin: PA12
+        signal: DP
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
+      - pin: PH4
+        signal: ULPI_NXT
+        af: 10
+      - pin: PI11
+        signal: ULPI_DIR
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     VREFBUF:

--- a/data/chips/STM32H7A3NI.yaml
+++ b/data/chips/STM32H7A3NI.yaml
@@ -4924,6 +4924,61 @@ cores:
           request: 72
     USB_OTG_HS:
       address: 0x40040000
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+      - pin: PA12
+        signal: DP
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
+      - pin: PH4
+        signal: ULPI_NXT
+        af: 10
+      - pin: PI11
+        signal: ULPI_DIR
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     VREFBUF:

--- a/data/chips/STM32H7A3QI.yaml
+++ b/data/chips/STM32H7A3QI.yaml
@@ -3899,6 +3899,55 @@ cores:
           request: 72
     USB_OTG_HS:
       address: 0x40040000
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+      - pin: PA12
+        signal: DP
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     VREFBUF:

--- a/data/chips/STM32H7A3RG.yaml
+++ b/data/chips/STM32H7A3RG.yaml
@@ -2709,6 +2709,52 @@ cores:
           request: 72
     USB_OTG_HS:
       address: 0x40040000
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+      - pin: PA12
+        signal: DP
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     VREFBUF:

--- a/data/chips/STM32H7A3RI.yaml
+++ b/data/chips/STM32H7A3RI.yaml
@@ -2709,6 +2709,52 @@ cores:
           request: 72
     USB_OTG_HS:
       address: 0x40040000
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+      - pin: PA12
+        signal: DP
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     VREFBUF:

--- a/data/chips/STM32H7A3VG.yaml
+++ b/data/chips/STM32H7A3VG.yaml
@@ -3759,6 +3759,55 @@ cores:
           request: 72
     USB_OTG_HS:
       address: 0x40040000
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+      - pin: PA12
+        signal: DP
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     VREFBUF:

--- a/data/chips/STM32H7A3VI.yaml
+++ b/data/chips/STM32H7A3VI.yaml
@@ -3759,6 +3759,55 @@ cores:
           request: 72
     USB_OTG_HS:
       address: 0x40040000
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+      - pin: PA12
+        signal: DP
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     VREFBUF:

--- a/data/chips/STM32H7A3ZG.yaml
+++ b/data/chips/STM32H7A3ZG.yaml
@@ -4297,6 +4297,55 @@ cores:
           request: 72
     USB_OTG_HS:
       address: 0x40040000
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+      - pin: PA12
+        signal: DP
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     VREFBUF:

--- a/data/chips/STM32H7A3ZI.yaml
+++ b/data/chips/STM32H7A3ZI.yaml
@@ -4297,6 +4297,55 @@ cores:
           request: 72
     USB_OTG_HS:
       address: 0x40040000
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+      - pin: PA12
+        signal: DP
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     VREFBUF:

--- a/data/chips/STM32H7B0AB.yaml
+++ b/data/chips/STM32H7B0AB.yaml
@@ -4452,6 +4452,55 @@ cores:
           request: 72
     USB_OTG_HS:
       address: 0x40040000
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+      - pin: PA12
+        signal: DP
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     VREFBUF:

--- a/data/chips/STM32H7B0IB.yaml
+++ b/data/chips/STM32H7B0IB.yaml
@@ -4756,6 +4756,61 @@ cores:
           request: 72
     USB_OTG_HS:
       address: 0x40040000
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+      - pin: PA12
+        signal: DP
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
+      - pin: PH4
+        signal: ULPI_NXT
+        af: 10
+      - pin: PI11
+        signal: ULPI_DIR
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     VREFBUF:

--- a/data/chips/STM32H7B0RB.yaml
+++ b/data/chips/STM32H7B0RB.yaml
@@ -2745,6 +2745,52 @@ cores:
           request: 72
     USB_OTG_HS:
       address: 0x40040000
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+      - pin: PA12
+        signal: DP
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     VREFBUF:

--- a/data/chips/STM32H7B0VB.yaml
+++ b/data/chips/STM32H7B0VB.yaml
@@ -3798,6 +3798,55 @@ cores:
           request: 72
     USB_OTG_HS:
       address: 0x40040000
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+      - pin: PA12
+        signal: DP
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     VREFBUF:

--- a/data/chips/STM32H7B0ZB.yaml
+++ b/data/chips/STM32H7B0ZB.yaml
@@ -4335,6 +4335,55 @@ cores:
           request: 72
     USB_OTG_HS:
       address: 0x40040000
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+      - pin: PA12
+        signal: DP
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     VREFBUF:

--- a/data/chips/STM32H7B3AI.yaml
+++ b/data/chips/STM32H7B3AI.yaml
@@ -4456,6 +4456,55 @@ cores:
           request: 72
     USB_OTG_HS:
       address: 0x40040000
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+      - pin: PA12
+        signal: DP
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     VREFBUF:

--- a/data/chips/STM32H7B3II.yaml
+++ b/data/chips/STM32H7B3II.yaml
@@ -4857,6 +4857,61 @@ cores:
           request: 72
     USB_OTG_HS:
       address: 0x40040000
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+      - pin: PA12
+        signal: DP
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
+      - pin: PH4
+        signal: ULPI_NXT
+        af: 10
+      - pin: PI11
+        signal: ULPI_DIR
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     VREFBUF:

--- a/data/chips/STM32H7B3LI.yaml
+++ b/data/chips/STM32H7B3LI.yaml
@@ -4974,6 +4974,61 @@ cores:
           request: 72
     USB_OTG_HS:
       address: 0x40040000
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+      - pin: PA12
+        signal: DP
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
+      - pin: PH4
+        signal: ULPI_NXT
+        af: 10
+      - pin: PI11
+        signal: ULPI_DIR
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     VREFBUF:

--- a/data/chips/STM32H7B3NI.yaml
+++ b/data/chips/STM32H7B3NI.yaml
@@ -4968,6 +4968,61 @@ cores:
           request: 72
     USB_OTG_HS:
       address: 0x40040000
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+      - pin: PA12
+        signal: DP
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
+      - pin: PH4
+        signal: ULPI_NXT
+        af: 10
+      - pin: PI11
+        signal: ULPI_DIR
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     VREFBUF:

--- a/data/chips/STM32H7B3QI.yaml
+++ b/data/chips/STM32H7B3QI.yaml
@@ -3939,6 +3939,55 @@ cores:
           request: 72
     USB_OTG_HS:
       address: 0x40040000
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+      - pin: PA12
+        signal: DP
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     VREFBUF:

--- a/data/chips/STM32H7B3RI.yaml
+++ b/data/chips/STM32H7B3RI.yaml
@@ -2749,6 +2749,52 @@ cores:
           request: 72
     USB_OTG_HS:
       address: 0x40040000
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+      - pin: PA12
+        signal: DP
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     VREFBUF:

--- a/data/chips/STM32H7B3VI.yaml
+++ b/data/chips/STM32H7B3VI.yaml
@@ -3799,6 +3799,55 @@ cores:
           request: 72
     USB_OTG_HS:
       address: 0x40040000
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+      - pin: PA12
+        signal: DP
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     VREFBUF:

--- a/data/chips/STM32H7B3ZI.yaml
+++ b/data/chips/STM32H7B3ZI.yaml
@@ -4341,6 +4341,55 @@ cores:
           request: 72
     USB_OTG_HS:
       address: 0x40040000
+      pins:
+      - pin: PA3
+        signal: ULPI_D0
+        af: 10
+      - pin: PA5
+        signal: ULPI_CK
+        af: 10
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+      - pin: PA12
+        signal: DP
+      - pin: PB0
+        signal: ULPI_D1
+        af: 10
+      - pin: PB1
+        signal: ULPI_D2
+        af: 10
+      - pin: PB5
+        signal: ULPI_D7
+        af: 10
+      - pin: PB10
+        signal: ULPI_D3
+        af: 10
+      - pin: PB11
+        signal: ULPI_D4
+        af: 10
+      - pin: PB12
+        signal: ULPI_D5
+        af: 10
+      - pin: PB13
+        signal: ULPI_D6
+        af: 10
+      - pin: PC0
+        signal: ULPI_STP
+        af: 10
+      - pin: PC2
+        signal: ULPI_DIR
+        af: 10
+      - pin: PC3
+        signal: ULPI_NXT
+        af: 10
       interrupts:
         GLOBAL: OTG_HS_EP1_OUT
     VREFBUF:

--- a/data/chips/STM32L475RC.yaml
+++ b/data/chips/STM32L475RC.yaml
@@ -2332,6 +2332,36 @@ cores:
           request: 2
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
+      - pin: PA13
+        signal: NOE
+        af: 10
+      - pin: PC9
+        signal: NOE
+        af: 10
       interrupts:
         GLOBAL: OTG_FS
     VREFINTCAL:

--- a/data/chips/STM32L475RE.yaml
+++ b/data/chips/STM32L475RE.yaml
@@ -2332,6 +2332,36 @@ cores:
           request: 2
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
+      - pin: PA13
+        signal: NOE
+        af: 10
+      - pin: PC9
+        signal: NOE
+        af: 10
       interrupts:
         GLOBAL: OTG_FS
     VREFINTCAL:

--- a/data/chips/STM32L475RG.yaml
+++ b/data/chips/STM32L475RG.yaml
@@ -2332,6 +2332,36 @@ cores:
           request: 2
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
+      - pin: PA13
+        signal: NOE
+        af: 10
+      - pin: PC9
+        signal: NOE
+        af: 10
       interrupts:
         GLOBAL: OTG_FS
     VREFINTCAL:

--- a/data/chips/STM32L475VC.yaml
+++ b/data/chips/STM32L475VC.yaml
@@ -2784,6 +2784,36 @@ cores:
           request: 2
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
+      - pin: PA13
+        signal: NOE
+        af: 10
+      - pin: PC9
+        signal: NOE
+        af: 10
       interrupts:
         GLOBAL: OTG_FS
     VREFINTCAL:

--- a/data/chips/STM32L475VE.yaml
+++ b/data/chips/STM32L475VE.yaml
@@ -2784,6 +2784,36 @@ cores:
           request: 2
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
+      - pin: PA13
+        signal: NOE
+        af: 10
+      - pin: PC9
+        signal: NOE
+        af: 10
       interrupts:
         GLOBAL: OTG_FS
     VREFINTCAL:

--- a/data/chips/STM32L475VG.yaml
+++ b/data/chips/STM32L475VG.yaml
@@ -2784,6 +2784,36 @@ cores:
           request: 2
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
+      - pin: PA13
+        signal: NOE
+        af: 10
+      - pin: PC9
+        signal: NOE
+        af: 10
       interrupts:
         GLOBAL: OTG_FS
     VREFINTCAL:

--- a/data/chips/STM32L476JE.yaml
+++ b/data/chips/STM32L476JE.yaml
@@ -2563,6 +2563,36 @@ cores:
           request: 2
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
+      - pin: PA13
+        signal: NOE
+        af: 10
+      - pin: PC9
+        signal: NOE
+        af: 10
       interrupts:
         GLOBAL: OTG_FS
     VREFINTCAL:

--- a/data/chips/STM32L476JG.yaml
+++ b/data/chips/STM32L476JG.yaml
@@ -2569,6 +2569,36 @@ cores:
           request: 2
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
+      - pin: PA13
+        signal: NOE
+        af: 10
+      - pin: PC9
+        signal: NOE
+        af: 10
       interrupts:
         GLOBAL: OTG_FS
     VREFINTCAL:

--- a/data/chips/STM32L476ME.yaml
+++ b/data/chips/STM32L476ME.yaml
@@ -2626,6 +2626,36 @@ cores:
           request: 2
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
+      - pin: PA13
+        signal: NOE
+        af: 10
+      - pin: PC9
+        signal: NOE
+        af: 10
       interrupts:
         GLOBAL: OTG_FS
     VREFINTCAL:

--- a/data/chips/STM32L476MG.yaml
+++ b/data/chips/STM32L476MG.yaml
@@ -2626,6 +2626,36 @@ cores:
           request: 2
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
+      - pin: PA13
+        signal: NOE
+        af: 10
+      - pin: PC9
+        signal: NOE
+        af: 10
       interrupts:
         GLOBAL: OTG_FS
     VREFINTCAL:

--- a/data/chips/STM32L476QE.yaml
+++ b/data/chips/STM32L476QE.yaml
@@ -3211,6 +3211,36 @@ cores:
           request: 2
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
+      - pin: PA13
+        signal: NOE
+        af: 10
+      - pin: PC9
+        signal: NOE
+        af: 10
       interrupts:
         GLOBAL: OTG_FS
     VREFINTCAL:

--- a/data/chips/STM32L476QG.yaml
+++ b/data/chips/STM32L476QG.yaml
@@ -3211,6 +3211,36 @@ cores:
           request: 2
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
+      - pin: PA13
+        signal: NOE
+        af: 10
+      - pin: PC9
+        signal: NOE
+        af: 10
       interrupts:
         GLOBAL: OTG_FS
     VREFINTCAL:

--- a/data/chips/STM32L476RC.yaml
+++ b/data/chips/STM32L476RC.yaml
@@ -2497,6 +2497,36 @@ cores:
           request: 2
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
+      - pin: PA13
+        signal: NOE
+        af: 10
+      - pin: PC9
+        signal: NOE
+        af: 10
       interrupts:
         GLOBAL: OTG_FS
     VREFINTCAL:

--- a/data/chips/STM32L476RE.yaml
+++ b/data/chips/STM32L476RE.yaml
@@ -2497,6 +2497,36 @@ cores:
           request: 2
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
+      - pin: PA13
+        signal: NOE
+        af: 10
+      - pin: PC9
+        signal: NOE
+        af: 10
       interrupts:
         GLOBAL: OTG_FS
     VREFINTCAL:

--- a/data/chips/STM32L476RG.yaml
+++ b/data/chips/STM32L476RG.yaml
@@ -2497,6 +2497,36 @@ cores:
           request: 2
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
+      - pin: PA13
+        signal: NOE
+        af: 10
+      - pin: PC9
+        signal: NOE
+        af: 10
       interrupts:
         GLOBAL: OTG_FS
     VREFINTCAL:

--- a/data/chips/STM32L476VC.yaml
+++ b/data/chips/STM32L476VC.yaml
@@ -2989,6 +2989,36 @@ cores:
           request: 2
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
+      - pin: PA13
+        signal: NOE
+        af: 10
+      - pin: PC9
+        signal: NOE
+        af: 10
       interrupts:
         GLOBAL: OTG_FS
     VREFINTCAL:

--- a/data/chips/STM32L476VE.yaml
+++ b/data/chips/STM32L476VE.yaml
@@ -2989,6 +2989,36 @@ cores:
           request: 2
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
+      - pin: PA13
+        signal: NOE
+        af: 10
+      - pin: PC9
+        signal: NOE
+        af: 10
       interrupts:
         GLOBAL: OTG_FS
     VREFINTCAL:

--- a/data/chips/STM32L476VG.yaml
+++ b/data/chips/STM32L476VG.yaml
@@ -2989,6 +2989,36 @@ cores:
           request: 2
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
+      - pin: PA13
+        signal: NOE
+        af: 10
+      - pin: PC9
+        signal: NOE
+        af: 10
       interrupts:
         GLOBAL: OTG_FS
     VREFINTCAL:

--- a/data/chips/STM32L476ZE.yaml
+++ b/data/chips/STM32L476ZE.yaml
@@ -3254,6 +3254,36 @@ cores:
           request: 2
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
+      - pin: PA13
+        signal: NOE
+        af: 10
+      - pin: PC9
+        signal: NOE
+        af: 10
       interrupts:
         GLOBAL: OTG_FS
     VREFINTCAL:

--- a/data/chips/STM32L476ZG.yaml
+++ b/data/chips/STM32L476ZG.yaml
@@ -3262,6 +3262,36 @@ cores:
           request: 2
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
+      - pin: PA13
+        signal: NOE
+        af: 10
+      - pin: PC9
+        signal: NOE
+        af: 10
       interrupts:
         GLOBAL: OTG_FS
     VREFINTCAL:

--- a/data/chips/STM32L485JC.yaml
+++ b/data/chips/STM32L485JC.yaml
@@ -2188,6 +2188,36 @@ cores:
           request: 2
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
+      - pin: PA13
+        signal: NOE
+        af: 10
+      - pin: PC9
+        signal: NOE
+        af: 10
       interrupts:
         GLOBAL: OTG_FS
     VREFINTCAL:

--- a/data/chips/STM32L485JE.yaml
+++ b/data/chips/STM32L485JE.yaml
@@ -2188,6 +2188,36 @@ cores:
           request: 2
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
+      - pin: PA13
+        signal: NOE
+        af: 10
+      - pin: PC9
+        signal: NOE
+        af: 10
       interrupts:
         GLOBAL: OTG_FS
     VREFINTCAL:

--- a/data/chips/STM32L486JG.yaml
+++ b/data/chips/STM32L486JG.yaml
@@ -2587,6 +2587,36 @@ cores:
           request: 2
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
+      - pin: PA13
+        signal: NOE
+        af: 10
+      - pin: PC9
+        signal: NOE
+        af: 10
       interrupts:
         GLOBAL: OTG_FS
     VREFINTCAL:

--- a/data/chips/STM32L486QG.yaml
+++ b/data/chips/STM32L486QG.yaml
@@ -3235,6 +3235,36 @@ cores:
           request: 2
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
+      - pin: PA13
+        signal: NOE
+        af: 10
+      - pin: PC9
+        signal: NOE
+        af: 10
       interrupts:
         GLOBAL: OTG_FS
     VREFINTCAL:

--- a/data/chips/STM32L486RG.yaml
+++ b/data/chips/STM32L486RG.yaml
@@ -2521,6 +2521,36 @@ cores:
           request: 2
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
+      - pin: PA13
+        signal: NOE
+        af: 10
+      - pin: PC9
+        signal: NOE
+        af: 10
       interrupts:
         GLOBAL: OTG_FS
     VREFINTCAL:

--- a/data/chips/STM32L486VG.yaml
+++ b/data/chips/STM32L486VG.yaml
@@ -3013,6 +3013,36 @@ cores:
           request: 2
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
+      - pin: PA13
+        signal: NOE
+        af: 10
+      - pin: PC9
+        signal: NOE
+        af: 10
       interrupts:
         GLOBAL: OTG_FS
     VREFINTCAL:

--- a/data/chips/STM32L486ZG.yaml
+++ b/data/chips/STM32L486ZG.yaml
@@ -3278,6 +3278,36 @@ cores:
           request: 2
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
+      - pin: PA13
+        signal: NOE
+        af: 10
+      - pin: PC9
+        signal: NOE
+        af: 10
       interrupts:
         GLOBAL: OTG_FS
     VREFINTCAL:

--- a/data/chips/STM32L496AE.yaml
+++ b/data/chips/STM32L496AE.yaml
@@ -3731,6 +3731,39 @@ cores:
           request: 2
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
+      - pin: PA13
+        signal: NOE
+        af: 10
+      - pin: PA14
+        signal: SOF
+        af: 10
+      - pin: PC9
+        signal: NOE
+        af: 10
       interrupts:
         GLOBAL: OTG_FS
     VREFINTCAL:

--- a/data/chips/STM32L496AG.yaml
+++ b/data/chips/STM32L496AG.yaml
@@ -3737,6 +3737,39 @@ cores:
           request: 2
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
+      - pin: PA13
+        signal: NOE
+        af: 10
+      - pin: PA14
+        signal: SOF
+        af: 10
+      - pin: PC9
+        signal: NOE
+        af: 10
       interrupts:
         GLOBAL: OTG_FS
     VREFINTCAL:

--- a/data/chips/STM32L496QE.yaml
+++ b/data/chips/STM32L496QE.yaml
@@ -3585,6 +3585,39 @@ cores:
           request: 2
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
+      - pin: PA13
+        signal: NOE
+        af: 10
+      - pin: PA14
+        signal: SOF
+        af: 10
+      - pin: PC9
+        signal: NOE
+        af: 10
       interrupts:
         GLOBAL: OTG_FS
     VREFINTCAL:

--- a/data/chips/STM32L496QG.yaml
+++ b/data/chips/STM32L496QG.yaml
@@ -3587,6 +3587,39 @@ cores:
           request: 2
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
+      - pin: PA13
+        signal: NOE
+        af: 10
+      - pin: PA14
+        signal: SOF
+        af: 10
+      - pin: PC9
+        signal: NOE
+        af: 10
       interrupts:
         GLOBAL: OTG_FS
     VREFINTCAL:

--- a/data/chips/STM32L496RE.yaml
+++ b/data/chips/STM32L496RE.yaml
@@ -2777,6 +2777,39 @@ cores:
           request: 2
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
+      - pin: PA13
+        signal: NOE
+        af: 10
+      - pin: PA14
+        signal: SOF
+        af: 10
+      - pin: PC9
+        signal: NOE
+        af: 10
       interrupts:
         GLOBAL: OTG_FS
     VREFINTCAL:

--- a/data/chips/STM32L496RG.yaml
+++ b/data/chips/STM32L496RG.yaml
@@ -2779,6 +2779,39 @@ cores:
           request: 2
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
+      - pin: PA13
+        signal: NOE
+        af: 10
+      - pin: PA14
+        signal: SOF
+        af: 10
+      - pin: PC9
+        signal: NOE
+        af: 10
       interrupts:
         GLOBAL: OTG_FS
     VREFINTCAL:

--- a/data/chips/STM32L496VE.yaml
+++ b/data/chips/STM32L496VE.yaml
@@ -3406,6 +3406,39 @@ cores:
           request: 2
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
+      - pin: PA13
+        signal: NOE
+        af: 10
+      - pin: PA14
+        signal: SOF
+        af: 10
+      - pin: PC9
+        signal: NOE
+        af: 10
       interrupts:
         GLOBAL: OTG_FS
     VREFINTCAL:

--- a/data/chips/STM32L496VG.yaml
+++ b/data/chips/STM32L496VG.yaml
@@ -3416,6 +3416,39 @@ cores:
           request: 2
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
+      - pin: PA13
+        signal: NOE
+        af: 10
+      - pin: PA14
+        signal: SOF
+        af: 10
+      - pin: PC9
+        signal: NOE
+        af: 10
       interrupts:
         GLOBAL: OTG_FS
     VREFINTCAL:

--- a/data/chips/STM32L496WG.yaml
+++ b/data/chips/STM32L496WG.yaml
@@ -3504,6 +3504,39 @@ cores:
           request: 2
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
+      - pin: PA13
+        signal: NOE
+        af: 10
+      - pin: PA14
+        signal: SOF
+        af: 10
+      - pin: PC9
+        signal: NOE
+        af: 10
       interrupts:
         GLOBAL: OTG_FS
     VREFINTCAL:

--- a/data/chips/STM32L496ZE.yaml
+++ b/data/chips/STM32L496ZE.yaml
@@ -3650,6 +3650,39 @@ cores:
           request: 2
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
+      - pin: PA13
+        signal: NOE
+        af: 10
+      - pin: PA14
+        signal: SOF
+        af: 10
+      - pin: PC9
+        signal: NOE
+        af: 10
       interrupts:
         GLOBAL: OTG_FS
     VREFINTCAL:

--- a/data/chips/STM32L496ZG.yaml
+++ b/data/chips/STM32L496ZG.yaml
@@ -3656,6 +3656,39 @@ cores:
           request: 2
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
+      - pin: PA13
+        signal: NOE
+        af: 10
+      - pin: PA14
+        signal: SOF
+        af: 10
+      - pin: PC9
+        signal: NOE
+        af: 10
       interrupts:
         GLOBAL: OTG_FS
     VREFINTCAL:

--- a/data/chips/STM32L4A6AG.yaml
+++ b/data/chips/STM32L4A6AG.yaml
@@ -3773,6 +3773,39 @@ cores:
           request: 2
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
+      - pin: PA13
+        signal: NOE
+        af: 10
+      - pin: PA14
+        signal: SOF
+        af: 10
+      - pin: PC9
+        signal: NOE
+        af: 10
       interrupts:
         GLOBAL: OTG_FS
     VREFINTCAL:

--- a/data/chips/STM32L4A6QG.yaml
+++ b/data/chips/STM32L4A6QG.yaml
@@ -3627,6 +3627,39 @@ cores:
           request: 2
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
+      - pin: PA13
+        signal: NOE
+        af: 10
+      - pin: PA14
+        signal: SOF
+        af: 10
+      - pin: PC9
+        signal: NOE
+        af: 10
       interrupts:
         GLOBAL: OTG_FS
     VREFINTCAL:

--- a/data/chips/STM32L4A6RG.yaml
+++ b/data/chips/STM32L4A6RG.yaml
@@ -2846,6 +2846,39 @@ cores:
           request: 2
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
+      - pin: PA13
+        signal: NOE
+        af: 10
+      - pin: PA14
+        signal: SOF
+        af: 10
+      - pin: PC9
+        signal: NOE
+        af: 10
       interrupts:
         GLOBAL: OTG_FS
     VREFINTCAL:

--- a/data/chips/STM32L4A6VG.yaml
+++ b/data/chips/STM32L4A6VG.yaml
@@ -3452,6 +3452,39 @@ cores:
           request: 2
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
+      - pin: PA13
+        signal: NOE
+        af: 10
+      - pin: PA14
+        signal: SOF
+        af: 10
+      - pin: PC9
+        signal: NOE
+        af: 10
       interrupts:
         GLOBAL: OTG_FS
     VREFINTCAL:

--- a/data/chips/STM32L4A6ZG.yaml
+++ b/data/chips/STM32L4A6ZG.yaml
@@ -3692,6 +3692,39 @@ cores:
           request: 2
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
+      - pin: PA13
+        signal: NOE
+        af: 10
+      - pin: PA14
+        signal: SOF
+        af: 10
+      - pin: PC9
+        signal: NOE
+        af: 10
       interrupts:
         GLOBAL: OTG_FS
     VREFINTCAL:

--- a/data/chips/STM32L4P5AE.yaml
+++ b/data/chips/STM32L4P5AE.yaml
@@ -4037,6 +4037,39 @@ cores:
           request: 30
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
+      - pin: PA13
+        signal: NOE
+        af: 10
+      - pin: PA14
+        signal: SOF
+        af: 10
+      - pin: PC9
+        signal: NOE
+        af: 10
       interrupts:
         GLOBAL: OTG_FS
     VREFINTCAL:

--- a/data/chips/STM32L4P5AG.yaml
+++ b/data/chips/STM32L4P5AG.yaml
@@ -4039,6 +4039,39 @@ cores:
           request: 30
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
+      - pin: PA13
+        signal: NOE
+        af: 10
+      - pin: PA14
+        signal: SOF
+        af: 10
+      - pin: PC9
+        signal: NOE
+        af: 10
       interrupts:
         GLOBAL: OTG_FS
     VREFINTCAL:

--- a/data/chips/STM32L4P5CE.yaml
+++ b/data/chips/STM32L4P5CE.yaml
@@ -2300,6 +2300,36 @@ cores:
           request: 30
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
+      - pin: PA13
+        signal: NOE
+        af: 10
+      - pin: PA14
+        signal: SOF
+        af: 10
       interrupts:
         GLOBAL: OTG_FS
     VREFINTCAL:

--- a/data/chips/STM32L4P5CG.yaml
+++ b/data/chips/STM32L4P5CG.yaml
@@ -2304,6 +2304,36 @@ cores:
           request: 30
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
+      - pin: PA13
+        signal: NOE
+        af: 10
+      - pin: PA14
+        signal: SOF
+        af: 10
       interrupts:
         GLOBAL: OTG_FS
     VREFINTCAL:

--- a/data/chips/STM32L4P5QE.yaml
+++ b/data/chips/STM32L4P5QE.yaml
@@ -3764,6 +3764,39 @@ cores:
           request: 30
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
+      - pin: PA13
+        signal: NOE
+        af: 10
+      - pin: PA14
+        signal: SOF
+        af: 10
+      - pin: PC9
+        signal: NOE
+        af: 10
       interrupts:
         GLOBAL: OTG_FS
     VREFINTCAL:

--- a/data/chips/STM32L4P5QG.yaml
+++ b/data/chips/STM32L4P5QG.yaml
@@ -3766,6 +3766,39 @@ cores:
           request: 30
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
+      - pin: PA13
+        signal: NOE
+        af: 10
+      - pin: PA14
+        signal: SOF
+        af: 10
+      - pin: PC9
+        signal: NOE
+        af: 10
       interrupts:
         GLOBAL: OTG_FS
     VREFINTCAL:

--- a/data/chips/STM32L4P5RE.yaml
+++ b/data/chips/STM32L4P5RE.yaml
@@ -2753,6 +2753,39 @@ cores:
           request: 30
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
+      - pin: PA13
+        signal: NOE
+        af: 10
+      - pin: PA14
+        signal: SOF
+        af: 10
+      - pin: PC9
+        signal: NOE
+        af: 10
       interrupts:
         GLOBAL: OTG_FS
     VREFINTCAL:

--- a/data/chips/STM32L4P5RG.yaml
+++ b/data/chips/STM32L4P5RG.yaml
@@ -2755,6 +2755,39 @@ cores:
           request: 30
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
+      - pin: PA13
+        signal: NOE
+        af: 10
+      - pin: PA14
+        signal: SOF
+        af: 10
+      - pin: PC9
+        signal: NOE
+        af: 10
       interrupts:
         GLOBAL: OTG_FS
     VREFINTCAL:

--- a/data/chips/STM32L4P5VE.yaml
+++ b/data/chips/STM32L4P5VE.yaml
@@ -3520,6 +3520,39 @@ cores:
           request: 30
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
+      - pin: PA13
+        signal: NOE
+        af: 10
+      - pin: PA14
+        signal: SOF
+        af: 10
+      - pin: PC9
+        signal: NOE
+        af: 10
       interrupts:
         GLOBAL: OTG_FS
     VREFINTCAL:

--- a/data/chips/STM32L4P5VG.yaml
+++ b/data/chips/STM32L4P5VG.yaml
@@ -3524,6 +3524,39 @@ cores:
           request: 30
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
+      - pin: PA13
+        signal: NOE
+        af: 10
+      - pin: PA14
+        signal: SOF
+        af: 10
+      - pin: PC9
+        signal: NOE
+        af: 10
       interrupts:
         GLOBAL: OTG_FS
     VREFINTCAL:

--- a/data/chips/STM32L4P5ZE.yaml
+++ b/data/chips/STM32L4P5ZE.yaml
@@ -3827,6 +3827,39 @@ cores:
           request: 30
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
+      - pin: PA13
+        signal: NOE
+        af: 10
+      - pin: PA14
+        signal: SOF
+        af: 10
+      - pin: PC9
+        signal: NOE
+        af: 10
       interrupts:
         GLOBAL: OTG_FS
     VREFINTCAL:

--- a/data/chips/STM32L4P5ZG.yaml
+++ b/data/chips/STM32L4P5ZG.yaml
@@ -3829,6 +3829,39 @@ cores:
           request: 30
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
+      - pin: PA13
+        signal: NOE
+        af: 10
+      - pin: PA14
+        signal: SOF
+        af: 10
+      - pin: PC9
+        signal: NOE
+        af: 10
       interrupts:
         GLOBAL: OTG_FS
     VREFINTCAL:

--- a/data/chips/STM32L4Q5AG.yaml
+++ b/data/chips/STM32L4Q5AG.yaml
@@ -4063,6 +4063,39 @@ cores:
           request: 30
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
+      - pin: PA13
+        signal: NOE
+        af: 10
+      - pin: PA14
+        signal: SOF
+        af: 10
+      - pin: PC9
+        signal: NOE
+        af: 10
       interrupts:
         GLOBAL: OTG_FS
     VREFINTCAL:

--- a/data/chips/STM32L4Q5CG.yaml
+++ b/data/chips/STM32L4Q5CG.yaml
@@ -2328,6 +2328,36 @@ cores:
           request: 30
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
+      - pin: PA13
+        signal: NOE
+        af: 10
+      - pin: PA14
+        signal: SOF
+        af: 10
       interrupts:
         GLOBAL: OTG_FS
     VREFINTCAL:

--- a/data/chips/STM32L4Q5QG.yaml
+++ b/data/chips/STM32L4Q5QG.yaml
@@ -3790,6 +3790,39 @@ cores:
           request: 30
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
+      - pin: PA13
+        signal: NOE
+        af: 10
+      - pin: PA14
+        signal: SOF
+        af: 10
+      - pin: PC9
+        signal: NOE
+        af: 10
       interrupts:
         GLOBAL: OTG_FS
     VREFINTCAL:

--- a/data/chips/STM32L4Q5RG.yaml
+++ b/data/chips/STM32L4Q5RG.yaml
@@ -2779,6 +2779,39 @@ cores:
           request: 30
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
+      - pin: PA13
+        signal: NOE
+        af: 10
+      - pin: PA14
+        signal: SOF
+        af: 10
+      - pin: PC9
+        signal: NOE
+        af: 10
       interrupts:
         GLOBAL: OTG_FS
     VREFINTCAL:

--- a/data/chips/STM32L4Q5VG.yaml
+++ b/data/chips/STM32L4Q5VG.yaml
@@ -3548,6 +3548,39 @@ cores:
           request: 30
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
+      - pin: PA13
+        signal: NOE
+        af: 10
+      - pin: PA14
+        signal: SOF
+        af: 10
+      - pin: PC9
+        signal: NOE
+        af: 10
       interrupts:
         GLOBAL: OTG_FS
     VREFINTCAL:

--- a/data/chips/STM32L4Q5ZG.yaml
+++ b/data/chips/STM32L4Q5ZG.yaml
@@ -3853,6 +3853,39 @@ cores:
           request: 30
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
+      - pin: PA13
+        signal: NOE
+        af: 10
+      - pin: PA14
+        signal: SOF
+        af: 10
+      - pin: PC9
+        signal: NOE
+        af: 10
       interrupts:
         GLOBAL: OTG_FS
     VREFINTCAL:

--- a/data/chips/STM32L4R5AG.yaml
+++ b/data/chips/STM32L4R5AG.yaml
@@ -3569,6 +3569,39 @@ cores:
           request: 29
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
+      - pin: PA13
+        signal: NOE
+        af: 10
+      - pin: PA14
+        signal: SOF
+        af: 10
+      - pin: PC9
+        signal: NOE
+        af: 10
       interrupts:
         GLOBAL: OTG_FS
     VREFINTCAL:

--- a/data/chips/STM32L4R5AI.yaml
+++ b/data/chips/STM32L4R5AI.yaml
@@ -3569,6 +3569,39 @@ cores:
           request: 29
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
+      - pin: PA13
+        signal: NOE
+        af: 10
+      - pin: PA14
+        signal: SOF
+        af: 10
+      - pin: PC9
+        signal: NOE
+        af: 10
       interrupts:
         GLOBAL: OTG_FS
     VREFINTCAL:

--- a/data/chips/STM32L4R5QG.yaml
+++ b/data/chips/STM32L4R5QG.yaml
@@ -3374,6 +3374,39 @@ cores:
           request: 29
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
+      - pin: PA13
+        signal: NOE
+        af: 10
+      - pin: PA14
+        signal: SOF
+        af: 10
+      - pin: PC9
+        signal: NOE
+        af: 10
       interrupts:
         GLOBAL: OTG_FS
     VREFINTCAL:

--- a/data/chips/STM32L4R5QI.yaml
+++ b/data/chips/STM32L4R5QI.yaml
@@ -3374,6 +3374,39 @@ cores:
           request: 29
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
+      - pin: PA13
+        signal: NOE
+        af: 10
+      - pin: PA14
+        signal: SOF
+        af: 10
+      - pin: PC9
+        signal: NOE
+        af: 10
       interrupts:
         GLOBAL: OTG_FS
     VREFINTCAL:

--- a/data/chips/STM32L4R5VG.yaml
+++ b/data/chips/STM32L4R5VG.yaml
@@ -3086,6 +3086,39 @@ cores:
           request: 29
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
+      - pin: PA13
+        signal: NOE
+        af: 10
+      - pin: PA14
+        signal: SOF
+        af: 10
+      - pin: PC9
+        signal: NOE
+        af: 10
       interrupts:
         GLOBAL: OTG_FS
     VREFINTCAL:

--- a/data/chips/STM32L4R5VI.yaml
+++ b/data/chips/STM32L4R5VI.yaml
@@ -3086,6 +3086,39 @@ cores:
           request: 29
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
+      - pin: PA13
+        signal: NOE
+        af: 10
+      - pin: PA14
+        signal: SOF
+        af: 10
+      - pin: PC9
+        signal: NOE
+        af: 10
       interrupts:
         GLOBAL: OTG_FS
     VREFINTCAL:

--- a/data/chips/STM32L4R5ZG.yaml
+++ b/data/chips/STM32L4R5ZG.yaml
@@ -3433,6 +3433,39 @@ cores:
           request: 29
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
+      - pin: PA13
+        signal: NOE
+        af: 10
+      - pin: PA14
+        signal: SOF
+        af: 10
+      - pin: PC9
+        signal: NOE
+        af: 10
       interrupts:
         GLOBAL: OTG_FS
     VREFINTCAL:

--- a/data/chips/STM32L4R5ZI.yaml
+++ b/data/chips/STM32L4R5ZI.yaml
@@ -3439,6 +3439,39 @@ cores:
           request: 29
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
+      - pin: PA13
+        signal: NOE
+        af: 10
+      - pin: PA14
+        signal: SOF
+        af: 10
+      - pin: PC9
+        signal: NOE
+        af: 10
       interrupts:
         GLOBAL: OTG_FS
     VREFINTCAL:

--- a/data/chips/STM32L4R7AI.yaml
+++ b/data/chips/STM32L4R7AI.yaml
@@ -3714,6 +3714,39 @@ cores:
           request: 29
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
+      - pin: PA13
+        signal: NOE
+        af: 10
+      - pin: PA14
+        signal: SOF
+        af: 10
+      - pin: PC9
+        signal: NOE
+        af: 10
       interrupts:
         GLOBAL: OTG_FS
     VREFINTCAL:

--- a/data/chips/STM32L4R7VI.yaml
+++ b/data/chips/STM32L4R7VI.yaml
@@ -3207,6 +3207,39 @@ cores:
           request: 29
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
+      - pin: PA13
+        signal: NOE
+        af: 10
+      - pin: PA14
+        signal: SOF
+        af: 10
+      - pin: PC9
+        signal: NOE
+        af: 10
       interrupts:
         GLOBAL: OTG_FS
     VREFINTCAL:

--- a/data/chips/STM32L4R7ZI.yaml
+++ b/data/chips/STM32L4R7ZI.yaml
@@ -3576,6 +3576,39 @@ cores:
           request: 29
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
+      - pin: PA13
+        signal: NOE
+        af: 10
+      - pin: PA14
+        signal: SOF
+        af: 10
+      - pin: PC9
+        signal: NOE
+        af: 10
       interrupts:
         GLOBAL: OTG_FS
     VREFINTCAL:

--- a/data/chips/STM32L4R9AG.yaml
+++ b/data/chips/STM32L4R9AG.yaml
@@ -3678,6 +3678,39 @@ cores:
           request: 29
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
+      - pin: PA13
+        signal: NOE
+        af: 10
+      - pin: PA14
+        signal: SOF
+        af: 10
+      - pin: PC9
+        signal: NOE
+        af: 10
       interrupts:
         GLOBAL: OTG_FS
     VREFINTCAL:

--- a/data/chips/STM32L4R9AI.yaml
+++ b/data/chips/STM32L4R9AI.yaml
@@ -3678,6 +3678,39 @@ cores:
           request: 29
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
+      - pin: PA13
+        signal: NOE
+        af: 10
+      - pin: PA14
+        signal: SOF
+        af: 10
+      - pin: PC9
+        signal: NOE
+        af: 10
       interrupts:
         GLOBAL: OTG_FS
     VREFINTCAL:

--- a/data/chips/STM32L4R9VG.yaml
+++ b/data/chips/STM32L4R9VG.yaml
@@ -3101,6 +3101,39 @@ cores:
           request: 29
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
+      - pin: PA13
+        signal: NOE
+        af: 10
+      - pin: PA14
+        signal: SOF
+        af: 10
+      - pin: PC9
+        signal: NOE
+        af: 10
       interrupts:
         GLOBAL: OTG_FS
     VREFINTCAL:

--- a/data/chips/STM32L4R9VI.yaml
+++ b/data/chips/STM32L4R9VI.yaml
@@ -3101,6 +3101,39 @@ cores:
           request: 29
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
+      - pin: PA13
+        signal: NOE
+        af: 10
+      - pin: PA14
+        signal: SOF
+        af: 10
+      - pin: PC9
+        signal: NOE
+        af: 10
       interrupts:
         GLOBAL: OTG_FS
     VREFINTCAL:

--- a/data/chips/STM32L4R9ZG.yaml
+++ b/data/chips/STM32L4R9ZG.yaml
@@ -3575,6 +3575,39 @@ cores:
           request: 29
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
+      - pin: PA13
+        signal: NOE
+        af: 10
+      - pin: PA14
+        signal: SOF
+        af: 10
+      - pin: PC9
+        signal: NOE
+        af: 10
       interrupts:
         GLOBAL: OTG_FS
     VREFINTCAL:

--- a/data/chips/STM32L4R9ZI.yaml
+++ b/data/chips/STM32L4R9ZI.yaml
@@ -3581,6 +3581,39 @@ cores:
           request: 29
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
+      - pin: PA13
+        signal: NOE
+        af: 10
+      - pin: PA14
+        signal: SOF
+        af: 10
+      - pin: PC9
+        signal: NOE
+        af: 10
       interrupts:
         GLOBAL: OTG_FS
     VREFINTCAL:

--- a/data/chips/STM32L4S5AI.yaml
+++ b/data/chips/STM32L4S5AI.yaml
@@ -3605,6 +3605,39 @@ cores:
           request: 29
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
+      - pin: PA13
+        signal: NOE
+        af: 10
+      - pin: PA14
+        signal: SOF
+        af: 10
+      - pin: PC9
+        signal: NOE
+        af: 10
       interrupts:
         GLOBAL: OTG_FS
     VREFINTCAL:

--- a/data/chips/STM32L4S5QI.yaml
+++ b/data/chips/STM32L4S5QI.yaml
@@ -3410,6 +3410,39 @@ cores:
           request: 29
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
+      - pin: PA13
+        signal: NOE
+        af: 10
+      - pin: PA14
+        signal: SOF
+        af: 10
+      - pin: PC9
+        signal: NOE
+        af: 10
       interrupts:
         GLOBAL: OTG_FS
     VREFINTCAL:

--- a/data/chips/STM32L4S5VI.yaml
+++ b/data/chips/STM32L4S5VI.yaml
@@ -3122,6 +3122,39 @@ cores:
           request: 29
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
+      - pin: PA13
+        signal: NOE
+        af: 10
+      - pin: PA14
+        signal: SOF
+        af: 10
+      - pin: PC9
+        signal: NOE
+        af: 10
       interrupts:
         GLOBAL: OTG_FS
     VREFINTCAL:

--- a/data/chips/STM32L4S5ZI.yaml
+++ b/data/chips/STM32L4S5ZI.yaml
@@ -3469,6 +3469,39 @@ cores:
           request: 29
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
+      - pin: PA13
+        signal: NOE
+        af: 10
+      - pin: PA14
+        signal: SOF
+        af: 10
+      - pin: PC9
+        signal: NOE
+        af: 10
       interrupts:
         GLOBAL: OTG_FS
     VREFINTCAL:

--- a/data/chips/STM32L4S7AI.yaml
+++ b/data/chips/STM32L4S7AI.yaml
@@ -3750,6 +3750,39 @@ cores:
           request: 29
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
+      - pin: PA13
+        signal: NOE
+        af: 10
+      - pin: PA14
+        signal: SOF
+        af: 10
+      - pin: PC9
+        signal: NOE
+        af: 10
       interrupts:
         GLOBAL: OTG_FS
     VREFINTCAL:

--- a/data/chips/STM32L4S7VI.yaml
+++ b/data/chips/STM32L4S7VI.yaml
@@ -3243,6 +3243,39 @@ cores:
           request: 29
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
+      - pin: PA13
+        signal: NOE
+        af: 10
+      - pin: PA14
+        signal: SOF
+        af: 10
+      - pin: PC9
+        signal: NOE
+        af: 10
       interrupts:
         GLOBAL: OTG_FS
     VREFINTCAL:

--- a/data/chips/STM32L4S7ZI.yaml
+++ b/data/chips/STM32L4S7ZI.yaml
@@ -3612,6 +3612,39 @@ cores:
           request: 29
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
+      - pin: PA13
+        signal: NOE
+        af: 10
+      - pin: PA14
+        signal: SOF
+        af: 10
+      - pin: PC9
+        signal: NOE
+        af: 10
       interrupts:
         GLOBAL: OTG_FS
     VREFINTCAL:

--- a/data/chips/STM32L4S9AI.yaml
+++ b/data/chips/STM32L4S9AI.yaml
@@ -3714,6 +3714,39 @@ cores:
           request: 29
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
+      - pin: PA13
+        signal: NOE
+        af: 10
+      - pin: PA14
+        signal: SOF
+        af: 10
+      - pin: PC9
+        signal: NOE
+        af: 10
       interrupts:
         GLOBAL: OTG_FS
     VREFINTCAL:

--- a/data/chips/STM32L4S9VI.yaml
+++ b/data/chips/STM32L4S9VI.yaml
@@ -3137,6 +3137,39 @@ cores:
           request: 29
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
+      - pin: PA13
+        signal: NOE
+        af: 10
+      - pin: PA14
+        signal: SOF
+        af: 10
+      - pin: PC9
+        signal: NOE
+        af: 10
       interrupts:
         GLOBAL: OTG_FS
     VREFINTCAL:

--- a/data/chips/STM32L4S9ZI.yaml
+++ b/data/chips/STM32L4S9ZI.yaml
@@ -3611,6 +3611,39 @@ cores:
           request: 29
     USB_OTG_FS:
       address: 0x50000000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
+      - pin: PA13
+        signal: NOE
+        af: 10
+      - pin: PA14
+        signal: SOF
+        af: 10
+      - pin: PC9
+        signal: NOE
+        af: 10
       interrupts:
         GLOBAL: OTG_FS
     VREFINTCAL:

--- a/data/chips/STM32U575AG.yaml
+++ b/data/chips/STM32U575AG.yaml
@@ -3715,6 +3715,39 @@ cores:
         GLOBAL: USART3
     USB_OTG_FS:
       address: 0x42040000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR1
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR1
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
+      - pin: PA13
+        signal: NOE
+        af: 10
+      - pin: PA14
+        signal: SOF
+        af: 10
+      - pin: PC9
+        signal: NOE
+        af: 10
       interrupts:
         GLOBAL: OTG_FS
     VREFBUF:

--- a/data/chips/STM32U575AI.yaml
+++ b/data/chips/STM32U575AI.yaml
@@ -3715,6 +3715,39 @@ cores:
         GLOBAL: USART3
     USB_OTG_FS:
       address: 0x42040000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR1
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR1
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
+      - pin: PA13
+        signal: NOE
+        af: 10
+      - pin: PA14
+        signal: SOF
+        af: 10
+      - pin: PC9
+        signal: NOE
+        af: 10
       interrupts:
         GLOBAL: OTG_FS
     VREFBUF:

--- a/data/chips/STM32U575CG.yaml
+++ b/data/chips/STM32U575CG.yaml
@@ -1838,6 +1838,36 @@ cores:
         GLOBAL: USART3
     USB_OTG_FS:
       address: 0x42040000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR1
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR1
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
+      - pin: PA13
+        signal: NOE
+        af: 10
+      - pin: PA14
+        signal: SOF
+        af: 10
       interrupts:
         GLOBAL: OTG_FS
     VREFBUF:

--- a/data/chips/STM32U575CI.yaml
+++ b/data/chips/STM32U575CI.yaml
@@ -1838,6 +1838,36 @@ cores:
         GLOBAL: USART3
     USB_OTG_FS:
       address: 0x42040000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR1
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR1
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
+      - pin: PA13
+        signal: NOE
+        af: 10
+      - pin: PA14
+        signal: SOF
+        af: 10
       interrupts:
         GLOBAL: OTG_FS
     VREFBUF:

--- a/data/chips/STM32U575OG.yaml
+++ b/data/chips/STM32U575OG.yaml
@@ -2677,6 +2677,39 @@ cores:
         GLOBAL: USART3
     USB_OTG_FS:
       address: 0x42040000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR1
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR1
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
+      - pin: PA13
+        signal: NOE
+        af: 10
+      - pin: PA14
+        signal: SOF
+        af: 10
+      - pin: PC9
+        signal: NOE
+        af: 10
       interrupts:
         GLOBAL: OTG_FS
     VREFBUF:

--- a/data/chips/STM32U575OI.yaml
+++ b/data/chips/STM32U575OI.yaml
@@ -2677,6 +2677,39 @@ cores:
         GLOBAL: USART3
     USB_OTG_FS:
       address: 0x42040000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR1
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR1
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
+      - pin: PA13
+        signal: NOE
+        af: 10
+      - pin: PA14
+        signal: SOF
+        af: 10
+      - pin: PC9
+        signal: NOE
+        af: 10
       interrupts:
         GLOBAL: OTG_FS
     VREFBUF:

--- a/data/chips/STM32U575QG.yaml
+++ b/data/chips/STM32U575QG.yaml
@@ -3388,6 +3388,39 @@ cores:
         GLOBAL: USART3
     USB_OTG_FS:
       address: 0x42040000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR1
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR1
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
+      - pin: PA13
+        signal: NOE
+        af: 10
+      - pin: PA14
+        signal: SOF
+        af: 10
+      - pin: PC9
+        signal: NOE
+        af: 10
       interrupts:
         GLOBAL: OTG_FS
     VREFBUF:

--- a/data/chips/STM32U575QI.yaml
+++ b/data/chips/STM32U575QI.yaml
@@ -3388,6 +3388,39 @@ cores:
         GLOBAL: USART3
     USB_OTG_FS:
       address: 0x42040000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR1
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR1
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
+      - pin: PA13
+        signal: NOE
+        af: 10
+      - pin: PA14
+        signal: SOF
+        af: 10
+      - pin: PC9
+        signal: NOE
+        af: 10
       interrupts:
         GLOBAL: OTG_FS
     VREFBUF:

--- a/data/chips/STM32U575RG.yaml
+++ b/data/chips/STM32U575RG.yaml
@@ -2246,6 +2246,39 @@ cores:
         GLOBAL: USART3
     USB_OTG_FS:
       address: 0x42040000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR1
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR1
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
+      - pin: PA13
+        signal: NOE
+        af: 10
+      - pin: PA14
+        signal: SOF
+        af: 10
+      - pin: PC9
+        signal: NOE
+        af: 10
       interrupts:
         GLOBAL: OTG_FS
     VREFBUF:

--- a/data/chips/STM32U575RI.yaml
+++ b/data/chips/STM32U575RI.yaml
@@ -2246,6 +2246,39 @@ cores:
         GLOBAL: USART3
     USB_OTG_FS:
       address: 0x42040000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR1
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR1
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
+      - pin: PA13
+        signal: NOE
+        af: 10
+      - pin: PA14
+        signal: SOF
+        af: 10
+      - pin: PC9
+        signal: NOE
+        af: 10
       interrupts:
         GLOBAL: OTG_FS
     VREFBUF:

--- a/data/chips/STM32U575VG.yaml
+++ b/data/chips/STM32U575VG.yaml
@@ -3048,6 +3048,39 @@ cores:
         GLOBAL: USART3
     USB_OTG_FS:
       address: 0x42040000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR1
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR1
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
+      - pin: PA13
+        signal: NOE
+        af: 10
+      - pin: PA14
+        signal: SOF
+        af: 10
+      - pin: PC9
+        signal: NOE
+        af: 10
       interrupts:
         GLOBAL: OTG_FS
     VREFBUF:

--- a/data/chips/STM32U575VI.yaml
+++ b/data/chips/STM32U575VI.yaml
@@ -3048,6 +3048,39 @@ cores:
         GLOBAL: USART3
     USB_OTG_FS:
       address: 0x42040000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR1
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR1
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
+      - pin: PA13
+        signal: NOE
+        af: 10
+      - pin: PA14
+        signal: SOF
+        af: 10
+      - pin: PC9
+        signal: NOE
+        af: 10
       interrupts:
         GLOBAL: OTG_FS
     VREFBUF:

--- a/data/chips/STM32U575ZG.yaml
+++ b/data/chips/STM32U575ZG.yaml
@@ -3472,6 +3472,39 @@ cores:
         GLOBAL: USART3
     USB_OTG_FS:
       address: 0x42040000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR1
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR1
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
+      - pin: PA13
+        signal: NOE
+        af: 10
+      - pin: PA14
+        signal: SOF
+        af: 10
+      - pin: PC9
+        signal: NOE
+        af: 10
       interrupts:
         GLOBAL: OTG_FS
     VREFBUF:

--- a/data/chips/STM32U575ZI.yaml
+++ b/data/chips/STM32U575ZI.yaml
@@ -3472,6 +3472,39 @@ cores:
         GLOBAL: USART3
     USB_OTG_FS:
       address: 0x42040000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR1
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR1
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
+      - pin: PA13
+        signal: NOE
+        af: 10
+      - pin: PA14
+        signal: SOF
+        af: 10
+      - pin: PC9
+        signal: NOE
+        af: 10
       interrupts:
         GLOBAL: OTG_FS
     VREFBUF:

--- a/data/chips/STM32U585AI.yaml
+++ b/data/chips/STM32U585AI.yaml
@@ -3780,6 +3780,39 @@ cores:
         GLOBAL: USART3
     USB_OTG_FS:
       address: 0x42040000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR1
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR1
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
+      - pin: PA13
+        signal: NOE
+        af: 10
+      - pin: PA14
+        signal: SOF
+        af: 10
+      - pin: PC9
+        signal: NOE
+        af: 10
       interrupts:
         GLOBAL: OTG_FS
     VREFBUF:

--- a/data/chips/STM32U585CI.yaml
+++ b/data/chips/STM32U585CI.yaml
@@ -1903,6 +1903,36 @@ cores:
         GLOBAL: USART3
     USB_OTG_FS:
       address: 0x42040000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR1
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR1
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
+      - pin: PA13
+        signal: NOE
+        af: 10
+      - pin: PA14
+        signal: SOF
+        af: 10
       interrupts:
         GLOBAL: OTG_FS
     VREFBUF:

--- a/data/chips/STM32U585OI.yaml
+++ b/data/chips/STM32U585OI.yaml
@@ -2742,6 +2742,39 @@ cores:
         GLOBAL: USART3
     USB_OTG_FS:
       address: 0x42040000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR1
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR1
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
+      - pin: PA13
+        signal: NOE
+        af: 10
+      - pin: PA14
+        signal: SOF
+        af: 10
+      - pin: PC9
+        signal: NOE
+        af: 10
       interrupts:
         GLOBAL: OTG_FS
     VREFBUF:

--- a/data/chips/STM32U585QE.yaml
+++ b/data/chips/STM32U585QE.yaml
@@ -3397,6 +3397,39 @@ cores:
         GLOBAL: USART3
     USB_OTG_FS:
       address: 0x42040000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR1
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR1
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
+      - pin: PA13
+        signal: NOE
+        af: 10
+      - pin: PA14
+        signal: SOF
+        af: 10
+      - pin: PC9
+        signal: NOE
+        af: 10
       interrupts:
         GLOBAL: OTG_FS
     VREFBUF:

--- a/data/chips/STM32U585QI.yaml
+++ b/data/chips/STM32U585QI.yaml
@@ -3451,6 +3451,39 @@ cores:
         GLOBAL: USART3
     USB_OTG_FS:
       address: 0x42040000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR1
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR1
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
+      - pin: PA13
+        signal: NOE
+        af: 10
+      - pin: PA14
+        signal: SOF
+        af: 10
+      - pin: PC9
+        signal: NOE
+        af: 10
       interrupts:
         GLOBAL: OTG_FS
     VREFBUF:

--- a/data/chips/STM32U585RI.yaml
+++ b/data/chips/STM32U585RI.yaml
@@ -2311,6 +2311,39 @@ cores:
         GLOBAL: USART3
     USB_OTG_FS:
       address: 0x42040000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR1
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR1
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
+      - pin: PA13
+        signal: NOE
+        af: 10
+      - pin: PA14
+        signal: SOF
+        af: 10
+      - pin: PC9
+        signal: NOE
+        af: 10
       interrupts:
         GLOBAL: OTG_FS
     VREFBUF:

--- a/data/chips/STM32U585VI.yaml
+++ b/data/chips/STM32U585VI.yaml
@@ -3113,6 +3113,39 @@ cores:
         GLOBAL: USART3
     USB_OTG_FS:
       address: 0x42040000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR1
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR1
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
+      - pin: PA13
+        signal: NOE
+        af: 10
+      - pin: PA14
+        signal: SOF
+        af: 10
+      - pin: PC9
+        signal: NOE
+        af: 10
       interrupts:
         GLOBAL: OTG_FS
     VREFBUF:

--- a/data/chips/STM32U585ZE.yaml
+++ b/data/chips/STM32U585ZE.yaml
@@ -3448,6 +3448,39 @@ cores:
         GLOBAL: USART3
     USB_OTG_FS:
       address: 0x42040000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR1
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR1
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
+      - pin: PA13
+        signal: NOE
+        af: 10
+      - pin: PA14
+        signal: SOF
+        af: 10
+      - pin: PC9
+        signal: NOE
+        af: 10
       interrupts:
         GLOBAL: OTG_FS
     VREFBUF:

--- a/data/chips/STM32U585ZI.yaml
+++ b/data/chips/STM32U585ZI.yaml
@@ -3511,6 +3511,39 @@ cores:
         GLOBAL: USART3
     USB_OTG_FS:
       address: 0x42040000
+      rcc:
+        clock: AHB2
+        registers:
+          enable:
+            register: AHB2ENR1
+            field: USB_OTG_FSEN
+          reset:
+            register: AHB2RSTR1
+            field: USB_OTG_FSRST
+      pins:
+      - pin: PA8
+        signal: SOF
+        af: 10
+      - pin: PA9
+        signal: VBUS
+      - pin: PA10
+        signal: ID
+        af: 10
+      - pin: PA11
+        signal: DM
+        af: 10
+      - pin: PA12
+        signal: DP
+        af: 10
+      - pin: PA13
+        signal: NOE
+        af: 10
+      - pin: PA14
+        signal: SOF
+        af: 10
+      - pin: PC9
+        signal: NOE
+        af: 10
       interrupts:
         GLOBAL: OTG_FS
     VREFBUF:

--- a/data/registers/rcc_f1.yaml
+++ b/data/registers/rcc_f1.yaml
@@ -81,7 +81,7 @@ fieldset/AHBENR:
       description: SDIO clock enable
       bit_offset: 10
       bit_size: 1
-    - name: OTGFSEN
+    - name: USB_OTG_FSEN
       description: USB OTG FS clock enable
       bit_offset: 12
       bit_size: 1
@@ -100,7 +100,7 @@ fieldset/AHBENR:
 fieldset/AHBRSTR:
   description: AHB peripheral clock reset register (RCC_AHBRSTR)
   fields:
-    - name: OTGFSRST
+    - name: USB_OTG_FSRST
       description: USB OTG FS reset
       bit_offset: 12
       bit_size: 1

--- a/data/registers/rcc_f2.yaml
+++ b/data/registers/rcc_f2.yaml
@@ -165,11 +165,11 @@ fieldset/AHB1ENR:
       description: Ethernet PTP clock enable
       bit_offset: 28
       bit_size: 1
-    - name: OTGHSEN
+    - name: USB_OTG_HSEN
       description: USB OTG HS clock enable
       bit_offset: 29
       bit_size: 1
-    - name: OTGHSULPIEN
+    - name: USB_OTG_HSULPIEN
       description: USB OTG HSULPI clock enable
       bit_offset: 30
       bit_size: 1
@@ -256,11 +256,11 @@ fieldset/AHB1LPENR:
       description: Ethernet PTP clock enable during Sleep mode
       bit_offset: 28
       bit_size: 1
-    - name: OTGHSLPEN
+    - name: USB_OTG_HSLPEN
       description: USB OTG HS clock enable during Sleep mode
       bit_offset: 29
       bit_size: 1
-    - name: OTGHSULPILPEN
+    - name: USB_OTG_HSULPILPEN
       description: USB OTG HS ULPI clock enable during Sleep mode
       bit_offset: 30
       bit_size: 1
@@ -319,7 +319,7 @@ fieldset/AHB1RSTR:
       description: Ethernet MAC reset
       bit_offset: 25
       bit_size: 1
-    - name: OTGHSRST
+    - name: USB_OTG_HSRST
       description: USB OTG HS module reset
       bit_offset: 29
       bit_size: 1
@@ -342,7 +342,7 @@ fieldset/AHB2ENR:
       description: Random number generator clock enable
       bit_offset: 6
       bit_size: 1
-    - name: OTGFSEN
+    - name: USB_OTG_FSEN
       description: USB OTG FS clock enable
       bit_offset: 7
       bit_size: 1
@@ -365,7 +365,7 @@ fieldset/AHB2LPENR:
       description: Random number generator clock enable during Sleep mode
       bit_offset: 6
       bit_size: 1
-    - name: OTGFSLPEN
+    - name: USB_OTG_FSLPEN
       description: USB OTG FS clock enable during Sleep mode
       bit_offset: 7
       bit_size: 1
@@ -388,7 +388,7 @@ fieldset/AHB2RSTR:
       description: Random number generator module reset
       bit_offset: 6
       bit_size: 1
-    - name: OTGFSRST
+    - name: USB_OTG_FSRST
       description: USB OTG FS module reset
       bit_offset: 7
       bit_size: 1

--- a/data/registers/rcc_f4.yaml
+++ b/data/registers/rcc_f4.yaml
@@ -181,11 +181,11 @@ fieldset/AHB1ENR:
       description: Ethernet PTP clock enable
       bit_offset: 28
       bit_size: 1
-    - name: OTGHSEN
+    - name: USB_OTG_HSEN
       description: USB OTG HS clock enable
       bit_offset: 29
       bit_size: 1
-    - name: OTGHSULPIEN
+    - name: USB_OTG_HSULPIEN
       description: USB OTG HSULPI clock enable
       bit_offset: 30
       bit_size: 1
@@ -288,11 +288,11 @@ fieldset/AHB1LPENR:
       description: Ethernet PTP clock enable during Sleep mode
       bit_offset: 28
       bit_size: 1
-    - name: OTGHSLPEN
+    - name: USB_OTG_HSLPEN
       description: USB OTG HS clock enable during Sleep mode
       bit_offset: 29
       bit_size: 1
-    - name: OTGHSULPILPEN
+    - name: USB_OTG_HSULPILPEN
       description: USB OTG HS ULPI clock enable during Sleep mode
       bit_offset: 30
       bit_size: 1
@@ -371,7 +371,7 @@ fieldset/AHB1RSTR:
       description: Ethernet MAC reset
       bit_offset: 25
       bit_size: 1
-    - name: OTGHSRST
+    - name: USB_OTG_HSRST
       description: USB OTG HS module reset
       bit_offset: 29
       bit_size: 1
@@ -390,7 +390,7 @@ fieldset/AHB1RSTR:
 fieldset/AHB2ENR:
   description: AHB2 peripheral clock enable register
   fields:
-    - name: OTGFSEN
+    - name: USB_OTG_FSEN
       description: USB OTG FS clock enable
       bit_offset: 7
       bit_size: 1
@@ -413,7 +413,7 @@ fieldset/AHB2ENR:
 fieldset/AHB2LPENR:
   description: AHB2 peripheral clock enable in low power mode register
   fields:
-    - name: OTGFSLPEN
+    - name: USB_OTG_FSLPEN
       description: USB OTG FS clock enable during Sleep mode
       bit_offset: 7
       bit_size: 1
@@ -444,7 +444,7 @@ fieldset/AHB2LPENR:
 fieldset/AHB2RSTR:
   description: AHB2 peripheral reset register
   fields:
-    - name: OTGFSRST
+    - name: USB_OTG_FSRST
       description: USB OTG FS module reset
       bit_offset: 7
       bit_size: 1

--- a/data/registers/rcc_l4.yaml
+++ b/data/registers/rcc_l4.yaml
@@ -280,7 +280,7 @@ fieldset/AHB2ENR:
       description: IO port I clock enable
       bit_offset: 8
       bit_size: 1
-    - name: OTGFSEN
+    - name: USB_OTG_FSEN
       description: OTG full speed clock enable
       bit_offset: 12
       bit_size: 1
@@ -351,7 +351,7 @@ fieldset/AHB2RSTR:
       description: IO port I reset
       bit_offset: 8
       bit_size: 1
-    - name: OTGFSRST
+    - name: USB_OTG_FSRST
       description: USB OTG FS reset
       bit_offset: 12
       bit_size: 1
@@ -430,7 +430,7 @@ fieldset/AHB2SMENR:
       description: SRAM2 interface clocks enable during Sleep and Stop modes
       bit_offset: 10
       bit_size: 1
-    - name: OTGFSSMEN
+    - name: USB_OTG_FSSMEN
       description: OTG full speed clocks enable during Sleep and Stop modes
       bit_offset: 12
       bit_size: 1

--- a/data/registers/rcc_u5.yaml
+++ b/data/registers/rcc_u5.yaml
@@ -406,7 +406,7 @@ fieldset/AHB2ENR1:
       description: "DCMI and PSSI clock enable\r Set and cleared by software."
       bit_offset: 12
       bit_size: 1
-    - name: OTGEN
+    - name: USB_OTG_FSEN
       description: "OTG_FS clock enable\r Set and cleared by software."
       bit_offset: 14
       bit_size: 1
@@ -520,7 +520,7 @@ fieldset/AHB2RSTR1:
       description: "DCMI and PSSI reset\r Set and cleared by software."
       bit_offset: 12
       bit_size: 1
-    - name: OTGRST
+    - name: USB_OTG_FSRST
       description: "OTG_FS reset\r Set and cleared by software."
       bit_offset: 14
       bit_size: 1
@@ -626,7 +626,7 @@ fieldset/AHB2SMENR1:
       description: "DCMI and PSSI clocks enable during Sleep and Stop modes\r Set and cleared by software."
       bit_offset: 12
       bit_size: 1
-    - name: OTGSMEN
+    - name: USB_OTG_FSSMEN
       description: "OTG_FS clocks enable during Sleep and Stop modes\r Set and cleared by software."
       bit_offset: 14
       bit_size: 1

--- a/stm32data/__main__.py
+++ b/stm32data/__main__.py
@@ -662,9 +662,14 @@ def parse_chips():
                         signal = 'SUBGHZSPI_' + signal[16:-3]
                     # TODO: What are those signals (well, GPIO is clear) Which peripheral do they belong to?
                     if signal not in {'GPIO', 'CEC', 'AUDIOCLK', 'VDDTCXO'} and 'EXTI' not in signal:
-                        periph, signal = signal.split('_', maxsplit=1)
-                        pins = periph_pins.setdefault(periph, [])
-                        pins.append(OrderedDict(pin=pin_name, signal=signal))
+                        # both peripherals and signals can have underscores in their names so there is no easy way to split
+                        # check if signal name starts with one of the peripheral names
+                        for periph in peri_kinds.keys():
+                            if signal.startswith(periph + '_'):
+                                signal = removeprefix(signal, periph + '_')
+                                pins = periph_pins.setdefault(periph, [])
+                                pins.append(OrderedDict(pin=pin_name, signal=signal))
+                                break
             for periph, pins in periph_pins.items():
                 pins = remove_duplicates(pins)
                 sort_pins(pins)

--- a/stm32data/__main__.py
+++ b/stm32data/__main__.py
@@ -502,6 +502,7 @@ def parse_chips():
     chip_groups = []
 
     for f in sorted(glob('sources/cubedb/mcu/STM32*.xml')):
+        f = f.replace(os.path.sep, '/')
         if 'STM32MP' in f:
             continue
         if 'STM32GBK' in f:
@@ -879,6 +880,7 @@ def remove_duplicates(item_list):
 def parse_gpio_af():
     # os.makedirs('data/gpio_af', exist_ok=True)
     for f in glob('sources/cubedb/mcu/IP/GPIO-*_gpio_v1_0_Modes.xml'):
+        f = f.replace(os.path.sep, '/')
 
         ff = removeprefix(f, 'sources/cubedb/mcu/IP/GPIO-')
         ff = removesuffix(ff, '_gpio_v1_0_Modes.xml')
@@ -963,6 +965,7 @@ dma_channels = {}
 
 def parse_dma():
     for f in glob('sources/cubedb/mcu/IP/*DMA-*Modes.xml'):
+        f = f.replace(os.path.sep, '/')
         is_explicitly_bdma = False
         ff = removeprefix(f, 'sources/cubedb/mcu/IP/')
         if not (ff.startswith('B') or ff.startswith('D')):
@@ -994,6 +997,7 @@ def parse_dma():
                 if ff.startswith('STM32L4S'):
                     dmamux_file = 'L4RS'
                 for mf in sorted(glob('data/dmamux/{}_*.yaml'.format(dmamux_file))):
+                    mf = mf.replace(os.path.sep, '/')
                     with open(mf, 'r') as yaml_file:
                         y = yaml.load(yaml_file)
                     mf = removesuffix(mf, '.yaml')
@@ -1110,6 +1114,7 @@ peripheral_to_clock = {}
 def parse_rcc_regs():
     print("parsing RCC registers")
     for f in glob('data/registers/rcc_*'):
+        f = f.replace(os.path.sep, '/')
         ff = removeprefix(f, 'data/registers/rcc_')
         ff = removesuffix(ff, '.yaml')
         family_clocks = {}
@@ -1160,6 +1165,7 @@ chip_interrupts = {}
 def parse_interrupts():
     print("parsing interrupts")
     for f in glob('sources/cubedb/mcu/IP/NVIC*_Modes.xml'):
+        f = f.replace(os.path.sep, '/')
         ff = removeprefix(f, 'sources/cubedb/mcu/IP/NVIC')
         ff = removesuffix(ff, '_Modes.xml')
 

--- a/stm32data/__main__.py
+++ b/stm32data/__main__.py
@@ -438,7 +438,11 @@ def cleanup_pin_name(pin_name):
 
 
 def parse_signal_name(signal_name):
-    parts = signal_name.split('_', 1)
+    if signal_name.startswith('USB_OTG_FS') or signal_name.startswith('USB_OTG_HS'):
+        parts = [signal_name[:10], signal_name[11:]]
+    else:
+        parts = signal_name.split('_', 1)
+
     if len(parts) == 1:
         return None
     peri_name = parts[0]

--- a/stm32data/__main__.py
+++ b/stm32data/__main__.py
@@ -336,7 +336,7 @@ per_mcu_files = {}
 
 def parse_documentations():
     print("linking files and documents")
-    with open('sources/mcufinder/files.json', 'r') as j:
+    with open('sources/mcufinder/files.json', 'r', encoding='utf-8') as j:
         files = json.load(j)
         for file in files['Files']:
             file_id = file['id_file']
@@ -348,7 +348,7 @@ def parse_documentations():
                     'type': file['type'],
                 })
 
-    with open('sources/mcufinder/mcus.json', 'r') as j:
+    with open('sources/mcufinder/mcus.json', 'r', encoding='utf-8') as j:
         mcus = json.load(j)
         for mcu in mcus['MCUs']:
             rpn = mcu['RPN']

--- a/stm32data/header.py
+++ b/stm32data/header.py
@@ -189,6 +189,7 @@ def parse_headers():
     os.makedirs('sources/headers_parsed', exist_ok=True)
     print('loading headers...')
     for f in glob('sources/headers/*.h'):
+        f = f.replace(os.path.sep, '/')
         # if 'stm32f4' not in f: continue
         ff = removeprefix(f, 'sources/headers/')
         ff = removesuffix(ff, '.h')


### PR DESCRIPTION
This fixes missing pin numbers in peripherals that have underscores in their names. Specifically `USB_OTG_FS` and `USB_OTG_HS`.

Also fixed paths in windows. The glob function returns paths with backward slashes.

I did not regenerate files, because I also get weird output unrelated to these changes. I gave editing permission for maintainers to do so.