### PR TITLE
Use "CAN" for chips with a single instance

### DIFF
--- a/data/chips/STM32F722IC.json
+++ b/data/chips/STM32F722IC.json
@@ -614,7 +614,7 @@
                     }
                 },
                 {
-                    "name": "CAN1",
+                    "name": "CAN",
                     "address": 1073767424,
                     "registers": {
                         "kind": "can",

--- a/data/chips/STM32F722IE.json
+++ b/data/chips/STM32F722IE.json
@@ -614,7 +614,7 @@
                     }
                 },
                 {
-                    "name": "CAN1",
+                    "name": "CAN",
                     "address": 1073767424,
                     "registers": {
                         "kind": "can",

--- a/data/chips/STM32F722RC.json
+++ b/data/chips/STM32F722RC.json
@@ -570,7 +570,7 @@
                     }
                 },
                 {
-                    "name": "CAN1",
+                    "name": "CAN",
                     "address": 1073767424,
                     "registers": {
                         "kind": "can",

--- a/data/chips/STM32F722RE.json
+++ b/data/chips/STM32F722RE.json
@@ -570,7 +570,7 @@
                     }
                 },
                 {
-                    "name": "CAN1",
+                    "name": "CAN",
                     "address": 1073767424,
                     "registers": {
                         "kind": "can",

--- a/data/chips/STM32F722VC.json
+++ b/data/chips/STM32F722VC.json
@@ -578,7 +578,7 @@
                     }
                 },
                 {
-                    "name": "CAN1",
+                    "name": "CAN",
                     "address": 1073767424,
                     "registers": {
                         "kind": "can",

--- a/data/chips/STM32F722VE.json
+++ b/data/chips/STM32F722VE.json
@@ -578,7 +578,7 @@
                     }
                 },
                 {
-                    "name": "CAN1",
+                    "name": "CAN",
                     "address": 1073767424,
                     "registers": {
                         "kind": "can",

--- a/data/chips/STM32F722ZC.json
+++ b/data/chips/STM32F722ZC.json
@@ -610,7 +610,7 @@
                     }
                 },
                 {
-                    "name": "CAN1",
+                    "name": "CAN",
                     "address": 1073767424,
                     "registers": {
                         "kind": "can",

--- a/data/chips/STM32F722ZE.json
+++ b/data/chips/STM32F722ZE.json
@@ -610,7 +610,7 @@
                     }
                 },
                 {
-                    "name": "CAN1",
+                    "name": "CAN",
                     "address": 1073767424,
                     "registers": {
                         "kind": "can",

--- a/data/chips/STM32F723IC.json
+++ b/data/chips/STM32F723IC.json
@@ -614,7 +614,7 @@
                     }
                 },
                 {
-                    "name": "CAN1",
+                    "name": "CAN",
                     "address": 1073767424,
                     "registers": {
                         "kind": "can",

--- a/data/chips/STM32F723IE.json
+++ b/data/chips/STM32F723IE.json
@@ -614,7 +614,7 @@
                     }
                 },
                 {
-                    "name": "CAN1",
+                    "name": "CAN",
                     "address": 1073767424,
                     "registers": {
                         "kind": "can",

--- a/data/chips/STM32F723VC.json
+++ b/data/chips/STM32F723VC.json
@@ -582,7 +582,7 @@
                     }
                 },
                 {
-                    "name": "CAN1",
+                    "name": "CAN",
                     "address": 1073767424,
                     "registers": {
                         "kind": "can",

--- a/data/chips/STM32F723VE.json
+++ b/data/chips/STM32F723VE.json
@@ -582,7 +582,7 @@
                     }
                 },
                 {
-                    "name": "CAN1",
+                    "name": "CAN",
                     "address": 1073767424,
                     "registers": {
                         "kind": "can",

--- a/data/chips/STM32F723ZC.json
+++ b/data/chips/STM32F723ZC.json
@@ -614,7 +614,7 @@
                     }
                 },
                 {
-                    "name": "CAN1",
+                    "name": "CAN",
                     "address": 1073767424,
                     "registers": {
                         "kind": "can",

--- a/data/chips/STM32F723ZE.json
+++ b/data/chips/STM32F723ZE.json
@@ -614,7 +614,7 @@
                     }
                 },
                 {
-                    "name": "CAN1",
+                    "name": "CAN",
                     "address": 1073767424,
                     "registers": {
                         "kind": "can",

--- a/data/chips/STM32F730I8.json
+++ b/data/chips/STM32F730I8.json
@@ -631,7 +631,7 @@
                     ]
                 },
                 {
-                    "name": "CAN1",
+                    "name": "CAN",
                     "address": 1073767424,
                     "registers": {
                         "kind": "can",

--- a/data/chips/STM32F730R8.json
+++ b/data/chips/STM32F730R8.json
@@ -591,7 +591,7 @@
                     ]
                 },
                 {
-                    "name": "CAN1",
+                    "name": "CAN",
                     "address": 1073767424,
                     "registers": {
                         "kind": "can",

--- a/data/chips/STM32F730V8.json
+++ b/data/chips/STM32F730V8.json
@@ -599,7 +599,7 @@
                     ]
                 },
                 {
-                    "name": "CAN1",
+                    "name": "CAN",
                     "address": 1073767424,
                     "registers": {
                         "kind": "can",

--- a/data/chips/STM32F730Z8.json
+++ b/data/chips/STM32F730Z8.json
@@ -631,7 +631,7 @@
                     ]
                 },
                 {
-                    "name": "CAN1",
+                    "name": "CAN",
                     "address": 1073767424,
                     "registers": {
                         "kind": "can",

--- a/data/chips/STM32F732IE.json
+++ b/data/chips/STM32F732IE.json
@@ -647,7 +647,7 @@
                     ]
                 },
                 {
-                    "name": "CAN1",
+                    "name": "CAN",
                     "address": 1073767424,
                     "registers": {
                         "kind": "can",

--- a/data/chips/STM32F732RE.json
+++ b/data/chips/STM32F732RE.json
@@ -603,7 +603,7 @@
                     ]
                 },
                 {
-                    "name": "CAN1",
+                    "name": "CAN",
                     "address": 1073767424,
                     "registers": {
                         "kind": "can",

--- a/data/chips/STM32F732VE.json
+++ b/data/chips/STM32F732VE.json
@@ -611,7 +611,7 @@
                     ]
                 },
                 {
-                    "name": "CAN1",
+                    "name": "CAN",
                     "address": 1073767424,
                     "registers": {
                         "kind": "can",

--- a/data/chips/STM32F732ZE.json
+++ b/data/chips/STM32F732ZE.json
@@ -643,7 +643,7 @@
                     ]
                 },
                 {
-                    "name": "CAN1",
+                    "name": "CAN",
                     "address": 1073767424,
                     "registers": {
                         "kind": "can",

--- a/data/chips/STM32F733IE.json
+++ b/data/chips/STM32F733IE.json
@@ -647,7 +647,7 @@
                     ]
                 },
                 {
-                    "name": "CAN1",
+                    "name": "CAN",
                     "address": 1073767424,
                     "registers": {
                         "kind": "can",

--- a/data/chips/STM32F733VE.json
+++ b/data/chips/STM32F733VE.json
@@ -615,7 +615,7 @@
                     ]
                 },
                 {
-                    "name": "CAN1",
+                    "name": "CAN",
                     "address": 1073767424,
                     "registers": {
                         "kind": "can",

--- a/data/chips/STM32F733ZE.json
+++ b/data/chips/STM32F733ZE.json
@@ -647,7 +647,7 @@
                     ]
                 },
                 {
-                    "name": "CAN1",
+                    "name": "CAN",
                     "address": 1073767424,
                     "registers": {
                         "kind": "can",

--- a/data/chips/STM32L431CB.json
+++ b/data/chips/STM32L431CB.json
@@ -480,7 +480,7 @@
                     }
                 },
                 {
-                    "name": "CAN1",
+                    "name": "CAN",
                     "address": 1073767424,
                     "registers": {
                         "kind": "can",

--- a/data/chips/STM32L431CC.json
+++ b/data/chips/STM32L431CC.json
@@ -480,7 +480,7 @@
                     }
                 },
                 {
-                    "name": "CAN1",
+                    "name": "CAN",
                     "address": 1073767424,
                     "registers": {
                         "kind": "can",

--- a/data/chips/STM32L431KB.json
+++ b/data/chips/STM32L431KB.json
@@ -468,7 +468,7 @@
                     }
                 },
                 {
-                    "name": "CAN1",
+                    "name": "CAN",
                     "address": 1073767424,
                     "registers": {
                         "kind": "can",

--- a/data/chips/STM32L431KC.json
+++ b/data/chips/STM32L431KC.json
@@ -468,7 +468,7 @@
                     }
                 },
                 {
-                    "name": "CAN1",
+                    "name": "CAN",
                     "address": 1073767424,
                     "registers": {
                         "kind": "can",

--- a/data/chips/STM32L431RB.json
+++ b/data/chips/STM32L431RB.json
@@ -500,7 +500,7 @@
                     }
                 },
                 {
-                    "name": "CAN1",
+                    "name": "CAN",
                     "address": 1073767424,
                     "registers": {
                         "kind": "can",

--- a/data/chips/STM32L431RC.json
+++ b/data/chips/STM32L431RC.json
@@ -500,7 +500,7 @@
                     }
                 },
                 {
-                    "name": "CAN1",
+                    "name": "CAN",
                     "address": 1073767424,
                     "registers": {
                         "kind": "can",

--- a/data/chips/STM32L431VC.json
+++ b/data/chips/STM32L431VC.json
@@ -496,7 +496,7 @@
                     }
                 },
                 {
-                    "name": "CAN1",
+                    "name": "CAN",
                     "address": 1073767424,
                     "registers": {
                         "kind": "can",

--- a/data/chips/STM32L432KB.json
+++ b/data/chips/STM32L432KB.json
@@ -474,7 +474,7 @@
                     }
                 },
                 {
-                    "name": "CAN1",
+                    "name": "CAN",
                     "address": 1073767424,
                     "registers": {
                         "kind": "can",

--- a/data/chips/STM32L432KC.json
+++ b/data/chips/STM32L432KC.json
@@ -474,7 +474,7 @@
                     }
                 },
                 {
-                    "name": "CAN1",
+                    "name": "CAN",
                     "address": 1073767424,
                     "registers": {
                         "kind": "can",

--- a/data/chips/STM32L433CB.json
+++ b/data/chips/STM32L433CB.json
@@ -492,7 +492,7 @@
                     }
                 },
                 {
-                    "name": "CAN1",
+                    "name": "CAN",
                     "address": 1073767424,
                     "registers": {
                         "kind": "can",

--- a/data/chips/STM32L433CC.json
+++ b/data/chips/STM32L433CC.json
@@ -492,7 +492,7 @@
                     }
                 },
                 {
-                    "name": "CAN1",
+                    "name": "CAN",
                     "address": 1073767424,
                     "registers": {
                         "kind": "can",

--- a/data/chips/STM32L433RB.json
+++ b/data/chips/STM32L433RB.json
@@ -512,7 +512,7 @@
                     }
                 },
                 {
-                    "name": "CAN1",
+                    "name": "CAN",
                     "address": 1073767424,
                     "registers": {
                         "kind": "can",

--- a/data/chips/STM32L433RC.json
+++ b/data/chips/STM32L433RC.json
@@ -522,7 +522,7 @@
                     }
                 },
                 {
-                    "name": "CAN1",
+                    "name": "CAN",
                     "address": 1073767424,
                     "registers": {
                         "kind": "can",

--- a/data/chips/STM32L433VC.json
+++ b/data/chips/STM32L433VC.json
@@ -508,7 +508,7 @@
                     }
                 },
                 {
-                    "name": "CAN1",
+                    "name": "CAN",
                     "address": 1073767424,
                     "registers": {
                         "kind": "can",

--- a/data/chips/STM32L442KC.json
+++ b/data/chips/STM32L442KC.json
@@ -517,7 +517,7 @@
                     ]
                 },
                 {
-                    "name": "CAN1",
+                    "name": "CAN",
                     "address": 1073767424,
                     "registers": {
                         "kind": "can",

--- a/data/chips/STM32L443CC.json
+++ b/data/chips/STM32L443CC.json
@@ -535,7 +535,7 @@
                     ]
                 },
                 {
-                    "name": "CAN1",
+                    "name": "CAN",
                     "address": 1073767424,
                     "registers": {
                         "kind": "can",

--- a/data/chips/STM32L443RC.json
+++ b/data/chips/STM32L443RC.json
@@ -555,7 +555,7 @@
                     ]
                 },
                 {
-                    "name": "CAN1",
+                    "name": "CAN",
                     "address": 1073767424,
                     "registers": {
                         "kind": "can",

--- a/data/chips/STM32L443VC.json
+++ b/data/chips/STM32L443VC.json
@@ -551,7 +551,7 @@
                     ]
                 },
                 {
-                    "name": "CAN1",
+                    "name": "CAN",
                     "address": 1073767424,
                     "registers": {
                         "kind": "can",

--- a/data/chips/STM32L451CC.json
+++ b/data/chips/STM32L451CC.json
@@ -468,7 +468,7 @@
                     }
                 },
                 {
-                    "name": "CAN1",
+                    "name": "CAN",
                     "address": 1073767424,
                     "registers": {
                         "kind": "can",

--- a/data/chips/STM32L451CE.json
+++ b/data/chips/STM32L451CE.json
@@ -472,7 +472,7 @@
                     }
                 },
                 {
-                    "name": "CAN1",
+                    "name": "CAN",
                     "address": 1073767424,
                     "registers": {
                         "kind": "can",

--- a/data/chips/STM32L451RC.json
+++ b/data/chips/STM32L451RC.json
@@ -500,7 +500,7 @@
                     }
                 },
                 {
-                    "name": "CAN1",
+                    "name": "CAN",
                     "address": 1073767424,
                     "registers": {
                         "kind": "can",

--- a/data/chips/STM32L451RE.json
+++ b/data/chips/STM32L451RE.json
@@ -500,7 +500,7 @@
                     }
                 },
                 {
-                    "name": "CAN1",
+                    "name": "CAN",
                     "address": 1073767424,
                     "registers": {
                         "kind": "can",

--- a/data/chips/STM32L451VC.json
+++ b/data/chips/STM32L451VC.json
@@ -496,7 +496,7 @@
                     }
                 },
                 {
-                    "name": "CAN1",
+                    "name": "CAN",
                     "address": 1073767424,
                     "registers": {
                         "kind": "can",

--- a/data/chips/STM32L451VE.json
+++ b/data/chips/STM32L451VE.json
@@ -496,7 +496,7 @@
                     }
                 },
                 {
-                    "name": "CAN1",
+                    "name": "CAN",
                     "address": 1073767424,
                     "registers": {
                         "kind": "can",

--- a/data/chips/STM32L452CC.json
+++ b/data/chips/STM32L452CC.json
@@ -474,7 +474,7 @@
                     }
                 },
                 {
-                    "name": "CAN1",
+                    "name": "CAN",
                     "address": 1073767424,
                     "registers": {
                         "kind": "can",

--- a/data/chips/STM32L452CE.json
+++ b/data/chips/STM32L452CE.json
@@ -478,7 +478,7 @@
                     }
                 },
                 {
-                    "name": "CAN1",
+                    "name": "CAN",
                     "address": 1073767424,
                     "registers": {
                         "kind": "can",

--- a/data/chips/STM32L452RC.json
+++ b/data/chips/STM32L452RC.json
@@ -506,7 +506,7 @@
                     }
                 },
                 {
-                    "name": "CAN1",
+                    "name": "CAN",
                     "address": 1073767424,
                     "registers": {
                         "kind": "can",

--- a/data/chips/STM32L452RE.json
+++ b/data/chips/STM32L452RE.json
@@ -516,7 +516,7 @@
                     }
                 },
                 {
-                    "name": "CAN1",
+                    "name": "CAN",
                     "address": 1073767424,
                     "registers": {
                         "kind": "can",

--- a/data/chips/STM32L452VC.json
+++ b/data/chips/STM32L452VC.json
@@ -502,7 +502,7 @@
                     }
                 },
                 {
-                    "name": "CAN1",
+                    "name": "CAN",
                     "address": 1073767424,
                     "registers": {
                         "kind": "can",

--- a/data/chips/STM32L452VE.json
+++ b/data/chips/STM32L452VE.json
@@ -502,7 +502,7 @@
                     }
                 },
                 {
-                    "name": "CAN1",
+                    "name": "CAN",
                     "address": 1073767424,
                     "registers": {
                         "kind": "can",

--- a/data/chips/STM32L462CE.json
+++ b/data/chips/STM32L462CE.json
@@ -527,7 +527,7 @@
                     ]
                 },
                 {
-                    "name": "CAN1",
+                    "name": "CAN",
                     "address": 1073767424,
                     "registers": {
                         "kind": "can",

--- a/data/chips/STM32L462RE.json
+++ b/data/chips/STM32L462RE.json
@@ -549,7 +549,7 @@
                     ]
                 },
                 {
-                    "name": "CAN1",
+                    "name": "CAN",
                     "address": 1073767424,
                     "registers": {
                         "kind": "can",

--- a/data/chips/STM32L462VE.json
+++ b/data/chips/STM32L462VE.json
@@ -545,7 +545,7 @@
                     ]
                 },
                 {
-                    "name": "CAN1",
+                    "name": "CAN",
                     "address": 1073767424,
                     "registers": {
                         "kind": "can",

--- a/data/chips/STM32L471QE.json
+++ b/data/chips/STM32L471QE.json
@@ -642,7 +642,7 @@
                     }
                 },
                 {
-                    "name": "CAN1",
+                    "name": "CAN",
                     "address": 1073767424,
                     "registers": {
                         "kind": "can",

--- a/data/chips/STM32L471QG.json
+++ b/data/chips/STM32L471QG.json
@@ -642,7 +642,7 @@
                     }
                 },
                 {
-                    "name": "CAN1",
+                    "name": "CAN",
                     "address": 1073767424,
                     "registers": {
                         "kind": "can",

--- a/data/chips/STM32L471RE.json
+++ b/data/chips/STM32L471RE.json
@@ -630,7 +630,7 @@
                     }
                 },
                 {
-                    "name": "CAN1",
+                    "name": "CAN",
                     "address": 1073767424,
                     "registers": {
                         "kind": "can",

--- a/data/chips/STM32L471RG.json
+++ b/data/chips/STM32L471RG.json
@@ -630,7 +630,7 @@
                     }
                 },
                 {
-                    "name": "CAN1",
+                    "name": "CAN",
                     "address": 1073767424,
                     "registers": {
                         "kind": "can",

--- a/data/chips/STM32L471VE.json
+++ b/data/chips/STM32L471VE.json
@@ -630,7 +630,7 @@
                     }
                 },
                 {
-                    "name": "CAN1",
+                    "name": "CAN",
                     "address": 1073767424,
                     "registers": {
                         "kind": "can",

--- a/data/chips/STM32L471VG.json
+++ b/data/chips/STM32L471VG.json
@@ -630,7 +630,7 @@
                     }
                 },
                 {
-                    "name": "CAN1",
+                    "name": "CAN",
                     "address": 1073767424,
                     "registers": {
                         "kind": "can",

--- a/data/chips/STM32L471ZE.json
+++ b/data/chips/STM32L471ZE.json
@@ -666,7 +666,7 @@
                     }
                 },
                 {
-                    "name": "CAN1",
+                    "name": "CAN",
                     "address": 1073767424,
                     "registers": {
                         "kind": "can",

--- a/data/chips/STM32L471ZG.json
+++ b/data/chips/STM32L471ZG.json
@@ -666,7 +666,7 @@
                     }
                 },
                 {
-                    "name": "CAN1",
+                    "name": "CAN",
                     "address": 1073767424,
                     "registers": {
                         "kind": "can",

--- a/data/chips/STM32L475RC.json
+++ b/data/chips/STM32L475RC.json
@@ -636,7 +636,7 @@
                     }
                 },
                 {
-                    "name": "CAN1",
+                    "name": "CAN",
                     "address": 1073767424,
                     "registers": {
                         "kind": "can",

--- a/data/chips/STM32L475RE.json
+++ b/data/chips/STM32L475RE.json
@@ -636,7 +636,7 @@
                     }
                 },
                 {
-                    "name": "CAN1",
+                    "name": "CAN",
                     "address": 1073767424,
                     "registers": {
                         "kind": "can",

--- a/data/chips/STM32L475RG.json
+++ b/data/chips/STM32L475RG.json
@@ -636,7 +636,7 @@
                     }
                 },
                 {
-                    "name": "CAN1",
+                    "name": "CAN",
                     "address": 1073767424,
                     "registers": {
                         "kind": "can",

--- a/data/chips/STM32L475VC.json
+++ b/data/chips/STM32L475VC.json
@@ -636,7 +636,7 @@
                     }
                 },
                 {
-                    "name": "CAN1",
+                    "name": "CAN",
                     "address": 1073767424,
                     "registers": {
                         "kind": "can",

--- a/data/chips/STM32L475VE.json
+++ b/data/chips/STM32L475VE.json
@@ -636,7 +636,7 @@
                     }
                 },
                 {
-                    "name": "CAN1",
+                    "name": "CAN",
                     "address": 1073767424,
                     "registers": {
                         "kind": "can",

--- a/data/chips/STM32L475VG.json
+++ b/data/chips/STM32L475VG.json
@@ -636,7 +636,7 @@
                     }
                 },
                 {
-                    "name": "CAN1",
+                    "name": "CAN",
                     "address": 1073767424,
                     "registers": {
                         "kind": "can",

--- a/data/chips/STM32L476JE.json
+++ b/data/chips/STM32L476JE.json
@@ -660,7 +660,7 @@
                     }
                 },
                 {
-                    "name": "CAN1",
+                    "name": "CAN",
                     "address": 1073767424,
                     "registers": {
                         "kind": "can",

--- a/data/chips/STM32L476JG.json
+++ b/data/chips/STM32L476JG.json
@@ -670,7 +670,7 @@
                     }
                 },
                 {
-                    "name": "CAN1",
+                    "name": "CAN",
                     "address": 1073767424,
                     "registers": {
                         "kind": "can",

--- a/data/chips/STM32L476ME.json
+++ b/data/chips/STM32L476ME.json
@@ -660,7 +660,7 @@
                     }
                 },
                 {
-                    "name": "CAN1",
+                    "name": "CAN",
                     "address": 1073767424,
                     "registers": {
                         "kind": "can",

--- a/data/chips/STM32L476MG.json
+++ b/data/chips/STM32L476MG.json
@@ -660,7 +660,7 @@
                     }
                 },
                 {
-                    "name": "CAN1",
+                    "name": "CAN",
                     "address": 1073767424,
                     "registers": {
                         "kind": "can",

--- a/data/chips/STM32L476QE.json
+++ b/data/chips/STM32L476QE.json
@@ -678,7 +678,7 @@
                     }
                 },
                 {
-                    "name": "CAN1",
+                    "name": "CAN",
                     "address": 1073767424,
                     "registers": {
                         "kind": "can",

--- a/data/chips/STM32L476QG.json
+++ b/data/chips/STM32L476QG.json
@@ -678,7 +678,7 @@
                     }
                 },
                 {
-                    "name": "CAN1",
+                    "name": "CAN",
                     "address": 1073767424,
                     "registers": {
                         "kind": "can",

--- a/data/chips/STM32L476RC.json
+++ b/data/chips/STM32L476RC.json
@@ -660,7 +660,7 @@
                     }
                 },
                 {
-                    "name": "CAN1",
+                    "name": "CAN",
                     "address": 1073767424,
                     "registers": {
                         "kind": "can",

--- a/data/chips/STM32L476RE.json
+++ b/data/chips/STM32L476RE.json
@@ -660,7 +660,7 @@
                     }
                 },
                 {
-                    "name": "CAN1",
+                    "name": "CAN",
                     "address": 1073767424,
                     "registers": {
                         "kind": "can",

--- a/data/chips/STM32L476RG.json
+++ b/data/chips/STM32L476RG.json
@@ -660,7 +660,7 @@
                     }
                 },
                 {
-                    "name": "CAN1",
+                    "name": "CAN",
                     "address": 1073767424,
                     "registers": {
                         "kind": "can",

--- a/data/chips/STM32L476VC.json
+++ b/data/chips/STM32L476VC.json
@@ -666,7 +666,7 @@
                     }
                 },
                 {
-                    "name": "CAN1",
+                    "name": "CAN",
                     "address": 1073767424,
                     "registers": {
                         "kind": "can",

--- a/data/chips/STM32L476VE.json
+++ b/data/chips/STM32L476VE.json
@@ -666,7 +666,7 @@
                     }
                 },
                 {
-                    "name": "CAN1",
+                    "name": "CAN",
                     "address": 1073767424,
                     "registers": {
                         "kind": "can",

--- a/data/chips/STM32L476VG.json
+++ b/data/chips/STM32L476VG.json
@@ -666,7 +666,7 @@
                     }
                 },
                 {
-                    "name": "CAN1",
+                    "name": "CAN",
                     "address": 1073767424,
                     "registers": {
                         "kind": "can",

--- a/data/chips/STM32L476ZE.json
+++ b/data/chips/STM32L476ZE.json
@@ -698,7 +698,7 @@
                     }
                 },
                 {
-                    "name": "CAN1",
+                    "name": "CAN",
                     "address": 1073767424,
                     "registers": {
                         "kind": "can",

--- a/data/chips/STM32L476ZG.json
+++ b/data/chips/STM32L476ZG.json
@@ -712,7 +712,7 @@
                     }
                 },
                 {
-                    "name": "CAN1",
+                    "name": "CAN",
                     "address": 1073767424,
                     "registers": {
                         "kind": "can",

--- a/data/chips/STM32L485JC.json
+++ b/data/chips/STM32L485JC.json
@@ -330,7 +330,7 @@
                     ]
                 },
                 {
-                    "name": "CAN1",
+                    "name": "CAN",
                     "address": 1073767424,
                     "registers": {
                         "kind": "can",

--- a/data/chips/STM32L485JE.json
+++ b/data/chips/STM32L485JE.json
@@ -330,7 +330,7 @@
                     ]
                 },
                 {
-                    "name": "CAN1",
+                    "name": "CAN",
                     "address": 1073767424,
                     "registers": {
                         "kind": "can",

--- a/data/chips/STM32L486JG.json
+++ b/data/chips/STM32L486JG.json
@@ -703,7 +703,7 @@
                     ]
                 },
                 {
-                    "name": "CAN1",
+                    "name": "CAN",
                     "address": 1073767424,
                     "registers": {
                         "kind": "can",

--- a/data/chips/STM32L486QG.json
+++ b/data/chips/STM32L486QG.json
@@ -721,7 +721,7 @@
                     ]
                 },
                 {
-                    "name": "CAN1",
+                    "name": "CAN",
                     "address": 1073767424,
                     "registers": {
                         "kind": "can",

--- a/data/chips/STM32L486RG.json
+++ b/data/chips/STM32L486RG.json
@@ -703,7 +703,7 @@
                     ]
                 },
                 {
-                    "name": "CAN1",
+                    "name": "CAN",
                     "address": 1073767424,
                     "registers": {
                         "kind": "can",

--- a/data/chips/STM32L486VG.json
+++ b/data/chips/STM32L486VG.json
@@ -709,7 +709,7 @@
                     ]
                 },
                 {
-                    "name": "CAN1",
+                    "name": "CAN",
                     "address": 1073767424,
                     "registers": {
                         "kind": "can",

--- a/data/chips/STM32L486ZG.json
+++ b/data/chips/STM32L486ZG.json
@@ -741,7 +741,7 @@
                     ]
                 },
                 {
-                    "name": "CAN1",
+                    "name": "CAN",
                     "address": 1073767424,
                     "registers": {
                         "kind": "can",

--- a/data/chips/STM32L4P5AE.json
+++ b/data/chips/STM32L4P5AE.json
@@ -611,7 +611,7 @@
                     }
                 },
                 {
-                    "name": "CAN1",
+                    "name": "CAN",
                     "address": 1073767424,
                     "registers": {
                         "kind": "can",

--- a/data/chips/STM32L4P5AG.json
+++ b/data/chips/STM32L4P5AG.json
@@ -615,7 +615,7 @@
                     }
                 },
                 {
-                    "name": "CAN1",
+                    "name": "CAN",
                     "address": 1073767424,
                     "registers": {
                         "kind": "can",

--- a/data/chips/STM32L4P5CE.json
+++ b/data/chips/STM32L4P5CE.json
@@ -567,7 +567,7 @@
                     }
                 },
                 {
-                    "name": "CAN1",
+                    "name": "CAN",
                     "address": 1073767424,
                     "registers": {
                         "kind": "can",

--- a/data/chips/STM32L4P5CG.json
+++ b/data/chips/STM32L4P5CG.json
@@ -575,7 +575,7 @@
                     }
                 },
                 {
-                    "name": "CAN1",
+                    "name": "CAN",
                     "address": 1073767424,
                     "registers": {
                         "kind": "can",

--- a/data/chips/STM32L4P5QE.json
+++ b/data/chips/STM32L4P5QE.json
@@ -611,7 +611,7 @@
                     }
                 },
                 {
-                    "name": "CAN1",
+                    "name": "CAN",
                     "address": 1073767424,
                     "registers": {
                         "kind": "can",

--- a/data/chips/STM32L4P5QG.json
+++ b/data/chips/STM32L4P5QG.json
@@ -615,7 +615,7 @@
                     }
                 },
                 {
-                    "name": "CAN1",
+                    "name": "CAN",
                     "address": 1073767424,
                     "registers": {
                         "kind": "can",

--- a/data/chips/STM32L4P5RE.json
+++ b/data/chips/STM32L4P5RE.json
@@ -611,7 +611,7 @@
                     }
                 },
                 {
-                    "name": "CAN1",
+                    "name": "CAN",
                     "address": 1073767424,
                     "registers": {
                         "kind": "can",

--- a/data/chips/STM32L4P5RG.json
+++ b/data/chips/STM32L4P5RG.json
@@ -615,7 +615,7 @@
                     }
                 },
                 {
-                    "name": "CAN1",
+                    "name": "CAN",
                     "address": 1073767424,
                     "registers": {
                         "kind": "can",

--- a/data/chips/STM32L4P5VE.json
+++ b/data/chips/STM32L4P5VE.json
@@ -615,7 +615,7 @@
                     }
                 },
                 {
-                    "name": "CAN1",
+                    "name": "CAN",
                     "address": 1073767424,
                     "registers": {
                         "kind": "can",

--- a/data/chips/STM32L4P5VG.json
+++ b/data/chips/STM32L4P5VG.json
@@ -623,7 +623,7 @@
                     }
                 },
                 {
-                    "name": "CAN1",
+                    "name": "CAN",
                     "address": 1073767424,
                     "registers": {
                         "kind": "can",

--- a/data/chips/STM32L4P5ZE.json
+++ b/data/chips/STM32L4P5ZE.json
@@ -611,7 +611,7 @@
                     }
                 },
                 {
-                    "name": "CAN1",
+                    "name": "CAN",
                     "address": 1073767424,
                     "registers": {
                         "kind": "can",

--- a/data/chips/STM32L4P5ZG.json
+++ b/data/chips/STM32L4P5ZG.json
@@ -615,7 +615,7 @@
                     }
                 },
                 {
-                    "name": "CAN1",
+                    "name": "CAN",
                     "address": 1073767424,
                     "registers": {
                         "kind": "can",

--- a/data/chips/STM32L4Q5AG.json
+++ b/data/chips/STM32L4Q5AG.json
@@ -648,7 +648,7 @@
                     ]
                 },
                 {
-                    "name": "CAN1",
+                    "name": "CAN",
                     "address": 1073767424,
                     "registers": {
                         "kind": "can",

--- a/data/chips/STM32L4Q5CG.json
+++ b/data/chips/STM32L4Q5CG.json
@@ -608,7 +608,7 @@
                     ]
                 },
                 {
-                    "name": "CAN1",
+                    "name": "CAN",
                     "address": 1073767424,
                     "registers": {
                         "kind": "can",

--- a/data/chips/STM32L4Q5QG.json
+++ b/data/chips/STM32L4Q5QG.json
@@ -648,7 +648,7 @@
                     ]
                 },
                 {
-                    "name": "CAN1",
+                    "name": "CAN",
                     "address": 1073767424,
                     "registers": {
                         "kind": "can",

--- a/data/chips/STM32L4Q5RG.json
+++ b/data/chips/STM32L4Q5RG.json
@@ -648,7 +648,7 @@
                     ]
                 },
                 {
-                    "name": "CAN1",
+                    "name": "CAN",
                     "address": 1073767424,
                     "registers": {
                         "kind": "can",

--- a/data/chips/STM32L4Q5VG.json
+++ b/data/chips/STM32L4Q5VG.json
@@ -656,7 +656,7 @@
                     ]
                 },
                 {
-                    "name": "CAN1",
+                    "name": "CAN",
                     "address": 1073767424,
                     "registers": {
                         "kind": "can",

--- a/data/chips/STM32L4Q5ZG.json
+++ b/data/chips/STM32L4Q5ZG.json
@@ -648,7 +648,7 @@
                     ]
                 },
                 {
-                    "name": "CAN1",
+                    "name": "CAN",
                     "address": 1073767424,
                     "registers": {
                         "kind": "can",

--- a/data/chips/STM32L4R5AG.json
+++ b/data/chips/STM32L4R5AG.json
@@ -529,7 +529,7 @@
                     }
                 },
                 {
-                    "name": "CAN1",
+                    "name": "CAN",
                     "address": 1073767424,
                     "registers": {
                         "kind": "can",

--- a/data/chips/STM32L4R5AI.json
+++ b/data/chips/STM32L4R5AI.json
@@ -529,7 +529,7 @@
                     }
                 },
                 {
-                    "name": "CAN1",
+                    "name": "CAN",
                     "address": 1073767424,
                     "registers": {
                         "kind": "can",

--- a/data/chips/STM32L4R5QG.json
+++ b/data/chips/STM32L4R5QG.json
@@ -529,7 +529,7 @@
                     }
                 },
                 {
-                    "name": "CAN1",
+                    "name": "CAN",
                     "address": 1073767424,
                     "registers": {
                         "kind": "can",

--- a/data/chips/STM32L4R5QI.json
+++ b/data/chips/STM32L4R5QI.json
@@ -529,7 +529,7 @@
                     }
                 },
                 {
-                    "name": "CAN1",
+                    "name": "CAN",
                     "address": 1073767424,
                     "registers": {
                         "kind": "can",

--- a/data/chips/STM32L4R5VG.json
+++ b/data/chips/STM32L4R5VG.json
@@ -529,7 +529,7 @@
                     }
                 },
                 {
-                    "name": "CAN1",
+                    "name": "CAN",
                     "address": 1073767424,
                     "registers": {
                         "kind": "can",

--- a/data/chips/STM32L4R5VI.json
+++ b/data/chips/STM32L4R5VI.json
@@ -529,7 +529,7 @@
                     }
                 },
                 {
-                    "name": "CAN1",
+                    "name": "CAN",
                     "address": 1073767424,
                     "registers": {
                         "kind": "can",

--- a/data/chips/STM32L4R5ZG.json
+++ b/data/chips/STM32L4R5ZG.json
@@ -533,7 +533,7 @@
                     }
                 },
                 {
-                    "name": "CAN1",
+                    "name": "CAN",
                     "address": 1073767424,
                     "registers": {
                         "kind": "can",

--- a/data/chips/STM32L4R5ZI.json
+++ b/data/chips/STM32L4R5ZI.json
@@ -543,7 +543,7 @@
                     }
                 },
                 {
-                    "name": "CAN1",
+                    "name": "CAN",
                     "address": 1073767424,
                     "registers": {
                         "kind": "can",

--- a/data/chips/STM32L4R7AI.json
+++ b/data/chips/STM32L4R7AI.json
@@ -529,7 +529,7 @@
                     }
                 },
                 {
-                    "name": "CAN1",
+                    "name": "CAN",
                     "address": 1073767424,
                     "registers": {
                         "kind": "can",

--- a/data/chips/STM32L4R7VI.json
+++ b/data/chips/STM32L4R7VI.json
@@ -529,7 +529,7 @@
                     }
                 },
                 {
-                    "name": "CAN1",
+                    "name": "CAN",
                     "address": 1073767424,
                     "registers": {
                         "kind": "can",

--- a/data/chips/STM32L4R7ZI.json
+++ b/data/chips/STM32L4R7ZI.json
@@ -529,7 +529,7 @@
                     }
                 },
                 {
-                    "name": "CAN1",
+                    "name": "CAN",
                     "address": 1073767424,
                     "registers": {
                         "kind": "can",

--- a/data/chips/STM32L4R9AG.json
+++ b/data/chips/STM32L4R9AG.json
@@ -531,7 +531,7 @@
                     }
                 },
                 {
-                    "name": "CAN1",
+                    "name": "CAN",
                     "address": 1073767424,
                     "registers": {
                         "kind": "can",

--- a/data/chips/STM32L4R9AI.json
+++ b/data/chips/STM32L4R9AI.json
@@ -531,7 +531,7 @@
                     }
                 },
                 {
-                    "name": "CAN1",
+                    "name": "CAN",
                     "address": 1073767424,
                     "registers": {
                         "kind": "can",

--- a/data/chips/STM32L4R9VG.json
+++ b/data/chips/STM32L4R9VG.json
@@ -531,7 +531,7 @@
                     }
                 },
                 {
-                    "name": "CAN1",
+                    "name": "CAN",
                     "address": 1073767424,
                     "registers": {
                         "kind": "can",

--- a/data/chips/STM32L4R9VI.json
+++ b/data/chips/STM32L4R9VI.json
@@ -531,7 +531,7 @@
                     }
                 },
                 {
-                    "name": "CAN1",
+                    "name": "CAN",
                     "address": 1073767424,
                     "registers": {
                         "kind": "can",

--- a/data/chips/STM32L4R9ZG.json
+++ b/data/chips/STM32L4R9ZG.json
@@ -543,7 +543,7 @@
                     }
                 },
                 {
-                    "name": "CAN1",
+                    "name": "CAN",
                     "address": 1073767424,
                     "registers": {
                         "kind": "can",

--- a/data/chips/STM32L4R9ZI.json
+++ b/data/chips/STM32L4R9ZI.json
@@ -553,7 +553,7 @@
                     }
                 },
                 {
-                    "name": "CAN1",
+                    "name": "CAN",
                     "address": 1073767424,
                     "registers": {
                         "kind": "can",

--- a/data/chips/STM32L4S5AI.json
+++ b/data/chips/STM32L4S5AI.json
@@ -562,7 +562,7 @@
                     ]
                 },
                 {
-                    "name": "CAN1",
+                    "name": "CAN",
                     "address": 1073767424,
                     "registers": {
                         "kind": "can",

--- a/data/chips/STM32L4S5QI.json
+++ b/data/chips/STM32L4S5QI.json
@@ -562,7 +562,7 @@
                     ]
                 },
                 {
-                    "name": "CAN1",
+                    "name": "CAN",
                     "address": 1073767424,
                     "registers": {
                         "kind": "can",

--- a/data/chips/STM32L4S5VI.json
+++ b/data/chips/STM32L4S5VI.json
@@ -562,7 +562,7 @@
                     ]
                 },
                 {
-                    "name": "CAN1",
+                    "name": "CAN",
                     "address": 1073767424,
                     "registers": {
                         "kind": "can",

--- a/data/chips/STM32L4S5ZI.json
+++ b/data/chips/STM32L4S5ZI.json
@@ -566,7 +566,7 @@
                     ]
                 },
                 {
-                    "name": "CAN1",
+                    "name": "CAN",
                     "address": 1073767424,
                     "registers": {
                         "kind": "can",

--- a/data/chips/STM32L4S7AI.json
+++ b/data/chips/STM32L4S7AI.json
@@ -562,7 +562,7 @@
                     ]
                 },
                 {
-                    "name": "CAN1",
+                    "name": "CAN",
                     "address": 1073767424,
                     "registers": {
                         "kind": "can",

--- a/data/chips/STM32L4S7VI.json
+++ b/data/chips/STM32L4S7VI.json
@@ -562,7 +562,7 @@
                     ]
                 },
                 {
-                    "name": "CAN1",
+                    "name": "CAN",
                     "address": 1073767424,
                     "registers": {
                         "kind": "can",

--- a/data/chips/STM32L4S7ZI.json
+++ b/data/chips/STM32L4S7ZI.json
@@ -562,7 +562,7 @@
                     ]
                 },
                 {
-                    "name": "CAN1",
+                    "name": "CAN",
                     "address": 1073767424,
                     "registers": {
                         "kind": "can",

--- a/data/chips/STM32L4S9AI.json
+++ b/data/chips/STM32L4S9AI.json
@@ -564,7 +564,7 @@
                     ]
                 },
                 {
-                    "name": "CAN1",
+                    "name": "CAN",
                     "address": 1073767424,
                     "registers": {
                         "kind": "can",

--- a/data/chips/STM32L4S9VI.json
+++ b/data/chips/STM32L4S9VI.json
@@ -564,7 +564,7 @@
                     ]
                 },
                 {
-                    "name": "CAN1",
+                    "name": "CAN",
                     "address": 1073767424,
                     "registers": {
                         "kind": "can",

--- a/data/chips/STM32L4S9ZI.json
+++ b/data/chips/STM32L4S9ZI.json
@@ -576,7 +576,7 @@
                     ]
                 },
                 {
-                    "name": "CAN1",
+                    "name": "CAN",
                     "address": 1073767424,
                     "registers": {
                         "kind": "can",


### PR DESCRIPTION
Required for the embassy trait implementations to be correct:
https://github.com/embassy-rs/embassy/blob/35636953b2048394733eaff95fad17970788d08a/embassy-stm32/src/can/bxcan.rs#L95