### PR TITLE
Unify SDMMC v1 and v2 register names

### DIFF
--- a/data/chips/STM32F103RC.json
+++ b/data/chips/STM32F103RC.json
@@ -1216,6 +1216,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073840128,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "AHB1",
                         "enable": {

--- a/data/chips/STM32F103RD.json
+++ b/data/chips/STM32F103RD.json
@@ -1216,6 +1216,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073840128,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "AHB1",
                         "enable": {

--- a/data/chips/STM32F103RE.json
+++ b/data/chips/STM32F103RE.json
@@ -1216,6 +1216,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073840128,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "AHB1",
                         "enable": {

--- a/data/chips/STM32F103RF.json
+++ b/data/chips/STM32F103RF.json
@@ -1206,6 +1206,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073840128,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "AHB1",
                         "enable": {

--- a/data/chips/STM32F103RG.json
+++ b/data/chips/STM32F103RG.json
@@ -1206,6 +1206,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073840128,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "AHB1",
                         "enable": {

--- a/data/chips/STM32F103VC.json
+++ b/data/chips/STM32F103VC.json
@@ -1439,6 +1439,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073840128,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "AHB1",
                         "enable": {

--- a/data/chips/STM32F103VD.json
+++ b/data/chips/STM32F103VD.json
@@ -1439,6 +1439,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073840128,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "AHB1",
                         "enable": {

--- a/data/chips/STM32F103VE.json
+++ b/data/chips/STM32F103VE.json
@@ -1439,6 +1439,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073840128,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "AHB1",
                         "enable": {

--- a/data/chips/STM32F103VF.json
+++ b/data/chips/STM32F103VF.json
@@ -1429,6 +1429,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073840128,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "AHB1",
                         "enable": {

--- a/data/chips/STM32F103VG.json
+++ b/data/chips/STM32F103VG.json
@@ -1429,6 +1429,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073840128,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "AHB1",
                         "enable": {

--- a/data/chips/STM32F103ZC.json
+++ b/data/chips/STM32F103ZC.json
@@ -1587,6 +1587,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073840128,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "AHB1",
                         "enable": {

--- a/data/chips/STM32F103ZD.json
+++ b/data/chips/STM32F103ZD.json
@@ -1587,6 +1587,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073840128,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "AHB1",
                         "enable": {

--- a/data/chips/STM32F103ZE.json
+++ b/data/chips/STM32F103ZE.json
@@ -1587,6 +1587,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073840128,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "AHB1",
                         "enable": {

--- a/data/chips/STM32F103ZF.json
+++ b/data/chips/STM32F103ZF.json
@@ -1581,6 +1581,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073840128,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "AHB1",
                         "enable": {

--- a/data/chips/STM32F103ZG.json
+++ b/data/chips/STM32F103ZG.json
@@ -1581,6 +1581,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073840128,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "AHB1",
                         "enable": {

--- a/data/chips/STM32F205RB.json
+++ b/data/chips/STM32F205RB.json
@@ -1455,6 +1455,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F205RC.json
+++ b/data/chips/STM32F205RC.json
@@ -1455,6 +1455,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F205RE.json
+++ b/data/chips/STM32F205RE.json
@@ -1459,6 +1459,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F205RF.json
+++ b/data/chips/STM32F205RF.json
@@ -1455,6 +1455,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F205RG.json
+++ b/data/chips/STM32F205RG.json
@@ -1463,6 +1463,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F205VB.json
+++ b/data/chips/STM32F205VB.json
@@ -1465,6 +1465,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F205VC.json
+++ b/data/chips/STM32F205VC.json
@@ -1465,6 +1465,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F205VE.json
+++ b/data/chips/STM32F205VE.json
@@ -1465,6 +1465,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F205VF.json
+++ b/data/chips/STM32F205VF.json
@@ -1465,6 +1465,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F205VG.json
+++ b/data/chips/STM32F205VG.json
@@ -1465,6 +1465,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F205ZC.json
+++ b/data/chips/STM32F205ZC.json
@@ -1512,6 +1512,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F205ZE.json
+++ b/data/chips/STM32F205ZE.json
@@ -1512,6 +1512,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F205ZF.json
+++ b/data/chips/STM32F205ZF.json
@@ -1512,6 +1512,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F205ZG.json
+++ b/data/chips/STM32F205ZG.json
@@ -1512,6 +1512,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F207IC.json
+++ b/data/chips/STM32F207IC.json
@@ -1966,6 +1966,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F207IE.json
+++ b/data/chips/STM32F207IE.json
@@ -1966,6 +1966,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F207IF.json
+++ b/data/chips/STM32F207IF.json
@@ -1966,6 +1966,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F207IG.json
+++ b/data/chips/STM32F207IG.json
@@ -1966,6 +1966,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F207VC.json
+++ b/data/chips/STM32F207VC.json
@@ -1740,6 +1740,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F207VE.json
+++ b/data/chips/STM32F207VE.json
@@ -1740,6 +1740,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F207VF.json
+++ b/data/chips/STM32F207VF.json
@@ -1740,6 +1740,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F207VG.json
+++ b/data/chips/STM32F207VG.json
@@ -1740,6 +1740,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F207ZC.json
+++ b/data/chips/STM32F207ZC.json
@@ -1817,6 +1817,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F207ZE.json
+++ b/data/chips/STM32F207ZE.json
@@ -1817,6 +1817,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F207ZF.json
+++ b/data/chips/STM32F207ZF.json
@@ -1817,6 +1817,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F207ZG.json
+++ b/data/chips/STM32F207ZG.json
@@ -1817,6 +1817,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F215RE.json
+++ b/data/chips/STM32F215RE.json
@@ -1517,6 +1517,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F215RG.json
+++ b/data/chips/STM32F215RG.json
@@ -1517,6 +1517,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F215VE.json
+++ b/data/chips/STM32F215VE.json
@@ -1527,6 +1527,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F215VG.json
+++ b/data/chips/STM32F215VG.json
@@ -1527,6 +1527,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F215ZE.json
+++ b/data/chips/STM32F215ZE.json
@@ -1574,6 +1574,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F215ZG.json
+++ b/data/chips/STM32F215ZG.json
@@ -1574,6 +1574,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F217IE.json
+++ b/data/chips/STM32F217IE.json
@@ -2028,6 +2028,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F217IG.json
+++ b/data/chips/STM32F217IG.json
@@ -2028,6 +2028,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F217VE.json
+++ b/data/chips/STM32F217VE.json
@@ -1802,6 +1802,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F217VG.json
+++ b/data/chips/STM32F217VG.json
@@ -1802,6 +1802,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F217ZE.json
+++ b/data/chips/STM32F217ZE.json
@@ -1879,6 +1879,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F217ZG.json
+++ b/data/chips/STM32F217ZG.json
@@ -1879,6 +1879,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F401RB.json
+++ b/data/chips/STM32F401RB.json
@@ -1070,6 +1070,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F401RC.json
+++ b/data/chips/STM32F401RC.json
@@ -1070,6 +1070,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F401RD.json
+++ b/data/chips/STM32F401RD.json
@@ -1070,6 +1070,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F401RE.json
+++ b/data/chips/STM32F401RE.json
@@ -1070,6 +1070,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F401VB.json
+++ b/data/chips/STM32F401VB.json
@@ -1079,6 +1079,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F401VC.json
+++ b/data/chips/STM32F401VC.json
@@ -1079,6 +1079,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F401VD.json
+++ b/data/chips/STM32F401VD.json
@@ -1079,6 +1079,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F401VE.json
+++ b/data/chips/STM32F401VE.json
@@ -1079,6 +1079,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F405OE.json
+++ b/data/chips/STM32F405OE.json
@@ -1459,6 +1459,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F405OG.json
+++ b/data/chips/STM32F405OG.json
@@ -1459,6 +1459,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F405RG.json
+++ b/data/chips/STM32F405RG.json
@@ -1477,6 +1477,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F405VG.json
+++ b/data/chips/STM32F405VG.json
@@ -1487,6 +1487,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F405ZG.json
+++ b/data/chips/STM32F405ZG.json
@@ -1534,6 +1534,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F407IE.json
+++ b/data/chips/STM32F407IE.json
@@ -2000,6 +2000,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F407IG.json
+++ b/data/chips/STM32F407IG.json
@@ -2000,6 +2000,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F407VE.json
+++ b/data/chips/STM32F407VE.json
@@ -1774,6 +1774,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F407VG.json
+++ b/data/chips/STM32F407VG.json
@@ -1774,6 +1774,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F407ZE.json
+++ b/data/chips/STM32F407ZE.json
@@ -1851,6 +1851,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F407ZG.json
+++ b/data/chips/STM32F407ZG.json
@@ -1851,6 +1851,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F411CC.json
+++ b/data/chips/STM32F411CC.json
@@ -1049,6 +1049,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F411CE.json
+++ b/data/chips/STM32F411CE.json
@@ -1055,6 +1055,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F411RC.json
+++ b/data/chips/STM32F411RC.json
@@ -1079,6 +1079,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F411RE.json
+++ b/data/chips/STM32F411RE.json
@@ -1085,6 +1085,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F411VC.json
+++ b/data/chips/STM32F411VC.json
@@ -1088,6 +1088,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F411VE.json
+++ b/data/chips/STM32F411VE.json
@@ -1094,6 +1094,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F412CE.json
+++ b/data/chips/STM32F412CE.json
@@ -1320,6 +1320,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F412CG.json
+++ b/data/chips/STM32F412CG.json
@@ -1320,6 +1320,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F412RE.json
+++ b/data/chips/STM32F412RE.json
@@ -1496,6 +1496,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F412RG.json
+++ b/data/chips/STM32F412RG.json
@@ -1496,6 +1496,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F412VE.json
+++ b/data/chips/STM32F412VE.json
@@ -1642,6 +1642,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F412VG.json
+++ b/data/chips/STM32F412VG.json
@@ -1642,6 +1642,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F412ZE.json
+++ b/data/chips/STM32F412ZE.json
@@ -1767,6 +1767,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F412ZG.json
+++ b/data/chips/STM32F412ZG.json
@@ -1767,6 +1767,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F413CG.json
+++ b/data/chips/STM32F413CG.json
@@ -1769,6 +1769,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F413CH.json
+++ b/data/chips/STM32F413CH.json
@@ -1769,6 +1769,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F413MG.json
+++ b/data/chips/STM32F413MG.json
@@ -2077,6 +2077,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F413MH.json
+++ b/data/chips/STM32F413MH.json
@@ -2077,6 +2077,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F413RG.json
+++ b/data/chips/STM32F413RG.json
@@ -2022,6 +2022,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F413RH.json
+++ b/data/chips/STM32F413RH.json
@@ -2022,6 +2022,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F413VG.json
+++ b/data/chips/STM32F413VG.json
@@ -2256,6 +2256,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F413VH.json
+++ b/data/chips/STM32F413VH.json
@@ -2256,6 +2256,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F413ZG.json
+++ b/data/chips/STM32F413ZG.json
@@ -2361,6 +2361,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F413ZH.json
+++ b/data/chips/STM32F413ZH.json
@@ -2361,6 +2361,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F415OG.json
+++ b/data/chips/STM32F415OG.json
@@ -1521,6 +1521,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F415RG.json
+++ b/data/chips/STM32F415RG.json
@@ -1539,6 +1539,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F415VG.json
+++ b/data/chips/STM32F415VG.json
@@ -1549,6 +1549,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F415ZG.json
+++ b/data/chips/STM32F415ZG.json
@@ -1596,6 +1596,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F417IE.json
+++ b/data/chips/STM32F417IE.json
@@ -2062,6 +2062,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F417IG.json
+++ b/data/chips/STM32F417IG.json
@@ -2062,6 +2062,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F417VE.json
+++ b/data/chips/STM32F417VE.json
@@ -1836,6 +1836,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F417VG.json
+++ b/data/chips/STM32F417VG.json
@@ -1836,6 +1836,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F417ZE.json
+++ b/data/chips/STM32F417ZE.json
@@ -1913,6 +1913,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F417ZG.json
+++ b/data/chips/STM32F417ZG.json
@@ -1913,6 +1913,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F423CH.json
+++ b/data/chips/STM32F423CH.json
@@ -1791,6 +1791,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F423MH.json
+++ b/data/chips/STM32F423MH.json
@@ -2099,6 +2099,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F423RH.json
+++ b/data/chips/STM32F423RH.json
@@ -2044,6 +2044,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F423VH.json
+++ b/data/chips/STM32F423VH.json
@@ -2278,6 +2278,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F423ZH.json
+++ b/data/chips/STM32F423ZH.json
@@ -2383,6 +2383,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F427AG.json
+++ b/data/chips/STM32F427AG.json
@@ -2678,6 +2678,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F427AI.json
+++ b/data/chips/STM32F427AI.json
@@ -2678,6 +2678,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F427IG.json
+++ b/data/chips/STM32F427IG.json
@@ -2814,6 +2814,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F427II.json
+++ b/data/chips/STM32F427II.json
@@ -2814,6 +2814,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F427VG.json
+++ b/data/chips/STM32F427VG.json
@@ -2234,6 +2234,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F427VI.json
+++ b/data/chips/STM32F427VI.json
@@ -2234,6 +2234,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F427ZG.json
+++ b/data/chips/STM32F427ZG.json
@@ -2541,6 +2541,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F427ZI.json
+++ b/data/chips/STM32F427ZI.json
@@ -2541,6 +2541,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F429AG.json
+++ b/data/chips/STM32F429AG.json
@@ -2986,6 +2986,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F429AI.json
+++ b/data/chips/STM32F429AI.json
@@ -2986,6 +2986,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F429BE.json
+++ b/data/chips/STM32F429BE.json
@@ -3246,6 +3246,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F429BG.json
+++ b/data/chips/STM32F429BG.json
@@ -3252,6 +3252,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F429BI.json
+++ b/data/chips/STM32F429BI.json
@@ -3252,6 +3252,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F429IE.json
+++ b/data/chips/STM32F429IE.json
@@ -3110,6 +3110,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F429IG.json
+++ b/data/chips/STM32F429IG.json
@@ -3122,6 +3122,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F429II.json
+++ b/data/chips/STM32F429II.json
@@ -3122,6 +3122,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F429NE.json
+++ b/data/chips/STM32F429NE.json
@@ -3246,6 +3246,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F429NG.json
+++ b/data/chips/STM32F429NG.json
@@ -3252,6 +3252,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F429NI.json
+++ b/data/chips/STM32F429NI.json
@@ -3252,6 +3252,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F429VE.json
+++ b/data/chips/STM32F429VE.json
@@ -2370,6 +2370,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F429VG.json
+++ b/data/chips/STM32F429VG.json
@@ -2376,6 +2376,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F429VI.json
+++ b/data/chips/STM32F429VI.json
@@ -2376,6 +2376,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F429ZE.json
+++ b/data/chips/STM32F429ZE.json
@@ -2742,6 +2742,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F429ZG.json
+++ b/data/chips/STM32F429ZG.json
@@ -2752,6 +2752,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F429ZI.json
+++ b/data/chips/STM32F429ZI.json
@@ -2752,6 +2752,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F437AI.json
+++ b/data/chips/STM32F437AI.json
@@ -2735,6 +2735,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F437IG.json
+++ b/data/chips/STM32F437IG.json
@@ -2871,6 +2871,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F437II.json
+++ b/data/chips/STM32F437II.json
@@ -2871,6 +2871,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F437VG.json
+++ b/data/chips/STM32F437VG.json
@@ -2291,6 +2291,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F437VI.json
+++ b/data/chips/STM32F437VI.json
@@ -2291,6 +2291,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F437ZG.json
+++ b/data/chips/STM32F437ZG.json
@@ -2598,6 +2598,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F437ZI.json
+++ b/data/chips/STM32F437ZI.json
@@ -2598,6 +2598,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F439AI.json
+++ b/data/chips/STM32F439AI.json
@@ -3043,6 +3043,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F439BG.json
+++ b/data/chips/STM32F439BG.json
@@ -3309,6 +3309,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F439BI.json
+++ b/data/chips/STM32F439BI.json
@@ -3309,6 +3309,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F439IG.json
+++ b/data/chips/STM32F439IG.json
@@ -3179,6 +3179,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F439II.json
+++ b/data/chips/STM32F439II.json
@@ -3179,6 +3179,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F439NG.json
+++ b/data/chips/STM32F439NG.json
@@ -3309,6 +3309,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F439NI.json
+++ b/data/chips/STM32F439NI.json
@@ -3309,6 +3309,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F439VG.json
+++ b/data/chips/STM32F439VG.json
@@ -2433,6 +2433,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F439VI.json
+++ b/data/chips/STM32F439VI.json
@@ -2433,6 +2433,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F439ZG.json
+++ b/data/chips/STM32F439ZG.json
@@ -2809,6 +2809,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F439ZI.json
+++ b/data/chips/STM32F439ZI.json
@@ -2809,6 +2809,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F446MC.json
+++ b/data/chips/STM32F446MC.json
@@ -1924,6 +1924,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F446ME.json
+++ b/data/chips/STM32F446ME.json
@@ -1924,6 +1924,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F446RC.json
+++ b/data/chips/STM32F446RC.json
@@ -1779,6 +1779,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F446RE.json
+++ b/data/chips/STM32F446RE.json
@@ -1779,6 +1779,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F446VC.json
+++ b/data/chips/STM32F446VC.json
@@ -2332,6 +2332,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F446VE.json
+++ b/data/chips/STM32F446VE.json
@@ -2332,6 +2332,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F446ZC.json
+++ b/data/chips/STM32F446ZC.json
@@ -2670,6 +2670,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F446ZE.json
+++ b/data/chips/STM32F446ZE.json
@@ -2670,6 +2670,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F469AE.json
+++ b/data/chips/STM32F469AE.json
@@ -2974,6 +2974,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F469AG.json
+++ b/data/chips/STM32F469AG.json
@@ -2974,6 +2974,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F469AI.json
+++ b/data/chips/STM32F469AI.json
@@ -2974,6 +2974,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F469BE.json
+++ b/data/chips/STM32F469BE.json
@@ -3424,6 +3424,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F469BG.json
+++ b/data/chips/STM32F469BG.json
@@ -3424,6 +3424,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F469BI.json
+++ b/data/chips/STM32F469BI.json
@@ -3424,6 +3424,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F469IE.json
+++ b/data/chips/STM32F469IE.json
@@ -3168,6 +3168,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F469IG.json
+++ b/data/chips/STM32F469IG.json
@@ -3168,6 +3168,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F469II.json
+++ b/data/chips/STM32F469II.json
@@ -3168,6 +3168,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F469NE.json
+++ b/data/chips/STM32F469NE.json
@@ -3424,6 +3424,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F469NG.json
+++ b/data/chips/STM32F469NG.json
@@ -3424,6 +3424,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F469NI.json
+++ b/data/chips/STM32F469NI.json
@@ -3424,6 +3424,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F469VE.json
+++ b/data/chips/STM32F469VE.json
@@ -2267,6 +2267,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F469VG.json
+++ b/data/chips/STM32F469VG.json
@@ -2267,6 +2267,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F469VI.json
+++ b/data/chips/STM32F469VI.json
@@ -2267,6 +2267,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F469ZE.json
+++ b/data/chips/STM32F469ZE.json
@@ -2669,6 +2669,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F469ZG.json
+++ b/data/chips/STM32F469ZG.json
@@ -2669,6 +2669,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F469ZI.json
+++ b/data/chips/STM32F469ZI.json
@@ -2669,6 +2669,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F479AG.json
+++ b/data/chips/STM32F479AG.json
@@ -3031,6 +3031,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F479AI.json
+++ b/data/chips/STM32F479AI.json
@@ -3031,6 +3031,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F479BG.json
+++ b/data/chips/STM32F479BG.json
@@ -3481,6 +3481,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F479BI.json
+++ b/data/chips/STM32F479BI.json
@@ -3481,6 +3481,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F479IG.json
+++ b/data/chips/STM32F479IG.json
@@ -3225,6 +3225,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F479II.json
+++ b/data/chips/STM32F479II.json
@@ -3225,6 +3225,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F479NG.json
+++ b/data/chips/STM32F479NG.json
@@ -3481,6 +3481,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F479NI.json
+++ b/data/chips/STM32F479NI.json
@@ -3481,6 +3481,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F479VG.json
+++ b/data/chips/STM32F479VG.json
@@ -2324,6 +2324,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F479VI.json
+++ b/data/chips/STM32F479VI.json
@@ -2324,6 +2324,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F479ZG.json
+++ b/data/chips/STM32F479ZG.json
@@ -2726,6 +2726,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F479ZI.json
+++ b/data/chips/STM32F479ZI.json
@@ -2726,6 +2726,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32L151QD.json
+++ b/data/chips/STM32L151QD.json
@@ -1733,6 +1733,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32L151RD.json
+++ b/data/chips/STM32L151RD.json
@@ -1278,6 +1278,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32L151VD.json
+++ b/data/chips/STM32L151VD.json
@@ -1568,6 +1568,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32L151ZD.json
+++ b/data/chips/STM32L151ZD.json
@@ -1753,6 +1753,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32L152QD.json
+++ b/data/chips/STM32L152QD.json
@@ -2036,6 +2036,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32L152RD.json
+++ b/data/chips/STM32L152RD.json
@@ -1521,6 +1521,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32L152VD.json
+++ b/data/chips/STM32L152VD.json
@@ -1871,6 +1871,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32L152ZD.json
+++ b/data/chips/STM32L152ZD.json
@@ -2056,6 +2056,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32L162QD.json
+++ b/data/chips/STM32L162QD.json
@@ -2056,6 +2056,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32L162RD.json
+++ b/data/chips/STM32L162RD.json
@@ -1535,6 +1535,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32L162VD.json
+++ b/data/chips/STM32L162VD.json
@@ -1891,6 +1891,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32L162ZD.json
+++ b/data/chips/STM32L162ZD.json
@@ -2076,6 +2076,11 @@
                 {
                     "name": "SDIO",
                     "address": 1073818624,
+                    "registers": {
+                        "kind": "sdmmc",
+                        "version": "v1",
+                        "block": "SDMMC"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/registers/sdmmc_v1.yaml
+++ b/data/registers/sdmmc_v1.yaml
@@ -73,7 +73,7 @@ block/SDMMC:
 fieldset/ARGR:
   description: argument register
   fields:
-    - name: CMDARGR
+    - name: CMDARG
       description: Command argument
       bit_offset: 0
       bit_size: 32

--- a/data/registers/sdmmc_v1.yaml
+++ b/data/registers/sdmmc_v1.yaml
@@ -357,43 +357,31 @@ fieldset/POWER:
 fieldset/RESP1R:
   description: response 1..4 register
   fields:
-    - name: CARDSTATUS
+    - name: CARDSTATUS1
       description: see Table 132
       bit_offset: 0
       bit_size: 32
-      array:
-        len: 1
-        stride: 0
 fieldset/RESP2R:
   description: response 1..4 register
   fields:
-    - name: CARDSTATUS
+    - name: CARDSTATUS2
       description: see Table 132
       bit_offset: 0
       bit_size: 32
-      array:
-        len: 1
-        stride: 0
 fieldset/RESP3R:
   description: response 1..4 register
   fields:
-    - name: CARDSTATUS
+    - name: CARDSTATUS3
       description: see Table 132
       bit_offset: 0
       bit_size: 32
-      array:
-        len: 1
-        stride: 0
 fieldset/RESP4R:
   description: response 1..4 register
   fields:
-    - name: CARDSTATUS
+    - name: CARDSTATUS4
       description: see Table 132
       bit_offset: 0
       bit_size: 32
-      array:
-        len: 1
-        stride: 0
 fieldset/RESPCMDR:
   description: command response register
   fields:

--- a/data/registers/sdmmc_v1.yaml
+++ b/data/registers/sdmmc_v1.yaml
@@ -10,66 +10,54 @@ block/SDMMC:
       description: SDI clock control register
       byte_offset: 4
       fieldset: CLKCR
-    - name: ARG
+    - name: ARGR
       description: argument register
       byte_offset: 8
-      fieldset: ARG
-    - name: CMD
+      fieldset: ARGR
+    - name: CMDR
       description: command register
       byte_offset: 12
-      fieldset: CMD
-    - name: RESPCMD
+      fieldset: CMDR
+    - name: RESPCMDR
       description: command response register
       byte_offset: 16
       access: Read
-      fieldset: RESPCMD
-    - name: RESP1
+      fieldset: RESPCMDR
+    - name: RESPR
       description: response 1..4 register
+      array:
+        len: 4
+        stride: 4
       byte_offset: 20
       access: Read
-      fieldset: RESP1
-    - name: RESP2
-      description: response 1..4 register
-      byte_offset: 24
-      access: Read
-      fieldset: RESP2
-    - name: RESP3
-      description: response 1..4 register
-      byte_offset: 28
-      access: Read
-      fieldset: RESP3
-    - name: RESP4
-      description: response 1..4 register
-      byte_offset: 32
-      access: Read
-      fieldset: RESP4
+      fieldset: RESP1R
     - name: DTIMER
       description: data timer register
       byte_offset: 36
       fieldset: DTIMER
-    - name: DLEN
+    - name: DLENR
       description: data length register
       byte_offset: 40
-      fieldset: DLEN
+      fieldset: DLENR
     - name: DCTRL
       description: data control register
       byte_offset: 44
       fieldset: DCTRL
-    - name: DCOUNT
+    - name: DCNTR
       description: data counter register
       byte_offset: 48
       access: Read
-      fieldset: DCOUNT
-    - name: STA
+      fieldset: DCNTR
+    - name: STAR
       description: status register
       byte_offset: 52
       access: Read
-      fieldset: STA
+      fieldset: STAR
     - name: ICR
       description: interrupt clear register
       byte_offset: 56
       fieldset: ICR
-    - name: MASK
+    - name: MASKR
       description: mask register
       byte_offset: 60
       fieldset: MASK
@@ -78,14 +66,14 @@ block/SDMMC:
       byte_offset: 72
       access: Read
       fieldset: FIFOCNT
-    - name: FIFO
+    - name: FIFOR
       description: data FIFO register
       byte_offset: 128
-      fieldset: FIFO
-fieldset/ARG:
+      fieldset: FIFOR
+fieldset/ARGR:
   description: argument register
   fields:
-    - name: CMDARG
+    - name: CMDARGR
       description: Command argument
       bit_offset: 0
       bit_size: 32
@@ -120,7 +108,7 @@ fieldset/CLKCR:
       description: HW Flow Control enable
       bit_offset: 14
       bit_size: 1
-fieldset/CMD:
+fieldset/CMDR:
   description: command register
   fields:
     - name: CMDINDEX
@@ -147,7 +135,7 @@ fieldset/CMD:
       description: SD I/O suspend command
       bit_offset: 11
       bit_size: 1
-fieldset/DCOUNT:
+fieldset/DCNTR:
   description: data counter register
   fields:
     - name: DATACOUNT
@@ -193,7 +181,7 @@ fieldset/DCTRL:
       description: SD I/O enable functions
       bit_offset: 11
       bit_size: 1
-fieldset/DLEN:
+fieldset/DLENR:
   description: data length register
   fields:
     - name: DATALENGTH
@@ -207,7 +195,7 @@ fieldset/DTIMER:
       description: Data timeout period
       bit_offset: 0
       bit_size: 32
-fieldset/FIFO:
+fieldset/FIFOR:
   description: data FIFO register
   fields:
     - name: FIFOData
@@ -268,7 +256,7 @@ fieldset/ICR:
       description: SDIOIT flag clear bit
       bit_offset: 22
       bit_size: 1
-fieldset/MASK:
+fieldset/MASKR:
   description: mask register
   fields:
     - name: CCRCFAILIE
@@ -366,7 +354,7 @@ fieldset/POWER:
       description: PWRCTRL
       bit_offset: 0
       bit_size: 2
-fieldset/RESP1:
+fieldset/RESP1R:
   description: response 1..4 register
   fields:
     - name: CARDSTATUS
@@ -376,7 +364,7 @@ fieldset/RESP1:
       array:
         len: 1
         stride: 0
-fieldset/RESP2:
+fieldset/RESP2R:
   description: response 1..4 register
   fields:
     - name: CARDSTATUS
@@ -386,7 +374,7 @@ fieldset/RESP2:
       array:
         len: 1
         stride: 0
-fieldset/RESP3:
+fieldset/RESP3R:
   description: response 1..4 register
   fields:
     - name: CARDSTATUS
@@ -396,7 +384,7 @@ fieldset/RESP3:
       array:
         len: 1
         stride: 0
-fieldset/RESP4:
+fieldset/RESP4R:
   description: response 1..4 register
   fields:
     - name: CARDSTATUS
@@ -406,14 +394,14 @@ fieldset/RESP4:
       array:
         len: 1
         stride: 0
-fieldset/RESPCMD:
+fieldset/RESPCMDR:
   description: command response register
   fields:
     - name: RESPCMD
       description: Response command index
       bit_offset: 0
       bit_size: 6
-fieldset/STA:
+fieldset/STAR:
   description: status register
   fields:
     - name: CCRCFAIL

--- a/data/registers/sdmmc_v1.yaml
+++ b/data/registers/sdmmc_v1.yaml
@@ -357,28 +357,28 @@ fieldset/POWER:
 fieldset/RESP1R:
   description: response 1..4 register
   fields:
-    - name: CARDSTATUS1
+    - name: CARDSTATUS
       description: see Table 132
       bit_offset: 0
       bit_size: 32
 fieldset/RESP2R:
   description: response 1..4 register
   fields:
-    - name: CARDSTATUS2
+    - name: CARDSTATUS
       description: see Table 132
       bit_offset: 0
       bit_size: 32
 fieldset/RESP3R:
   description: response 1..4 register
   fields:
-    - name: CARDSTATUS3
+    - name: CARDSTATUS
       description: see Table 132
       bit_offset: 0
       bit_size: 32
 fieldset/RESP4R:
   description: response 1..4 register
   fields:
-    - name: CARDSTATUS4
+    - name: CARDSTATUS
       description: see Table 132
       bit_offset: 0
       bit_size: 32

--- a/data/registers/sdmmc_v1.yaml
+++ b/data/registers/sdmmc_v1.yaml
@@ -60,7 +60,7 @@ block/SDMMC:
     - name: MASKR
       description: mask register
       byte_offset: 60
-      fieldset: MASK
+      fieldset: MASKR
     - name: FIFOCNT
       description: FIFO counter register
       byte_offset: 72

--- a/data/registers/sdmmc_v2.yaml
+++ b/data/registers/sdmmc_v2.yaml
@@ -505,28 +505,28 @@ fieldset/POWER:
 fieldset/RESP1R:
   description: "The SDMMC_RESP1/2/3/4R registers contain the status of a card, which is part of the received response."
   fields:
-    - name: CARDSTATUS1
+    - name: CARDSTATUS
       description: see Table 432
       bit_offset: 0
       bit_size: 32
 fieldset/RESP2R:
   description: "The SDMMC_RESP1/2/3/4R registers contain the status of a card, which is part of the received response."
   fields:
-    - name: CARDSTATUS2
+    - name: CARDSTATUS
       description: see Table404.
       bit_offset: 0
       bit_size: 32
 fieldset/RESP3R:
   description: "The SDMMC_RESP1/2/3/4R registers contain the status of a card, which is part of the received response."
   fields:
-    - name: CARDSTATUS3
+    - name: CARDSTATUS
       description: see Table404.
       bit_offset: 0
       bit_size: 32
 fieldset/RESP4R:
   description: "The SDMMC_RESP1/2/3/4R registers contain the status of a card, which is part of the received response."
   fields:
-    - name: CARDSTATUS4
+    - name: CARDSTATUS
       description: see Table404.
       bit_offset: 0
       bit_size: 32

--- a/stm32data/__main__.py
+++ b/stm32data/__main__.py
@@ -153,6 +153,7 @@ perimap = [
     ('.*:RTC:rtc2_v2_6', ('rtc', 'v2', 'RTC')),
     ('.*:RTC:rtc2_v2_WB', ('rtc', 'wb', 'RTC')),
     ('.*:SAI:sai1_v1_1', ('sai', 'v1', 'SAI')),
+    ('.*:SDIO:sdmmc_v1_2', ('sdmmc', 'v1', 'SDMMC')),
     ('.*:SDMMC:sdmmc_v1_3', ('sdmmc', 'v1', 'SDMMC')),
     ('.*:SPDIFRX:spdifrx1_v1_0', ('spdifrx', 'v1', 'SPDIFRX')),
     ('.*:USB_OTG_FS:otgfs1_v1_2', ('otgfs', 'v1', 'OTG_FS')),


### PR DESCRIPTION
SDMMC v2 is an extension of SDMMC v1 peripheral so most of the registers are the same. This PR fixes minor inconsistencies between register names.

This also assigns SDIO peripheral to SDMMC v1 as they are identical (?).

Keeping this as draft now, until SDMMC v1 driver is ready for embassy.