### PR TITLE
STM32G0 updates

### DIFF
--- a/data/chips/STM32G030C6.json
+++ b/data/chips/STM32G030C6.json
@@ -470,6 +470,11 @@
                 {
                     "name": "FLASH",
                     "address": 1073881088,
+                    "registers": {
+                        "kind": "flash",
+                        "version": "g0",
+                        "block": "FLASH"
+                    },
                     "rcc": {
                         "clock": "AHB1",
                         "enable": {

--- a/data/chips/STM32G030C8.json
+++ b/data/chips/STM32G030C8.json
@@ -470,6 +470,11 @@
                 {
                     "name": "FLASH",
                     "address": 1073881088,
+                    "registers": {
+                        "kind": "flash",
+                        "version": "g0",
+                        "block": "FLASH"
+                    },
                     "rcc": {
                         "clock": "AHB1",
                         "enable": {

--- a/data/chips/STM32G030F6.json
+++ b/data/chips/STM32G030F6.json
@@ -470,6 +470,11 @@
                 {
                     "name": "FLASH",
                     "address": 1073881088,
+                    "registers": {
+                        "kind": "flash",
+                        "version": "g0",
+                        "block": "FLASH"
+                    },
                     "rcc": {
                         "clock": "AHB1",
                         "enable": {

--- a/data/chips/STM32G030J6.json
+++ b/data/chips/STM32G030J6.json
@@ -446,6 +446,11 @@
                 {
                     "name": "FLASH",
                     "address": 1073881088,
+                    "registers": {
+                        "kind": "flash",
+                        "version": "g0",
+                        "block": "FLASH"
+                    },
                     "rcc": {
                         "clock": "AHB1",
                         "enable": {

--- a/data/chips/STM32G030K6.json
+++ b/data/chips/STM32G030K6.json
@@ -470,6 +470,11 @@
                 {
                     "name": "FLASH",
                     "address": 1073881088,
+                    "registers": {
+                        "kind": "flash",
+                        "version": "g0",
+                        "block": "FLASH"
+                    },
                     "rcc": {
                         "clock": "AHB1",
                         "enable": {

--- a/data/chips/STM32G030K8.json
+++ b/data/chips/STM32G030K8.json
@@ -470,6 +470,11 @@
                 {
                     "name": "FLASH",
                     "address": 1073881088,
+                    "registers": {
+                        "kind": "flash",
+                        "version": "g0",
+                        "block": "FLASH"
+                    },
                     "rcc": {
                         "clock": "AHB1",
                         "enable": {

--- a/data/chips/STM32G031C4.json
+++ b/data/chips/STM32G031C4.json
@@ -474,6 +474,11 @@
                 {
                     "name": "FLASH",
                     "address": 1073881088,
+                    "registers": {
+                        "kind": "flash",
+                        "version": "g0",
+                        "block": "FLASH"
+                    },
                     "rcc": {
                         "clock": "AHB1",
                         "enable": {

--- a/data/chips/STM32G031C6.json
+++ b/data/chips/STM32G031C6.json
@@ -474,6 +474,11 @@
                 {
                     "name": "FLASH",
                     "address": 1073881088,
+                    "registers": {
+                        "kind": "flash",
+                        "version": "g0",
+                        "block": "FLASH"
+                    },
                     "rcc": {
                         "clock": "AHB1",
                         "enable": {

--- a/data/chips/STM32G031C8.json
+++ b/data/chips/STM32G031C8.json
@@ -474,6 +474,11 @@
                 {
                     "name": "FLASH",
                     "address": 1073881088,
+                    "registers": {
+                        "kind": "flash",
+                        "version": "g0",
+                        "block": "FLASH"
+                    },
                     "rcc": {
                         "clock": "AHB1",
                         "enable": {

--- a/data/chips/STM32G031F4.json
+++ b/data/chips/STM32G031F4.json
@@ -470,6 +470,11 @@
                 {
                     "name": "FLASH",
                     "address": 1073881088,
+                    "registers": {
+                        "kind": "flash",
+                        "version": "g0",
+                        "block": "FLASH"
+                    },
                     "rcc": {
                         "clock": "AHB1",
                         "enable": {

--- a/data/chips/STM32G031F6.json
+++ b/data/chips/STM32G031F6.json
@@ -470,6 +470,11 @@
                 {
                     "name": "FLASH",
                     "address": 1073881088,
+                    "registers": {
+                        "kind": "flash",
+                        "version": "g0",
+                        "block": "FLASH"
+                    },
                     "rcc": {
                         "clock": "AHB1",
                         "enable": {

--- a/data/chips/STM32G031F8.json
+++ b/data/chips/STM32G031F8.json
@@ -470,6 +470,11 @@
                 {
                     "name": "FLASH",
                     "address": 1073881088,
+                    "registers": {
+                        "kind": "flash",
+                        "version": "g0",
+                        "block": "FLASH"
+                    },
                     "rcc": {
                         "clock": "AHB1",
                         "enable": {

--- a/data/chips/STM32G031G4.json
+++ b/data/chips/STM32G031G4.json
@@ -466,6 +466,11 @@
                 {
                     "name": "FLASH",
                     "address": 1073881088,
+                    "registers": {
+                        "kind": "flash",
+                        "version": "g0",
+                        "block": "FLASH"
+                    },
                     "rcc": {
                         "clock": "AHB1",
                         "enable": {

--- a/data/chips/STM32G031G6.json
+++ b/data/chips/STM32G031G6.json
@@ -466,6 +466,11 @@
                 {
                     "name": "FLASH",
                     "address": 1073881088,
+                    "registers": {
+                        "kind": "flash",
+                        "version": "g0",
+                        "block": "FLASH"
+                    },
                     "rcc": {
                         "clock": "AHB1",
                         "enable": {

--- a/data/chips/STM32G031G8.json
+++ b/data/chips/STM32G031G8.json
@@ -466,6 +466,11 @@
                 {
                     "name": "FLASH",
                     "address": 1073881088,
+                    "registers": {
+                        "kind": "flash",
+                        "version": "g0",
+                        "block": "FLASH"
+                    },
                     "rcc": {
                         "clock": "AHB1",
                         "enable": {

--- a/data/chips/STM32G031J4.json
+++ b/data/chips/STM32G031J4.json
@@ -446,6 +446,11 @@
                 {
                     "name": "FLASH",
                     "address": 1073881088,
+                    "registers": {
+                        "kind": "flash",
+                        "version": "g0",
+                        "block": "FLASH"
+                    },
                     "rcc": {
                         "clock": "AHB1",
                         "enable": {

--- a/data/chips/STM32G031J6.json
+++ b/data/chips/STM32G031J6.json
@@ -446,6 +446,11 @@
                 {
                     "name": "FLASH",
                     "address": 1073881088,
+                    "registers": {
+                        "kind": "flash",
+                        "version": "g0",
+                        "block": "FLASH"
+                    },
                     "rcc": {
                         "clock": "AHB1",
                         "enable": {

--- a/data/chips/STM32G031K4.json
+++ b/data/chips/STM32G031K4.json
@@ -474,6 +474,11 @@
                 {
                     "name": "FLASH",
                     "address": 1073881088,
+                    "registers": {
+                        "kind": "flash",
+                        "version": "g0",
+                        "block": "FLASH"
+                    },
                     "rcc": {
                         "clock": "AHB1",
                         "enable": {

--- a/data/chips/STM32G031K6.json
+++ b/data/chips/STM32G031K6.json
@@ -474,6 +474,11 @@
                 {
                     "name": "FLASH",
                     "address": 1073881088,
+                    "registers": {
+                        "kind": "flash",
+                        "version": "g0",
+                        "block": "FLASH"
+                    },
                     "rcc": {
                         "clock": "AHB1",
                         "enable": {

--- a/data/chips/STM32G031K8.json
+++ b/data/chips/STM32G031K8.json
@@ -474,6 +474,11 @@
                 {
                     "name": "FLASH",
                     "address": 1073881088,
+                    "registers": {
+                        "kind": "flash",
+                        "version": "g0",
+                        "block": "FLASH"
+                    },
                     "rcc": {
                         "clock": "AHB1",
                         "enable": {

--- a/data/chips/STM32G031Y8.json
+++ b/data/chips/STM32G031Y8.json
@@ -470,6 +470,11 @@
                 {
                     "name": "FLASH",
                     "address": 1073881088,
+                    "registers": {
+                        "kind": "flash",
+                        "version": "g0",
+                        "block": "FLASH"
+                    },
                     "rcc": {
                         "clock": "AHB1",
                         "enable": {

--- a/data/chips/STM32G041C6.json
+++ b/data/chips/STM32G041C6.json
@@ -507,6 +507,11 @@
                 {
                     "name": "FLASH",
                     "address": 1073881088,
+                    "registers": {
+                        "kind": "flash",
+                        "version": "g0",
+                        "block": "FLASH"
+                    },
                     "rcc": {
                         "clock": "AHB1",
                         "enable": {

--- a/data/chips/STM32G041C8.json
+++ b/data/chips/STM32G041C8.json
@@ -507,6 +507,11 @@
                 {
                     "name": "FLASH",
                     "address": 1073881088,
+                    "registers": {
+                        "kind": "flash",
+                        "version": "g0",
+                        "block": "FLASH"
+                    },
                     "rcc": {
                         "clock": "AHB1",
                         "enable": {

--- a/data/chips/STM32G041F6.json
+++ b/data/chips/STM32G041F6.json
@@ -503,6 +503,11 @@
                 {
                     "name": "FLASH",
                     "address": 1073881088,
+                    "registers": {
+                        "kind": "flash",
+                        "version": "g0",
+                        "block": "FLASH"
+                    },
                     "rcc": {
                         "clock": "AHB1",
                         "enable": {

--- a/data/chips/STM32G041F8.json
+++ b/data/chips/STM32G041F8.json
@@ -503,6 +503,11 @@
                 {
                     "name": "FLASH",
                     "address": 1073881088,
+                    "registers": {
+                        "kind": "flash",
+                        "version": "g0",
+                        "block": "FLASH"
+                    },
                     "rcc": {
                         "clock": "AHB1",
                         "enable": {

--- a/data/chips/STM32G041G6.json
+++ b/data/chips/STM32G041G6.json
@@ -499,6 +499,11 @@
                 {
                     "name": "FLASH",
                     "address": 1073881088,
+                    "registers": {
+                        "kind": "flash",
+                        "version": "g0",
+                        "block": "FLASH"
+                    },
                     "rcc": {
                         "clock": "AHB1",
                         "enable": {

--- a/data/chips/STM32G041G8.json
+++ b/data/chips/STM32G041G8.json
@@ -499,6 +499,11 @@
                 {
                     "name": "FLASH",
                     "address": 1073881088,
+                    "registers": {
+                        "kind": "flash",
+                        "version": "g0",
+                        "block": "FLASH"
+                    },
                     "rcc": {
                         "clock": "AHB1",
                         "enable": {

--- a/data/chips/STM32G041J6.json
+++ b/data/chips/STM32G041J6.json
@@ -479,6 +479,11 @@
                 {
                     "name": "FLASH",
                     "address": 1073881088,
+                    "registers": {
+                        "kind": "flash",
+                        "version": "g0",
+                        "block": "FLASH"
+                    },
                     "rcc": {
                         "clock": "AHB1",
                         "enable": {

--- a/data/chips/STM32G041K6.json
+++ b/data/chips/STM32G041K6.json
@@ -507,6 +507,11 @@
                 {
                     "name": "FLASH",
                     "address": 1073881088,
+                    "registers": {
+                        "kind": "flash",
+                        "version": "g0",
+                        "block": "FLASH"
+                    },
                     "rcc": {
                         "clock": "AHB1",
                         "enable": {

--- a/data/chips/STM32G041K8.json
+++ b/data/chips/STM32G041K8.json
@@ -507,6 +507,11 @@
                 {
                     "name": "FLASH",
                     "address": 1073881088,
+                    "registers": {
+                        "kind": "flash",
+                        "version": "g0",
+                        "block": "FLASH"
+                    },
                     "rcc": {
                         "clock": "AHB1",
                         "enable": {

--- a/data/chips/STM32G041Y8.json
+++ b/data/chips/STM32G041Y8.json
@@ -503,6 +503,11 @@
                 {
                     "name": "FLASH",
                     "address": 1073881088,
+                    "registers": {
+                        "kind": "flash",
+                        "version": "g0",
+                        "block": "FLASH"
+                    },
                     "rcc": {
                         "clock": "AHB1",
                         "enable": {

--- a/data/chips/STM32G050C6.json
+++ b/data/chips/STM32G050C6.json
@@ -310,6 +310,11 @@
                 {
                     "name": "FLASH",
                     "address": 1073881088,
+                    "registers": {
+                        "kind": "flash",
+                        "version": "g0",
+                        "block": "FLASH"
+                    },
                     "rcc": {
                         "clock": "AHB1",
                         "enable": {

--- a/data/chips/STM32G050C8.json
+++ b/data/chips/STM32G050C8.json
@@ -310,6 +310,11 @@
                 {
                     "name": "FLASH",
                     "address": 1073881088,
+                    "registers": {
+                        "kind": "flash",
+                        "version": "g0",
+                        "block": "FLASH"
+                    },
                     "rcc": {
                         "clock": "AHB1",
                         "enable": {

--- a/data/chips/STM32G050F6.json
+++ b/data/chips/STM32G050F6.json
@@ -298,6 +298,11 @@
                 {
                     "name": "FLASH",
                     "address": 1073881088,
+                    "registers": {
+                        "kind": "flash",
+                        "version": "g0",
+                        "block": "FLASH"
+                    },
                     "rcc": {
                         "clock": "AHB1",
                         "enable": {

--- a/data/chips/STM32G050K6.json
+++ b/data/chips/STM32G050K6.json
@@ -298,6 +298,11 @@
                 {
                     "name": "FLASH",
                     "address": 1073881088,
+                    "registers": {
+                        "kind": "flash",
+                        "version": "g0",
+                        "block": "FLASH"
+                    },
                     "rcc": {
                         "clock": "AHB1",
                         "enable": {

--- a/data/chips/STM32G050K8.json
+++ b/data/chips/STM32G050K8.json
@@ -298,6 +298,11 @@
                 {
                     "name": "FLASH",
                     "address": 1073881088,
+                    "registers": {
+                        "kind": "flash",
+                        "version": "g0",
+                        "block": "FLASH"
+                    },
                     "rcc": {
                         "clock": "AHB1",
                         "enable": {

--- a/data/chips/STM32G051C6.json
+++ b/data/chips/STM32G051C6.json
@@ -481,6 +481,11 @@
                 {
                     "name": "FLASH",
                     "address": 1073881088,
+                    "registers": {
+                        "kind": "flash",
+                        "version": "g0",
+                        "block": "FLASH"
+                    },
                     "rcc": {
                         "clock": "AHB1",
                         "enable": {

--- a/data/chips/STM32G051C8.json
+++ b/data/chips/STM32G051C8.json
@@ -481,6 +481,11 @@
                 {
                     "name": "FLASH",
                     "address": 1073881088,
+                    "registers": {
+                        "kind": "flash",
+                        "version": "g0",
+                        "block": "FLASH"
+                    },
                     "rcc": {
                         "clock": "AHB1",
                         "enable": {

--- a/data/chips/STM32G051F6.json
+++ b/data/chips/STM32G051F6.json
@@ -455,6 +455,11 @@
                 {
                     "name": "FLASH",
                     "address": 1073881088,
+                    "registers": {
+                        "kind": "flash",
+                        "version": "g0",
+                        "block": "FLASH"
+                    },
                     "rcc": {
                         "clock": "AHB1",
                         "enable": {

--- a/data/chips/STM32G051F8.json
+++ b/data/chips/STM32G051F8.json
@@ -459,6 +459,11 @@
                 {
                     "name": "FLASH",
                     "address": 1073881088,
+                    "registers": {
+                        "kind": "flash",
+                        "version": "g0",
+                        "block": "FLASH"
+                    },
                     "rcc": {
                         "clock": "AHB1",
                         "enable": {

--- a/data/chips/STM32G051G6.json
+++ b/data/chips/STM32G051G6.json
@@ -447,6 +447,11 @@
                 {
                     "name": "FLASH",
                     "address": 1073881088,
+                    "registers": {
+                        "kind": "flash",
+                        "version": "g0",
+                        "block": "FLASH"
+                    },
                     "rcc": {
                         "clock": "AHB1",
                         "enable": {

--- a/data/chips/STM32G051G8.json
+++ b/data/chips/STM32G051G8.json
@@ -447,6 +447,11 @@
                 {
                     "name": "FLASH",
                     "address": 1073881088,
+                    "registers": {
+                        "kind": "flash",
+                        "version": "g0",
+                        "block": "FLASH"
+                    },
                     "rcc": {
                         "clock": "AHB1",
                         "enable": {

--- a/data/chips/STM32G051K6.json
+++ b/data/chips/STM32G051K6.json
@@ -459,6 +459,11 @@
                 {
                     "name": "FLASH",
                     "address": 1073881088,
+                    "registers": {
+                        "kind": "flash",
+                        "version": "g0",
+                        "block": "FLASH"
+                    },
                     "rcc": {
                         "clock": "AHB1",
                         "enable": {

--- a/data/chips/STM32G051K8.json
+++ b/data/chips/STM32G051K8.json
@@ -459,6 +459,11 @@
                 {
                     "name": "FLASH",
                     "address": 1073881088,
+                    "registers": {
+                        "kind": "flash",
+                        "version": "g0",
+                        "block": "FLASH"
+                    },
                     "rcc": {
                         "clock": "AHB1",
                         "enable": {

--- a/data/chips/STM32G061C6.json
+++ b/data/chips/STM32G061C6.json
@@ -514,6 +514,11 @@
                 {
                     "name": "FLASH",
                     "address": 1073881088,
+                    "registers": {
+                        "kind": "flash",
+                        "version": "g0",
+                        "block": "FLASH"
+                    },
                     "rcc": {
                         "clock": "AHB1",
                         "enable": {

--- a/data/chips/STM32G061C8.json
+++ b/data/chips/STM32G061C8.json
@@ -514,6 +514,11 @@
                 {
                     "name": "FLASH",
                     "address": 1073881088,
+                    "registers": {
+                        "kind": "flash",
+                        "version": "g0",
+                        "block": "FLASH"
+                    },
                     "rcc": {
                         "clock": "AHB1",
                         "enable": {

--- a/data/chips/STM32G061F6.json
+++ b/data/chips/STM32G061F6.json
@@ -488,6 +488,11 @@
                 {
                     "name": "FLASH",
                     "address": 1073881088,
+                    "registers": {
+                        "kind": "flash",
+                        "version": "g0",
+                        "block": "FLASH"
+                    },
                     "rcc": {
                         "clock": "AHB1",
                         "enable": {

--- a/data/chips/STM32G061F8.json
+++ b/data/chips/STM32G061F8.json
@@ -492,6 +492,11 @@
                 {
                     "name": "FLASH",
                     "address": 1073881088,
+                    "registers": {
+                        "kind": "flash",
+                        "version": "g0",
+                        "block": "FLASH"
+                    },
                     "rcc": {
                         "clock": "AHB1",
                         "enable": {

--- a/data/chips/STM32G061G6.json
+++ b/data/chips/STM32G061G6.json
@@ -480,6 +480,11 @@
                 {
                     "name": "FLASH",
                     "address": 1073881088,
+                    "registers": {
+                        "kind": "flash",
+                        "version": "g0",
+                        "block": "FLASH"
+                    },
                     "rcc": {
                         "clock": "AHB1",
                         "enable": {

--- a/data/chips/STM32G061G8.json
+++ b/data/chips/STM32G061G8.json
@@ -480,6 +480,11 @@
                 {
                     "name": "FLASH",
                     "address": 1073881088,
+                    "registers": {
+                        "kind": "flash",
+                        "version": "g0",
+                        "block": "FLASH"
+                    },
                     "rcc": {
                         "clock": "AHB1",
                         "enable": {

--- a/data/chips/STM32G061K6.json
+++ b/data/chips/STM32G061K6.json
@@ -492,6 +492,11 @@
                 {
                     "name": "FLASH",
                     "address": 1073881088,
+                    "registers": {
+                        "kind": "flash",
+                        "version": "g0",
+                        "block": "FLASH"
+                    },
                     "rcc": {
                         "clock": "AHB1",
                         "enable": {

--- a/data/chips/STM32G061K8.json
+++ b/data/chips/STM32G061K8.json
@@ -492,6 +492,11 @@
                 {
                     "name": "FLASH",
                     "address": 1073881088,
+                    "registers": {
+                        "kind": "flash",
+                        "version": "g0",
+                        "block": "FLASH"
+                    },
                     "rcc": {
                         "clock": "AHB1",
                         "enable": {

--- a/data/chips/STM32G070CB.json
+++ b/data/chips/STM32G070CB.json
@@ -470,6 +470,11 @@
                 {
                     "name": "FLASH",
                     "address": 1073881088,
+                    "registers": {
+                        "kind": "flash",
+                        "version": "g0",
+                        "block": "FLASH"
+                    },
                     "rcc": {
                         "clock": "AHB1",
                         "enable": {

--- a/data/chips/STM32G070KB.json
+++ b/data/chips/STM32G070KB.json
@@ -458,6 +458,11 @@
                 {
                     "name": "FLASH",
                     "address": 1073881088,
+                    "registers": {
+                        "kind": "flash",
+                        "version": "g0",
+                        "block": "FLASH"
+                    },
                     "rcc": {
                         "clock": "AHB1",
                         "enable": {

--- a/data/chips/STM32G070RB.json
+++ b/data/chips/STM32G070RB.json
@@ -478,6 +478,11 @@
                 {
                     "name": "FLASH",
                     "address": 1073881088,
+                    "registers": {
+                        "kind": "flash",
+                        "version": "g0",
+                        "block": "FLASH"
+                    },
                     "rcc": {
                         "clock": "AHB1",
                         "enable": {

--- a/data/chips/STM32G071C6.json
+++ b/data/chips/STM32G071C6.json
@@ -476,6 +476,11 @@
                 {
                     "name": "FLASH",
                     "address": 1073881088,
+                    "registers": {
+                        "kind": "flash",
+                        "version": "g0",
+                        "block": "FLASH"
+                    },
                     "rcc": {
                         "clock": "AHB1",
                         "enable": {

--- a/data/chips/STM32G071C8.json
+++ b/data/chips/STM32G071C8.json
@@ -651,6 +651,11 @@
                 {
                     "name": "FLASH",
                     "address": 1073881088,
+                    "registers": {
+                        "kind": "flash",
+                        "version": "g0",
+                        "block": "FLASH"
+                    },
                     "rcc": {
                         "clock": "AHB1",
                         "enable": {

--- a/data/chips/STM32G071CB.json
+++ b/data/chips/STM32G071CB.json
@@ -651,6 +651,11 @@
                 {
                     "name": "FLASH",
                     "address": 1073881088,
+                    "registers": {
+                        "kind": "flash",
+                        "version": "g0",
+                        "block": "FLASH"
+                    },
                     "rcc": {
                         "clock": "AHB1",
                         "enable": {

--- a/data/chips/STM32G071EB.json
+++ b/data/chips/STM32G071EB.json
@@ -609,6 +609,11 @@
                 {
                     "name": "FLASH",
                     "address": 1073881088,
+                    "registers": {
+                        "kind": "flash",
+                        "version": "g0",
+                        "block": "FLASH"
+                    },
                     "rcc": {
                         "clock": "AHB1",
                         "enable": {

--- a/data/chips/STM32G071G6.json
+++ b/data/chips/STM32G071G6.json
@@ -442,6 +442,11 @@
                 {
                     "name": "FLASH",
                     "address": 1073881088,
+                    "registers": {
+                        "kind": "flash",
+                        "version": "g0",
+                        "block": "FLASH"
+                    },
                     "rcc": {
                         "clock": "AHB1",
                         "enable": {

--- a/data/chips/STM32G071G8.json
+++ b/data/chips/STM32G071G8.json
@@ -621,6 +621,11 @@
                 {
                     "name": "FLASH",
                     "address": 1073881088,
+                    "registers": {
+                        "kind": "flash",
+                        "version": "g0",
+                        "block": "FLASH"
+                    },
                     "rcc": {
                         "clock": "AHB1",
                         "enable": {

--- a/data/chips/STM32G071GB.json
+++ b/data/chips/STM32G071GB.json
@@ -621,6 +621,11 @@
                 {
                     "name": "FLASH",
                     "address": 1073881088,
+                    "registers": {
+                        "kind": "flash",
+                        "version": "g0",
+                        "block": "FLASH"
+                    },
                     "rcc": {
                         "clock": "AHB1",
                         "enable": {

--- a/data/chips/STM32G071K6.json
+++ b/data/chips/STM32G071K6.json
@@ -454,6 +454,11 @@
                 {
                     "name": "FLASH",
                     "address": 1073881088,
+                    "registers": {
+                        "kind": "flash",
+                        "version": "g0",
+                        "block": "FLASH"
+                    },
                     "rcc": {
                         "clock": "AHB1",
                         "enable": {

--- a/data/chips/STM32G071K8.json
+++ b/data/chips/STM32G071K8.json
@@ -637,6 +637,11 @@
                 {
                     "name": "FLASH",
                     "address": 1073881088,
+                    "registers": {
+                        "kind": "flash",
+                        "version": "g0",
+                        "block": "FLASH"
+                    },
                     "rcc": {
                         "clock": "AHB1",
                         "enable": {

--- a/data/chips/STM32G071KB.json
+++ b/data/chips/STM32G071KB.json
@@ -637,6 +637,11 @@
                 {
                     "name": "FLASH",
                     "address": 1073881088,
+                    "registers": {
+                        "kind": "flash",
+                        "version": "g0",
+                        "block": "FLASH"
+                    },
                     "rcc": {
                         "clock": "AHB1",
                         "enable": {

--- a/data/chips/STM32G071R6.json
+++ b/data/chips/STM32G071R6.json
@@ -488,6 +488,11 @@
                 {
                     "name": "FLASH",
                     "address": 1073881088,
+                    "registers": {
+                        "kind": "flash",
+                        "version": "g0",
+                        "block": "FLASH"
+                    },
                     "rcc": {
                         "clock": "AHB1",
                         "enable": {

--- a/data/chips/STM32G071R8.json
+++ b/data/chips/STM32G071R8.json
@@ -663,6 +663,11 @@
                 {
                     "name": "FLASH",
                     "address": 1073881088,
+                    "registers": {
+                        "kind": "flash",
+                        "version": "g0",
+                        "block": "FLASH"
+                    },
                     "rcc": {
                         "clock": "AHB1",
                         "enable": {

--- a/data/chips/STM32G071RB.json
+++ b/data/chips/STM32G071RB.json
@@ -667,6 +667,11 @@
                 {
                     "name": "FLASH",
                     "address": 1073881088,
+                    "registers": {
+                        "kind": "flash",
+                        "version": "g0",
+                        "block": "FLASH"
+                    },
                     "rcc": {
                         "clock": "AHB1",
                         "enable": {

--- a/data/chips/STM32G081CB.json
+++ b/data/chips/STM32G081CB.json
@@ -684,6 +684,11 @@
                 {
                     "name": "FLASH",
                     "address": 1073881088,
+                    "registers": {
+                        "kind": "flash",
+                        "version": "g0",
+                        "block": "FLASH"
+                    },
                     "rcc": {
                         "clock": "AHB1",
                         "enable": {

--- a/data/chips/STM32G081EB.json
+++ b/data/chips/STM32G081EB.json
@@ -642,6 +642,11 @@
                 {
                     "name": "FLASH",
                     "address": 1073881088,
+                    "registers": {
+                        "kind": "flash",
+                        "version": "g0",
+                        "block": "FLASH"
+                    },
                     "rcc": {
                         "clock": "AHB1",
                         "enable": {

--- a/data/chips/STM32G081GB.json
+++ b/data/chips/STM32G081GB.json
@@ -654,6 +654,11 @@
                 {
                     "name": "FLASH",
                     "address": 1073881088,
+                    "registers": {
+                        "kind": "flash",
+                        "version": "g0",
+                        "block": "FLASH"
+                    },
                     "rcc": {
                         "clock": "AHB1",
                         "enable": {

--- a/data/chips/STM32G081KB.json
+++ b/data/chips/STM32G081KB.json
@@ -670,6 +670,11 @@
                 {
                     "name": "FLASH",
                     "address": 1073881088,
+                    "registers": {
+                        "kind": "flash",
+                        "version": "g0",
+                        "block": "FLASH"
+                    },
                     "rcc": {
                         "clock": "AHB1",
                         "enable": {

--- a/data/chips/STM32G081RB.json
+++ b/data/chips/STM32G081RB.json
@@ -700,6 +700,11 @@
                 {
                     "name": "FLASH",
                     "address": 1073881088,
+                    "registers": {
+                        "kind": "flash",
+                        "version": "g0",
+                        "block": "FLASH"
+                    },
                     "rcc": {
                         "clock": "AHB1",
                         "enable": {

--- a/data/chips/STM32G0B0CE.json
+++ b/data/chips/STM32G0B0CE.json
@@ -692,6 +692,11 @@
                 {
                     "name": "FLASH",
                     "address": 1073881088,
+                    "registers": {
+                        "kind": "flash",
+                        "version": "g0",
+                        "block": "FLASH"
+                    },
                     "rcc": {
                         "clock": "AHB1",
                         "enable": {

--- a/data/chips/STM32G0B0KE.json
+++ b/data/chips/STM32G0B0KE.json
@@ -680,6 +680,11 @@
                 {
                     "name": "FLASH",
                     "address": 1073881088,
+                    "registers": {
+                        "kind": "flash",
+                        "version": "g0",
+                        "block": "FLASH"
+                    },
                     "rcc": {
                         "clock": "AHB1",
                         "enable": {

--- a/data/chips/STM32G0B0RE.json
+++ b/data/chips/STM32G0B0RE.json
@@ -700,6 +700,11 @@
                 {
                     "name": "FLASH",
                     "address": 1073881088,
+                    "registers": {
+                        "kind": "flash",
+                        "version": "g0",
+                        "block": "FLASH"
+                    },
                     "rcc": {
                         "clock": "AHB1",
                         "enable": {

--- a/data/chips/STM32G0B0VE.json
+++ b/data/chips/STM32G0B0VE.json
@@ -700,6 +700,11 @@
                 {
                     "name": "FLASH",
                     "address": 1073881088,
+                    "registers": {
+                        "kind": "flash",
+                        "version": "g0",
+                        "block": "FLASH"
+                    },
                     "rcc": {
                         "clock": "AHB1",
                         "enable": {

--- a/data/chips/STM32G0B1CB.json
+++ b/data/chips/STM32G0B1CB.json
@@ -1024,6 +1024,11 @@
                 {
                     "name": "FLASH",
                     "address": 1073881088,
+                    "registers": {
+                        "kind": "flash",
+                        "version": "g0",
+                        "block": "FLASH"
+                    },
                     "rcc": {
                         "clock": "AHB1",
                         "enable": {

--- a/data/chips/STM32G0B1CC.json
+++ b/data/chips/STM32G0B1CC.json
@@ -1024,6 +1024,11 @@
                 {
                     "name": "FLASH",
                     "address": 1073881088,
+                    "registers": {
+                        "kind": "flash",
+                        "version": "g0",
+                        "block": "FLASH"
+                    },
                     "rcc": {
                         "clock": "AHB1",
                         "enable": {

--- a/data/chips/STM32G0B1CE.json
+++ b/data/chips/STM32G0B1CE.json
@@ -1024,6 +1024,11 @@
                 {
                     "name": "FLASH",
                     "address": 1073881088,
+                    "registers": {
+                        "kind": "flash",
+                        "version": "g0",
+                        "block": "FLASH"
+                    },
                     "rcc": {
                         "clock": "AHB1",
                         "enable": {

--- a/data/chips/STM32G0B1KB.json
+++ b/data/chips/STM32G0B1KB.json
@@ -992,6 +992,11 @@
                 {
                     "name": "FLASH",
                     "address": 1073881088,
+                    "registers": {
+                        "kind": "flash",
+                        "version": "g0",
+                        "block": "FLASH"
+                    },
                     "rcc": {
                         "clock": "AHB1",
                         "enable": {

--- a/data/chips/STM32G0B1KC.json
+++ b/data/chips/STM32G0B1KC.json
@@ -992,6 +992,11 @@
                 {
                     "name": "FLASH",
                     "address": 1073881088,
+                    "registers": {
+                        "kind": "flash",
+                        "version": "g0",
+                        "block": "FLASH"
+                    },
                     "rcc": {
                         "clock": "AHB1",
                         "enable": {

--- a/data/chips/STM32G0B1KE.json
+++ b/data/chips/STM32G0B1KE.json
@@ -992,6 +992,11 @@
                 {
                     "name": "FLASH",
                     "address": 1073881088,
+                    "registers": {
+                        "kind": "flash",
+                        "version": "g0",
+                        "block": "FLASH"
+                    },
                     "rcc": {
                         "clock": "AHB1",
                         "enable": {

--- a/data/chips/STM32G0B1MB.json
+++ b/data/chips/STM32G0B1MB.json
@@ -1094,6 +1094,11 @@
                 {
                     "name": "FLASH",
                     "address": 1073881088,
+                    "registers": {
+                        "kind": "flash",
+                        "version": "g0",
+                        "block": "FLASH"
+                    },
                     "rcc": {
                         "clock": "AHB1",
                         "enable": {

--- a/data/chips/STM32G0B1MC.json
+++ b/data/chips/STM32G0B1MC.json
@@ -1094,6 +1094,11 @@
                 {
                     "name": "FLASH",
                     "address": 1073881088,
+                    "registers": {
+                        "kind": "flash",
+                        "version": "g0",
+                        "block": "FLASH"
+                    },
                     "rcc": {
                         "clock": "AHB1",
                         "enable": {

--- a/data/chips/STM32G0B1ME.json
+++ b/data/chips/STM32G0B1ME.json
@@ -1094,6 +1094,11 @@
                 {
                     "name": "FLASH",
                     "address": 1073881088,
+                    "registers": {
+                        "kind": "flash",
+                        "version": "g0",
+                        "block": "FLASH"
+                    },
                     "rcc": {
                         "clock": "AHB1",
                         "enable": {

--- a/data/chips/STM32G0B1NE.json
+++ b/data/chips/STM32G0B1NE.json
@@ -683,6 +683,11 @@
                 {
                     "name": "FLASH",
                     "address": 1073881088,
+                    "registers": {
+                        "kind": "flash",
+                        "version": "g0",
+                        "block": "FLASH"
+                    },
                     "rcc": {
                         "clock": "AHB1",
                         "enable": {

--- a/data/chips/STM32G0B1RB.json
+++ b/data/chips/STM32G0B1RB.json
@@ -1074,6 +1074,11 @@
                 {
                     "name": "FLASH",
                     "address": 1073881088,
+                    "registers": {
+                        "kind": "flash",
+                        "version": "g0",
+                        "block": "FLASH"
+                    },
                     "rcc": {
                         "clock": "AHB1",
                         "enable": {

--- a/data/chips/STM32G0B1RC.json
+++ b/data/chips/STM32G0B1RC.json
@@ -1074,6 +1074,11 @@
                 {
                     "name": "FLASH",
                     "address": 1073881088,
+                    "registers": {
+                        "kind": "flash",
+                        "version": "g0",
+                        "block": "FLASH"
+                    },
                     "rcc": {
                         "clock": "AHB1",
                         "enable": {

--- a/data/chips/STM32G0B1RE.json
+++ b/data/chips/STM32G0B1RE.json
@@ -1074,6 +1074,11 @@
                 {
                     "name": "FLASH",
                     "address": 1073881088,
+                    "registers": {
+                        "kind": "flash",
+                        "version": "g0",
+                        "block": "FLASH"
+                    },
                     "rcc": {
                         "clock": "AHB1",
                         "enable": {

--- a/data/chips/STM32G0B1VB.json
+++ b/data/chips/STM32G0B1VB.json
@@ -1098,6 +1098,11 @@
                 {
                     "name": "FLASH",
                     "address": 1073881088,
+                    "registers": {
+                        "kind": "flash",
+                        "version": "g0",
+                        "block": "FLASH"
+                    },
                     "rcc": {
                         "clock": "AHB1",
                         "enable": {

--- a/data/chips/STM32G0B1VC.json
+++ b/data/chips/STM32G0B1VC.json
@@ -1098,6 +1098,11 @@
                 {
                     "name": "FLASH",
                     "address": 1073881088,
+                    "registers": {
+                        "kind": "flash",
+                        "version": "g0",
+                        "block": "FLASH"
+                    },
                     "rcc": {
                         "clock": "AHB1",
                         "enable": {

--- a/data/chips/STM32G0B1VE.json
+++ b/data/chips/STM32G0B1VE.json
@@ -1098,6 +1098,11 @@
                 {
                     "name": "FLASH",
                     "address": 1073881088,
+                    "registers": {
+                        "kind": "flash",
+                        "version": "g0",
+                        "block": "FLASH"
+                    },
                     "rcc": {
                         "clock": "AHB1",
                         "enable": {

--- a/data/chips/STM32G0C1CC.json
+++ b/data/chips/STM32G0C1CC.json
@@ -1057,6 +1057,11 @@
                 {
                     "name": "FLASH",
                     "address": 1073881088,
+                    "registers": {
+                        "kind": "flash",
+                        "version": "g0",
+                        "block": "FLASH"
+                    },
                     "rcc": {
                         "clock": "AHB1",
                         "enable": {

--- a/data/chips/STM32G0C1CE.json
+++ b/data/chips/STM32G0C1CE.json
@@ -1057,6 +1057,11 @@
                 {
                     "name": "FLASH",
                     "address": 1073881088,
+                    "registers": {
+                        "kind": "flash",
+                        "version": "g0",
+                        "block": "FLASH"
+                    },
                     "rcc": {
                         "clock": "AHB1",
                         "enable": {

--- a/data/chips/STM32G0C1KC.json
+++ b/data/chips/STM32G0C1KC.json
@@ -1025,6 +1025,11 @@
                 {
                     "name": "FLASH",
                     "address": 1073881088,
+                    "registers": {
+                        "kind": "flash",
+                        "version": "g0",
+                        "block": "FLASH"
+                    },
                     "rcc": {
                         "clock": "AHB1",
                         "enable": {

--- a/data/chips/STM32G0C1KE.json
+++ b/data/chips/STM32G0C1KE.json
@@ -1025,6 +1025,11 @@
                 {
                     "name": "FLASH",
                     "address": 1073881088,
+                    "registers": {
+                        "kind": "flash",
+                        "version": "g0",
+                        "block": "FLASH"
+                    },
                     "rcc": {
                         "clock": "AHB1",
                         "enable": {

--- a/data/chips/STM32G0C1MC.json
+++ b/data/chips/STM32G0C1MC.json
@@ -1127,6 +1127,11 @@
                 {
                     "name": "FLASH",
                     "address": 1073881088,
+                    "registers": {
+                        "kind": "flash",
+                        "version": "g0",
+                        "block": "FLASH"
+                    },
                     "rcc": {
                         "clock": "AHB1",
                         "enable": {

--- a/data/chips/STM32G0C1ME.json
+++ b/data/chips/STM32G0C1ME.json
@@ -1127,6 +1127,11 @@
                 {
                     "name": "FLASH",
                     "address": 1073881088,
+                    "registers": {
+                        "kind": "flash",
+                        "version": "g0",
+                        "block": "FLASH"
+                    },
                     "rcc": {
                         "clock": "AHB1",
                         "enable": {

--- a/data/chips/STM32G0C1NE.json
+++ b/data/chips/STM32G0C1NE.json
@@ -716,6 +716,11 @@
                 {
                     "name": "FLASH",
                     "address": 1073881088,
+                    "registers": {
+                        "kind": "flash",
+                        "version": "g0",
+                        "block": "FLASH"
+                    },
                     "rcc": {
                         "clock": "AHB1",
                         "enable": {

--- a/data/chips/STM32G0C1RC.json
+++ b/data/chips/STM32G0C1RC.json
@@ -1107,6 +1107,11 @@
                 {
                     "name": "FLASH",
                     "address": 1073881088,
+                    "registers": {
+                        "kind": "flash",
+                        "version": "g0",
+                        "block": "FLASH"
+                    },
                     "rcc": {
                         "clock": "AHB1",
                         "enable": {

--- a/data/chips/STM32G0C1RE.json
+++ b/data/chips/STM32G0C1RE.json
@@ -1107,6 +1107,11 @@
                 {
                     "name": "FLASH",
                     "address": 1073881088,
+                    "registers": {
+                        "kind": "flash",
+                        "version": "g0",
+                        "block": "FLASH"
+                    },
                     "rcc": {
                         "clock": "AHB1",
                         "enable": {

--- a/data/chips/STM32G0C1VC.json
+++ b/data/chips/STM32G0C1VC.json
@@ -1131,6 +1131,11 @@
                 {
                     "name": "FLASH",
                     "address": 1073881088,
+                    "registers": {
+                        "kind": "flash",
+                        "version": "g0",
+                        "block": "FLASH"
+                    },
                     "rcc": {
                         "clock": "AHB1",
                         "enable": {

--- a/data/chips/STM32G0C1VE.json
+++ b/data/chips/STM32G0C1VE.json
@@ -1131,6 +1131,11 @@
                 {
                     "name": "FLASH",
                     "address": 1073881088,
+                    "registers": {
+                        "kind": "flash",
+                        "version": "g0",
+                        "block": "FLASH"
+                    },
                     "rcc": {
                         "clock": "AHB1",
                         "enable": {

--- a/data/registers/flash_g0.yaml
+++ b/data/registers/flash_g0.yaml
@@ -1,0 +1,454 @@
+---
+block/FLASH:
+  description: Flash
+  items:
+    - name: ACR
+      description: Access control register
+      byte_offset: 0
+      fieldset: ACR
+    - name: KEYR
+      description: Flash key register
+      byte_offset: 8
+      access: Write
+      fieldset: KEYR
+    - name: OPTKEYR
+      description: Option byte key register
+      byte_offset: 12
+      access: Write
+      fieldset: OPTKEYR
+    - name: SR
+      description: Status register
+      byte_offset: 16
+      fieldset: SR
+    - name: CR
+      description: Flash control register
+      byte_offset: 20
+      fieldset: CR
+    - name: ECCR
+      description: Flash ECC register
+      byte_offset: 24
+      fieldset: ECCR
+    - name: OPTR
+      description: Flash option register
+      byte_offset: 32
+      fieldset: OPTR
+    - name: PCROP1ASR
+      description: Flash PCROP zone A Start address register
+      byte_offset: 36
+      access: Read
+      fieldset: PCROP1ASR
+    - name: PCROP1AER
+      description: Flash PCROP zone A End address register
+      byte_offset: 40
+      access: Read
+      fieldset: PCROP1AER
+    - name: WRP1AR
+      description: Flash WRP area A address register
+      byte_offset: 44
+      access: Read
+      fieldset: WRP1AR
+    - name: WRP1BR
+      description: Flash WRP area B address register
+      byte_offset: 48
+      access: Read
+      fieldset: WRP1BR
+    - name: PCROP1BSR
+      description: Flash PCROP zone B Start address register
+      byte_offset: 52
+      access: Read
+      fieldset: PCROP1BSR
+    - name: PCROP1BER
+      description: Flash PCROP zone B End address register
+      byte_offset: 56
+      access: Read
+      fieldset: PCROP1BER
+    - name: SECR
+      description: Flash Security register
+      byte_offset: 128
+      access: Read
+      fieldset: SECR
+fieldset/ACR:
+  description: Access control register
+  fields:
+    - name: LATENCY
+      description: Latency
+      bit_offset: 0
+      bit_size: 3
+      enum: LATENCY
+    - name: PRFTEN
+      description: Prefetch enable
+      bit_offset: 8
+      bit_size: 1
+    - name: ICEN
+      description: Instruction cache enable
+      bit_offset: 9
+      bit_size: 1
+    - name: ICRST
+      description: Instruction cache reset
+      bit_offset: 11
+      bit_size: 1
+    - name: EMPTY
+      description: Flash User area empty
+      bit_offset: 16
+      bit_size: 1
+    - name: DBG_SWEN
+      description: Debug access software enable
+      bit_offset: 18
+      bit_size: 1
+fieldset/CR:
+  description: Flash control register
+  fields:
+    - name: PG
+      description: Programming
+      bit_offset: 0
+      bit_size: 1
+    - name: PER
+      description: Page erase
+      bit_offset: 1
+      bit_size: 1
+    - name: MER
+      description: Mass erase
+      bit_offset: 2
+      bit_size: 1
+    - name: PNB
+      description: Page number
+      bit_offset: 3
+      bit_size: 6
+    - name: STRT
+      description: Start
+      bit_offset: 16
+      bit_size: 1
+    - name: OPTSTRT
+      description: Options modification start
+      bit_offset: 17
+      bit_size: 1
+    - name: FSTPG
+      description: Fast programming
+      bit_offset: 18
+      bit_size: 1
+    - name: EOPIE
+      description: End of operation interrupt enable
+      bit_offset: 24
+      bit_size: 1
+    - name: ERRIE
+      description: Error interrupt enable
+      bit_offset: 25
+      bit_size: 1
+    - name: RDERRIE
+      description: PCROP read error interrupt enable
+      bit_offset: 26
+      bit_size: 1
+    - name: OBL_LAUNCH
+      description: Force the option byte loading
+      bit_offset: 27
+      bit_size: 1
+    - name: SEC_PROT
+      description: Securable memory area protection enable
+      bit_offset: 28
+      bit_size: 1
+    - name: OPTLOCK
+      description: Options Lock
+      bit_offset: 30
+      bit_size: 1
+    - name: LOCK
+      description: FLASH_CR Lock
+      bit_offset: 31
+      bit_size: 1
+fieldset/ECCR:
+  description: Flash ECC register
+  fields:
+    - name: ADDR_ECC
+      description: ECC fail address
+      bit_offset: 0
+      bit_size: 14
+    - name: SYSF_ECC
+      description: ECC fail for Corrected ECC Error or Double ECC Error in info block
+      bit_offset: 20
+      bit_size: 1
+    - name: ECCIE
+      description: ECC correction interrupt enable
+      bit_offset: 24
+      bit_size: 1
+    - name: ECCC
+      description: ECC correction
+      bit_offset: 30
+      bit_size: 1
+    - name: ECCD
+      description: ECC detection
+      bit_offset: 31
+      bit_size: 1
+fieldset/KEYR:
+  description: Flash key register
+  fields:
+    - name: KEYR
+      description: KEYR
+      bit_offset: 0
+      bit_size: 32
+fieldset/OPTKEYR:
+  description: Option byte key register
+  fields:
+    - name: OPTKEYR
+      description: Option byte key
+      bit_offset: 0
+      bit_size: 32
+fieldset/OPTR:
+  description: Flash option register
+  fields:
+    - name: RDP
+      description: Read protection level
+      bit_offset: 0
+      bit_size: 8
+      enum: RDP
+    - name: BOREN
+      description: BOR reset Level
+      bit_offset: 8
+      bit_size: 1
+    - name: BORF_LEV
+      description: These bits contain the VDD supply level threshold that activates the reset
+      bit_offset: 9
+      bit_size: 2
+      enum: BORF_LEV
+    - name: BORR_LEV
+      description: These bits contain the VDD supply level threshold that releases the reset.
+      bit_offset: 11
+      bit_size: 2
+      enum: BORR_LEV
+    - name: nRST_STOP
+      description: nRST_STOP
+      bit_offset: 13
+      bit_size: 1
+    - name: nRST_STDBY
+      description: nRST_STDBY
+      bit_offset: 14
+      bit_size: 1
+    - name: nRSTS_HDW
+      description: nRSTS_HDW
+      bit_offset: 15
+      bit_size: 1
+    - name: IDWG_SW
+      description: Independent watchdog selection
+      bit_offset: 16
+      bit_size: 1
+    - name: IWDG_STOP
+      description: Independent watchdog counter freeze in Stop mode
+      bit_offset: 17
+      bit_size: 1
+    - name: IWDG_STDBY
+      description: Independent watchdog counter freeze in Standby mode
+      bit_offset: 18
+      bit_size: 1
+    - name: WWDG_SW
+      description: Window watchdog selection
+      bit_offset: 19
+      bit_size: 1
+    - name: RAM_PARITY_CHECK
+      description: SRAM parity check control
+      bit_offset: 22
+      bit_size: 1
+    - name: nBOOT_SEL
+      description: nBOOT_SEL
+      bit_offset: 24
+      bit_size: 1
+    - name: nBOOT1
+      description: Boot configuration
+      bit_offset: 25
+      bit_size: 1
+    - name: nBOOT0
+      description: nBOOT0 option bit
+      bit_offset: 26
+      bit_size: 1
+    - name: NRST_MODE
+      description: NRST_MODE
+      bit_offset: 27
+      bit_size: 2
+      enum: NRST_MODE
+    - name: IRHEN
+      description: Internal reset holder enable bit
+      bit_offset: 29
+      bit_size: 1
+fieldset/PCROP1AER:
+  description: Flash PCROP zone A End address register
+  fields:
+    - name: PCROP1A_END
+      description: PCROP1A area end offset
+      bit_offset: 0
+      bit_size: 8
+    - name: PCROP_RDP
+      description: PCROP area preserved when RDP level decreased
+      bit_offset: 31
+      bit_size: 1
+fieldset/PCROP1ASR:
+  description: Flash PCROP zone A Start address register
+  fields:
+    - name: PCROP1A_STRT
+      description: PCROP1A area start offset
+      bit_offset: 0
+      bit_size: 8
+fieldset/PCROP1BER:
+  description: Flash PCROP zone B End address register
+  fields:
+    - name: PCROP1B_END
+      description: PCROP1B area end offset
+      bit_offset: 0
+      bit_size: 8
+fieldset/PCROP1BSR:
+  description: Flash PCROP zone B Start address register
+  fields:
+    - name: PCROP1B_STRT
+      description: PCROP1B area start offset
+      bit_offset: 0
+      bit_size: 8
+fieldset/SECR:
+  description: Flash Security register
+  fields:
+    - name: SEC_SIZE
+      description: Securable memory area size
+      bit_offset: 0
+      bit_size: 7
+    - name: BOOT_LOCK
+      description: used to force boot from user area
+      bit_offset: 16
+      bit_size: 1
+fieldset/SR:
+  description: Status register
+  fields:
+    - name: EOP
+      description: End of operation
+      bit_offset: 0
+      bit_size: 1
+    - name: OPERR
+      description: Operation error
+      bit_offset: 1
+      bit_size: 1
+    - name: PROGERR
+      description: Programming error
+      bit_offset: 3
+      bit_size: 1
+    - name: WRPERR
+      description: Write protected error
+      bit_offset: 4
+      bit_size: 1
+    - name: PGAERR
+      description: Programming alignment error
+      bit_offset: 5
+      bit_size: 1
+    - name: SIZERR
+      description: Size error
+      bit_offset: 6
+      bit_size: 1
+    - name: PGSERR
+      description: Programming sequence error
+      bit_offset: 7
+      bit_size: 1
+    - name: MISERR
+      description: Fast programming data miss error
+      bit_offset: 8
+      bit_size: 1
+    - name: FASTERR
+      description: Fast programming error
+      bit_offset: 9
+      bit_size: 1
+    - name: RDERR
+      description: PCROP read error
+      bit_offset: 14
+      bit_size: 1
+    - name: OPTVERR
+      description: Option and Engineering bits loading validity error
+      bit_offset: 15
+      bit_size: 1
+    - name: BSY
+      description: Busy
+      bit_offset: 16
+      bit_size: 1
+    - name: CFGBSY
+      description: Programming or erase configuration busy.
+      bit_offset: 18
+      bit_size: 1
+fieldset/WRP1AR:
+  description: Flash WRP area A address register
+  fields:
+    - name: WRP1A_STRT
+      description: WRP area A start offset
+      bit_offset: 0
+      bit_size: 6
+    - name: WRP1A_END
+      description: WRP area A end offset
+      bit_offset: 16
+      bit_size: 6
+fieldset/WRP1BR:
+  description: Flash WRP area B address register
+  fields:
+    - name: WRP1B_STRT
+      description: WRP area B start offset
+      bit_offset: 0
+      bit_size: 6
+    - name: WRP1B_END
+      description: WRP area B end offset
+      bit_offset: 16
+      bit_size: 6
+enum/LATENCY:
+  bit_size: 3
+  variants:
+    - name: WS0
+      description: Zero wait states
+      value: 0b000
+    - name: WS1
+      description: One wait state
+      value: 0b001
+    - name: WS2
+      description: Two wait states
+      values: 0b010
+enum/NRST_MODE:
+  bit_size: 2
+  variants:
+    - name: INPUT_ONLY
+      description: Reset pin is in reset input mode only
+      value: 0b01
+    - name: GPIO
+      description: Reset pin is in GPIO mode only
+      value: 0b10
+    - name: INPUT_OUTPUT
+      description: Reset pin is in resety input and output mode
+      value: 0b11
+enum/BORR_LEV:
+  bit_size: 2
+  variants:
+    - name: RISING_0
+      description: BOR rising level 1 with threshold around 2.1V
+      value: 0b00
+    - name: RISING_1
+      description: BOR rising level 2 with threshold around 2.3V
+      value: 0b01
+    - name: RISING_2
+      description: BOR rising level 3 with threshold around 2.6V
+      value: 0b10
+    - name: RISING_3
+      description: BOR rising level 4 with threshold around 2.9V
+      value: 0b11
+enum/BORF_LEV:
+  bit_size: 2
+  variants:
+    - name: FALLING_0
+      description: BOR falling level 1 with threshold around 2.0V
+      value: 0b00
+    - name: FALLING_1
+      description: BOR falling level 2 with threshold around 2.2V
+      value: 0b01
+    - name: FALLING_2
+      description: BOR falling level 3 with threshold around 2.5V
+      value: 0b10
+    - name: FALLING_3
+      description: BOR falling level 4 with threshold around 2.8V
+      value: 0b11
+enum/RDP:
+  bit_size: 8
+  variants:
+    - name: LEVEL_0
+      value: 0xAA
+      description: Read protection not active
+    - name: LEVEL_1
+      value: 0xBB
+      description: Memories read protection active
+    - name: LEVEL_2
+      value: 0xCC
+      description: Chip read protection active

--- a/data/registers/flash_g0.yaml
+++ b/data/registers/flash_g0.yaml
@@ -397,7 +397,7 @@ enum/LATENCY:
       value: 0b001
     - name: WS2
       description: Two wait states
-      values: 0b010
+      value: 0b010
 enum/NRST_MODE:
   bit_size: 2
   variants:

--- a/data/registers/rcc_g0.yaml
+++ b/data/registers/rcc_g0.yaml
@@ -778,7 +778,7 @@ fieldset/CCIPR2:
   description: Peripherals independent clock configuration register 2
   fields:
     - name: I2S1SEL
-      description: 2S1SEL
+      description: I2S1SEL
       bit_offset: 0
       bit_size: 2
     - name: I2S2SEL

--- a/data/registers/rcc_g0.yaml
+++ b/data/registers/rcc_g0.yaml
@@ -683,6 +683,7 @@ fieldset/BDCR:
       description: LSE oscillator drive capability
       bit_offset: 3
       bit_size: 2
+      enum: LSEDRV
     - name: LSECSSON
       description: CSS on LSE enable
       bit_offset: 5
@@ -695,6 +696,7 @@ fieldset/BDCR:
       description: RTC clock source selection
       bit_offset: 8
       bit_size: 2
+      enum: RTCSEL
     - name: RTCEN
       description: RTC clock enable
       bit_offset: 15
@@ -718,62 +720,77 @@ fieldset/CCIPR:
       description: USART1 clock source selection
       bit_offset: 0
       bit_size: 2
+      enum: USART1SEL
     - name: USART2SEL
       description: USART2 clock source selection
       bit_offset: 2
       bit_size: 2
+      enum: USART2SEL
     - name: USART3SEL
       description: USART3 clock source selection
       bit_offset: 4
       bit_size: 2
+      enum: USART3SEL
     - name: CECSEL
       description: HDMI CEC clock source selection
       bit_offset: 6
       bit_size: 1
+      enum: CECSEL
     - name: LPUART2SEL
       description: LPUART2 clock source selection
       bit_offset: 8
       bit_size: 2
+      enum: LPUART2SEL
     - name: LPUART1SEL
       description: LPUART1 clock source selection
       bit_offset: 10
       bit_size: 2
+      enum: LPUART1SEL
     - name: I2C1SEL
       description: I2C1 clock source selection
       bit_offset: 12
       bit_size: 2
+      enum: I2C1SEL
     - name: I2S2SEL
       description: I2S1 clock source selection
       bit_offset: 14
       bit_size: 2
+      enum: I2C2I2S1SEL
     - name: LPTIM1SEL
       description: LPTIM1 clock source selection
       bit_offset: 18
       bit_size: 2
+      enum: LPTIM1SEL
     - name: LPTIM2SEL
       description: LPTIM2 clock source selection
       bit_offset: 20
       bit_size: 2
+      enum: LPTIM2SEL
     - name: TIM1SEL
       description: TIM1 clock source selection
       bit_offset: 22
       bit_size: 1
+      enum: TIM1SEL
     - name: TIM15SEL
       description: TIM15 clock source selection
       bit_offset: 24
       bit_size: 1
+      enum: TIM15SEL
     - name: RNGSEL
       description: RNG clock source selection
       bit_offset: 26
       bit_size: 2
+      enum: RNGSEL
     - name: RNGDIV
       description: Division factor of RNG clock divider
       bit_offset: 28
       bit_size: 2
+      enum: RNGDIV
     - name: ADCSEL
       description: ADCs clock source selection
       bit_offset: 30
       bit_size: 2
+      enum: ADCSEL
 fieldset/CCIPR2:
   description: Peripherals independent clock configuration register 2
   fields:
@@ -781,18 +798,22 @@ fieldset/CCIPR2:
       description: I2S1SEL
       bit_offset: 0
       bit_size: 2
+      enum: I2S1SEL
     - name: I2S2SEL
       description: I2S2SEL
       bit_offset: 2
       bit_size: 2
+      enum: I2S2SEL
     - name: FDCANSEL
       description: FDCANSEL
       bit_offset: 8
       bit_size: 2
+      enum: FDCANSEL
     - name: USBSEL
       description: USBSEL
       bit_offset: 12
       bit_size: 2
+      enum: USBSEL
 fieldset/CFGR:
   description: Clock configuration register
   fields:
@@ -800,34 +821,42 @@ fieldset/CFGR:
       description: System clock switch
       bit_offset: 0
       bit_size: 3
+      enum: SW
     - name: SWS
       description: System clock switch status
       bit_offset: 3
       bit_size: 3
+      enum: SWS
     - name: HPRE
       description: AHB prescaler
       bit_offset: 8
       bit_size: 4
+      enum: HPRE
     - name: PPRE
       description: APB prescaler
       bit_offset: 12
       bit_size: 3
+      enum: PPRE
     - name: MCO2SEL
       description: MCO2SEL
       bit_offset: 16
       bit_size: 4
+      enum: MCO2SEL
     - name: MCO2PRE
       description: MCO2PRE
       bit_offset: 20
       bit_size: 4
+      enum: MCO2PRE
     - name: MCOSEL
       description: Microcontroller clock output
       bit_offset: 24
       bit_size: 3
+      enum: MCOSEL
     - name: MCOPRE
       description: Microcontroller clock output prescaler
       bit_offset: 28
       bit_size: 3
+      enum: MCOPRE
 fieldset/CICR:
   description: Clock interrupt clear register
   fields:
@@ -940,6 +969,7 @@ fieldset/CR:
       description: HSI16 clock division factor
       bit_offset: 11
       bit_size: 3
+      enum: HSIDIV
     - name: HSEON
       description: HSE clock enable
       bit_offset: 16
@@ -1109,6 +1139,7 @@ fieldset/PLLSYSCFGR:
       description: PLL input clock source
       bit_offset: 0
       bit_size: 2
+      enum: PLLSRC
     - name: PLLM
       description: Division factor M of the PLL input clock divider
       bit_offset: 4
@@ -1141,3 +1172,561 @@ fieldset/PLLSYSCFGR:
       description: PLL VCO division factor R for PLLRCLK clock output
       bit_offset: 29
       bit_size: 3
+enum/HSIDIV:
+  bit_size: 3
+  variants:
+    - name: Div1
+      description: HSI clock is not divided
+      value: 0b000
+    - name: Div2
+      description: HSI clock is divided by 2
+      value: 0b001
+    - name: Div4
+      description: HSI clock is divided by 4
+      value: 0b010
+    - name: Div8
+      description: HSI clock is divided by 8
+      value: 0b011
+    - name: Div16
+      description: HSI clock is divided by 16
+      value: 0b100
+    - name: Div32
+      description: HSI clock is divided by 32
+      value: 0b101
+    - name: Div64
+      description: HSI clock is divided by 64
+      value: 0b110
+    - name: Div128
+      description: HSI clock is divided by 128
+      value: 0b111
+enum/MCOPRE:
+  bit_size: 4
+  variants:
+    - name: Div1
+      description: MCO1 not divided
+      value: 0b0000
+    - name: Div2
+      description: MCO1 clock is divided by 2
+      value: 0b0001
+    - name: Div4
+      description: MCO1 clock is divided by 4
+      value: 0b0010
+    - name: Div8
+      description: MCO1 clock is divided by 8
+      value: 0b0011
+    - name: Div16
+      description: MCO1 clock is divided divided by 16
+      value: 0b0100
+    - name: Div32
+      description: MCO1 clock is divided divided by 32
+      value: 0b0101
+    - name: Div64
+      description: MCO1 clock is divided divided by 64
+      value: 0b0110
+    - name: Div128
+      description: MCO1 clock is divided divided by 128
+      value: 0b0111
+    - name: Div256
+      description: MCO1 clock is divided divided by 256
+      value: 0b1000
+    - name: Div512
+      description: MCO1 clock is divided divided by 512
+      value: 0b1001
+    - name: Div1024
+      description: MCO1 clock is divided divided by 1024
+      value: 0b1010
+enum/MCOSEL:
+  bit_size: 4
+  variants:
+    - name: NoClock
+      description: No clock, MCO output disabled
+      value: 0b0000
+    - name: SYSCLK
+      description: SYSCLK selected as MCO1 source
+      value: 0b0001
+    - name: HSI48
+      description: HSI48 selected as MCO1 source
+      value: 0b0010
+    - name: HSI16
+      description: HSI16 selected as MCO1 source
+      value: 0b0011
+    - name: HSE
+      description: HSE selected as MCO1 source
+      value: 0b0100
+    - name: PLLRCLK
+      description: PLLRCLK selected as MCO1 source
+      value: 0b0101
+    - name: LSI
+      description: LSI selected as MCO1 source
+      value: 0b0110
+    - name: LSE
+      description: LSE selected as MCO1 source
+      value: 0b0111
+    - name: PLLPCLK
+      description: PLLPCLK selected as MCO1 source
+      value: 0b1000
+    - name: PLLQCLK
+      description: PLLQCLK selected as MCO1 source
+      value: 0b1001
+    - name: RTCCLK
+      description: RTCCLK selected as MCO1 source
+      value: 0b1010
+    - name: RTC_WKUP
+      description: RTC_Wakeup selected as MCO1 source
+      value: 0b1011
+enum/MCO2PRE:
+  bit_size: 4
+  variants:
+    - name: Div1
+      description: MCO2 not divided
+      value: 0b0000
+    - name: Div2
+      description: MCO2 clock is divided by 2
+      value: 0b0001
+    - name: Div4
+      description: MCO2 clock is divided by 4
+      value: 0b0010
+    - name: Div8
+      description: MCO2 clock is divided by 8
+      value: 0b0011
+    - name: Div16
+      description: MCO2 clock is divided divided by 16
+      value: 0b0100
+    - name: Div32
+      description: MCO2 clock is divided divided by 32
+      value: 0b0101
+    - name: Div64
+      description: MCO2 clock is divided divided by 64
+      value: 0b0110
+    - name: Div128
+      description: MCO2 clock is divided divided by 128
+      value: 0b0111
+    - name: Div256
+      description: MCO2 clock is divided divided by 256
+      value: 0b1000
+    - name: Div512
+      description: MCO2 clock is divided divided by 512
+      value: 0b1001
+    - name: Div1024
+      description: MCO2 clock is divided divided by 1024
+      value: 0b1010
+enum/MCO2SEL:
+  bit_size: 4
+  variants:
+    - name: NoClock
+      description: No clock, MCO2 output disabled
+      value: 0b0000
+    - name: SYSCLK
+      description: SYSCLK selected as MCO2 source
+      value: 0b0001
+    - name: HSI48
+      description: HSI48 selected as MCO2 source
+      value: 0b0010
+    - name: HSI16
+      description: HSI16 selected as MCO2 source
+      value: 0b0011
+    - name: HSE
+      description: HSE selected as MCO2 source
+      value: 0b0100
+    - name: PLLRCLK
+      description: PLLRCLK selected as MCO2 source
+      value: 0b0101
+    - name: LSI
+      description: LSI selected as MCO2 source
+      value: 0b0110
+    - name: LSE
+      description: LSE selected as MCO2 source
+      value: 0b0111
+    - name: PLLPCLK
+      description: PLLPCLK selected as MCO2 source
+      value: 0b1000
+    - name: PLLQCLK
+      description: PLLQCLK selected as MCO2 source
+      value: 0b1001
+    - name: RTCCLK
+      description: RTCCLK selected as MCO2 source
+      value: 0b1010
+    - name: RTC_WKUP
+      description: RTC_Wakeup selected as MCO2 source
+      value: 0b1011
+enum/PPRE:
+  bit_size: 4
+  variants:
+    - name: Div1
+      description: HCLK not divided
+      value: 0b00
+    - name: Div2
+      description: HCLK is divided by 2
+      value: 0b100
+    - name: Div4
+      description: HCLK is divided by 4
+      value: 0b101
+    - name: Div8
+      description: HCLK is divided by 8
+      value: 0b110
+    - name: Div16
+      description: HCLK is divided by 16
+      value: 0b111
+enum/HPRE:
+  bit_size: 4
+  variants:
+    - name: Div1
+      description: SYSCLK not divided
+      value: 0b0000
+    - name: Div2
+      description: SYSCLK is divided by 2
+      value: 0b1000
+    - name: Div4
+      description: SYSCLK is divided by 4
+      value: 0b1001
+    - name: Div8
+      description: SYSCLK is divided by 8
+      value: 0b1010
+    - name: Div16
+      description: SYSCLK is divided by 16
+      value: 0b1011
+    - name: Div64
+      description: SYSCLK is divided by 64
+      value: 0b1100
+    - name: Div128
+      description: SYSCLK is divided by 128
+      value: 0b1101
+    - name: Div256
+      description: SYSCLK is divided by 256
+      value: 0b1110
+    - name: Div512
+      description: SYSCLK is divided by 512
+      value: 0b1111
+enum/SWS:
+  bit_size: 3
+  variants:
+    - name: HSI
+      description: HSI used as system clock
+      value: 0b000
+    - name: HSE
+      description: HSE used as system clock
+      value: 0b001
+    - name: PLLRCLK
+      description: PLLRCLK used as system clock
+      value: 0b010
+    - name: LSI
+      description: LSI used as system clock
+      value: 0b011
+    - name: LSE
+      description: LSE used as system clock
+      value: 0b100
+enum/SW:
+  bit_size: 3
+  variants:
+    - name: HSI
+      description: HSI selected as system clock
+      value: 0b000
+    - name: HSE
+      description: HSE selected as system clock
+      value: 0b001
+    - name: PLLRCLK
+      description: PLLRCLK selected as system clock
+      value: 0b010
+    - name: LSI
+      description: LSI selected as system clock
+      value: 0b011
+    - name: LSE
+      description: LSE selected as system clock
+      value: 0b100
+enum/PLLSRC:
+  bit_size: 2
+  variants:
+    - name: NoClock
+      description: No clock selected as PLL entry clock source
+      value: 0b00
+    - name: HSI16
+      description: HSI16 selected as PLL entry clock source
+      value: 0b10
+    - name: HSE
+      description: HSE selected as PLL entry clock source
+      value: 0b11
+enum/ADCSEL:
+  bit_size: 2
+  variants:
+    - name: SYSCLK
+      description: SYSCLK used as ADC clock source
+      value: 0b00
+    - name: PLLPCLK
+      description: PLLPCLK used as ADC clock source
+      value: 0b01
+    - name: HSI16
+      description: HSI16 used as ADC clock source
+      value: 0b10
+enum/RNGDIV:
+  bit_size: 2
+  variants:
+    - name: Div1
+      description: RNG clock is not divided
+      value: 0b00
+    - name: Div2
+      description: RNG clock is divided by 2
+      value: 0b01
+    - name: Div4
+      description: RNG clock is divided by 4
+      value: 0b10
+    - name: Div8
+      description: RNG clock is divided by 8
+      value: 0b11
+enum/RNGSEL:
+  bit_size: 2
+  variants:
+    - name: NoClock
+      description: No clock used as RNG clock source
+      value: 0b00
+    - name: HSI16_Div8
+      description: HSI divided by 8 used as RNG clock source
+      value: 0b01
+    - name: SYSCLK
+      description: SYSCLK used as RNG clock source
+      value: 0b10
+    - name: PLLQCLK
+      description: PLLQCLK used as RNG clock source
+      value: 0b11
+enum/TIM15SEL:
+  bit_size: 1
+  variants:
+    - name: TIMPCLK
+      description: TIMPCLK used as TIM15 clock source
+      value: 0
+    - name: PLLQCLK
+      description: PLLQCLK used as TIM15 clock source
+      value: 1
+enum/TIM1SEL:
+  bit_size: 1
+  variants:
+    - name: TIMPCLK
+      description: TIMPCLK used as TIM1 clock source
+      value: 0b0
+    - name: PLLQCLK
+      description: PLLQCLK used as TIM1 clock source
+      value: 0b1
+enum/LPTIM2SEL:
+  bit_size: 2
+  variants:
+    - name: PCLK
+      description: PCLK used as LPTIM2 clock source
+      value: 0b00
+    - name: LSI
+      description: LSI used as LPTIM2 clock source
+      value: 0b01
+    - name: HSI16
+      description: HSI16 used as LPTIM2 clock source
+      value: 0b10
+    - name: LSE
+      description: LSE used as LPTIM2 clock source
+      value: 0b11
+enum/LPTIM1SEL:
+  bit_size: 2
+  variants:
+    - name: PCLK
+      description: PCLK used as LPTIM1 clock source
+      value: 0b00
+    - name: LSI
+      description: LSI used as LPTIM1 clock source
+      value: 0b01
+    - name: HSI16
+      description: HSI16 used as LPTIM1 clock source
+      value: 0b10
+    - name: LSE
+      description: LSE used as LPTIM1 clock source
+      value: 0b11
+enum/I2C2I2S1SEL:
+  bit_size: 2
+  variants:
+    - name: PCLK
+      description: PCLK used as I2C2/I2S2 clock source
+      value: 0b00
+    - name: SYSCLK
+      description: SYSCLK used as I2C2/I2S2 clock source
+      value: 0b01
+    - name: HSI16
+      description: HSI16 used as I2C2/I2S2 clock source
+      value: 0b10
+    - name: I2S_CKIN
+      description: External clock used as I2C2/I2S2 clock source
+      value: 0b11
+enum/I2C1SEL:
+  bit_size: 2
+  variants:
+    - name: PCLK
+      description: PCLK used as I2C1 clock source
+      value: 0b00
+    - name: SYSCLK
+      description: SYSCLK used as I2C1 clock source
+      value: 0b01
+    - name: HSI16
+      description: HSI16 used as I2C1 clock source
+      value: 0b10
+enum/LPUART1SEL:
+  bit_size: 2
+  variants:
+    - name: PCLK
+      description: PCLK used as LPUART1 clock source
+      value: 0b00
+    - name: SYSCLK
+      description: SYSCLK used as LPUART1 clock source
+      value: 0b01
+    - name: HSI16
+      description: HSI16 used as LPUART1 clock source
+      value: 0b10
+    - name: LSE
+      description: LSE used as LPUART1 clock source
+      value: 0b11
+enum/LPUART2SEL:
+  bit_size: 2
+  variants:
+    - name: PCLK
+      description: PCLK used as LPUART2 clock source
+      value: 0b00
+    - name: SYSCLK
+      description: SYSCLK used as LPUART2 clock source
+      value: 0b01
+    - name: HSI16
+      description: HSI16 used as LPUART2 clock source
+      value: 0b10
+    - name: LSE
+      description: LSE used as LPUART2 clock source
+      value: 0b11
+enum/CECSEL:
+  bit_size: 1
+  variants:
+    - name: HSI16_Div488
+      description: HSI16 divided by 488 used as CEC clock
+      value: 0b0
+    - name: LSE
+      description: LSE used as CEC clock
+      value: 0b1
+enum/USART3SEL:
+  bit_size: 2
+  variants:
+    - name: PCLK
+      description: PCLK used as USART3 clock source
+      value: 0b00
+    - name: SYSCLK
+      description: SYSCLK used as USART3 clock source
+      value: 0b01
+    - name: HSI16
+      description: HSI16 used as USART3 clock source
+      value: 0b10
+    - name: LSE
+      description: LSE used as USART3 clock source
+      value: 0b11
+enum/USART2SEL:
+  bit_size: 2
+  variants:
+    - name: PCLK
+      description: PCLK used as USART2 clock source
+      value: 0b00
+    - name: SYSCLK
+      description: SYSCLK used as USART2 clock source
+      value: 0b01
+    - name: HSI16
+      description: HSI16 used as USART2 clock source
+      value: 0b10
+    - name: LSE
+      description: LSE used as USART2 clock source
+      value: 0b11
+enum/USART1SEL:
+  bit_size: 2
+  variants:
+    - name: PCLK
+      description: PCLK used as USART1 clock source
+      value: 0b00
+    - name: SYSCLK
+      description: SYSCLK used as USART1 clock source
+      value: 0b01
+    - name: HSI16
+      description: HSI16 used as USART1 clock source
+      value: 0b10
+    - name: LSE
+      description: LSE used as USART1 clock source
+      value: 0b11
+enum/USBSEL:
+  bit_size: 2
+  variants:
+    - name: HSI48
+      description: HSI48 used as USB clock source
+      value: 0b00
+    - name: PLLQCLK
+      description: PLLQCLK used as USB clock source
+      value: 0b01
+    - name: HSE
+      description: HSE used as USB clock source
+      value: 0b10
+enum/FDCANSEL:
+  bit_size: 2
+  variants:
+    - name: PCLK
+      description: PCLK used as FDCAN clock source
+      value: 0b00
+    - name: PLLQCLK
+      description: PLLQCLK used as FDCAN clock source
+      value: 0b01
+    - name: HSE
+      description: HSE used as FDCAN clock source
+      value: 0b10
+enum/I2S2SEL:
+  bit_size: 2
+  variants:
+    - name: SYSCLK
+      description: SYSCLK used as I2S2 clock source
+      value: 0b00
+    - name: PLLPCLK
+      description: PLLPCLK used as I2S2 clock source
+      value: 0b01
+    - name: HSI16
+      description: HSI used as I2S2 clock source
+      value: 0b10
+    - name: I2S_CKIN
+      description: External clock used as I2S2 clock source
+      value: 0b11
+enum/I2S1SEL:
+  bit_size: 2
+  variants:
+    - name: SYSCLK
+      description: SYSCLK used as I2S1 clock source
+      value: 0b00
+    - name: PLLPCLK
+      description: PLLPCLK used as I2S1 clock source
+      value: 0b01
+    - name: HSI16
+      description: HSI used as I2S1 clock source
+      value: 0b10
+    - name: I2S_CKIN
+      description: External clock used as I2S1 clock source
+      value: 0b11
+enum/RTCSEL:
+  bit_size: 2
+  variants:
+    - name: NoClock
+      description: No clock used as RTC clock
+      value: 0b00
+    - name: LSE
+      description: LSE used as RTC clock
+      value: 0b01
+    - name: LSI
+      description: LSI used as RTC clock
+      value: 0b10
+    - name: HSE_Div32
+      description: HSE divided by 32 used as RTC clock
+      value: 0b11
+enum/LSEDRV:
+  bit_size: 2
+  variants:
+    - name: Low
+      description: Low driving capability
+      value: 0b00
+    - name: MediumLow
+      description: Medium low driving capability
+      value: 0b01
+    - name: MediumHigh
+      description: Medium high driving capability
+      value: 0b10
+    - name: High
+      description: High driving capability
+      value: 0b11

--- a/data/registers/rcc_g0.yaml
+++ b/data/registers/rcc_g0.yaml
@@ -792,7 +792,7 @@ fieldset/CCIPR2:
     - name: USBSEL
       description: USBSEL
       bit_offset: 12
-      bit_size: 1
+      bit_size: 2
 fieldset/CFGR:
   description: Clock configuration register
   fields:

--- a/stm32data/__main__.py
+++ b/stm32data/__main__.py
@@ -213,6 +213,7 @@ perimap = [
     ('STM32L4.*:FLASH:.*', ('flash', 'l4', 'FLASH')),
     ('STM32U5.*:FLASH:.*', ('flash', 'u5', 'FLASH')),
     ('STM32WB.*:FLASH:.*', ('flash', 'wb55', 'FLASH')),
+    ('STM32G0.*:FLASH:.*', ('flash', 'g0', 'FLASH')),
     ('STM32F7.*:ETH:ETH:ethermac110_v2_0', ('eth', 'v1c', 'ETH')),
     ('.*ETH:ethermac110_v3_0', ('eth', 'v2', 'ETH')),
 


### PR DESCRIPTION
Additions and fixes for the G0 family.

NOTE: The addition of enums for the RCC breaks embassy-stm32/src/rcc/rcc_g0.rs. I am preparing a fix for that.