### PR TITLE
F2: Add SYSCFG/FLASH/PWR, fix DBGMCU SVD typos

### DIFF
--- a/data/chips/STM32F205RB.json
+++ b/data/chips/STM32F205RB.json
@@ -942,6 +942,11 @@
                 {
                     "name": "FLASH",
                     "address": 1073888256,
+                    "registers": {
+                        "kind": "flash",
+                        "version": "f2",
+                        "block": "FLASH"
+                    },
                     "interrupts": [
                         {
                             "interrupt": "FLASH",
@@ -1338,6 +1343,11 @@
                 {
                     "name": "PWR",
                     "address": 1073770496,
+                    "registers": {
+                        "kind": "pwr",
+                        "version": "f2",
+                        "block": "PWR"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {
@@ -1805,6 +1815,11 @@
                 {
                     "name": "SYSCFG",
                     "address": 1073821696,
+                    "registers": {
+                        "kind": "syscfg",
+                        "version": "f2",
+                        "block": "SYSCFG"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F205RC.json
+++ b/data/chips/STM32F205RC.json
@@ -942,6 +942,11 @@
                 {
                     "name": "FLASH",
                     "address": 1073888256,
+                    "registers": {
+                        "kind": "flash",
+                        "version": "f2",
+                        "block": "FLASH"
+                    },
                     "interrupts": [
                         {
                             "interrupt": "FLASH",
@@ -1338,6 +1343,11 @@
                 {
                     "name": "PWR",
                     "address": 1073770496,
+                    "registers": {
+                        "kind": "pwr",
+                        "version": "f2",
+                        "block": "PWR"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {
@@ -1805,6 +1815,11 @@
                 {
                     "name": "SYSCFG",
                     "address": 1073821696,
+                    "registers": {
+                        "kind": "syscfg",
+                        "version": "f2",
+                        "block": "SYSCFG"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F205RE.json
+++ b/data/chips/STM32F205RE.json
@@ -946,6 +946,11 @@
                 {
                     "name": "FLASH",
                     "address": 1073888256,
+                    "registers": {
+                        "kind": "flash",
+                        "version": "f2",
+                        "block": "FLASH"
+                    },
                     "interrupts": [
                         {
                             "interrupt": "FLASH",
@@ -1342,6 +1347,11 @@
                 {
                     "name": "PWR",
                     "address": 1073770496,
+                    "registers": {
+                        "kind": "pwr",
+                        "version": "f2",
+                        "block": "PWR"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {
@@ -1809,6 +1819,11 @@
                 {
                     "name": "SYSCFG",
                     "address": 1073821696,
+                    "registers": {
+                        "kind": "syscfg",
+                        "version": "f2",
+                        "block": "SYSCFG"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F205RF.json
+++ b/data/chips/STM32F205RF.json
@@ -942,6 +942,11 @@
                 {
                     "name": "FLASH",
                     "address": 1073888256,
+                    "registers": {
+                        "kind": "flash",
+                        "version": "f2",
+                        "block": "FLASH"
+                    },
                     "interrupts": [
                         {
                             "interrupt": "FLASH",
@@ -1338,6 +1343,11 @@
                 {
                     "name": "PWR",
                     "address": 1073770496,
+                    "registers": {
+                        "kind": "pwr",
+                        "version": "f2",
+                        "block": "PWR"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {
@@ -1805,6 +1815,11 @@
                 {
                     "name": "SYSCFG",
                     "address": 1073821696,
+                    "registers": {
+                        "kind": "syscfg",
+                        "version": "f2",
+                        "block": "SYSCFG"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F205RG.json
+++ b/data/chips/STM32F205RG.json
@@ -950,6 +950,11 @@
                 {
                     "name": "FLASH",
                     "address": 1073888256,
+                    "registers": {
+                        "kind": "flash",
+                        "version": "f2",
+                        "block": "FLASH"
+                    },
                     "interrupts": [
                         {
                             "interrupt": "FLASH",
@@ -1346,6 +1351,11 @@
                 {
                     "name": "PWR",
                     "address": 1073770496,
+                    "registers": {
+                        "kind": "pwr",
+                        "version": "f2",
+                        "block": "PWR"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {
@@ -1813,6 +1823,11 @@
                 {
                     "name": "SYSCFG",
                     "address": 1073821696,
+                    "registers": {
+                        "kind": "syscfg",
+                        "version": "f2",
+                        "block": "SYSCFG"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F205VB.json
+++ b/data/chips/STM32F205VB.json
@@ -952,6 +952,11 @@
                 {
                     "name": "FLASH",
                     "address": 1073888256,
+                    "registers": {
+                        "kind": "flash",
+                        "version": "f2",
+                        "block": "FLASH"
+                    },
                     "interrupts": [
                         {
                             "interrupt": "FLASH",
@@ -1348,6 +1353,11 @@
                 {
                     "name": "PWR",
                     "address": 1073770496,
+                    "registers": {
+                        "kind": "pwr",
+                        "version": "f2",
+                        "block": "PWR"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {
@@ -1815,6 +1825,11 @@
                 {
                     "name": "SYSCFG",
                     "address": 1073821696,
+                    "registers": {
+                        "kind": "syscfg",
+                        "version": "f2",
+                        "block": "SYSCFG"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F205VC.json
+++ b/data/chips/STM32F205VC.json
@@ -952,6 +952,11 @@
                 {
                     "name": "FLASH",
                     "address": 1073888256,
+                    "registers": {
+                        "kind": "flash",
+                        "version": "f2",
+                        "block": "FLASH"
+                    },
                     "interrupts": [
                         {
                             "interrupt": "FLASH",
@@ -1348,6 +1353,11 @@
                 {
                     "name": "PWR",
                     "address": 1073770496,
+                    "registers": {
+                        "kind": "pwr",
+                        "version": "f2",
+                        "block": "PWR"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {
@@ -1815,6 +1825,11 @@
                 {
                     "name": "SYSCFG",
                     "address": 1073821696,
+                    "registers": {
+                        "kind": "syscfg",
+                        "version": "f2",
+                        "block": "SYSCFG"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F205VE.json
+++ b/data/chips/STM32F205VE.json
@@ -952,6 +952,11 @@
                 {
                     "name": "FLASH",
                     "address": 1073888256,
+                    "registers": {
+                        "kind": "flash",
+                        "version": "f2",
+                        "block": "FLASH"
+                    },
                     "interrupts": [
                         {
                             "interrupt": "FLASH",
@@ -1348,6 +1353,11 @@
                 {
                     "name": "PWR",
                     "address": 1073770496,
+                    "registers": {
+                        "kind": "pwr",
+                        "version": "f2",
+                        "block": "PWR"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {
@@ -1815,6 +1825,11 @@
                 {
                     "name": "SYSCFG",
                     "address": 1073821696,
+                    "registers": {
+                        "kind": "syscfg",
+                        "version": "f2",
+                        "block": "SYSCFG"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F205VF.json
+++ b/data/chips/STM32F205VF.json
@@ -952,6 +952,11 @@
                 {
                     "name": "FLASH",
                     "address": 1073888256,
+                    "registers": {
+                        "kind": "flash",
+                        "version": "f2",
+                        "block": "FLASH"
+                    },
                     "interrupts": [
                         {
                             "interrupt": "FLASH",
@@ -1348,6 +1353,11 @@
                 {
                     "name": "PWR",
                     "address": 1073770496,
+                    "registers": {
+                        "kind": "pwr",
+                        "version": "f2",
+                        "block": "PWR"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {
@@ -1815,6 +1825,11 @@
                 {
                     "name": "SYSCFG",
                     "address": 1073821696,
+                    "registers": {
+                        "kind": "syscfg",
+                        "version": "f2",
+                        "block": "SYSCFG"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F205VG.json
+++ b/data/chips/STM32F205VG.json
@@ -952,6 +952,11 @@
                 {
                     "name": "FLASH",
                     "address": 1073888256,
+                    "registers": {
+                        "kind": "flash",
+                        "version": "f2",
+                        "block": "FLASH"
+                    },
                     "interrupts": [
                         {
                             "interrupt": "FLASH",
@@ -1348,6 +1353,11 @@
                 {
                     "name": "PWR",
                     "address": 1073770496,
+                    "registers": {
+                        "kind": "pwr",
+                        "version": "f2",
+                        "block": "PWR"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {
@@ -1815,6 +1825,11 @@
                 {
                     "name": "SYSCFG",
                     "address": 1073821696,
+                    "registers": {
+                        "kind": "syscfg",
+                        "version": "f2",
+                        "block": "SYSCFG"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F205ZC.json
+++ b/data/chips/STM32F205ZC.json
@@ -984,6 +984,11 @@
                 {
                     "name": "FLASH",
                     "address": 1073888256,
+                    "registers": {
+                        "kind": "flash",
+                        "version": "f2",
+                        "block": "FLASH"
+                    },
                     "interrupts": [
                         {
                             "interrupt": "FLASH",
@@ -1395,6 +1400,11 @@
                 {
                     "name": "PWR",
                     "address": 1073770496,
+                    "registers": {
+                        "kind": "pwr",
+                        "version": "f2",
+                        "block": "PWR"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {
@@ -1862,6 +1872,11 @@
                 {
                     "name": "SYSCFG",
                     "address": 1073821696,
+                    "registers": {
+                        "kind": "syscfg",
+                        "version": "f2",
+                        "block": "SYSCFG"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F205ZE.json
+++ b/data/chips/STM32F205ZE.json
@@ -984,6 +984,11 @@
                 {
                     "name": "FLASH",
                     "address": 1073888256,
+                    "registers": {
+                        "kind": "flash",
+                        "version": "f2",
+                        "block": "FLASH"
+                    },
                     "interrupts": [
                         {
                             "interrupt": "FLASH",
@@ -1395,6 +1400,11 @@
                 {
                     "name": "PWR",
                     "address": 1073770496,
+                    "registers": {
+                        "kind": "pwr",
+                        "version": "f2",
+                        "block": "PWR"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {
@@ -1862,6 +1872,11 @@
                 {
                     "name": "SYSCFG",
                     "address": 1073821696,
+                    "registers": {
+                        "kind": "syscfg",
+                        "version": "f2",
+                        "block": "SYSCFG"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F205ZF.json
+++ b/data/chips/STM32F205ZF.json
@@ -984,6 +984,11 @@
                 {
                     "name": "FLASH",
                     "address": 1073888256,
+                    "registers": {
+                        "kind": "flash",
+                        "version": "f2",
+                        "block": "FLASH"
+                    },
                     "interrupts": [
                         {
                             "interrupt": "FLASH",
@@ -1395,6 +1400,11 @@
                 {
                     "name": "PWR",
                     "address": 1073770496,
+                    "registers": {
+                        "kind": "pwr",
+                        "version": "f2",
+                        "block": "PWR"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {
@@ -1862,6 +1872,11 @@
                 {
                     "name": "SYSCFG",
                     "address": 1073821696,
+                    "registers": {
+                        "kind": "syscfg",
+                        "version": "f2",
+                        "block": "SYSCFG"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F205ZG.json
+++ b/data/chips/STM32F205ZG.json
@@ -984,6 +984,11 @@
                 {
                     "name": "FLASH",
                     "address": 1073888256,
+                    "registers": {
+                        "kind": "flash",
+                        "version": "f2",
+                        "block": "FLASH"
+                    },
                     "interrupts": [
                         {
                             "interrupt": "FLASH",
@@ -1395,6 +1400,11 @@
                 {
                     "name": "PWR",
                     "address": 1073770496,
+                    "registers": {
+                        "kind": "pwr",
+                        "version": "f2",
+                        "block": "PWR"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {
@@ -1862,6 +1872,11 @@
                 {
                     "name": "SYSCFG",
                     "address": 1073821696,
+                    "registers": {
+                        "kind": "syscfg",
+                        "version": "f2",
+                        "block": "SYSCFG"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F207IC.json
+++ b/data/chips/STM32F207IC.json
@@ -1403,6 +1403,11 @@
                 {
                     "name": "FLASH",
                     "address": 1073888256,
+                    "registers": {
+                        "kind": "flash",
+                        "version": "f2",
+                        "block": "FLASH"
+                    },
                     "interrupts": [
                         {
                             "interrupt": "FLASH",
@@ -1844,6 +1849,11 @@
                 {
                     "name": "PWR",
                     "address": 1073770496,
+                    "registers": {
+                        "kind": "pwr",
+                        "version": "f2",
+                        "block": "PWR"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {
@@ -2336,6 +2346,11 @@
                 {
                     "name": "SYSCFG",
                     "address": 1073821696,
+                    "registers": {
+                        "kind": "syscfg",
+                        "version": "f2",
+                        "block": "SYSCFG"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F207IE.json
+++ b/data/chips/STM32F207IE.json
@@ -1403,6 +1403,11 @@
                 {
                     "name": "FLASH",
                     "address": 1073888256,
+                    "registers": {
+                        "kind": "flash",
+                        "version": "f2",
+                        "block": "FLASH"
+                    },
                     "interrupts": [
                         {
                             "interrupt": "FLASH",
@@ -1844,6 +1849,11 @@
                 {
                     "name": "PWR",
                     "address": 1073770496,
+                    "registers": {
+                        "kind": "pwr",
+                        "version": "f2",
+                        "block": "PWR"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {
@@ -2336,6 +2346,11 @@
                 {
                     "name": "SYSCFG",
                     "address": 1073821696,
+                    "registers": {
+                        "kind": "syscfg",
+                        "version": "f2",
+                        "block": "SYSCFG"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F207IF.json
+++ b/data/chips/STM32F207IF.json
@@ -1403,6 +1403,11 @@
                 {
                     "name": "FLASH",
                     "address": 1073888256,
+                    "registers": {
+                        "kind": "flash",
+                        "version": "f2",
+                        "block": "FLASH"
+                    },
                     "interrupts": [
                         {
                             "interrupt": "FLASH",
@@ -1844,6 +1849,11 @@
                 {
                     "name": "PWR",
                     "address": 1073770496,
+                    "registers": {
+                        "kind": "pwr",
+                        "version": "f2",
+                        "block": "PWR"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {
@@ -2336,6 +2346,11 @@
                 {
                     "name": "SYSCFG",
                     "address": 1073821696,
+                    "registers": {
+                        "kind": "syscfg",
+                        "version": "f2",
+                        "block": "SYSCFG"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F207IG.json
+++ b/data/chips/STM32F207IG.json
@@ -1403,6 +1403,11 @@
                 {
                     "name": "FLASH",
                     "address": 1073888256,
+                    "registers": {
+                        "kind": "flash",
+                        "version": "f2",
+                        "block": "FLASH"
+                    },
                     "interrupts": [
                         {
                             "interrupt": "FLASH",
@@ -1844,6 +1849,11 @@
                 {
                     "name": "PWR",
                     "address": 1073770496,
+                    "registers": {
+                        "kind": "pwr",
+                        "version": "f2",
+                        "block": "PWR"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {
@@ -2336,6 +2346,11 @@
                 {
                     "name": "SYSCFG",
                     "address": 1073821696,
+                    "registers": {
+                        "kind": "syscfg",
+                        "version": "f2",
+                        "block": "SYSCFG"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F207VC.json
+++ b/data/chips/STM32F207VC.json
@@ -1227,6 +1227,11 @@
                 {
                     "name": "FLASH",
                     "address": 1073888256,
+                    "registers": {
+                        "kind": "flash",
+                        "version": "f2",
+                        "block": "FLASH"
+                    },
                     "interrupts": [
                         {
                             "interrupt": "FLASH",
@@ -1623,6 +1628,11 @@
                 {
                     "name": "PWR",
                     "address": 1073770496,
+                    "registers": {
+                        "kind": "pwr",
+                        "version": "f2",
+                        "block": "PWR"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {
@@ -2090,6 +2100,11 @@
                 {
                     "name": "SYSCFG",
                     "address": 1073821696,
+                    "registers": {
+                        "kind": "syscfg",
+                        "version": "f2",
+                        "block": "SYSCFG"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F207VE.json
+++ b/data/chips/STM32F207VE.json
@@ -1227,6 +1227,11 @@
                 {
                     "name": "FLASH",
                     "address": 1073888256,
+                    "registers": {
+                        "kind": "flash",
+                        "version": "f2",
+                        "block": "FLASH"
+                    },
                     "interrupts": [
                         {
                             "interrupt": "FLASH",
@@ -1623,6 +1628,11 @@
                 {
                     "name": "PWR",
                     "address": 1073770496,
+                    "registers": {
+                        "kind": "pwr",
+                        "version": "f2",
+                        "block": "PWR"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {
@@ -2090,6 +2100,11 @@
                 {
                     "name": "SYSCFG",
                     "address": 1073821696,
+                    "registers": {
+                        "kind": "syscfg",
+                        "version": "f2",
+                        "block": "SYSCFG"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F207VF.json
+++ b/data/chips/STM32F207VF.json
@@ -1227,6 +1227,11 @@
                 {
                     "name": "FLASH",
                     "address": 1073888256,
+                    "registers": {
+                        "kind": "flash",
+                        "version": "f2",
+                        "block": "FLASH"
+                    },
                     "interrupts": [
                         {
                             "interrupt": "FLASH",
@@ -1623,6 +1628,11 @@
                 {
                     "name": "PWR",
                     "address": 1073770496,
+                    "registers": {
+                        "kind": "pwr",
+                        "version": "f2",
+                        "block": "PWR"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {
@@ -2090,6 +2100,11 @@
                 {
                     "name": "SYSCFG",
                     "address": 1073821696,
+                    "registers": {
+                        "kind": "syscfg",
+                        "version": "f2",
+                        "block": "SYSCFG"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F207VG.json
+++ b/data/chips/STM32F207VG.json
@@ -1227,6 +1227,11 @@
                 {
                     "name": "FLASH",
                     "address": 1073888256,
+                    "registers": {
+                        "kind": "flash",
+                        "version": "f2",
+                        "block": "FLASH"
+                    },
                     "interrupts": [
                         {
                             "interrupt": "FLASH",
@@ -1623,6 +1628,11 @@
                 {
                     "name": "PWR",
                     "address": 1073770496,
+                    "registers": {
+                        "kind": "pwr",
+                        "version": "f2",
+                        "block": "PWR"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {
@@ -2090,6 +2100,11 @@
                 {
                     "name": "SYSCFG",
                     "address": 1073821696,
+                    "registers": {
+                        "kind": "syscfg",
+                        "version": "f2",
+                        "block": "SYSCFG"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F207ZC.json
+++ b/data/chips/STM32F207ZC.json
@@ -1289,6 +1289,11 @@
                 {
                     "name": "FLASH",
                     "address": 1073888256,
+                    "registers": {
+                        "kind": "flash",
+                        "version": "f2",
+                        "block": "FLASH"
+                    },
                     "interrupts": [
                         {
                             "interrupt": "FLASH",
@@ -1700,6 +1705,11 @@
                 {
                     "name": "PWR",
                     "address": 1073770496,
+                    "registers": {
+                        "kind": "pwr",
+                        "version": "f2",
+                        "block": "PWR"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {
@@ -2167,6 +2177,11 @@
                 {
                     "name": "SYSCFG",
                     "address": 1073821696,
+                    "registers": {
+                        "kind": "syscfg",
+                        "version": "f2",
+                        "block": "SYSCFG"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F207ZE.json
+++ b/data/chips/STM32F207ZE.json
@@ -1289,6 +1289,11 @@
                 {
                     "name": "FLASH",
                     "address": 1073888256,
+                    "registers": {
+                        "kind": "flash",
+                        "version": "f2",
+                        "block": "FLASH"
+                    },
                     "interrupts": [
                         {
                             "interrupt": "FLASH",
@@ -1700,6 +1705,11 @@
                 {
                     "name": "PWR",
                     "address": 1073770496,
+                    "registers": {
+                        "kind": "pwr",
+                        "version": "f2",
+                        "block": "PWR"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {
@@ -2167,6 +2177,11 @@
                 {
                     "name": "SYSCFG",
                     "address": 1073821696,
+                    "registers": {
+                        "kind": "syscfg",
+                        "version": "f2",
+                        "block": "SYSCFG"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F207ZF.json
+++ b/data/chips/STM32F207ZF.json
@@ -1289,6 +1289,11 @@
                 {
                     "name": "FLASH",
                     "address": 1073888256,
+                    "registers": {
+                        "kind": "flash",
+                        "version": "f2",
+                        "block": "FLASH"
+                    },
                     "interrupts": [
                         {
                             "interrupt": "FLASH",
@@ -1700,6 +1705,11 @@
                 {
                     "name": "PWR",
                     "address": 1073770496,
+                    "registers": {
+                        "kind": "pwr",
+                        "version": "f2",
+                        "block": "PWR"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {
@@ -2167,6 +2177,11 @@
                 {
                     "name": "SYSCFG",
                     "address": 1073821696,
+                    "registers": {
+                        "kind": "syscfg",
+                        "version": "f2",
+                        "block": "SYSCFG"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F207ZG.json
+++ b/data/chips/STM32F207ZG.json
@@ -1289,6 +1289,11 @@
                 {
                     "name": "FLASH",
                     "address": 1073888256,
+                    "registers": {
+                        "kind": "flash",
+                        "version": "f2",
+                        "block": "FLASH"
+                    },
                     "interrupts": [
                         {
                             "interrupt": "FLASH",
@@ -1700,6 +1705,11 @@
                 {
                     "name": "PWR",
                     "address": 1073770496,
+                    "registers": {
+                        "kind": "pwr",
+                        "version": "f2",
+                        "block": "PWR"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {
@@ -2167,6 +2177,11 @@
                 {
                     "name": "SYSCFG",
                     "address": 1073821696,
+                    "registers": {
+                        "kind": "syscfg",
+                        "version": "f2",
+                        "block": "SYSCFG"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F215RE.json
+++ b/data/chips/STM32F215RE.json
@@ -975,6 +975,11 @@
                 {
                     "name": "FLASH",
                     "address": 1073888256,
+                    "registers": {
+                        "kind": "flash",
+                        "version": "f2",
+                        "block": "FLASH"
+                    },
                     "interrupts": [
                         {
                             "interrupt": "FLASH",
@@ -1395,6 +1400,11 @@
                 {
                     "name": "PWR",
                     "address": 1073770496,
+                    "registers": {
+                        "kind": "pwr",
+                        "version": "f2",
+                        "block": "PWR"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {
@@ -1867,6 +1877,11 @@
                 {
                     "name": "SYSCFG",
                     "address": 1073821696,
+                    "registers": {
+                        "kind": "syscfg",
+                        "version": "f2",
+                        "block": "SYSCFG"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F215RG.json
+++ b/data/chips/STM32F215RG.json
@@ -975,6 +975,11 @@
                 {
                     "name": "FLASH",
                     "address": 1073888256,
+                    "registers": {
+                        "kind": "flash",
+                        "version": "f2",
+                        "block": "FLASH"
+                    },
                     "interrupts": [
                         {
                             "interrupt": "FLASH",
@@ -1395,6 +1400,11 @@
                 {
                     "name": "PWR",
                     "address": 1073770496,
+                    "registers": {
+                        "kind": "pwr",
+                        "version": "f2",
+                        "block": "PWR"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {
@@ -1867,6 +1877,11 @@
                 {
                     "name": "SYSCFG",
                     "address": 1073821696,
+                    "registers": {
+                        "kind": "syscfg",
+                        "version": "f2",
+                        "block": "SYSCFG"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F215VE.json
+++ b/data/chips/STM32F215VE.json
@@ -985,6 +985,11 @@
                 {
                     "name": "FLASH",
                     "address": 1073888256,
+                    "registers": {
+                        "kind": "flash",
+                        "version": "f2",
+                        "block": "FLASH"
+                    },
                     "interrupts": [
                         {
                             "interrupt": "FLASH",
@@ -1405,6 +1410,11 @@
                 {
                     "name": "PWR",
                     "address": 1073770496,
+                    "registers": {
+                        "kind": "pwr",
+                        "version": "f2",
+                        "block": "PWR"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {
@@ -1877,6 +1887,11 @@
                 {
                     "name": "SYSCFG",
                     "address": 1073821696,
+                    "registers": {
+                        "kind": "syscfg",
+                        "version": "f2",
+                        "block": "SYSCFG"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F215VG.json
+++ b/data/chips/STM32F215VG.json
@@ -985,6 +985,11 @@
                 {
                     "name": "FLASH",
                     "address": 1073888256,
+                    "registers": {
+                        "kind": "flash",
+                        "version": "f2",
+                        "block": "FLASH"
+                    },
                     "interrupts": [
                         {
                             "interrupt": "FLASH",
@@ -1405,6 +1410,11 @@
                 {
                     "name": "PWR",
                     "address": 1073770496,
+                    "registers": {
+                        "kind": "pwr",
+                        "version": "f2",
+                        "block": "PWR"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {
@@ -1877,6 +1887,11 @@
                 {
                     "name": "SYSCFG",
                     "address": 1073821696,
+                    "registers": {
+                        "kind": "syscfg",
+                        "version": "f2",
+                        "block": "SYSCFG"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F215ZE.json
+++ b/data/chips/STM32F215ZE.json
@@ -1017,6 +1017,11 @@
                 {
                     "name": "FLASH",
                     "address": 1073888256,
+                    "registers": {
+                        "kind": "flash",
+                        "version": "f2",
+                        "block": "FLASH"
+                    },
                     "interrupts": [
                         {
                             "interrupt": "FLASH",
@@ -1452,6 +1457,11 @@
                 {
                     "name": "PWR",
                     "address": 1073770496,
+                    "registers": {
+                        "kind": "pwr",
+                        "version": "f2",
+                        "block": "PWR"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {
@@ -1924,6 +1934,11 @@
                 {
                     "name": "SYSCFG",
                     "address": 1073821696,
+                    "registers": {
+                        "kind": "syscfg",
+                        "version": "f2",
+                        "block": "SYSCFG"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F215ZG.json
+++ b/data/chips/STM32F215ZG.json
@@ -1017,6 +1017,11 @@
                 {
                     "name": "FLASH",
                     "address": 1073888256,
+                    "registers": {
+                        "kind": "flash",
+                        "version": "f2",
+                        "block": "FLASH"
+                    },
                     "interrupts": [
                         {
                             "interrupt": "FLASH",
@@ -1452,6 +1457,11 @@
                 {
                     "name": "PWR",
                     "address": 1073770496,
+                    "registers": {
+                        "kind": "pwr",
+                        "version": "f2",
+                        "block": "PWR"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {
@@ -1924,6 +1934,11 @@
                 {
                     "name": "SYSCFG",
                     "address": 1073821696,
+                    "registers": {
+                        "kind": "syscfg",
+                        "version": "f2",
+                        "block": "SYSCFG"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F217IE.json
+++ b/data/chips/STM32F217IE.json
@@ -1436,6 +1436,11 @@
                 {
                     "name": "FLASH",
                     "address": 1073888256,
+                    "registers": {
+                        "kind": "flash",
+                        "version": "f2",
+                        "block": "FLASH"
+                    },
                     "interrupts": [
                         {
                             "interrupt": "FLASH",
@@ -1901,6 +1906,11 @@
                 {
                     "name": "PWR",
                     "address": 1073770496,
+                    "registers": {
+                        "kind": "pwr",
+                        "version": "f2",
+                        "block": "PWR"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {
@@ -2398,6 +2408,11 @@
                 {
                     "name": "SYSCFG",
                     "address": 1073821696,
+                    "registers": {
+                        "kind": "syscfg",
+                        "version": "f2",
+                        "block": "SYSCFG"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F217IG.json
+++ b/data/chips/STM32F217IG.json
@@ -1436,6 +1436,11 @@
                 {
                     "name": "FLASH",
                     "address": 1073888256,
+                    "registers": {
+                        "kind": "flash",
+                        "version": "f2",
+                        "block": "FLASH"
+                    },
                     "interrupts": [
                         {
                             "interrupt": "FLASH",
@@ -1901,6 +1906,11 @@
                 {
                     "name": "PWR",
                     "address": 1073770496,
+                    "registers": {
+                        "kind": "pwr",
+                        "version": "f2",
+                        "block": "PWR"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {
@@ -2398,6 +2408,11 @@
                 {
                     "name": "SYSCFG",
                     "address": 1073821696,
+                    "registers": {
+                        "kind": "syscfg",
+                        "version": "f2",
+                        "block": "SYSCFG"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F217VE.json
+++ b/data/chips/STM32F217VE.json
@@ -1260,6 +1260,11 @@
                 {
                     "name": "FLASH",
                     "address": 1073888256,
+                    "registers": {
+                        "kind": "flash",
+                        "version": "f2",
+                        "block": "FLASH"
+                    },
                     "interrupts": [
                         {
                             "interrupt": "FLASH",
@@ -1680,6 +1685,11 @@
                 {
                     "name": "PWR",
                     "address": 1073770496,
+                    "registers": {
+                        "kind": "pwr",
+                        "version": "f2",
+                        "block": "PWR"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {
@@ -2152,6 +2162,11 @@
                 {
                     "name": "SYSCFG",
                     "address": 1073821696,
+                    "registers": {
+                        "kind": "syscfg",
+                        "version": "f2",
+                        "block": "SYSCFG"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F217VG.json
+++ b/data/chips/STM32F217VG.json
@@ -1260,6 +1260,11 @@
                 {
                     "name": "FLASH",
                     "address": 1073888256,
+                    "registers": {
+                        "kind": "flash",
+                        "version": "f2",
+                        "block": "FLASH"
+                    },
                     "interrupts": [
                         {
                             "interrupt": "FLASH",
@@ -1680,6 +1685,11 @@
                 {
                     "name": "PWR",
                     "address": 1073770496,
+                    "registers": {
+                        "kind": "pwr",
+                        "version": "f2",
+                        "block": "PWR"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {
@@ -2152,6 +2162,11 @@
                 {
                     "name": "SYSCFG",
                     "address": 1073821696,
+                    "registers": {
+                        "kind": "syscfg",
+                        "version": "f2",
+                        "block": "SYSCFG"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F217ZE.json
+++ b/data/chips/STM32F217ZE.json
@@ -1322,6 +1322,11 @@
                 {
                     "name": "FLASH",
                     "address": 1073888256,
+                    "registers": {
+                        "kind": "flash",
+                        "version": "f2",
+                        "block": "FLASH"
+                    },
                     "interrupts": [
                         {
                             "interrupt": "FLASH",
@@ -1757,6 +1762,11 @@
                 {
                     "name": "PWR",
                     "address": 1073770496,
+                    "registers": {
+                        "kind": "pwr",
+                        "version": "f2",
+                        "block": "PWR"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {
@@ -2229,6 +2239,11 @@
                 {
                     "name": "SYSCFG",
                     "address": 1073821696,
+                    "registers": {
+                        "kind": "syscfg",
+                        "version": "f2",
+                        "block": "SYSCFG"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/chips/STM32F217ZG.json
+++ b/data/chips/STM32F217ZG.json
@@ -1322,6 +1322,11 @@
                 {
                     "name": "FLASH",
                     "address": 1073888256,
+                    "registers": {
+                        "kind": "flash",
+                        "version": "f2",
+                        "block": "FLASH"
+                    },
                     "interrupts": [
                         {
                             "interrupt": "FLASH",
@@ -1757,6 +1762,11 @@
                 {
                     "name": "PWR",
                     "address": 1073770496,
+                    "registers": {
+                        "kind": "pwr",
+                        "version": "f2",
+                        "block": "PWR"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {
@@ -2229,6 +2239,11 @@
                 {
                     "name": "SYSCFG",
                     "address": 1073821696,
+                    "registers": {
+                        "kind": "syscfg",
+                        "version": "f2",
+                        "block": "SYSCFG"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {

--- a/data/registers/dbgmcu_f2.yaml
+++ b/data/registers/dbgmcu_f2.yaml
@@ -70,16 +70,16 @@ fieldset/APB1_FZ:
       description: IWDEG
       bit_offset: 12
       bit_size: 1
-    - name: DBG_J2C1_SMBUS_TIMEOUT
-      description: DBG_J2C1_SMBUS_TIMEOUT
+    - name: I2C1_SMBUS_TIMEOUT
+      description: I2C1_SMBUS_TIMEOUT
       bit_offset: 21
       bit_size: 1
-    - name: DBG_J2C2_SMBUS_TIMEOUT
-      description: DBG_J2C2_SMBUS_TIMEOUT
+    - name: I2C2_SMBUS_TIMEOUT
+      description: I2C2_SMBUS_TIMEOUT
       bit_offset: 22
       bit_size: 1
-    - name: DBG_J2C3SMBUS_TIMEOUT
-      description: DBG_J2C3SMBUS_TIMEOUT
+    - name: I2C3_SMBUS_TIMEOUT
+      description: I2C3_SMBUS_TIMEOUT
       bit_offset: 23
       bit_size: 1
     - name: CAN1

--- a/data/registers/flash_f2.yaml
+++ b/data/registers/flash_f2.yaml
@@ -1,0 +1,328 @@
+---
+block/FLASH:
+  description: FLASH
+  items:
+    - name: ACR
+      description: Flash access control register
+      byte_offset: 0
+      fieldset: ACR
+    - name: KEYR
+      description: Flash key register
+      byte_offset: 4
+      access: Write
+      fieldset: KEYR
+    - name: OPTKEYR
+      description: Flash option key register
+      byte_offset: 8
+      access: Write
+      fieldset: OPTKEYR
+    - name: SR
+      description: Status register
+      byte_offset: 12
+      fieldset: SR
+    - name: CR
+      description: Control register
+      byte_offset: 16
+      fieldset: CR
+    - name: OPTCR
+      description: Flash option control register
+      byte_offset: 20
+      fieldset: OPTCR
+fieldset/ACR:
+  description: Flash access control register
+  fields:
+    - name: LATENCY
+      description: Latency
+      bit_offset: 0
+      bit_size: 3
+      enum: LATENCY
+    - name: PRFTEN
+      description: Prefetch enable
+      bit_offset: 8
+      bit_size: 1
+      enum: PRFTEN
+    - name: ICEN
+      description: Instruction cache enable
+      bit_offset: 9
+      bit_size: 1
+      enum: ICEN
+    - name: DCEN
+      description: Data cache enable
+      bit_offset: 10
+      bit_size: 1
+      enum: DCEN
+    - name: ICRST
+      description: Instruction cache reset
+      bit_offset: 11
+      bit_size: 1
+      enum: ICRST
+    - name: DCRST
+      description: Data cache reset
+      bit_offset: 12
+      bit_size: 1
+      enum: DCRST
+fieldset/CR:
+  description: Control register
+  fields:
+    - name: PG
+      description: Programming
+      bit_offset: 0
+      bit_size: 1
+      enum: PG
+    - name: SER
+      description: Sector Erase
+      bit_offset: 1
+      bit_size: 1
+      enum: SER
+    - name: MER
+      description: Mass Erase
+      bit_offset: 2
+      bit_size: 1
+      enum: MER
+    - name: SNB
+      description: Sector number
+      bit_offset: 3
+      bit_size: 4
+    - name: PSIZE
+      description: Program size
+      bit_offset: 8
+      bit_size: 2
+      enum: PSIZE
+    - name: STRT
+      description: Start
+      bit_offset: 16
+      bit_size: 1
+      enum: STRT
+    - name: EOPIE
+      description: End of operation interrupt enable
+      bit_offset: 24
+      bit_size: 1
+      enum: EOPIE
+    - name: ERRIE
+      description: Error interrupt enable
+      bit_offset: 25
+      bit_size: 1
+      enum: ERRIE
+    - name: LOCK
+      description: Lock
+      bit_offset: 31
+      bit_size: 1
+      enum: LOCK
+fieldset/KEYR:
+  description: Flash key register
+  fields:
+    - name: KEY
+      description: FPEC key
+      bit_offset: 0
+      bit_size: 32
+fieldset/OPTCR:
+  description: Flash option control register
+  fields:
+    - name: OPTLOCK
+      description: Option lock
+      bit_offset: 0
+      bit_size: 1
+    - name: OPTSTRT
+      description: Option start
+      bit_offset: 1
+      bit_size: 1
+    - name: BOR_LEV
+      description: BOR reset Level
+      bit_offset: 2
+      bit_size: 2
+    - name: WDG_SW
+      description: WDG_SW User option bytes
+      bit_offset: 5
+      bit_size: 1
+    - name: nRST_STOP
+      description: nRST_STOP User option bytes
+      bit_offset: 6
+      bit_size: 1
+    - name: nRST_STDBY
+      description: nRST_STDBY User option bytes
+      bit_offset: 7
+      bit_size: 1
+    - name: RDP
+      description: Read protect
+      bit_offset: 8
+      bit_size: 8
+    - name: nWRP
+      description: Not write protect
+      bit_offset: 16
+      bit_size: 12
+fieldset/OPTKEYR:
+  description: Flash option key register
+  fields:
+    - name: OPTKEY
+      description: Option byte key
+      bit_offset: 0
+      bit_size: 32
+fieldset/SR:
+  description: Status register
+  fields:
+    - name: EOP
+      description: End of operation
+      bit_offset: 0
+      bit_size: 1
+    - name: OPERR
+      description: Operation error
+      bit_offset: 1
+      bit_size: 1
+    - name: WRPERR
+      description: Write protection error
+      bit_offset: 4
+      bit_size: 1
+    - name: PGAERR
+      description: Programming alignment error
+      bit_offset: 5
+      bit_size: 1
+    - name: PGPERR
+      description: Programming parallelism error
+      bit_offset: 6
+      bit_size: 1
+    - name: PGSERR
+      description: Programming sequence error
+      bit_offset: 7
+      bit_size: 1
+    - name: BSY
+      description: Busy
+      bit_offset: 16
+      bit_size: 1
+enum/DCEN:
+  bit_size: 1
+  variants:
+    - name: Disabled
+      description: Data cache is disabled
+      value: 0
+    - name: Enabled
+      description: Data cache is enabled
+      value: 1
+enum/DCRST:
+  bit_size: 1
+  variants:
+    - name: NotReset
+      description: Data cache is not reset
+      value: 0
+    - name: Reset
+      description: Data cache is reset
+      value: 1
+enum/EOPIE:
+  bit_size: 1
+  variants:
+    - name: Disabled
+      description: End of operation interrupt disabled
+      value: 0
+    - name: Enabled
+      description: End of operation interrupt enabled
+      value: 1
+enum/ERRIE:
+  bit_size: 1
+  variants:
+    - name: Disabled
+      description: Error interrupt generation disabled
+      value: 0
+    - name: Enabled
+      description: Error interrupt generation enabled
+      value: 1
+enum/ICEN:
+  bit_size: 1
+  variants:
+    - name: Disabled
+      description: Instruction cache is disabled
+      value: 0
+    - name: Enabled
+      description: Instruction cache is enabled
+      value: 1
+enum/ICRST:
+  bit_size: 1
+  variants:
+    - name: NotReset
+      description: Instruction cache is not reset
+      value: 0
+    - name: Reset
+      description: Instruction cache is reset
+      value: 1
+enum/LATENCY:
+  bit_size: 3
+  variants:
+    - name: WS0
+      description: 0 wait states
+      value: 0
+    - name: WS1
+      description: 1 wait states
+      value: 1
+    - name: WS2
+      description: 2 wait states
+      value: 2
+    - name: WS3
+      description: 3 wait states
+      value: 3
+    - name: WS4
+      description: 4 wait states
+      value: 4
+    - name: WS5
+      description: 5 wait states
+      value: 5
+    - name: WS6
+      description: 6 wait states
+      value: 6
+    - name: WS7
+      description: 7 wait states
+      value: 7
+enum/LOCK:
+  bit_size: 1
+  variants:
+    - name: Unlocked
+      description: FLASH_CR register is unlocked
+      value: 0
+    - name: Locked
+      description: FLASH_CR register is locked
+      value: 1
+enum/MER:
+  bit_size: 1
+  variants:
+    - name: MassErase
+      description: Erase activated for all user sectors
+      value: 1
+enum/PG:
+  bit_size: 1
+  variants:
+    - name: Program
+      description: Flash programming activated
+      value: 1
+enum/PRFTEN:
+  bit_size: 1
+  variants:
+    - name: Disabled
+      description: Prefetch is disabled
+      value: 0
+    - name: Enabled
+      description: Prefetch is enabled
+      value: 1
+enum/PSIZE:
+  bit_size: 2
+  variants:
+    - name: PSIZE8
+      description: Program x8
+      value: 0
+    - name: PSIZE16
+      description: Program x16
+      value: 1
+    - name: PSIZE32
+      description: Program x32
+      value: 2
+    - name: PSIZE64
+      description: Program x64
+      value: 3
+enum/SER:
+  bit_size: 1
+  variants:
+    - name: SectorErase
+      description: Erase activated for selected sector
+      value: 1
+enum/STRT:
+  bit_size: 1
+  variants:
+    - name: Start
+      description: Trigger an erase operation
+      value: 1

--- a/data/registers/pwr_f2.yaml
+++ b/data/registers/pwr_f2.yaml
@@ -1,0 +1,84 @@
+---
+block/PWR:
+  description: Power control
+  items:
+    - name: CR
+      description: power control register
+      byte_offset: 0
+      fieldset: CR
+    - name: CSR
+      description: power control/status register
+      byte_offset: 4
+      fieldset: CSR
+fieldset/CR:
+  description: power control register
+  fields:
+    - name: LPDS
+      description: Low-power deep sleep
+      bit_offset: 0
+      bit_size: 1
+    - name: PDDS
+      description: Power down deepsleep
+      bit_offset: 1
+      bit_size: 1
+      enum: PDDS
+    - name: CWUF
+      description: Clear wakeup flag
+      bit_offset: 2
+      bit_size: 1
+    - name: CSBF
+      description: Clear standby flag
+      bit_offset: 3
+      bit_size: 1
+    - name: PVDE
+      description: Power voltage detector enable
+      bit_offset: 4
+      bit_size: 1
+    - name: PLS
+      description: PVD level selection
+      bit_offset: 5
+      bit_size: 3
+    - name: DBP
+      description: Disable backup domain write protection
+      bit_offset: 8
+      bit_size: 1
+    - name: FPDS
+      description: Flash power down in Stop mode
+      bit_offset: 9
+      bit_size: 1
+fieldset/CSR:
+  description: power control/status register
+  fields:
+    - name: WUF
+      description: Wakeup flag
+      bit_offset: 0
+      bit_size: 1
+    - name: SBF
+      description: Standby flag
+      bit_offset: 1
+      bit_size: 1
+    - name: PVDO
+      description: PVD output
+      bit_offset: 2
+      bit_size: 1
+    - name: BRR
+      description: Backup regulator ready
+      bit_offset: 3
+      bit_size: 1
+    - name: EWUP
+      description: Enable WKUP pin
+      bit_offset: 8
+      bit_size: 1
+    - name: BRE
+      description: Backup regulator enable
+      bit_offset: 9
+      bit_size: 1
+enum/PDDS:
+  bit_size: 1
+  variants:
+    - name: STOP_MODE
+      description: Enter Stop mode when the CPU enters deepsleep
+      value: 0
+    - name: STANDBY_MODE
+      description: Enter Standby mode when the CPU enters deepsleep
+      value: 1

--- a/data/registers/syscfg_f2.yaml
+++ b/data/registers/syscfg_f2.yaml
@@ -1,0 +1,75 @@
+---
+block/SYSCFG:
+  description: System configuration controller
+  items:
+    - name: MEMRMP
+      description: memory remap register
+      byte_offset: 0
+      fieldset: MEMRMP
+    - name: PMC
+      description: peripheral mode configuration register
+      byte_offset: 4
+      fieldset: PMC
+    - name: EXTICR
+      description: external interrupt configuration register 1
+      array:
+        len: 4
+        stride: 4
+      byte_offset: 8
+      fieldset: EXTICR
+    - name: CMPCR
+      description: Compensation cell control register
+      byte_offset: 32
+      access: Read
+      fieldset: CMPCR
+fieldset/MEMRMP:
+  description: memory remap register
+  fields:
+    - name: MEM_MODE
+      description: Memory mapping selection
+      bit_offset: 0
+      bit_size: 2
+      enum: MEM_MODE
+fieldset/PMC:
+  description: peripheral mode configuration register
+  fields:
+    - name: MII_RMII_SEL
+      description: Ethernet PHY interface selection
+      bit_offset: 23
+      bit_size: 1
+fieldset/EXTICR:
+  description: external interrupt configuration register 1
+  fields:
+    - name: EXTI
+      description: EXTI x configuration (x = 0 to 3)
+      bit_offset: 0
+      bit_size: 4
+      array:
+        len: 4
+        stride: 4
+fieldset/CMPCR:
+  description: Compensation cell control register
+  fields:
+    - name: CMP_PD
+      description: Compensation cell power-down
+      bit_offset: 0
+      bit_size: 1
+    - name: READY
+      description: Compensation cell ready flag
+      bit_offset: 8
+      bit_size: 1
+enum/MEM_MODE:
+  bit_size: 2
+  variants:
+    - name: MainFlash
+      description: Main Flash memory mapped at 0x0000_0000
+      value: 0
+    - name: SystemFlash
+      description: System Flash memory mapped at 0x0000_0000
+      value: 1
+    - name: FSMC
+      description: FSMC Bank1 (NOR/PSRAM 1 and 2) mapped at 0x0000_0000
+      value: 2
+    - name: SRAM
+      description: Embedded SRAM mapped at 0x0000_0000
+      value: 3

--- a/stm32data/__main__.py
+++ b/stm32data/__main__.py
@@ -209,6 +209,7 @@ perimap = [
     ('STM32H7.*:FLASH:.*', ('flash', 'h7', 'FLASH')),
     ('STM32F0.*:FLASH:.*', ('flash', 'f0', 'FLASH')),
     ('STM32F1.*:FLASH:.*', ('flash', 'f1', 'FLASH')),
+    ('STM32F2.*:FLASH:.*', ('flash', 'f2', 'FLASH')),
     ('STM32F3.*:FLASH:.*', ('flash', 'f3', 'FLASH')),
     ('STM32F4.*:FLASH:.*', ('flash', 'f4', 'FLASH')),
     ('STM32F7.*:FLASH:.*', ('flash', 'f7', 'FLASH')),

--- a/stm32data/__main__.py
+++ b/stm32data/__main__.py
@@ -129,6 +129,7 @@ perimap = [
     ('.*:ADC_COMMON:aditf4_v3_0_WL', ('adccommon', 'v3', 'ADC_COMMON')),
     ('.*:DCMI:.*', ('dcmi', 'v1', 'DCMI')),
     ('STM32F0.*:SYSCFG:.*',  ('syscfg', 'f0', 'SYSCFG')),
+    ('STM32F2.*:SYSCFG:.*',  ('syscfg', 'f2', 'SYSCFG')),
     ('STM32F3.*:SYSCFG:.*',  ('syscfg', 'f3', 'SYSCFG')),
     ('STM32F4.*:SYSCFG:.*',  ('syscfg', 'f4', 'SYSCFG')),
     ('STM32F7.*:SYSCFG:.*',  ('syscfg', 'f7', 'SYSCFG')),

--- a/stm32data/__main__.py
+++ b/stm32data/__main__.py
@@ -199,6 +199,7 @@ perimap = [
     ('STM32G4.*:PWR:.*', ('pwr', 'g4', 'PWR')),
     ('STM32H7(42|43|53|50).*:PWR:.*', ('pwr', 'h7', 'PWR')),
     ('STM32H7.*:PWR:.*', ('pwr', 'h7smps', 'PWR')),
+    ('STM32F2.*:PWR:.*', ('pwr', 'f2', 'PWR')),
     ('STM32F3.*:PWR:.*', ('pwr', 'f3', 'PWR')),
     ('STM32F4.*:PWR:.*', ('pwr', 'f4', 'PWR')),
     ('STM32F7.*:PWR:.*', ('pwr', 'f7', 'PWR')),


### PR DESCRIPTION
I've got a project using STM32F215 and am working on contributing possible F2 support to embassy :smile:
Here's the first batch of improvements, which hopefully will be enough to add basic support for this family in embassy.

After these changes, at least the following F2 peripherals are still missing proper register definitions:

* DCMI
* CRYP
* IWDG
* HASH
* RTC
* SPI1
* SPI2
* SPI3
* SDIO
* ETH
* FSMC

I'll probably add at least SPI and FSMC in a later pull request since I'm going to need those :smile: 