### PR TITLE
FSMC register block

### DIFF
--- a/data/chips/STM32F100VC.json
+++ b/data/chips/STM32F100VC.json
@@ -654,7 +654,12 @@
                 },
                 {
                     "name": "FSMC",
-                    "address": 1610612736,
+                    "address": 2684354560,
+                    "registers": {
+                        "kind": "fsmc",
+                        "version": "v1",
+                        "block": "FSMC"
+                    },
                     "rcc": {
                         "clock": "AHB1",
                         "enable": {

--- a/data/chips/STM32F100VD.json
+++ b/data/chips/STM32F100VD.json
@@ -654,7 +654,12 @@
                 },
                 {
                     "name": "FSMC",
-                    "address": 1610612736,
+                    "address": 2684354560,
+                    "registers": {
+                        "kind": "fsmc",
+                        "version": "v1",
+                        "block": "FSMC"
+                    },
                     "rcc": {
                         "clock": "AHB1",
                         "enable": {

--- a/data/chips/STM32F100VE.json
+++ b/data/chips/STM32F100VE.json
@@ -654,7 +654,12 @@
                 },
                 {
                     "name": "FSMC",
-                    "address": 1610612736,
+                    "address": 2684354560,
+                    "registers": {
+                        "kind": "fsmc",
+                        "version": "v1",
+                        "block": "FSMC"
+                    },
                     "rcc": {
                         "clock": "AHB1",
                         "enable": {

--- a/data/chips/STM32F100ZC.json
+++ b/data/chips/STM32F100ZC.json
@@ -654,7 +654,12 @@
                 },
                 {
                     "name": "FSMC",
-                    "address": 1610612736,
+                    "address": 2684354560,
+                    "registers": {
+                        "kind": "fsmc",
+                        "version": "v1",
+                        "block": "FSMC"
+                    },
                     "rcc": {
                         "clock": "AHB1",
                         "enable": {

--- a/data/chips/STM32F100ZD.json
+++ b/data/chips/STM32F100ZD.json
@@ -654,7 +654,12 @@
                 },
                 {
                     "name": "FSMC",
-                    "address": 1610612736,
+                    "address": 2684354560,
+                    "registers": {
+                        "kind": "fsmc",
+                        "version": "v1",
+                        "block": "FSMC"
+                    },
                     "rcc": {
                         "clock": "AHB1",
                         "enable": {

--- a/data/chips/STM32F100ZE.json
+++ b/data/chips/STM32F100ZE.json
@@ -654,7 +654,12 @@
                 },
                 {
                     "name": "FSMC",
-                    "address": 1610612736,
+                    "address": 2684354560,
+                    "registers": {
+                        "kind": "fsmc",
+                        "version": "v1",
+                        "block": "FSMC"
+                    },
                     "rcc": {
                         "clock": "AHB1",
                         "enable": {

--- a/data/chips/STM32F101VC.json
+++ b/data/chips/STM32F101VC.json
@@ -647,7 +647,12 @@
                 },
                 {
                     "name": "FSMC",
-                    "address": 1610612736,
+                    "address": 2684354560,
+                    "registers": {
+                        "kind": "fsmc",
+                        "version": "v1",
+                        "block": "FSMC"
+                    },
                     "rcc": {
                         "clock": "AHB1",
                         "enable": {

--- a/data/chips/STM32F101VD.json
+++ b/data/chips/STM32F101VD.json
@@ -647,7 +647,12 @@
                 },
                 {
                     "name": "FSMC",
-                    "address": 1610612736,
+                    "address": 2684354560,
+                    "registers": {
+                        "kind": "fsmc",
+                        "version": "v1",
+                        "block": "FSMC"
+                    },
                     "rcc": {
                         "clock": "AHB1",
                         "enable": {

--- a/data/chips/STM32F101VE.json
+++ b/data/chips/STM32F101VE.json
@@ -641,7 +641,12 @@
                 },
                 {
                     "name": "FSMC",
-                    "address": 1610612736,
+                    "address": 2684354560,
+                    "registers": {
+                        "kind": "fsmc",
+                        "version": "v1",
+                        "block": "FSMC"
+                    },
                     "rcc": {
                         "clock": "AHB1",
                         "enable": {

--- a/data/chips/STM32F101VF.json
+++ b/data/chips/STM32F101VF.json
@@ -635,7 +635,12 @@
                 },
                 {
                     "name": "FSMC",
-                    "address": 1610612736,
+                    "address": 2684354560,
+                    "registers": {
+                        "kind": "fsmc",
+                        "version": "v1",
+                        "block": "FSMC"
+                    },
                     "rcc": {
                         "clock": "AHB1",
                         "enable": {

--- a/data/chips/STM32F101VG.json
+++ b/data/chips/STM32F101VG.json
@@ -635,7 +635,12 @@
                 },
                 {
                     "name": "FSMC",
-                    "address": 1610612736,
+                    "address": 2684354560,
+                    "registers": {
+                        "kind": "fsmc",
+                        "version": "v1",
+                        "block": "FSMC"
+                    },
                     "rcc": {
                         "clock": "AHB1",
                         "enable": {

--- a/data/chips/STM32F101ZC.json
+++ b/data/chips/STM32F101ZC.json
@@ -641,7 +641,12 @@
                 },
                 {
                     "name": "FSMC",
-                    "address": 1610612736,
+                    "address": 2684354560,
+                    "registers": {
+                        "kind": "fsmc",
+                        "version": "v1",
+                        "block": "FSMC"
+                    },
                     "rcc": {
                         "clock": "AHB1",
                         "enable": {

--- a/data/chips/STM32F101ZD.json
+++ b/data/chips/STM32F101ZD.json
@@ -641,7 +641,12 @@
                 },
                 {
                     "name": "FSMC",
-                    "address": 1610612736,
+                    "address": 2684354560,
+                    "registers": {
+                        "kind": "fsmc",
+                        "version": "v1",
+                        "block": "FSMC"
+                    },
                     "rcc": {
                         "clock": "AHB1",
                         "enable": {

--- a/data/chips/STM32F101ZE.json
+++ b/data/chips/STM32F101ZE.json
@@ -641,7 +641,12 @@
                 },
                 {
                     "name": "FSMC",
-                    "address": 1610612736,
+                    "address": 2684354560,
+                    "registers": {
+                        "kind": "fsmc",
+                        "version": "v1",
+                        "block": "FSMC"
+                    },
                     "rcc": {
                         "clock": "AHB1",
                         "enable": {

--- a/data/chips/STM32F101ZF.json
+++ b/data/chips/STM32F101ZF.json
@@ -611,7 +611,12 @@
                 },
                 {
                     "name": "FSMC",
-                    "address": 1610612736,
+                    "address": 2684354560,
+                    "registers": {
+                        "kind": "fsmc",
+                        "version": "v1",
+                        "block": "FSMC"
+                    },
                     "rcc": {
                         "clock": "AHB1",
                         "enable": {

--- a/data/chips/STM32F101ZG.json
+++ b/data/chips/STM32F101ZG.json
@@ -635,7 +635,12 @@
                 },
                 {
                     "name": "FSMC",
-                    "address": 1610612736,
+                    "address": 2684354560,
+                    "registers": {
+                        "kind": "fsmc",
+                        "version": "v1",
+                        "block": "FSMC"
+                    },
                     "rcc": {
                         "clock": "AHB1",
                         "enable": {

--- a/data/chips/STM32F103VC.json
+++ b/data/chips/STM32F103VC.json
@@ -867,7 +867,12 @@
                 },
                 {
                     "name": "FSMC",
-                    "address": 1610612736,
+                    "address": 2684354560,
+                    "registers": {
+                        "kind": "fsmc",
+                        "version": "v1",
+                        "block": "FSMC"
+                    },
                     "rcc": {
                         "clock": "AHB1",
                         "enable": {

--- a/data/chips/STM32F103VD.json
+++ b/data/chips/STM32F103VD.json
@@ -867,7 +867,12 @@
                 },
                 {
                     "name": "FSMC",
-                    "address": 1610612736,
+                    "address": 2684354560,
+                    "registers": {
+                        "kind": "fsmc",
+                        "version": "v1",
+                        "block": "FSMC"
+                    },
                     "rcc": {
                         "clock": "AHB1",
                         "enable": {

--- a/data/chips/STM32F103VE.json
+++ b/data/chips/STM32F103VE.json
@@ -867,7 +867,12 @@
                 },
                 {
                     "name": "FSMC",
-                    "address": 1610612736,
+                    "address": 2684354560,
+                    "registers": {
+                        "kind": "fsmc",
+                        "version": "v1",
+                        "block": "FSMC"
+                    },
                     "rcc": {
                         "clock": "AHB1",
                         "enable": {

--- a/data/chips/STM32F103VF.json
+++ b/data/chips/STM32F103VF.json
@@ -857,7 +857,12 @@
                 },
                 {
                     "name": "FSMC",
-                    "address": 1610612736,
+                    "address": 2684354560,
+                    "registers": {
+                        "kind": "fsmc",
+                        "version": "v1",
+                        "block": "FSMC"
+                    },
                     "rcc": {
                         "clock": "AHB1",
                         "enable": {

--- a/data/chips/STM32F103VG.json
+++ b/data/chips/STM32F103VG.json
@@ -857,7 +857,12 @@
                 },
                 {
                     "name": "FSMC",
-                    "address": 1610612736,
+                    "address": 2684354560,
+                    "registers": {
+                        "kind": "fsmc",
+                        "version": "v1",
+                        "block": "FSMC"
+                    },
                     "rcc": {
                         "clock": "AHB1",
                         "enable": {

--- a/data/chips/STM32F103ZC.json
+++ b/data/chips/STM32F103ZC.json
@@ -887,7 +887,12 @@
                 },
                 {
                     "name": "FSMC",
-                    "address": 1610612736,
+                    "address": 2684354560,
+                    "registers": {
+                        "kind": "fsmc",
+                        "version": "v1",
+                        "block": "FSMC"
+                    },
                     "rcc": {
                         "clock": "AHB1",
                         "enable": {

--- a/data/chips/STM32F103ZD.json
+++ b/data/chips/STM32F103ZD.json
@@ -887,7 +887,12 @@
                 },
                 {
                     "name": "FSMC",
-                    "address": 1610612736,
+                    "address": 2684354560,
+                    "registers": {
+                        "kind": "fsmc",
+                        "version": "v1",
+                        "block": "FSMC"
+                    },
                     "rcc": {
                         "clock": "AHB1",
                         "enable": {

--- a/data/chips/STM32F103ZE.json
+++ b/data/chips/STM32F103ZE.json
@@ -887,7 +887,12 @@
                 },
                 {
                     "name": "FSMC",
-                    "address": 1610612736,
+                    "address": 2684354560,
+                    "registers": {
+                        "kind": "fsmc",
+                        "version": "v1",
+                        "block": "FSMC"
+                    },
                     "rcc": {
                         "clock": "AHB1",
                         "enable": {

--- a/data/chips/STM32F103ZF.json
+++ b/data/chips/STM32F103ZF.json
@@ -881,7 +881,12 @@
                 },
                 {
                     "name": "FSMC",
-                    "address": 1610612736,
+                    "address": 2684354560,
+                    "registers": {
+                        "kind": "fsmc",
+                        "version": "v1",
+                        "block": "FSMC"
+                    },
                     "rcc": {
                         "clock": "AHB1",
                         "enable": {

--- a/data/chips/STM32F103ZG.json
+++ b/data/chips/STM32F103ZG.json
@@ -881,7 +881,12 @@
                 },
                 {
                     "name": "FSMC",
-                    "address": 1610612736,
+                    "address": 2684354560,
+                    "registers": {
+                        "kind": "fsmc",
+                        "version": "v1",
+                        "block": "FSMC"
+                    },
                     "rcc": {
                         "clock": "AHB1",
                         "enable": {

--- a/data/chips/STM32F205VB.json
+++ b/data/chips/STM32F205VB.json
@@ -960,6 +960,289 @@
                     ]
                 },
                 {
+                    "name": "FSMC",
+                    "address": 2684354560,
+                    "registers": {
+                        "kind": "fsmc",
+                        "version": "v1",
+                        "block": "FSMC"
+                    },
+                    "rcc": {
+                        "clock": "AHB3",
+                        "enable": {
+                            "register": "AHB3ENR",
+                            "field": "FSMCEN"
+                        },
+                        "reset": {
+                            "register": "AHB3RSTR",
+                            "field": "FSMCRST"
+                        }
+                    },
+                    "pins": [
+                        {
+                            "pin": "PB7",
+                            "signal": "NL",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD0",
+                            "signal": "D2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD0",
+                            "signal": "DA2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD1",
+                            "signal": "D3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD1",
+                            "signal": "DA3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD3",
+                            "signal": "CLK",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD4",
+                            "signal": "NOE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD5",
+                            "signal": "NWE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD6",
+                            "signal": "NWAIT",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD7",
+                            "signal": "NCE2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD7",
+                            "signal": "NE1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD8",
+                            "signal": "D13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD8",
+                            "signal": "DA13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD9",
+                            "signal": "D14",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD9",
+                            "signal": "DA14",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD10",
+                            "signal": "D15",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD10",
+                            "signal": "DA15",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD11",
+                            "signal": "A16",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD11",
+                            "signal": "CLE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD12",
+                            "signal": "A17",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD12",
+                            "signal": "ALE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD13",
+                            "signal": "A18",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD14",
+                            "signal": "D0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD14",
+                            "signal": "DA0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD15",
+                            "signal": "D1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD15",
+                            "signal": "DA1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE0",
+                            "signal": "NBL0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE1",
+                            "signal": "NBL1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE2",
+                            "signal": "A23",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE3",
+                            "signal": "A19",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE4",
+                            "signal": "A20",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE5",
+                            "signal": "A21",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE6",
+                            "signal": "A22",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE7",
+                            "signal": "D4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE7",
+                            "signal": "DA4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE8",
+                            "signal": "D5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE8",
+                            "signal": "DA5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE9",
+                            "signal": "D6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE9",
+                            "signal": "DA6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE10",
+                            "signal": "D7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE10",
+                            "signal": "DA7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE11",
+                            "signal": "D8",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE11",
+                            "signal": "DA8",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE12",
+                            "signal": "D9",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE12",
+                            "signal": "DA9",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE13",
+                            "signal": "D10",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE13",
+                            "signal": "DA10",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE14",
+                            "signal": "D11",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE14",
+                            "signal": "DA11",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE15",
+                            "signal": "D12",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE15",
+                            "signal": "DA12",
+                            "af": 12
+                        }
+                    ],
+                    "interrupts": [
+                        {
+                            "interrupt": "FSMC",
+                            "signal": "GLOBAL"
+                        }
+                    ]
+                },
+                {
                     "name": "GPIOA",
                     "address": 1073872896,
                     "registers": {

--- a/data/chips/STM32F205VC.json
+++ b/data/chips/STM32F205VC.json
@@ -960,6 +960,289 @@
                     ]
                 },
                 {
+                    "name": "FSMC",
+                    "address": 2684354560,
+                    "registers": {
+                        "kind": "fsmc",
+                        "version": "v1",
+                        "block": "FSMC"
+                    },
+                    "rcc": {
+                        "clock": "AHB3",
+                        "enable": {
+                            "register": "AHB3ENR",
+                            "field": "FSMCEN"
+                        },
+                        "reset": {
+                            "register": "AHB3RSTR",
+                            "field": "FSMCRST"
+                        }
+                    },
+                    "pins": [
+                        {
+                            "pin": "PB7",
+                            "signal": "NL",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD0",
+                            "signal": "D2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD0",
+                            "signal": "DA2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD1",
+                            "signal": "D3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD1",
+                            "signal": "DA3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD3",
+                            "signal": "CLK",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD4",
+                            "signal": "NOE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD5",
+                            "signal": "NWE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD6",
+                            "signal": "NWAIT",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD7",
+                            "signal": "NCE2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD7",
+                            "signal": "NE1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD8",
+                            "signal": "D13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD8",
+                            "signal": "DA13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD9",
+                            "signal": "D14",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD9",
+                            "signal": "DA14",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD10",
+                            "signal": "D15",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD10",
+                            "signal": "DA15",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD11",
+                            "signal": "A16",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD11",
+                            "signal": "CLE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD12",
+                            "signal": "A17",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD12",
+                            "signal": "ALE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD13",
+                            "signal": "A18",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD14",
+                            "signal": "D0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD14",
+                            "signal": "DA0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD15",
+                            "signal": "D1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD15",
+                            "signal": "DA1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE0",
+                            "signal": "NBL0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE1",
+                            "signal": "NBL1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE2",
+                            "signal": "A23",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE3",
+                            "signal": "A19",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE4",
+                            "signal": "A20",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE5",
+                            "signal": "A21",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE6",
+                            "signal": "A22",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE7",
+                            "signal": "D4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE7",
+                            "signal": "DA4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE8",
+                            "signal": "D5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE8",
+                            "signal": "DA5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE9",
+                            "signal": "D6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE9",
+                            "signal": "DA6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE10",
+                            "signal": "D7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE10",
+                            "signal": "DA7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE11",
+                            "signal": "D8",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE11",
+                            "signal": "DA8",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE12",
+                            "signal": "D9",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE12",
+                            "signal": "DA9",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE13",
+                            "signal": "D10",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE13",
+                            "signal": "DA10",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE14",
+                            "signal": "D11",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE14",
+                            "signal": "DA11",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE15",
+                            "signal": "D12",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE15",
+                            "signal": "DA12",
+                            "af": 12
+                        }
+                    ],
+                    "interrupts": [
+                        {
+                            "interrupt": "FSMC",
+                            "signal": "GLOBAL"
+                        }
+                    ]
+                },
+                {
                     "name": "GPIOA",
                     "address": 1073872896,
                     "registers": {

--- a/data/chips/STM32F205VE.json
+++ b/data/chips/STM32F205VE.json
@@ -960,6 +960,289 @@
                     ]
                 },
                 {
+                    "name": "FSMC",
+                    "address": 2684354560,
+                    "registers": {
+                        "kind": "fsmc",
+                        "version": "v1",
+                        "block": "FSMC"
+                    },
+                    "rcc": {
+                        "clock": "AHB3",
+                        "enable": {
+                            "register": "AHB3ENR",
+                            "field": "FSMCEN"
+                        },
+                        "reset": {
+                            "register": "AHB3RSTR",
+                            "field": "FSMCRST"
+                        }
+                    },
+                    "pins": [
+                        {
+                            "pin": "PB7",
+                            "signal": "NL",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD0",
+                            "signal": "D2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD0",
+                            "signal": "DA2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD1",
+                            "signal": "D3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD1",
+                            "signal": "DA3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD3",
+                            "signal": "CLK",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD4",
+                            "signal": "NOE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD5",
+                            "signal": "NWE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD6",
+                            "signal": "NWAIT",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD7",
+                            "signal": "NCE2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD7",
+                            "signal": "NE1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD8",
+                            "signal": "D13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD8",
+                            "signal": "DA13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD9",
+                            "signal": "D14",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD9",
+                            "signal": "DA14",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD10",
+                            "signal": "D15",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD10",
+                            "signal": "DA15",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD11",
+                            "signal": "A16",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD11",
+                            "signal": "CLE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD12",
+                            "signal": "A17",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD12",
+                            "signal": "ALE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD13",
+                            "signal": "A18",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD14",
+                            "signal": "D0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD14",
+                            "signal": "DA0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD15",
+                            "signal": "D1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD15",
+                            "signal": "DA1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE0",
+                            "signal": "NBL0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE1",
+                            "signal": "NBL1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE2",
+                            "signal": "A23",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE3",
+                            "signal": "A19",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE4",
+                            "signal": "A20",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE5",
+                            "signal": "A21",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE6",
+                            "signal": "A22",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE7",
+                            "signal": "D4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE7",
+                            "signal": "DA4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE8",
+                            "signal": "D5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE8",
+                            "signal": "DA5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE9",
+                            "signal": "D6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE9",
+                            "signal": "DA6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE10",
+                            "signal": "D7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE10",
+                            "signal": "DA7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE11",
+                            "signal": "D8",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE11",
+                            "signal": "DA8",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE12",
+                            "signal": "D9",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE12",
+                            "signal": "DA9",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE13",
+                            "signal": "D10",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE13",
+                            "signal": "DA10",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE14",
+                            "signal": "D11",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE14",
+                            "signal": "DA11",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE15",
+                            "signal": "D12",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE15",
+                            "signal": "DA12",
+                            "af": 12
+                        }
+                    ],
+                    "interrupts": [
+                        {
+                            "interrupt": "FSMC",
+                            "signal": "GLOBAL"
+                        }
+                    ]
+                },
+                {
                     "name": "GPIOA",
                     "address": 1073872896,
                     "registers": {

--- a/data/chips/STM32F205VF.json
+++ b/data/chips/STM32F205VF.json
@@ -960,6 +960,289 @@
                     ]
                 },
                 {
+                    "name": "FSMC",
+                    "address": 2684354560,
+                    "registers": {
+                        "kind": "fsmc",
+                        "version": "v1",
+                        "block": "FSMC"
+                    },
+                    "rcc": {
+                        "clock": "AHB3",
+                        "enable": {
+                            "register": "AHB3ENR",
+                            "field": "FSMCEN"
+                        },
+                        "reset": {
+                            "register": "AHB3RSTR",
+                            "field": "FSMCRST"
+                        }
+                    },
+                    "pins": [
+                        {
+                            "pin": "PB7",
+                            "signal": "NL",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD0",
+                            "signal": "D2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD0",
+                            "signal": "DA2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD1",
+                            "signal": "D3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD1",
+                            "signal": "DA3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD3",
+                            "signal": "CLK",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD4",
+                            "signal": "NOE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD5",
+                            "signal": "NWE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD6",
+                            "signal": "NWAIT",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD7",
+                            "signal": "NCE2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD7",
+                            "signal": "NE1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD8",
+                            "signal": "D13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD8",
+                            "signal": "DA13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD9",
+                            "signal": "D14",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD9",
+                            "signal": "DA14",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD10",
+                            "signal": "D15",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD10",
+                            "signal": "DA15",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD11",
+                            "signal": "A16",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD11",
+                            "signal": "CLE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD12",
+                            "signal": "A17",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD12",
+                            "signal": "ALE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD13",
+                            "signal": "A18",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD14",
+                            "signal": "D0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD14",
+                            "signal": "DA0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD15",
+                            "signal": "D1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD15",
+                            "signal": "DA1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE0",
+                            "signal": "NBL0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE1",
+                            "signal": "NBL1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE2",
+                            "signal": "A23",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE3",
+                            "signal": "A19",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE4",
+                            "signal": "A20",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE5",
+                            "signal": "A21",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE6",
+                            "signal": "A22",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE7",
+                            "signal": "D4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE7",
+                            "signal": "DA4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE8",
+                            "signal": "D5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE8",
+                            "signal": "DA5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE9",
+                            "signal": "D6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE9",
+                            "signal": "DA6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE10",
+                            "signal": "D7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE10",
+                            "signal": "DA7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE11",
+                            "signal": "D8",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE11",
+                            "signal": "DA8",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE12",
+                            "signal": "D9",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE12",
+                            "signal": "DA9",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE13",
+                            "signal": "D10",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE13",
+                            "signal": "DA10",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE14",
+                            "signal": "D11",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE14",
+                            "signal": "DA11",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE15",
+                            "signal": "D12",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE15",
+                            "signal": "DA12",
+                            "af": 12
+                        }
+                    ],
+                    "interrupts": [
+                        {
+                            "interrupt": "FSMC",
+                            "signal": "GLOBAL"
+                        }
+                    ]
+                },
+                {
                     "name": "GPIOA",
                     "address": 1073872896,
                     "registers": {

--- a/data/chips/STM32F205VG.json
+++ b/data/chips/STM32F205VG.json
@@ -960,6 +960,289 @@
                     ]
                 },
                 {
+                    "name": "FSMC",
+                    "address": 2684354560,
+                    "registers": {
+                        "kind": "fsmc",
+                        "version": "v1",
+                        "block": "FSMC"
+                    },
+                    "rcc": {
+                        "clock": "AHB3",
+                        "enable": {
+                            "register": "AHB3ENR",
+                            "field": "FSMCEN"
+                        },
+                        "reset": {
+                            "register": "AHB3RSTR",
+                            "field": "FSMCRST"
+                        }
+                    },
+                    "pins": [
+                        {
+                            "pin": "PB7",
+                            "signal": "NL",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD0",
+                            "signal": "D2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD0",
+                            "signal": "DA2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD1",
+                            "signal": "D3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD1",
+                            "signal": "DA3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD3",
+                            "signal": "CLK",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD4",
+                            "signal": "NOE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD5",
+                            "signal": "NWE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD6",
+                            "signal": "NWAIT",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD7",
+                            "signal": "NCE2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD7",
+                            "signal": "NE1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD8",
+                            "signal": "D13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD8",
+                            "signal": "DA13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD9",
+                            "signal": "D14",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD9",
+                            "signal": "DA14",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD10",
+                            "signal": "D15",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD10",
+                            "signal": "DA15",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD11",
+                            "signal": "A16",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD11",
+                            "signal": "CLE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD12",
+                            "signal": "A17",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD12",
+                            "signal": "ALE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD13",
+                            "signal": "A18",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD14",
+                            "signal": "D0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD14",
+                            "signal": "DA0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD15",
+                            "signal": "D1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD15",
+                            "signal": "DA1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE0",
+                            "signal": "NBL0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE1",
+                            "signal": "NBL1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE2",
+                            "signal": "A23",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE3",
+                            "signal": "A19",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE4",
+                            "signal": "A20",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE5",
+                            "signal": "A21",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE6",
+                            "signal": "A22",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE7",
+                            "signal": "D4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE7",
+                            "signal": "DA4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE8",
+                            "signal": "D5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE8",
+                            "signal": "DA5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE9",
+                            "signal": "D6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE9",
+                            "signal": "DA6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE10",
+                            "signal": "D7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE10",
+                            "signal": "DA7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE11",
+                            "signal": "D8",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE11",
+                            "signal": "DA8",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE12",
+                            "signal": "D9",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE12",
+                            "signal": "DA9",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE13",
+                            "signal": "D10",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE13",
+                            "signal": "DA10",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE14",
+                            "signal": "D11",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE14",
+                            "signal": "DA11",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE15",
+                            "signal": "D12",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE15",
+                            "signal": "DA12",
+                            "af": 12
+                        }
+                    ],
+                    "interrupts": [
+                        {
+                            "interrupt": "FSMC",
+                            "signal": "GLOBAL"
+                        }
+                    ]
+                },
+                {
                     "name": "GPIOA",
                     "address": 1073872896,
                     "registers": {

--- a/data/chips/STM32F205ZC.json
+++ b/data/chips/STM32F205ZC.json
@@ -992,6 +992,444 @@
                     ]
                 },
                 {
+                    "name": "FSMC",
+                    "address": 2684354560,
+                    "registers": {
+                        "kind": "fsmc",
+                        "version": "v1",
+                        "block": "FSMC"
+                    },
+                    "rcc": {
+                        "clock": "AHB3",
+                        "enable": {
+                            "register": "AHB3ENR",
+                            "field": "FSMCEN"
+                        },
+                        "reset": {
+                            "register": "AHB3RSTR",
+                            "field": "FSMCRST"
+                        }
+                    },
+                    "pins": [
+                        {
+                            "pin": "PB7",
+                            "signal": "NL",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD0",
+                            "signal": "D2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD0",
+                            "signal": "DA2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD1",
+                            "signal": "D3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD1",
+                            "signal": "DA3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD3",
+                            "signal": "CLK",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD4",
+                            "signal": "NOE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD5",
+                            "signal": "NWE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD6",
+                            "signal": "NWAIT",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD7",
+                            "signal": "NCE2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD7",
+                            "signal": "NE1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD8",
+                            "signal": "D13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD8",
+                            "signal": "DA13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD9",
+                            "signal": "D14",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD9",
+                            "signal": "DA14",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD10",
+                            "signal": "D15",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD10",
+                            "signal": "DA15",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD11",
+                            "signal": "A16",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD11",
+                            "signal": "CLE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD12",
+                            "signal": "A17",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD12",
+                            "signal": "ALE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD13",
+                            "signal": "A18",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD14",
+                            "signal": "D0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD14",
+                            "signal": "DA0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD15",
+                            "signal": "D1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD15",
+                            "signal": "DA1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE0",
+                            "signal": "NBL0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE1",
+                            "signal": "NBL1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE2",
+                            "signal": "A23",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE3",
+                            "signal": "A19",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE4",
+                            "signal": "A20",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE5",
+                            "signal": "A21",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE6",
+                            "signal": "A22",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE7",
+                            "signal": "D4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE7",
+                            "signal": "DA4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE8",
+                            "signal": "D5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE8",
+                            "signal": "DA5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE9",
+                            "signal": "D6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE9",
+                            "signal": "DA6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE10",
+                            "signal": "D7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE10",
+                            "signal": "DA7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE11",
+                            "signal": "D8",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE11",
+                            "signal": "DA8",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE12",
+                            "signal": "D9",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE12",
+                            "signal": "DA9",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE13",
+                            "signal": "D10",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE13",
+                            "signal": "DA10",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE14",
+                            "signal": "D11",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE14",
+                            "signal": "DA11",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE15",
+                            "signal": "D12",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE15",
+                            "signal": "DA12",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF0",
+                            "signal": "A0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF1",
+                            "signal": "A1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF2",
+                            "signal": "A2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF3",
+                            "signal": "A3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF4",
+                            "signal": "A4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF5",
+                            "signal": "A5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF6",
+                            "signal": "NIORD",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF7",
+                            "signal": "NREG",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF8",
+                            "signal": "NIOWR",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF9",
+                            "signal": "CD",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF10",
+                            "signal": "INTR",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF12",
+                            "signal": "A6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF13",
+                            "signal": "A7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF14",
+                            "signal": "A8",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF15",
+                            "signal": "A9",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG0",
+                            "signal": "A10",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG1",
+                            "signal": "A11",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG2",
+                            "signal": "A12",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG3",
+                            "signal": "A13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG4",
+                            "signal": "A14",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG5",
+                            "signal": "A15",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG6",
+                            "signal": "INT2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG7",
+                            "signal": "INT3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG9",
+                            "signal": "NCE3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG9",
+                            "signal": "NE2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG10",
+                            "signal": "NCE4_1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG10",
+                            "signal": "NE3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG11",
+                            "signal": "NCE4_2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG12",
+                            "signal": "NE4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG13",
+                            "signal": "A24",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG14",
+                            "signal": "A25",
+                            "af": 12
+                        }
+                    ],
+                    "interrupts": [
+                        {
+                            "interrupt": "FSMC",
+                            "signal": "GLOBAL"
+                        }
+                    ]
+                },
+                {
                     "name": "GPIOA",
                     "address": 1073872896,
                     "registers": {

--- a/data/chips/STM32F205ZE.json
+++ b/data/chips/STM32F205ZE.json
@@ -992,6 +992,444 @@
                     ]
                 },
                 {
+                    "name": "FSMC",
+                    "address": 2684354560,
+                    "registers": {
+                        "kind": "fsmc",
+                        "version": "v1",
+                        "block": "FSMC"
+                    },
+                    "rcc": {
+                        "clock": "AHB3",
+                        "enable": {
+                            "register": "AHB3ENR",
+                            "field": "FSMCEN"
+                        },
+                        "reset": {
+                            "register": "AHB3RSTR",
+                            "field": "FSMCRST"
+                        }
+                    },
+                    "pins": [
+                        {
+                            "pin": "PB7",
+                            "signal": "NL",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD0",
+                            "signal": "D2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD0",
+                            "signal": "DA2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD1",
+                            "signal": "D3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD1",
+                            "signal": "DA3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD3",
+                            "signal": "CLK",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD4",
+                            "signal": "NOE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD5",
+                            "signal": "NWE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD6",
+                            "signal": "NWAIT",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD7",
+                            "signal": "NCE2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD7",
+                            "signal": "NE1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD8",
+                            "signal": "D13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD8",
+                            "signal": "DA13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD9",
+                            "signal": "D14",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD9",
+                            "signal": "DA14",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD10",
+                            "signal": "D15",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD10",
+                            "signal": "DA15",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD11",
+                            "signal": "A16",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD11",
+                            "signal": "CLE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD12",
+                            "signal": "A17",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD12",
+                            "signal": "ALE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD13",
+                            "signal": "A18",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD14",
+                            "signal": "D0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD14",
+                            "signal": "DA0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD15",
+                            "signal": "D1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD15",
+                            "signal": "DA1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE0",
+                            "signal": "NBL0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE1",
+                            "signal": "NBL1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE2",
+                            "signal": "A23",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE3",
+                            "signal": "A19",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE4",
+                            "signal": "A20",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE5",
+                            "signal": "A21",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE6",
+                            "signal": "A22",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE7",
+                            "signal": "D4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE7",
+                            "signal": "DA4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE8",
+                            "signal": "D5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE8",
+                            "signal": "DA5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE9",
+                            "signal": "D6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE9",
+                            "signal": "DA6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE10",
+                            "signal": "D7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE10",
+                            "signal": "DA7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE11",
+                            "signal": "D8",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE11",
+                            "signal": "DA8",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE12",
+                            "signal": "D9",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE12",
+                            "signal": "DA9",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE13",
+                            "signal": "D10",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE13",
+                            "signal": "DA10",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE14",
+                            "signal": "D11",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE14",
+                            "signal": "DA11",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE15",
+                            "signal": "D12",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE15",
+                            "signal": "DA12",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF0",
+                            "signal": "A0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF1",
+                            "signal": "A1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF2",
+                            "signal": "A2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF3",
+                            "signal": "A3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF4",
+                            "signal": "A4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF5",
+                            "signal": "A5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF6",
+                            "signal": "NIORD",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF7",
+                            "signal": "NREG",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF8",
+                            "signal": "NIOWR",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF9",
+                            "signal": "CD",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF10",
+                            "signal": "INTR",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF12",
+                            "signal": "A6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF13",
+                            "signal": "A7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF14",
+                            "signal": "A8",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF15",
+                            "signal": "A9",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG0",
+                            "signal": "A10",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG1",
+                            "signal": "A11",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG2",
+                            "signal": "A12",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG3",
+                            "signal": "A13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG4",
+                            "signal": "A14",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG5",
+                            "signal": "A15",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG6",
+                            "signal": "INT2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG7",
+                            "signal": "INT3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG9",
+                            "signal": "NCE3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG9",
+                            "signal": "NE2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG10",
+                            "signal": "NCE4_1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG10",
+                            "signal": "NE3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG11",
+                            "signal": "NCE4_2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG12",
+                            "signal": "NE4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG13",
+                            "signal": "A24",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG14",
+                            "signal": "A25",
+                            "af": 12
+                        }
+                    ],
+                    "interrupts": [
+                        {
+                            "interrupt": "FSMC",
+                            "signal": "GLOBAL"
+                        }
+                    ]
+                },
+                {
                     "name": "GPIOA",
                     "address": 1073872896,
                     "registers": {

--- a/data/chips/STM32F205ZF.json
+++ b/data/chips/STM32F205ZF.json
@@ -992,6 +992,444 @@
                     ]
                 },
                 {
+                    "name": "FSMC",
+                    "address": 2684354560,
+                    "registers": {
+                        "kind": "fsmc",
+                        "version": "v1",
+                        "block": "FSMC"
+                    },
+                    "rcc": {
+                        "clock": "AHB3",
+                        "enable": {
+                            "register": "AHB3ENR",
+                            "field": "FSMCEN"
+                        },
+                        "reset": {
+                            "register": "AHB3RSTR",
+                            "field": "FSMCRST"
+                        }
+                    },
+                    "pins": [
+                        {
+                            "pin": "PB7",
+                            "signal": "NL",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD0",
+                            "signal": "D2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD0",
+                            "signal": "DA2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD1",
+                            "signal": "D3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD1",
+                            "signal": "DA3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD3",
+                            "signal": "CLK",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD4",
+                            "signal": "NOE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD5",
+                            "signal": "NWE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD6",
+                            "signal": "NWAIT",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD7",
+                            "signal": "NCE2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD7",
+                            "signal": "NE1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD8",
+                            "signal": "D13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD8",
+                            "signal": "DA13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD9",
+                            "signal": "D14",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD9",
+                            "signal": "DA14",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD10",
+                            "signal": "D15",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD10",
+                            "signal": "DA15",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD11",
+                            "signal": "A16",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD11",
+                            "signal": "CLE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD12",
+                            "signal": "A17",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD12",
+                            "signal": "ALE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD13",
+                            "signal": "A18",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD14",
+                            "signal": "D0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD14",
+                            "signal": "DA0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD15",
+                            "signal": "D1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD15",
+                            "signal": "DA1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE0",
+                            "signal": "NBL0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE1",
+                            "signal": "NBL1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE2",
+                            "signal": "A23",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE3",
+                            "signal": "A19",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE4",
+                            "signal": "A20",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE5",
+                            "signal": "A21",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE6",
+                            "signal": "A22",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE7",
+                            "signal": "D4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE7",
+                            "signal": "DA4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE8",
+                            "signal": "D5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE8",
+                            "signal": "DA5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE9",
+                            "signal": "D6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE9",
+                            "signal": "DA6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE10",
+                            "signal": "D7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE10",
+                            "signal": "DA7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE11",
+                            "signal": "D8",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE11",
+                            "signal": "DA8",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE12",
+                            "signal": "D9",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE12",
+                            "signal": "DA9",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE13",
+                            "signal": "D10",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE13",
+                            "signal": "DA10",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE14",
+                            "signal": "D11",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE14",
+                            "signal": "DA11",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE15",
+                            "signal": "D12",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE15",
+                            "signal": "DA12",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF0",
+                            "signal": "A0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF1",
+                            "signal": "A1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF2",
+                            "signal": "A2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF3",
+                            "signal": "A3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF4",
+                            "signal": "A4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF5",
+                            "signal": "A5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF6",
+                            "signal": "NIORD",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF7",
+                            "signal": "NREG",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF8",
+                            "signal": "NIOWR",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF9",
+                            "signal": "CD",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF10",
+                            "signal": "INTR",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF12",
+                            "signal": "A6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF13",
+                            "signal": "A7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF14",
+                            "signal": "A8",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF15",
+                            "signal": "A9",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG0",
+                            "signal": "A10",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG1",
+                            "signal": "A11",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG2",
+                            "signal": "A12",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG3",
+                            "signal": "A13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG4",
+                            "signal": "A14",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG5",
+                            "signal": "A15",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG6",
+                            "signal": "INT2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG7",
+                            "signal": "INT3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG9",
+                            "signal": "NCE3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG9",
+                            "signal": "NE2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG10",
+                            "signal": "NCE4_1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG10",
+                            "signal": "NE3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG11",
+                            "signal": "NCE4_2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG12",
+                            "signal": "NE4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG13",
+                            "signal": "A24",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG14",
+                            "signal": "A25",
+                            "af": 12
+                        }
+                    ],
+                    "interrupts": [
+                        {
+                            "interrupt": "FSMC",
+                            "signal": "GLOBAL"
+                        }
+                    ]
+                },
+                {
                     "name": "GPIOA",
                     "address": 1073872896,
                     "registers": {

--- a/data/chips/STM32F205ZG.json
+++ b/data/chips/STM32F205ZG.json
@@ -992,6 +992,444 @@
                     ]
                 },
                 {
+                    "name": "FSMC",
+                    "address": 2684354560,
+                    "registers": {
+                        "kind": "fsmc",
+                        "version": "v1",
+                        "block": "FSMC"
+                    },
+                    "rcc": {
+                        "clock": "AHB3",
+                        "enable": {
+                            "register": "AHB3ENR",
+                            "field": "FSMCEN"
+                        },
+                        "reset": {
+                            "register": "AHB3RSTR",
+                            "field": "FSMCRST"
+                        }
+                    },
+                    "pins": [
+                        {
+                            "pin": "PB7",
+                            "signal": "NL",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD0",
+                            "signal": "D2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD0",
+                            "signal": "DA2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD1",
+                            "signal": "D3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD1",
+                            "signal": "DA3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD3",
+                            "signal": "CLK",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD4",
+                            "signal": "NOE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD5",
+                            "signal": "NWE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD6",
+                            "signal": "NWAIT",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD7",
+                            "signal": "NCE2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD7",
+                            "signal": "NE1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD8",
+                            "signal": "D13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD8",
+                            "signal": "DA13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD9",
+                            "signal": "D14",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD9",
+                            "signal": "DA14",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD10",
+                            "signal": "D15",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD10",
+                            "signal": "DA15",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD11",
+                            "signal": "A16",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD11",
+                            "signal": "CLE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD12",
+                            "signal": "A17",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD12",
+                            "signal": "ALE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD13",
+                            "signal": "A18",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD14",
+                            "signal": "D0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD14",
+                            "signal": "DA0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD15",
+                            "signal": "D1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD15",
+                            "signal": "DA1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE0",
+                            "signal": "NBL0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE1",
+                            "signal": "NBL1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE2",
+                            "signal": "A23",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE3",
+                            "signal": "A19",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE4",
+                            "signal": "A20",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE5",
+                            "signal": "A21",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE6",
+                            "signal": "A22",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE7",
+                            "signal": "D4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE7",
+                            "signal": "DA4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE8",
+                            "signal": "D5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE8",
+                            "signal": "DA5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE9",
+                            "signal": "D6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE9",
+                            "signal": "DA6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE10",
+                            "signal": "D7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE10",
+                            "signal": "DA7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE11",
+                            "signal": "D8",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE11",
+                            "signal": "DA8",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE12",
+                            "signal": "D9",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE12",
+                            "signal": "DA9",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE13",
+                            "signal": "D10",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE13",
+                            "signal": "DA10",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE14",
+                            "signal": "D11",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE14",
+                            "signal": "DA11",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE15",
+                            "signal": "D12",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE15",
+                            "signal": "DA12",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF0",
+                            "signal": "A0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF1",
+                            "signal": "A1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF2",
+                            "signal": "A2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF3",
+                            "signal": "A3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF4",
+                            "signal": "A4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF5",
+                            "signal": "A5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF6",
+                            "signal": "NIORD",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF7",
+                            "signal": "NREG",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF8",
+                            "signal": "NIOWR",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF9",
+                            "signal": "CD",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF10",
+                            "signal": "INTR",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF12",
+                            "signal": "A6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF13",
+                            "signal": "A7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF14",
+                            "signal": "A8",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF15",
+                            "signal": "A9",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG0",
+                            "signal": "A10",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG1",
+                            "signal": "A11",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG2",
+                            "signal": "A12",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG3",
+                            "signal": "A13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG4",
+                            "signal": "A14",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG5",
+                            "signal": "A15",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG6",
+                            "signal": "INT2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG7",
+                            "signal": "INT3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG9",
+                            "signal": "NCE3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG9",
+                            "signal": "NE2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG10",
+                            "signal": "NCE4_1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG10",
+                            "signal": "NE3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG11",
+                            "signal": "NCE4_2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG12",
+                            "signal": "NE4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG13",
+                            "signal": "A24",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG14",
+                            "signal": "A25",
+                            "af": 12
+                        }
+                    ],
+                    "interrupts": [
+                        {
+                            "interrupt": "FSMC",
+                            "signal": "GLOBAL"
+                        }
+                    ]
+                },
+                {
                     "name": "GPIOA",
                     "address": 1073872896,
                     "registers": {

--- a/data/chips/STM32F207IC.json
+++ b/data/chips/STM32F207IC.json
@@ -1411,6 +1411,444 @@
                     ]
                 },
                 {
+                    "name": "FSMC",
+                    "address": 2684354560,
+                    "registers": {
+                        "kind": "fsmc",
+                        "version": "v1",
+                        "block": "FSMC"
+                    },
+                    "rcc": {
+                        "clock": "AHB3",
+                        "enable": {
+                            "register": "AHB3ENR",
+                            "field": "FSMCEN"
+                        },
+                        "reset": {
+                            "register": "AHB3RSTR",
+                            "field": "FSMCRST"
+                        }
+                    },
+                    "pins": [
+                        {
+                            "pin": "PB7",
+                            "signal": "NL",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD0",
+                            "signal": "D2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD0",
+                            "signal": "DA2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD1",
+                            "signal": "D3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD1",
+                            "signal": "DA3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD3",
+                            "signal": "CLK",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD4",
+                            "signal": "NOE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD5",
+                            "signal": "NWE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD6",
+                            "signal": "NWAIT",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD7",
+                            "signal": "NCE2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD7",
+                            "signal": "NE1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD8",
+                            "signal": "D13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD8",
+                            "signal": "DA13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD9",
+                            "signal": "D14",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD9",
+                            "signal": "DA14",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD10",
+                            "signal": "D15",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD10",
+                            "signal": "DA15",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD11",
+                            "signal": "A16",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD11",
+                            "signal": "CLE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD12",
+                            "signal": "A17",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD12",
+                            "signal": "ALE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD13",
+                            "signal": "A18",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD14",
+                            "signal": "D0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD14",
+                            "signal": "DA0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD15",
+                            "signal": "D1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD15",
+                            "signal": "DA1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE0",
+                            "signal": "NBL0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE1",
+                            "signal": "NBL1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE2",
+                            "signal": "A23",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE3",
+                            "signal": "A19",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE4",
+                            "signal": "A20",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE5",
+                            "signal": "A21",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE6",
+                            "signal": "A22",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE7",
+                            "signal": "D4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE7",
+                            "signal": "DA4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE8",
+                            "signal": "D5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE8",
+                            "signal": "DA5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE9",
+                            "signal": "D6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE9",
+                            "signal": "DA6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE10",
+                            "signal": "D7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE10",
+                            "signal": "DA7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE11",
+                            "signal": "D8",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE11",
+                            "signal": "DA8",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE12",
+                            "signal": "D9",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE12",
+                            "signal": "DA9",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE13",
+                            "signal": "D10",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE13",
+                            "signal": "DA10",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE14",
+                            "signal": "D11",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE14",
+                            "signal": "DA11",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE15",
+                            "signal": "D12",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE15",
+                            "signal": "DA12",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF0",
+                            "signal": "A0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF1",
+                            "signal": "A1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF2",
+                            "signal": "A2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF3",
+                            "signal": "A3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF4",
+                            "signal": "A4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF5",
+                            "signal": "A5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF6",
+                            "signal": "NIORD",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF7",
+                            "signal": "NREG",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF8",
+                            "signal": "NIOWR",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF9",
+                            "signal": "CD",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF10",
+                            "signal": "INTR",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF12",
+                            "signal": "A6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF13",
+                            "signal": "A7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF14",
+                            "signal": "A8",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF15",
+                            "signal": "A9",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG0",
+                            "signal": "A10",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG1",
+                            "signal": "A11",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG2",
+                            "signal": "A12",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG3",
+                            "signal": "A13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG4",
+                            "signal": "A14",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG5",
+                            "signal": "A15",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG6",
+                            "signal": "INT2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG7",
+                            "signal": "INT3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG9",
+                            "signal": "NCE3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG9",
+                            "signal": "NE2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG10",
+                            "signal": "NCE4_1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG10",
+                            "signal": "NE3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG11",
+                            "signal": "NCE4_2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG12",
+                            "signal": "NE4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG13",
+                            "signal": "A24",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG14",
+                            "signal": "A25",
+                            "af": 12
+                        }
+                    ],
+                    "interrupts": [
+                        {
+                            "interrupt": "FSMC",
+                            "signal": "GLOBAL"
+                        }
+                    ]
+                },
+                {
                     "name": "GPIOA",
                     "address": 1073872896,
                     "registers": {

--- a/data/chips/STM32F207IE.json
+++ b/data/chips/STM32F207IE.json
@@ -1411,6 +1411,444 @@
                     ]
                 },
                 {
+                    "name": "FSMC",
+                    "address": 2684354560,
+                    "registers": {
+                        "kind": "fsmc",
+                        "version": "v1",
+                        "block": "FSMC"
+                    },
+                    "rcc": {
+                        "clock": "AHB3",
+                        "enable": {
+                            "register": "AHB3ENR",
+                            "field": "FSMCEN"
+                        },
+                        "reset": {
+                            "register": "AHB3RSTR",
+                            "field": "FSMCRST"
+                        }
+                    },
+                    "pins": [
+                        {
+                            "pin": "PB7",
+                            "signal": "NL",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD0",
+                            "signal": "D2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD0",
+                            "signal": "DA2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD1",
+                            "signal": "D3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD1",
+                            "signal": "DA3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD3",
+                            "signal": "CLK",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD4",
+                            "signal": "NOE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD5",
+                            "signal": "NWE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD6",
+                            "signal": "NWAIT",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD7",
+                            "signal": "NCE2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD7",
+                            "signal": "NE1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD8",
+                            "signal": "D13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD8",
+                            "signal": "DA13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD9",
+                            "signal": "D14",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD9",
+                            "signal": "DA14",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD10",
+                            "signal": "D15",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD10",
+                            "signal": "DA15",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD11",
+                            "signal": "A16",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD11",
+                            "signal": "CLE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD12",
+                            "signal": "A17",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD12",
+                            "signal": "ALE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD13",
+                            "signal": "A18",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD14",
+                            "signal": "D0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD14",
+                            "signal": "DA0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD15",
+                            "signal": "D1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD15",
+                            "signal": "DA1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE0",
+                            "signal": "NBL0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE1",
+                            "signal": "NBL1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE2",
+                            "signal": "A23",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE3",
+                            "signal": "A19",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE4",
+                            "signal": "A20",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE5",
+                            "signal": "A21",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE6",
+                            "signal": "A22",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE7",
+                            "signal": "D4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE7",
+                            "signal": "DA4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE8",
+                            "signal": "D5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE8",
+                            "signal": "DA5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE9",
+                            "signal": "D6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE9",
+                            "signal": "DA6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE10",
+                            "signal": "D7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE10",
+                            "signal": "DA7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE11",
+                            "signal": "D8",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE11",
+                            "signal": "DA8",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE12",
+                            "signal": "D9",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE12",
+                            "signal": "DA9",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE13",
+                            "signal": "D10",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE13",
+                            "signal": "DA10",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE14",
+                            "signal": "D11",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE14",
+                            "signal": "DA11",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE15",
+                            "signal": "D12",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE15",
+                            "signal": "DA12",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF0",
+                            "signal": "A0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF1",
+                            "signal": "A1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF2",
+                            "signal": "A2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF3",
+                            "signal": "A3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF4",
+                            "signal": "A4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF5",
+                            "signal": "A5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF6",
+                            "signal": "NIORD",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF7",
+                            "signal": "NREG",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF8",
+                            "signal": "NIOWR",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF9",
+                            "signal": "CD",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF10",
+                            "signal": "INTR",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF12",
+                            "signal": "A6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF13",
+                            "signal": "A7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF14",
+                            "signal": "A8",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF15",
+                            "signal": "A9",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG0",
+                            "signal": "A10",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG1",
+                            "signal": "A11",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG2",
+                            "signal": "A12",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG3",
+                            "signal": "A13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG4",
+                            "signal": "A14",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG5",
+                            "signal": "A15",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG6",
+                            "signal": "INT2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG7",
+                            "signal": "INT3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG9",
+                            "signal": "NCE3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG9",
+                            "signal": "NE2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG10",
+                            "signal": "NCE4_1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG10",
+                            "signal": "NE3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG11",
+                            "signal": "NCE4_2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG12",
+                            "signal": "NE4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG13",
+                            "signal": "A24",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG14",
+                            "signal": "A25",
+                            "af": 12
+                        }
+                    ],
+                    "interrupts": [
+                        {
+                            "interrupt": "FSMC",
+                            "signal": "GLOBAL"
+                        }
+                    ]
+                },
+                {
                     "name": "GPIOA",
                     "address": 1073872896,
                     "registers": {

--- a/data/chips/STM32F207IF.json
+++ b/data/chips/STM32F207IF.json
@@ -1411,6 +1411,444 @@
                     ]
                 },
                 {
+                    "name": "FSMC",
+                    "address": 2684354560,
+                    "registers": {
+                        "kind": "fsmc",
+                        "version": "v1",
+                        "block": "FSMC"
+                    },
+                    "rcc": {
+                        "clock": "AHB3",
+                        "enable": {
+                            "register": "AHB3ENR",
+                            "field": "FSMCEN"
+                        },
+                        "reset": {
+                            "register": "AHB3RSTR",
+                            "field": "FSMCRST"
+                        }
+                    },
+                    "pins": [
+                        {
+                            "pin": "PB7",
+                            "signal": "NL",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD0",
+                            "signal": "D2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD0",
+                            "signal": "DA2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD1",
+                            "signal": "D3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD1",
+                            "signal": "DA3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD3",
+                            "signal": "CLK",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD4",
+                            "signal": "NOE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD5",
+                            "signal": "NWE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD6",
+                            "signal": "NWAIT",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD7",
+                            "signal": "NCE2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD7",
+                            "signal": "NE1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD8",
+                            "signal": "D13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD8",
+                            "signal": "DA13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD9",
+                            "signal": "D14",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD9",
+                            "signal": "DA14",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD10",
+                            "signal": "D15",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD10",
+                            "signal": "DA15",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD11",
+                            "signal": "A16",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD11",
+                            "signal": "CLE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD12",
+                            "signal": "A17",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD12",
+                            "signal": "ALE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD13",
+                            "signal": "A18",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD14",
+                            "signal": "D0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD14",
+                            "signal": "DA0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD15",
+                            "signal": "D1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD15",
+                            "signal": "DA1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE0",
+                            "signal": "NBL0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE1",
+                            "signal": "NBL1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE2",
+                            "signal": "A23",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE3",
+                            "signal": "A19",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE4",
+                            "signal": "A20",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE5",
+                            "signal": "A21",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE6",
+                            "signal": "A22",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE7",
+                            "signal": "D4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE7",
+                            "signal": "DA4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE8",
+                            "signal": "D5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE8",
+                            "signal": "DA5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE9",
+                            "signal": "D6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE9",
+                            "signal": "DA6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE10",
+                            "signal": "D7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE10",
+                            "signal": "DA7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE11",
+                            "signal": "D8",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE11",
+                            "signal": "DA8",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE12",
+                            "signal": "D9",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE12",
+                            "signal": "DA9",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE13",
+                            "signal": "D10",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE13",
+                            "signal": "DA10",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE14",
+                            "signal": "D11",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE14",
+                            "signal": "DA11",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE15",
+                            "signal": "D12",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE15",
+                            "signal": "DA12",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF0",
+                            "signal": "A0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF1",
+                            "signal": "A1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF2",
+                            "signal": "A2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF3",
+                            "signal": "A3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF4",
+                            "signal": "A4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF5",
+                            "signal": "A5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF6",
+                            "signal": "NIORD",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF7",
+                            "signal": "NREG",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF8",
+                            "signal": "NIOWR",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF9",
+                            "signal": "CD",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF10",
+                            "signal": "INTR",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF12",
+                            "signal": "A6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF13",
+                            "signal": "A7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF14",
+                            "signal": "A8",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF15",
+                            "signal": "A9",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG0",
+                            "signal": "A10",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG1",
+                            "signal": "A11",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG2",
+                            "signal": "A12",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG3",
+                            "signal": "A13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG4",
+                            "signal": "A14",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG5",
+                            "signal": "A15",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG6",
+                            "signal": "INT2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG7",
+                            "signal": "INT3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG9",
+                            "signal": "NCE3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG9",
+                            "signal": "NE2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG10",
+                            "signal": "NCE4_1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG10",
+                            "signal": "NE3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG11",
+                            "signal": "NCE4_2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG12",
+                            "signal": "NE4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG13",
+                            "signal": "A24",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG14",
+                            "signal": "A25",
+                            "af": 12
+                        }
+                    ],
+                    "interrupts": [
+                        {
+                            "interrupt": "FSMC",
+                            "signal": "GLOBAL"
+                        }
+                    ]
+                },
+                {
                     "name": "GPIOA",
                     "address": 1073872896,
                     "registers": {

--- a/data/chips/STM32F207IG.json
+++ b/data/chips/STM32F207IG.json
@@ -1411,6 +1411,444 @@
                     ]
                 },
                 {
+                    "name": "FSMC",
+                    "address": 2684354560,
+                    "registers": {
+                        "kind": "fsmc",
+                        "version": "v1",
+                        "block": "FSMC"
+                    },
+                    "rcc": {
+                        "clock": "AHB3",
+                        "enable": {
+                            "register": "AHB3ENR",
+                            "field": "FSMCEN"
+                        },
+                        "reset": {
+                            "register": "AHB3RSTR",
+                            "field": "FSMCRST"
+                        }
+                    },
+                    "pins": [
+                        {
+                            "pin": "PB7",
+                            "signal": "NL",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD0",
+                            "signal": "D2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD0",
+                            "signal": "DA2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD1",
+                            "signal": "D3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD1",
+                            "signal": "DA3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD3",
+                            "signal": "CLK",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD4",
+                            "signal": "NOE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD5",
+                            "signal": "NWE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD6",
+                            "signal": "NWAIT",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD7",
+                            "signal": "NCE2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD7",
+                            "signal": "NE1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD8",
+                            "signal": "D13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD8",
+                            "signal": "DA13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD9",
+                            "signal": "D14",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD9",
+                            "signal": "DA14",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD10",
+                            "signal": "D15",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD10",
+                            "signal": "DA15",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD11",
+                            "signal": "A16",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD11",
+                            "signal": "CLE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD12",
+                            "signal": "A17",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD12",
+                            "signal": "ALE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD13",
+                            "signal": "A18",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD14",
+                            "signal": "D0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD14",
+                            "signal": "DA0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD15",
+                            "signal": "D1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD15",
+                            "signal": "DA1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE0",
+                            "signal": "NBL0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE1",
+                            "signal": "NBL1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE2",
+                            "signal": "A23",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE3",
+                            "signal": "A19",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE4",
+                            "signal": "A20",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE5",
+                            "signal": "A21",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE6",
+                            "signal": "A22",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE7",
+                            "signal": "D4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE7",
+                            "signal": "DA4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE8",
+                            "signal": "D5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE8",
+                            "signal": "DA5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE9",
+                            "signal": "D6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE9",
+                            "signal": "DA6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE10",
+                            "signal": "D7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE10",
+                            "signal": "DA7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE11",
+                            "signal": "D8",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE11",
+                            "signal": "DA8",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE12",
+                            "signal": "D9",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE12",
+                            "signal": "DA9",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE13",
+                            "signal": "D10",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE13",
+                            "signal": "DA10",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE14",
+                            "signal": "D11",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE14",
+                            "signal": "DA11",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE15",
+                            "signal": "D12",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE15",
+                            "signal": "DA12",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF0",
+                            "signal": "A0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF1",
+                            "signal": "A1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF2",
+                            "signal": "A2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF3",
+                            "signal": "A3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF4",
+                            "signal": "A4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF5",
+                            "signal": "A5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF6",
+                            "signal": "NIORD",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF7",
+                            "signal": "NREG",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF8",
+                            "signal": "NIOWR",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF9",
+                            "signal": "CD",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF10",
+                            "signal": "INTR",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF12",
+                            "signal": "A6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF13",
+                            "signal": "A7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF14",
+                            "signal": "A8",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF15",
+                            "signal": "A9",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG0",
+                            "signal": "A10",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG1",
+                            "signal": "A11",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG2",
+                            "signal": "A12",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG3",
+                            "signal": "A13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG4",
+                            "signal": "A14",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG5",
+                            "signal": "A15",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG6",
+                            "signal": "INT2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG7",
+                            "signal": "INT3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG9",
+                            "signal": "NCE3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG9",
+                            "signal": "NE2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG10",
+                            "signal": "NCE4_1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG10",
+                            "signal": "NE3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG11",
+                            "signal": "NCE4_2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG12",
+                            "signal": "NE4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG13",
+                            "signal": "A24",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG14",
+                            "signal": "A25",
+                            "af": 12
+                        }
+                    ],
+                    "interrupts": [
+                        {
+                            "interrupt": "FSMC",
+                            "signal": "GLOBAL"
+                        }
+                    ]
+                },
+                {
                     "name": "GPIOA",
                     "address": 1073872896,
                     "registers": {

--- a/data/chips/STM32F207VC.json
+++ b/data/chips/STM32F207VC.json
@@ -1235,6 +1235,289 @@
                     ]
                 },
                 {
+                    "name": "FSMC",
+                    "address": 2684354560,
+                    "registers": {
+                        "kind": "fsmc",
+                        "version": "v1",
+                        "block": "FSMC"
+                    },
+                    "rcc": {
+                        "clock": "AHB3",
+                        "enable": {
+                            "register": "AHB3ENR",
+                            "field": "FSMCEN"
+                        },
+                        "reset": {
+                            "register": "AHB3RSTR",
+                            "field": "FSMCRST"
+                        }
+                    },
+                    "pins": [
+                        {
+                            "pin": "PB7",
+                            "signal": "NL",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD0",
+                            "signal": "D2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD0",
+                            "signal": "DA2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD1",
+                            "signal": "D3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD1",
+                            "signal": "DA3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD3",
+                            "signal": "CLK",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD4",
+                            "signal": "NOE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD5",
+                            "signal": "NWE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD6",
+                            "signal": "NWAIT",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD7",
+                            "signal": "NCE2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD7",
+                            "signal": "NE1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD8",
+                            "signal": "D13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD8",
+                            "signal": "DA13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD9",
+                            "signal": "D14",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD9",
+                            "signal": "DA14",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD10",
+                            "signal": "D15",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD10",
+                            "signal": "DA15",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD11",
+                            "signal": "A16",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD11",
+                            "signal": "CLE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD12",
+                            "signal": "A17",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD12",
+                            "signal": "ALE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD13",
+                            "signal": "A18",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD14",
+                            "signal": "D0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD14",
+                            "signal": "DA0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD15",
+                            "signal": "D1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD15",
+                            "signal": "DA1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE0",
+                            "signal": "NBL0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE1",
+                            "signal": "NBL1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE2",
+                            "signal": "A23",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE3",
+                            "signal": "A19",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE4",
+                            "signal": "A20",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE5",
+                            "signal": "A21",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE6",
+                            "signal": "A22",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE7",
+                            "signal": "D4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE7",
+                            "signal": "DA4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE8",
+                            "signal": "D5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE8",
+                            "signal": "DA5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE9",
+                            "signal": "D6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE9",
+                            "signal": "DA6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE10",
+                            "signal": "D7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE10",
+                            "signal": "DA7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE11",
+                            "signal": "D8",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE11",
+                            "signal": "DA8",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE12",
+                            "signal": "D9",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE12",
+                            "signal": "DA9",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE13",
+                            "signal": "D10",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE13",
+                            "signal": "DA10",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE14",
+                            "signal": "D11",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE14",
+                            "signal": "DA11",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE15",
+                            "signal": "D12",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE15",
+                            "signal": "DA12",
+                            "af": 12
+                        }
+                    ],
+                    "interrupts": [
+                        {
+                            "interrupt": "FSMC",
+                            "signal": "GLOBAL"
+                        }
+                    ]
+                },
+                {
                     "name": "GPIOA",
                     "address": 1073872896,
                     "registers": {

--- a/data/chips/STM32F207VE.json
+++ b/data/chips/STM32F207VE.json
@@ -1235,6 +1235,289 @@
                     ]
                 },
                 {
+                    "name": "FSMC",
+                    "address": 2684354560,
+                    "registers": {
+                        "kind": "fsmc",
+                        "version": "v1",
+                        "block": "FSMC"
+                    },
+                    "rcc": {
+                        "clock": "AHB3",
+                        "enable": {
+                            "register": "AHB3ENR",
+                            "field": "FSMCEN"
+                        },
+                        "reset": {
+                            "register": "AHB3RSTR",
+                            "field": "FSMCRST"
+                        }
+                    },
+                    "pins": [
+                        {
+                            "pin": "PB7",
+                            "signal": "NL",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD0",
+                            "signal": "D2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD0",
+                            "signal": "DA2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD1",
+                            "signal": "D3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD1",
+                            "signal": "DA3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD3",
+                            "signal": "CLK",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD4",
+                            "signal": "NOE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD5",
+                            "signal": "NWE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD6",
+                            "signal": "NWAIT",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD7",
+                            "signal": "NCE2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD7",
+                            "signal": "NE1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD8",
+                            "signal": "D13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD8",
+                            "signal": "DA13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD9",
+                            "signal": "D14",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD9",
+                            "signal": "DA14",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD10",
+                            "signal": "D15",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD10",
+                            "signal": "DA15",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD11",
+                            "signal": "A16",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD11",
+                            "signal": "CLE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD12",
+                            "signal": "A17",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD12",
+                            "signal": "ALE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD13",
+                            "signal": "A18",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD14",
+                            "signal": "D0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD14",
+                            "signal": "DA0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD15",
+                            "signal": "D1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD15",
+                            "signal": "DA1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE0",
+                            "signal": "NBL0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE1",
+                            "signal": "NBL1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE2",
+                            "signal": "A23",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE3",
+                            "signal": "A19",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE4",
+                            "signal": "A20",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE5",
+                            "signal": "A21",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE6",
+                            "signal": "A22",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE7",
+                            "signal": "D4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE7",
+                            "signal": "DA4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE8",
+                            "signal": "D5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE8",
+                            "signal": "DA5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE9",
+                            "signal": "D6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE9",
+                            "signal": "DA6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE10",
+                            "signal": "D7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE10",
+                            "signal": "DA7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE11",
+                            "signal": "D8",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE11",
+                            "signal": "DA8",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE12",
+                            "signal": "D9",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE12",
+                            "signal": "DA9",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE13",
+                            "signal": "D10",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE13",
+                            "signal": "DA10",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE14",
+                            "signal": "D11",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE14",
+                            "signal": "DA11",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE15",
+                            "signal": "D12",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE15",
+                            "signal": "DA12",
+                            "af": 12
+                        }
+                    ],
+                    "interrupts": [
+                        {
+                            "interrupt": "FSMC",
+                            "signal": "GLOBAL"
+                        }
+                    ]
+                },
+                {
                     "name": "GPIOA",
                     "address": 1073872896,
                     "registers": {

--- a/data/chips/STM32F207VF.json
+++ b/data/chips/STM32F207VF.json
@@ -1235,6 +1235,289 @@
                     ]
                 },
                 {
+                    "name": "FSMC",
+                    "address": 2684354560,
+                    "registers": {
+                        "kind": "fsmc",
+                        "version": "v1",
+                        "block": "FSMC"
+                    },
+                    "rcc": {
+                        "clock": "AHB3",
+                        "enable": {
+                            "register": "AHB3ENR",
+                            "field": "FSMCEN"
+                        },
+                        "reset": {
+                            "register": "AHB3RSTR",
+                            "field": "FSMCRST"
+                        }
+                    },
+                    "pins": [
+                        {
+                            "pin": "PB7",
+                            "signal": "NL",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD0",
+                            "signal": "D2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD0",
+                            "signal": "DA2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD1",
+                            "signal": "D3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD1",
+                            "signal": "DA3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD3",
+                            "signal": "CLK",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD4",
+                            "signal": "NOE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD5",
+                            "signal": "NWE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD6",
+                            "signal": "NWAIT",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD7",
+                            "signal": "NCE2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD7",
+                            "signal": "NE1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD8",
+                            "signal": "D13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD8",
+                            "signal": "DA13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD9",
+                            "signal": "D14",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD9",
+                            "signal": "DA14",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD10",
+                            "signal": "D15",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD10",
+                            "signal": "DA15",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD11",
+                            "signal": "A16",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD11",
+                            "signal": "CLE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD12",
+                            "signal": "A17",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD12",
+                            "signal": "ALE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD13",
+                            "signal": "A18",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD14",
+                            "signal": "D0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD14",
+                            "signal": "DA0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD15",
+                            "signal": "D1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD15",
+                            "signal": "DA1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE0",
+                            "signal": "NBL0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE1",
+                            "signal": "NBL1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE2",
+                            "signal": "A23",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE3",
+                            "signal": "A19",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE4",
+                            "signal": "A20",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE5",
+                            "signal": "A21",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE6",
+                            "signal": "A22",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE7",
+                            "signal": "D4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE7",
+                            "signal": "DA4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE8",
+                            "signal": "D5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE8",
+                            "signal": "DA5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE9",
+                            "signal": "D6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE9",
+                            "signal": "DA6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE10",
+                            "signal": "D7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE10",
+                            "signal": "DA7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE11",
+                            "signal": "D8",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE11",
+                            "signal": "DA8",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE12",
+                            "signal": "D9",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE12",
+                            "signal": "DA9",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE13",
+                            "signal": "D10",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE13",
+                            "signal": "DA10",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE14",
+                            "signal": "D11",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE14",
+                            "signal": "DA11",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE15",
+                            "signal": "D12",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE15",
+                            "signal": "DA12",
+                            "af": 12
+                        }
+                    ],
+                    "interrupts": [
+                        {
+                            "interrupt": "FSMC",
+                            "signal": "GLOBAL"
+                        }
+                    ]
+                },
+                {
                     "name": "GPIOA",
                     "address": 1073872896,
                     "registers": {

--- a/data/chips/STM32F207VG.json
+++ b/data/chips/STM32F207VG.json
@@ -1235,6 +1235,289 @@
                     ]
                 },
                 {
+                    "name": "FSMC",
+                    "address": 2684354560,
+                    "registers": {
+                        "kind": "fsmc",
+                        "version": "v1",
+                        "block": "FSMC"
+                    },
+                    "rcc": {
+                        "clock": "AHB3",
+                        "enable": {
+                            "register": "AHB3ENR",
+                            "field": "FSMCEN"
+                        },
+                        "reset": {
+                            "register": "AHB3RSTR",
+                            "field": "FSMCRST"
+                        }
+                    },
+                    "pins": [
+                        {
+                            "pin": "PB7",
+                            "signal": "NL",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD0",
+                            "signal": "D2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD0",
+                            "signal": "DA2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD1",
+                            "signal": "D3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD1",
+                            "signal": "DA3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD3",
+                            "signal": "CLK",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD4",
+                            "signal": "NOE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD5",
+                            "signal": "NWE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD6",
+                            "signal": "NWAIT",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD7",
+                            "signal": "NCE2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD7",
+                            "signal": "NE1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD8",
+                            "signal": "D13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD8",
+                            "signal": "DA13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD9",
+                            "signal": "D14",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD9",
+                            "signal": "DA14",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD10",
+                            "signal": "D15",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD10",
+                            "signal": "DA15",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD11",
+                            "signal": "A16",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD11",
+                            "signal": "CLE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD12",
+                            "signal": "A17",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD12",
+                            "signal": "ALE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD13",
+                            "signal": "A18",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD14",
+                            "signal": "D0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD14",
+                            "signal": "DA0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD15",
+                            "signal": "D1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD15",
+                            "signal": "DA1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE0",
+                            "signal": "NBL0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE1",
+                            "signal": "NBL1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE2",
+                            "signal": "A23",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE3",
+                            "signal": "A19",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE4",
+                            "signal": "A20",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE5",
+                            "signal": "A21",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE6",
+                            "signal": "A22",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE7",
+                            "signal": "D4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE7",
+                            "signal": "DA4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE8",
+                            "signal": "D5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE8",
+                            "signal": "DA5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE9",
+                            "signal": "D6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE9",
+                            "signal": "DA6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE10",
+                            "signal": "D7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE10",
+                            "signal": "DA7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE11",
+                            "signal": "D8",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE11",
+                            "signal": "DA8",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE12",
+                            "signal": "D9",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE12",
+                            "signal": "DA9",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE13",
+                            "signal": "D10",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE13",
+                            "signal": "DA10",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE14",
+                            "signal": "D11",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE14",
+                            "signal": "DA11",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE15",
+                            "signal": "D12",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE15",
+                            "signal": "DA12",
+                            "af": 12
+                        }
+                    ],
+                    "interrupts": [
+                        {
+                            "interrupt": "FSMC",
+                            "signal": "GLOBAL"
+                        }
+                    ]
+                },
+                {
                     "name": "GPIOA",
                     "address": 1073872896,
                     "registers": {

--- a/data/chips/STM32F207ZC.json
+++ b/data/chips/STM32F207ZC.json
@@ -1297,6 +1297,444 @@
                     ]
                 },
                 {
+                    "name": "FSMC",
+                    "address": 2684354560,
+                    "registers": {
+                        "kind": "fsmc",
+                        "version": "v1",
+                        "block": "FSMC"
+                    },
+                    "rcc": {
+                        "clock": "AHB3",
+                        "enable": {
+                            "register": "AHB3ENR",
+                            "field": "FSMCEN"
+                        },
+                        "reset": {
+                            "register": "AHB3RSTR",
+                            "field": "FSMCRST"
+                        }
+                    },
+                    "pins": [
+                        {
+                            "pin": "PB7",
+                            "signal": "NL",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD0",
+                            "signal": "D2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD0",
+                            "signal": "DA2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD1",
+                            "signal": "D3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD1",
+                            "signal": "DA3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD3",
+                            "signal": "CLK",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD4",
+                            "signal": "NOE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD5",
+                            "signal": "NWE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD6",
+                            "signal": "NWAIT",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD7",
+                            "signal": "NCE2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD7",
+                            "signal": "NE1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD8",
+                            "signal": "D13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD8",
+                            "signal": "DA13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD9",
+                            "signal": "D14",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD9",
+                            "signal": "DA14",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD10",
+                            "signal": "D15",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD10",
+                            "signal": "DA15",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD11",
+                            "signal": "A16",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD11",
+                            "signal": "CLE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD12",
+                            "signal": "A17",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD12",
+                            "signal": "ALE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD13",
+                            "signal": "A18",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD14",
+                            "signal": "D0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD14",
+                            "signal": "DA0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD15",
+                            "signal": "D1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD15",
+                            "signal": "DA1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE0",
+                            "signal": "NBL0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE1",
+                            "signal": "NBL1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE2",
+                            "signal": "A23",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE3",
+                            "signal": "A19",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE4",
+                            "signal": "A20",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE5",
+                            "signal": "A21",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE6",
+                            "signal": "A22",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE7",
+                            "signal": "D4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE7",
+                            "signal": "DA4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE8",
+                            "signal": "D5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE8",
+                            "signal": "DA5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE9",
+                            "signal": "D6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE9",
+                            "signal": "DA6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE10",
+                            "signal": "D7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE10",
+                            "signal": "DA7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE11",
+                            "signal": "D8",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE11",
+                            "signal": "DA8",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE12",
+                            "signal": "D9",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE12",
+                            "signal": "DA9",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE13",
+                            "signal": "D10",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE13",
+                            "signal": "DA10",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE14",
+                            "signal": "D11",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE14",
+                            "signal": "DA11",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE15",
+                            "signal": "D12",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE15",
+                            "signal": "DA12",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF0",
+                            "signal": "A0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF1",
+                            "signal": "A1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF2",
+                            "signal": "A2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF3",
+                            "signal": "A3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF4",
+                            "signal": "A4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF5",
+                            "signal": "A5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF6",
+                            "signal": "NIORD",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF7",
+                            "signal": "NREG",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF8",
+                            "signal": "NIOWR",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF9",
+                            "signal": "CD",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF10",
+                            "signal": "INTR",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF12",
+                            "signal": "A6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF13",
+                            "signal": "A7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF14",
+                            "signal": "A8",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF15",
+                            "signal": "A9",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG0",
+                            "signal": "A10",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG1",
+                            "signal": "A11",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG2",
+                            "signal": "A12",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG3",
+                            "signal": "A13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG4",
+                            "signal": "A14",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG5",
+                            "signal": "A15",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG6",
+                            "signal": "INT2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG7",
+                            "signal": "INT3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG9",
+                            "signal": "NCE3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG9",
+                            "signal": "NE2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG10",
+                            "signal": "NCE4_1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG10",
+                            "signal": "NE3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG11",
+                            "signal": "NCE4_2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG12",
+                            "signal": "NE4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG13",
+                            "signal": "A24",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG14",
+                            "signal": "A25",
+                            "af": 12
+                        }
+                    ],
+                    "interrupts": [
+                        {
+                            "interrupt": "FSMC",
+                            "signal": "GLOBAL"
+                        }
+                    ]
+                },
+                {
                     "name": "GPIOA",
                     "address": 1073872896,
                     "registers": {

--- a/data/chips/STM32F207ZE.json
+++ b/data/chips/STM32F207ZE.json
@@ -1297,6 +1297,444 @@
                     ]
                 },
                 {
+                    "name": "FSMC",
+                    "address": 2684354560,
+                    "registers": {
+                        "kind": "fsmc",
+                        "version": "v1",
+                        "block": "FSMC"
+                    },
+                    "rcc": {
+                        "clock": "AHB3",
+                        "enable": {
+                            "register": "AHB3ENR",
+                            "field": "FSMCEN"
+                        },
+                        "reset": {
+                            "register": "AHB3RSTR",
+                            "field": "FSMCRST"
+                        }
+                    },
+                    "pins": [
+                        {
+                            "pin": "PB7",
+                            "signal": "NL",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD0",
+                            "signal": "D2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD0",
+                            "signal": "DA2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD1",
+                            "signal": "D3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD1",
+                            "signal": "DA3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD3",
+                            "signal": "CLK",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD4",
+                            "signal": "NOE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD5",
+                            "signal": "NWE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD6",
+                            "signal": "NWAIT",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD7",
+                            "signal": "NCE2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD7",
+                            "signal": "NE1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD8",
+                            "signal": "D13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD8",
+                            "signal": "DA13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD9",
+                            "signal": "D14",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD9",
+                            "signal": "DA14",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD10",
+                            "signal": "D15",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD10",
+                            "signal": "DA15",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD11",
+                            "signal": "A16",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD11",
+                            "signal": "CLE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD12",
+                            "signal": "A17",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD12",
+                            "signal": "ALE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD13",
+                            "signal": "A18",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD14",
+                            "signal": "D0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD14",
+                            "signal": "DA0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD15",
+                            "signal": "D1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD15",
+                            "signal": "DA1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE0",
+                            "signal": "NBL0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE1",
+                            "signal": "NBL1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE2",
+                            "signal": "A23",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE3",
+                            "signal": "A19",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE4",
+                            "signal": "A20",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE5",
+                            "signal": "A21",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE6",
+                            "signal": "A22",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE7",
+                            "signal": "D4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE7",
+                            "signal": "DA4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE8",
+                            "signal": "D5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE8",
+                            "signal": "DA5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE9",
+                            "signal": "D6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE9",
+                            "signal": "DA6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE10",
+                            "signal": "D7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE10",
+                            "signal": "DA7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE11",
+                            "signal": "D8",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE11",
+                            "signal": "DA8",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE12",
+                            "signal": "D9",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE12",
+                            "signal": "DA9",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE13",
+                            "signal": "D10",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE13",
+                            "signal": "DA10",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE14",
+                            "signal": "D11",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE14",
+                            "signal": "DA11",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE15",
+                            "signal": "D12",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE15",
+                            "signal": "DA12",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF0",
+                            "signal": "A0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF1",
+                            "signal": "A1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF2",
+                            "signal": "A2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF3",
+                            "signal": "A3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF4",
+                            "signal": "A4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF5",
+                            "signal": "A5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF6",
+                            "signal": "NIORD",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF7",
+                            "signal": "NREG",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF8",
+                            "signal": "NIOWR",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF9",
+                            "signal": "CD",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF10",
+                            "signal": "INTR",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF12",
+                            "signal": "A6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF13",
+                            "signal": "A7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF14",
+                            "signal": "A8",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF15",
+                            "signal": "A9",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG0",
+                            "signal": "A10",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG1",
+                            "signal": "A11",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG2",
+                            "signal": "A12",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG3",
+                            "signal": "A13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG4",
+                            "signal": "A14",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG5",
+                            "signal": "A15",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG6",
+                            "signal": "INT2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG7",
+                            "signal": "INT3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG9",
+                            "signal": "NCE3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG9",
+                            "signal": "NE2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG10",
+                            "signal": "NCE4_1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG10",
+                            "signal": "NE3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG11",
+                            "signal": "NCE4_2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG12",
+                            "signal": "NE4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG13",
+                            "signal": "A24",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG14",
+                            "signal": "A25",
+                            "af": 12
+                        }
+                    ],
+                    "interrupts": [
+                        {
+                            "interrupt": "FSMC",
+                            "signal": "GLOBAL"
+                        }
+                    ]
+                },
+                {
                     "name": "GPIOA",
                     "address": 1073872896,
                     "registers": {

--- a/data/chips/STM32F207ZF.json
+++ b/data/chips/STM32F207ZF.json
@@ -1297,6 +1297,444 @@
                     ]
                 },
                 {
+                    "name": "FSMC",
+                    "address": 2684354560,
+                    "registers": {
+                        "kind": "fsmc",
+                        "version": "v1",
+                        "block": "FSMC"
+                    },
+                    "rcc": {
+                        "clock": "AHB3",
+                        "enable": {
+                            "register": "AHB3ENR",
+                            "field": "FSMCEN"
+                        },
+                        "reset": {
+                            "register": "AHB3RSTR",
+                            "field": "FSMCRST"
+                        }
+                    },
+                    "pins": [
+                        {
+                            "pin": "PB7",
+                            "signal": "NL",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD0",
+                            "signal": "D2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD0",
+                            "signal": "DA2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD1",
+                            "signal": "D3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD1",
+                            "signal": "DA3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD3",
+                            "signal": "CLK",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD4",
+                            "signal": "NOE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD5",
+                            "signal": "NWE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD6",
+                            "signal": "NWAIT",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD7",
+                            "signal": "NCE2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD7",
+                            "signal": "NE1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD8",
+                            "signal": "D13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD8",
+                            "signal": "DA13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD9",
+                            "signal": "D14",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD9",
+                            "signal": "DA14",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD10",
+                            "signal": "D15",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD10",
+                            "signal": "DA15",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD11",
+                            "signal": "A16",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD11",
+                            "signal": "CLE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD12",
+                            "signal": "A17",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD12",
+                            "signal": "ALE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD13",
+                            "signal": "A18",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD14",
+                            "signal": "D0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD14",
+                            "signal": "DA0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD15",
+                            "signal": "D1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD15",
+                            "signal": "DA1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE0",
+                            "signal": "NBL0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE1",
+                            "signal": "NBL1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE2",
+                            "signal": "A23",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE3",
+                            "signal": "A19",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE4",
+                            "signal": "A20",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE5",
+                            "signal": "A21",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE6",
+                            "signal": "A22",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE7",
+                            "signal": "D4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE7",
+                            "signal": "DA4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE8",
+                            "signal": "D5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE8",
+                            "signal": "DA5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE9",
+                            "signal": "D6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE9",
+                            "signal": "DA6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE10",
+                            "signal": "D7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE10",
+                            "signal": "DA7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE11",
+                            "signal": "D8",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE11",
+                            "signal": "DA8",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE12",
+                            "signal": "D9",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE12",
+                            "signal": "DA9",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE13",
+                            "signal": "D10",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE13",
+                            "signal": "DA10",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE14",
+                            "signal": "D11",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE14",
+                            "signal": "DA11",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE15",
+                            "signal": "D12",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE15",
+                            "signal": "DA12",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF0",
+                            "signal": "A0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF1",
+                            "signal": "A1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF2",
+                            "signal": "A2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF3",
+                            "signal": "A3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF4",
+                            "signal": "A4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF5",
+                            "signal": "A5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF6",
+                            "signal": "NIORD",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF7",
+                            "signal": "NREG",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF8",
+                            "signal": "NIOWR",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF9",
+                            "signal": "CD",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF10",
+                            "signal": "INTR",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF12",
+                            "signal": "A6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF13",
+                            "signal": "A7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF14",
+                            "signal": "A8",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF15",
+                            "signal": "A9",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG0",
+                            "signal": "A10",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG1",
+                            "signal": "A11",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG2",
+                            "signal": "A12",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG3",
+                            "signal": "A13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG4",
+                            "signal": "A14",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG5",
+                            "signal": "A15",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG6",
+                            "signal": "INT2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG7",
+                            "signal": "INT3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG9",
+                            "signal": "NCE3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG9",
+                            "signal": "NE2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG10",
+                            "signal": "NCE4_1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG10",
+                            "signal": "NE3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG11",
+                            "signal": "NCE4_2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG12",
+                            "signal": "NE4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG13",
+                            "signal": "A24",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG14",
+                            "signal": "A25",
+                            "af": 12
+                        }
+                    ],
+                    "interrupts": [
+                        {
+                            "interrupt": "FSMC",
+                            "signal": "GLOBAL"
+                        }
+                    ]
+                },
+                {
                     "name": "GPIOA",
                     "address": 1073872896,
                     "registers": {

--- a/data/chips/STM32F207ZG.json
+++ b/data/chips/STM32F207ZG.json
@@ -1297,6 +1297,444 @@
                     ]
                 },
                 {
+                    "name": "FSMC",
+                    "address": 2684354560,
+                    "registers": {
+                        "kind": "fsmc",
+                        "version": "v1",
+                        "block": "FSMC"
+                    },
+                    "rcc": {
+                        "clock": "AHB3",
+                        "enable": {
+                            "register": "AHB3ENR",
+                            "field": "FSMCEN"
+                        },
+                        "reset": {
+                            "register": "AHB3RSTR",
+                            "field": "FSMCRST"
+                        }
+                    },
+                    "pins": [
+                        {
+                            "pin": "PB7",
+                            "signal": "NL",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD0",
+                            "signal": "D2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD0",
+                            "signal": "DA2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD1",
+                            "signal": "D3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD1",
+                            "signal": "DA3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD3",
+                            "signal": "CLK",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD4",
+                            "signal": "NOE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD5",
+                            "signal": "NWE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD6",
+                            "signal": "NWAIT",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD7",
+                            "signal": "NCE2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD7",
+                            "signal": "NE1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD8",
+                            "signal": "D13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD8",
+                            "signal": "DA13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD9",
+                            "signal": "D14",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD9",
+                            "signal": "DA14",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD10",
+                            "signal": "D15",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD10",
+                            "signal": "DA15",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD11",
+                            "signal": "A16",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD11",
+                            "signal": "CLE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD12",
+                            "signal": "A17",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD12",
+                            "signal": "ALE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD13",
+                            "signal": "A18",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD14",
+                            "signal": "D0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD14",
+                            "signal": "DA0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD15",
+                            "signal": "D1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD15",
+                            "signal": "DA1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE0",
+                            "signal": "NBL0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE1",
+                            "signal": "NBL1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE2",
+                            "signal": "A23",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE3",
+                            "signal": "A19",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE4",
+                            "signal": "A20",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE5",
+                            "signal": "A21",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE6",
+                            "signal": "A22",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE7",
+                            "signal": "D4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE7",
+                            "signal": "DA4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE8",
+                            "signal": "D5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE8",
+                            "signal": "DA5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE9",
+                            "signal": "D6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE9",
+                            "signal": "DA6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE10",
+                            "signal": "D7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE10",
+                            "signal": "DA7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE11",
+                            "signal": "D8",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE11",
+                            "signal": "DA8",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE12",
+                            "signal": "D9",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE12",
+                            "signal": "DA9",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE13",
+                            "signal": "D10",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE13",
+                            "signal": "DA10",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE14",
+                            "signal": "D11",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE14",
+                            "signal": "DA11",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE15",
+                            "signal": "D12",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE15",
+                            "signal": "DA12",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF0",
+                            "signal": "A0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF1",
+                            "signal": "A1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF2",
+                            "signal": "A2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF3",
+                            "signal": "A3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF4",
+                            "signal": "A4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF5",
+                            "signal": "A5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF6",
+                            "signal": "NIORD",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF7",
+                            "signal": "NREG",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF8",
+                            "signal": "NIOWR",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF9",
+                            "signal": "CD",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF10",
+                            "signal": "INTR",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF12",
+                            "signal": "A6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF13",
+                            "signal": "A7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF14",
+                            "signal": "A8",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF15",
+                            "signal": "A9",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG0",
+                            "signal": "A10",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG1",
+                            "signal": "A11",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG2",
+                            "signal": "A12",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG3",
+                            "signal": "A13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG4",
+                            "signal": "A14",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG5",
+                            "signal": "A15",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG6",
+                            "signal": "INT2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG7",
+                            "signal": "INT3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG9",
+                            "signal": "NCE3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG9",
+                            "signal": "NE2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG10",
+                            "signal": "NCE4_1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG10",
+                            "signal": "NE3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG11",
+                            "signal": "NCE4_2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG12",
+                            "signal": "NE4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG13",
+                            "signal": "A24",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG14",
+                            "signal": "A25",
+                            "af": 12
+                        }
+                    ],
+                    "interrupts": [
+                        {
+                            "interrupt": "FSMC",
+                            "signal": "GLOBAL"
+                        }
+                    ]
+                },
+                {
                     "name": "GPIOA",
                     "address": 1073872896,
                     "registers": {

--- a/data/chips/STM32F215VE.json
+++ b/data/chips/STM32F215VE.json
@@ -993,6 +993,289 @@
                     ]
                 },
                 {
+                    "name": "FSMC",
+                    "address": 2684354560,
+                    "registers": {
+                        "kind": "fsmc",
+                        "version": "v1",
+                        "block": "FSMC"
+                    },
+                    "rcc": {
+                        "clock": "AHB3",
+                        "enable": {
+                            "register": "AHB3ENR",
+                            "field": "FSMCEN"
+                        },
+                        "reset": {
+                            "register": "AHB3RSTR",
+                            "field": "FSMCRST"
+                        }
+                    },
+                    "pins": [
+                        {
+                            "pin": "PB7",
+                            "signal": "NL",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD0",
+                            "signal": "D2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD0",
+                            "signal": "DA2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD1",
+                            "signal": "D3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD1",
+                            "signal": "DA3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD3",
+                            "signal": "CLK",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD4",
+                            "signal": "NOE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD5",
+                            "signal": "NWE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD6",
+                            "signal": "NWAIT",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD7",
+                            "signal": "NCE2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD7",
+                            "signal": "NE1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD8",
+                            "signal": "D13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD8",
+                            "signal": "DA13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD9",
+                            "signal": "D14",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD9",
+                            "signal": "DA14",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD10",
+                            "signal": "D15",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD10",
+                            "signal": "DA15",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD11",
+                            "signal": "A16",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD11",
+                            "signal": "CLE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD12",
+                            "signal": "A17",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD12",
+                            "signal": "ALE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD13",
+                            "signal": "A18",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD14",
+                            "signal": "D0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD14",
+                            "signal": "DA0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD15",
+                            "signal": "D1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD15",
+                            "signal": "DA1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE0",
+                            "signal": "NBL0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE1",
+                            "signal": "NBL1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE2",
+                            "signal": "A23",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE3",
+                            "signal": "A19",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE4",
+                            "signal": "A20",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE5",
+                            "signal": "A21",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE6",
+                            "signal": "A22",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE7",
+                            "signal": "D4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE7",
+                            "signal": "DA4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE8",
+                            "signal": "D5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE8",
+                            "signal": "DA5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE9",
+                            "signal": "D6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE9",
+                            "signal": "DA6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE10",
+                            "signal": "D7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE10",
+                            "signal": "DA7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE11",
+                            "signal": "D8",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE11",
+                            "signal": "DA8",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE12",
+                            "signal": "D9",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE12",
+                            "signal": "DA9",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE13",
+                            "signal": "D10",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE13",
+                            "signal": "DA10",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE14",
+                            "signal": "D11",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE14",
+                            "signal": "DA11",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE15",
+                            "signal": "D12",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE15",
+                            "signal": "DA12",
+                            "af": 12
+                        }
+                    ],
+                    "interrupts": [
+                        {
+                            "interrupt": "FSMC",
+                            "signal": "GLOBAL"
+                        }
+                    ]
+                },
+                {
                     "name": "GPIOA",
                     "address": 1073872896,
                     "registers": {

--- a/data/chips/STM32F215VG.json
+++ b/data/chips/STM32F215VG.json
@@ -993,6 +993,289 @@
                     ]
                 },
                 {
+                    "name": "FSMC",
+                    "address": 2684354560,
+                    "registers": {
+                        "kind": "fsmc",
+                        "version": "v1",
+                        "block": "FSMC"
+                    },
+                    "rcc": {
+                        "clock": "AHB3",
+                        "enable": {
+                            "register": "AHB3ENR",
+                            "field": "FSMCEN"
+                        },
+                        "reset": {
+                            "register": "AHB3RSTR",
+                            "field": "FSMCRST"
+                        }
+                    },
+                    "pins": [
+                        {
+                            "pin": "PB7",
+                            "signal": "NL",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD0",
+                            "signal": "D2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD0",
+                            "signal": "DA2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD1",
+                            "signal": "D3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD1",
+                            "signal": "DA3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD3",
+                            "signal": "CLK",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD4",
+                            "signal": "NOE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD5",
+                            "signal": "NWE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD6",
+                            "signal": "NWAIT",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD7",
+                            "signal": "NCE2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD7",
+                            "signal": "NE1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD8",
+                            "signal": "D13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD8",
+                            "signal": "DA13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD9",
+                            "signal": "D14",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD9",
+                            "signal": "DA14",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD10",
+                            "signal": "D15",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD10",
+                            "signal": "DA15",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD11",
+                            "signal": "A16",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD11",
+                            "signal": "CLE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD12",
+                            "signal": "A17",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD12",
+                            "signal": "ALE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD13",
+                            "signal": "A18",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD14",
+                            "signal": "D0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD14",
+                            "signal": "DA0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD15",
+                            "signal": "D1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD15",
+                            "signal": "DA1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE0",
+                            "signal": "NBL0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE1",
+                            "signal": "NBL1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE2",
+                            "signal": "A23",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE3",
+                            "signal": "A19",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE4",
+                            "signal": "A20",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE5",
+                            "signal": "A21",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE6",
+                            "signal": "A22",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE7",
+                            "signal": "D4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE7",
+                            "signal": "DA4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE8",
+                            "signal": "D5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE8",
+                            "signal": "DA5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE9",
+                            "signal": "D6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE9",
+                            "signal": "DA6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE10",
+                            "signal": "D7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE10",
+                            "signal": "DA7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE11",
+                            "signal": "D8",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE11",
+                            "signal": "DA8",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE12",
+                            "signal": "D9",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE12",
+                            "signal": "DA9",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE13",
+                            "signal": "D10",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE13",
+                            "signal": "DA10",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE14",
+                            "signal": "D11",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE14",
+                            "signal": "DA11",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE15",
+                            "signal": "D12",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE15",
+                            "signal": "DA12",
+                            "af": 12
+                        }
+                    ],
+                    "interrupts": [
+                        {
+                            "interrupt": "FSMC",
+                            "signal": "GLOBAL"
+                        }
+                    ]
+                },
+                {
                     "name": "GPIOA",
                     "address": 1073872896,
                     "registers": {

--- a/data/chips/STM32F215ZE.json
+++ b/data/chips/STM32F215ZE.json
@@ -1025,6 +1025,444 @@
                     ]
                 },
                 {
+                    "name": "FSMC",
+                    "address": 2684354560,
+                    "registers": {
+                        "kind": "fsmc",
+                        "version": "v1",
+                        "block": "FSMC"
+                    },
+                    "rcc": {
+                        "clock": "AHB3",
+                        "enable": {
+                            "register": "AHB3ENR",
+                            "field": "FSMCEN"
+                        },
+                        "reset": {
+                            "register": "AHB3RSTR",
+                            "field": "FSMCRST"
+                        }
+                    },
+                    "pins": [
+                        {
+                            "pin": "PB7",
+                            "signal": "NL",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD0",
+                            "signal": "D2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD0",
+                            "signal": "DA2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD1",
+                            "signal": "D3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD1",
+                            "signal": "DA3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD3",
+                            "signal": "CLK",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD4",
+                            "signal": "NOE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD5",
+                            "signal": "NWE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD6",
+                            "signal": "NWAIT",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD7",
+                            "signal": "NCE2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD7",
+                            "signal": "NE1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD8",
+                            "signal": "D13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD8",
+                            "signal": "DA13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD9",
+                            "signal": "D14",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD9",
+                            "signal": "DA14",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD10",
+                            "signal": "D15",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD10",
+                            "signal": "DA15",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD11",
+                            "signal": "A16",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD11",
+                            "signal": "CLE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD12",
+                            "signal": "A17",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD12",
+                            "signal": "ALE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD13",
+                            "signal": "A18",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD14",
+                            "signal": "D0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD14",
+                            "signal": "DA0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD15",
+                            "signal": "D1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD15",
+                            "signal": "DA1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE0",
+                            "signal": "NBL0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE1",
+                            "signal": "NBL1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE2",
+                            "signal": "A23",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE3",
+                            "signal": "A19",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE4",
+                            "signal": "A20",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE5",
+                            "signal": "A21",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE6",
+                            "signal": "A22",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE7",
+                            "signal": "D4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE7",
+                            "signal": "DA4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE8",
+                            "signal": "D5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE8",
+                            "signal": "DA5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE9",
+                            "signal": "D6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE9",
+                            "signal": "DA6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE10",
+                            "signal": "D7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE10",
+                            "signal": "DA7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE11",
+                            "signal": "D8",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE11",
+                            "signal": "DA8",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE12",
+                            "signal": "D9",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE12",
+                            "signal": "DA9",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE13",
+                            "signal": "D10",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE13",
+                            "signal": "DA10",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE14",
+                            "signal": "D11",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE14",
+                            "signal": "DA11",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE15",
+                            "signal": "D12",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE15",
+                            "signal": "DA12",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF0",
+                            "signal": "A0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF1",
+                            "signal": "A1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF2",
+                            "signal": "A2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF3",
+                            "signal": "A3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF4",
+                            "signal": "A4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF5",
+                            "signal": "A5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF6",
+                            "signal": "NIORD",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF7",
+                            "signal": "NREG",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF8",
+                            "signal": "NIOWR",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF9",
+                            "signal": "CD",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF10",
+                            "signal": "INTR",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF12",
+                            "signal": "A6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF13",
+                            "signal": "A7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF14",
+                            "signal": "A8",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF15",
+                            "signal": "A9",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG0",
+                            "signal": "A10",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG1",
+                            "signal": "A11",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG2",
+                            "signal": "A12",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG3",
+                            "signal": "A13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG4",
+                            "signal": "A14",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG5",
+                            "signal": "A15",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG6",
+                            "signal": "INT2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG7",
+                            "signal": "INT3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG9",
+                            "signal": "NCE3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG9",
+                            "signal": "NE2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG10",
+                            "signal": "NCE4_1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG10",
+                            "signal": "NE3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG11",
+                            "signal": "NCE4_2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG12",
+                            "signal": "NE4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG13",
+                            "signal": "A24",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG14",
+                            "signal": "A25",
+                            "af": 12
+                        }
+                    ],
+                    "interrupts": [
+                        {
+                            "interrupt": "FSMC",
+                            "signal": "GLOBAL"
+                        }
+                    ]
+                },
+                {
                     "name": "GPIOA",
                     "address": 1073872896,
                     "registers": {

--- a/data/chips/STM32F215ZG.json
+++ b/data/chips/STM32F215ZG.json
@@ -1025,6 +1025,444 @@
                     ]
                 },
                 {
+                    "name": "FSMC",
+                    "address": 2684354560,
+                    "registers": {
+                        "kind": "fsmc",
+                        "version": "v1",
+                        "block": "FSMC"
+                    },
+                    "rcc": {
+                        "clock": "AHB3",
+                        "enable": {
+                            "register": "AHB3ENR",
+                            "field": "FSMCEN"
+                        },
+                        "reset": {
+                            "register": "AHB3RSTR",
+                            "field": "FSMCRST"
+                        }
+                    },
+                    "pins": [
+                        {
+                            "pin": "PB7",
+                            "signal": "NL",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD0",
+                            "signal": "D2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD0",
+                            "signal": "DA2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD1",
+                            "signal": "D3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD1",
+                            "signal": "DA3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD3",
+                            "signal": "CLK",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD4",
+                            "signal": "NOE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD5",
+                            "signal": "NWE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD6",
+                            "signal": "NWAIT",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD7",
+                            "signal": "NCE2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD7",
+                            "signal": "NE1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD8",
+                            "signal": "D13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD8",
+                            "signal": "DA13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD9",
+                            "signal": "D14",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD9",
+                            "signal": "DA14",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD10",
+                            "signal": "D15",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD10",
+                            "signal": "DA15",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD11",
+                            "signal": "A16",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD11",
+                            "signal": "CLE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD12",
+                            "signal": "A17",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD12",
+                            "signal": "ALE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD13",
+                            "signal": "A18",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD14",
+                            "signal": "D0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD14",
+                            "signal": "DA0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD15",
+                            "signal": "D1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD15",
+                            "signal": "DA1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE0",
+                            "signal": "NBL0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE1",
+                            "signal": "NBL1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE2",
+                            "signal": "A23",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE3",
+                            "signal": "A19",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE4",
+                            "signal": "A20",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE5",
+                            "signal": "A21",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE6",
+                            "signal": "A22",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE7",
+                            "signal": "D4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE7",
+                            "signal": "DA4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE8",
+                            "signal": "D5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE8",
+                            "signal": "DA5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE9",
+                            "signal": "D6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE9",
+                            "signal": "DA6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE10",
+                            "signal": "D7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE10",
+                            "signal": "DA7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE11",
+                            "signal": "D8",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE11",
+                            "signal": "DA8",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE12",
+                            "signal": "D9",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE12",
+                            "signal": "DA9",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE13",
+                            "signal": "D10",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE13",
+                            "signal": "DA10",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE14",
+                            "signal": "D11",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE14",
+                            "signal": "DA11",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE15",
+                            "signal": "D12",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE15",
+                            "signal": "DA12",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF0",
+                            "signal": "A0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF1",
+                            "signal": "A1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF2",
+                            "signal": "A2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF3",
+                            "signal": "A3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF4",
+                            "signal": "A4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF5",
+                            "signal": "A5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF6",
+                            "signal": "NIORD",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF7",
+                            "signal": "NREG",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF8",
+                            "signal": "NIOWR",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF9",
+                            "signal": "CD",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF10",
+                            "signal": "INTR",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF12",
+                            "signal": "A6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF13",
+                            "signal": "A7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF14",
+                            "signal": "A8",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF15",
+                            "signal": "A9",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG0",
+                            "signal": "A10",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG1",
+                            "signal": "A11",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG2",
+                            "signal": "A12",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG3",
+                            "signal": "A13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG4",
+                            "signal": "A14",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG5",
+                            "signal": "A15",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG6",
+                            "signal": "INT2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG7",
+                            "signal": "INT3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG9",
+                            "signal": "NCE3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG9",
+                            "signal": "NE2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG10",
+                            "signal": "NCE4_1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG10",
+                            "signal": "NE3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG11",
+                            "signal": "NCE4_2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG12",
+                            "signal": "NE4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG13",
+                            "signal": "A24",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG14",
+                            "signal": "A25",
+                            "af": 12
+                        }
+                    ],
+                    "interrupts": [
+                        {
+                            "interrupt": "FSMC",
+                            "signal": "GLOBAL"
+                        }
+                    ]
+                },
+                {
                     "name": "GPIOA",
                     "address": 1073872896,
                     "registers": {

--- a/data/chips/STM32F217IE.json
+++ b/data/chips/STM32F217IE.json
@@ -1444,6 +1444,444 @@
                     ]
                 },
                 {
+                    "name": "FSMC",
+                    "address": 2684354560,
+                    "registers": {
+                        "kind": "fsmc",
+                        "version": "v1",
+                        "block": "FSMC"
+                    },
+                    "rcc": {
+                        "clock": "AHB3",
+                        "enable": {
+                            "register": "AHB3ENR",
+                            "field": "FSMCEN"
+                        },
+                        "reset": {
+                            "register": "AHB3RSTR",
+                            "field": "FSMCRST"
+                        }
+                    },
+                    "pins": [
+                        {
+                            "pin": "PB7",
+                            "signal": "NL",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD0",
+                            "signal": "D2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD0",
+                            "signal": "DA2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD1",
+                            "signal": "D3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD1",
+                            "signal": "DA3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD3",
+                            "signal": "CLK",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD4",
+                            "signal": "NOE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD5",
+                            "signal": "NWE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD6",
+                            "signal": "NWAIT",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD7",
+                            "signal": "NCE2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD7",
+                            "signal": "NE1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD8",
+                            "signal": "D13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD8",
+                            "signal": "DA13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD9",
+                            "signal": "D14",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD9",
+                            "signal": "DA14",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD10",
+                            "signal": "D15",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD10",
+                            "signal": "DA15",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD11",
+                            "signal": "A16",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD11",
+                            "signal": "CLE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD12",
+                            "signal": "A17",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD12",
+                            "signal": "ALE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD13",
+                            "signal": "A18",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD14",
+                            "signal": "D0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD14",
+                            "signal": "DA0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD15",
+                            "signal": "D1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD15",
+                            "signal": "DA1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE0",
+                            "signal": "NBL0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE1",
+                            "signal": "NBL1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE2",
+                            "signal": "A23",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE3",
+                            "signal": "A19",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE4",
+                            "signal": "A20",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE5",
+                            "signal": "A21",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE6",
+                            "signal": "A22",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE7",
+                            "signal": "D4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE7",
+                            "signal": "DA4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE8",
+                            "signal": "D5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE8",
+                            "signal": "DA5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE9",
+                            "signal": "D6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE9",
+                            "signal": "DA6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE10",
+                            "signal": "D7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE10",
+                            "signal": "DA7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE11",
+                            "signal": "D8",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE11",
+                            "signal": "DA8",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE12",
+                            "signal": "D9",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE12",
+                            "signal": "DA9",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE13",
+                            "signal": "D10",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE13",
+                            "signal": "DA10",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE14",
+                            "signal": "D11",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE14",
+                            "signal": "DA11",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE15",
+                            "signal": "D12",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE15",
+                            "signal": "DA12",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF0",
+                            "signal": "A0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF1",
+                            "signal": "A1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF2",
+                            "signal": "A2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF3",
+                            "signal": "A3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF4",
+                            "signal": "A4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF5",
+                            "signal": "A5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF6",
+                            "signal": "NIORD",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF7",
+                            "signal": "NREG",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF8",
+                            "signal": "NIOWR",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF9",
+                            "signal": "CD",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF10",
+                            "signal": "INTR",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF12",
+                            "signal": "A6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF13",
+                            "signal": "A7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF14",
+                            "signal": "A8",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF15",
+                            "signal": "A9",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG0",
+                            "signal": "A10",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG1",
+                            "signal": "A11",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG2",
+                            "signal": "A12",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG3",
+                            "signal": "A13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG4",
+                            "signal": "A14",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG5",
+                            "signal": "A15",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG6",
+                            "signal": "INT2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG7",
+                            "signal": "INT3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG9",
+                            "signal": "NCE3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG9",
+                            "signal": "NE2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG10",
+                            "signal": "NCE4_1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG10",
+                            "signal": "NE3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG11",
+                            "signal": "NCE4_2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG12",
+                            "signal": "NE4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG13",
+                            "signal": "A24",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG14",
+                            "signal": "A25",
+                            "af": 12
+                        }
+                    ],
+                    "interrupts": [
+                        {
+                            "interrupt": "FSMC",
+                            "signal": "GLOBAL"
+                        }
+                    ]
+                },
+                {
                     "name": "GPIOA",
                     "address": 1073872896,
                     "registers": {

--- a/data/chips/STM32F217IG.json
+++ b/data/chips/STM32F217IG.json
@@ -1444,6 +1444,444 @@
                     ]
                 },
                 {
+                    "name": "FSMC",
+                    "address": 2684354560,
+                    "registers": {
+                        "kind": "fsmc",
+                        "version": "v1",
+                        "block": "FSMC"
+                    },
+                    "rcc": {
+                        "clock": "AHB3",
+                        "enable": {
+                            "register": "AHB3ENR",
+                            "field": "FSMCEN"
+                        },
+                        "reset": {
+                            "register": "AHB3RSTR",
+                            "field": "FSMCRST"
+                        }
+                    },
+                    "pins": [
+                        {
+                            "pin": "PB7",
+                            "signal": "NL",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD0",
+                            "signal": "D2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD0",
+                            "signal": "DA2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD1",
+                            "signal": "D3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD1",
+                            "signal": "DA3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD3",
+                            "signal": "CLK",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD4",
+                            "signal": "NOE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD5",
+                            "signal": "NWE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD6",
+                            "signal": "NWAIT",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD7",
+                            "signal": "NCE2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD7",
+                            "signal": "NE1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD8",
+                            "signal": "D13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD8",
+                            "signal": "DA13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD9",
+                            "signal": "D14",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD9",
+                            "signal": "DA14",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD10",
+                            "signal": "D15",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD10",
+                            "signal": "DA15",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD11",
+                            "signal": "A16",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD11",
+                            "signal": "CLE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD12",
+                            "signal": "A17",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD12",
+                            "signal": "ALE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD13",
+                            "signal": "A18",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD14",
+                            "signal": "D0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD14",
+                            "signal": "DA0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD15",
+                            "signal": "D1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD15",
+                            "signal": "DA1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE0",
+                            "signal": "NBL0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE1",
+                            "signal": "NBL1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE2",
+                            "signal": "A23",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE3",
+                            "signal": "A19",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE4",
+                            "signal": "A20",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE5",
+                            "signal": "A21",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE6",
+                            "signal": "A22",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE7",
+                            "signal": "D4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE7",
+                            "signal": "DA4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE8",
+                            "signal": "D5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE8",
+                            "signal": "DA5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE9",
+                            "signal": "D6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE9",
+                            "signal": "DA6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE10",
+                            "signal": "D7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE10",
+                            "signal": "DA7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE11",
+                            "signal": "D8",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE11",
+                            "signal": "DA8",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE12",
+                            "signal": "D9",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE12",
+                            "signal": "DA9",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE13",
+                            "signal": "D10",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE13",
+                            "signal": "DA10",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE14",
+                            "signal": "D11",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE14",
+                            "signal": "DA11",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE15",
+                            "signal": "D12",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE15",
+                            "signal": "DA12",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF0",
+                            "signal": "A0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF1",
+                            "signal": "A1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF2",
+                            "signal": "A2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF3",
+                            "signal": "A3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF4",
+                            "signal": "A4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF5",
+                            "signal": "A5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF6",
+                            "signal": "NIORD",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF7",
+                            "signal": "NREG",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF8",
+                            "signal": "NIOWR",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF9",
+                            "signal": "CD",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF10",
+                            "signal": "INTR",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF12",
+                            "signal": "A6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF13",
+                            "signal": "A7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF14",
+                            "signal": "A8",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF15",
+                            "signal": "A9",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG0",
+                            "signal": "A10",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG1",
+                            "signal": "A11",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG2",
+                            "signal": "A12",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG3",
+                            "signal": "A13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG4",
+                            "signal": "A14",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG5",
+                            "signal": "A15",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG6",
+                            "signal": "INT2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG7",
+                            "signal": "INT3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG9",
+                            "signal": "NCE3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG9",
+                            "signal": "NE2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG10",
+                            "signal": "NCE4_1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG10",
+                            "signal": "NE3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG11",
+                            "signal": "NCE4_2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG12",
+                            "signal": "NE4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG13",
+                            "signal": "A24",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG14",
+                            "signal": "A25",
+                            "af": 12
+                        }
+                    ],
+                    "interrupts": [
+                        {
+                            "interrupt": "FSMC",
+                            "signal": "GLOBAL"
+                        }
+                    ]
+                },
+                {
                     "name": "GPIOA",
                     "address": 1073872896,
                     "registers": {

--- a/data/chips/STM32F217VE.json
+++ b/data/chips/STM32F217VE.json
@@ -1268,6 +1268,289 @@
                     ]
                 },
                 {
+                    "name": "FSMC",
+                    "address": 2684354560,
+                    "registers": {
+                        "kind": "fsmc",
+                        "version": "v1",
+                        "block": "FSMC"
+                    },
+                    "rcc": {
+                        "clock": "AHB3",
+                        "enable": {
+                            "register": "AHB3ENR",
+                            "field": "FSMCEN"
+                        },
+                        "reset": {
+                            "register": "AHB3RSTR",
+                            "field": "FSMCRST"
+                        }
+                    },
+                    "pins": [
+                        {
+                            "pin": "PB7",
+                            "signal": "NL",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD0",
+                            "signal": "D2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD0",
+                            "signal": "DA2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD1",
+                            "signal": "D3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD1",
+                            "signal": "DA3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD3",
+                            "signal": "CLK",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD4",
+                            "signal": "NOE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD5",
+                            "signal": "NWE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD6",
+                            "signal": "NWAIT",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD7",
+                            "signal": "NCE2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD7",
+                            "signal": "NE1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD8",
+                            "signal": "D13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD8",
+                            "signal": "DA13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD9",
+                            "signal": "D14",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD9",
+                            "signal": "DA14",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD10",
+                            "signal": "D15",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD10",
+                            "signal": "DA15",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD11",
+                            "signal": "A16",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD11",
+                            "signal": "CLE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD12",
+                            "signal": "A17",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD12",
+                            "signal": "ALE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD13",
+                            "signal": "A18",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD14",
+                            "signal": "D0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD14",
+                            "signal": "DA0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD15",
+                            "signal": "D1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD15",
+                            "signal": "DA1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE0",
+                            "signal": "NBL0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE1",
+                            "signal": "NBL1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE2",
+                            "signal": "A23",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE3",
+                            "signal": "A19",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE4",
+                            "signal": "A20",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE5",
+                            "signal": "A21",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE6",
+                            "signal": "A22",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE7",
+                            "signal": "D4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE7",
+                            "signal": "DA4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE8",
+                            "signal": "D5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE8",
+                            "signal": "DA5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE9",
+                            "signal": "D6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE9",
+                            "signal": "DA6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE10",
+                            "signal": "D7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE10",
+                            "signal": "DA7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE11",
+                            "signal": "D8",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE11",
+                            "signal": "DA8",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE12",
+                            "signal": "D9",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE12",
+                            "signal": "DA9",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE13",
+                            "signal": "D10",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE13",
+                            "signal": "DA10",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE14",
+                            "signal": "D11",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE14",
+                            "signal": "DA11",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE15",
+                            "signal": "D12",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE15",
+                            "signal": "DA12",
+                            "af": 12
+                        }
+                    ],
+                    "interrupts": [
+                        {
+                            "interrupt": "FSMC",
+                            "signal": "GLOBAL"
+                        }
+                    ]
+                },
+                {
                     "name": "GPIOA",
                     "address": 1073872896,
                     "registers": {

--- a/data/chips/STM32F217VG.json
+++ b/data/chips/STM32F217VG.json
@@ -1268,6 +1268,289 @@
                     ]
                 },
                 {
+                    "name": "FSMC",
+                    "address": 2684354560,
+                    "registers": {
+                        "kind": "fsmc",
+                        "version": "v1",
+                        "block": "FSMC"
+                    },
+                    "rcc": {
+                        "clock": "AHB3",
+                        "enable": {
+                            "register": "AHB3ENR",
+                            "field": "FSMCEN"
+                        },
+                        "reset": {
+                            "register": "AHB3RSTR",
+                            "field": "FSMCRST"
+                        }
+                    },
+                    "pins": [
+                        {
+                            "pin": "PB7",
+                            "signal": "NL",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD0",
+                            "signal": "D2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD0",
+                            "signal": "DA2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD1",
+                            "signal": "D3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD1",
+                            "signal": "DA3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD3",
+                            "signal": "CLK",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD4",
+                            "signal": "NOE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD5",
+                            "signal": "NWE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD6",
+                            "signal": "NWAIT",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD7",
+                            "signal": "NCE2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD7",
+                            "signal": "NE1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD8",
+                            "signal": "D13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD8",
+                            "signal": "DA13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD9",
+                            "signal": "D14",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD9",
+                            "signal": "DA14",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD10",
+                            "signal": "D15",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD10",
+                            "signal": "DA15",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD11",
+                            "signal": "A16",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD11",
+                            "signal": "CLE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD12",
+                            "signal": "A17",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD12",
+                            "signal": "ALE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD13",
+                            "signal": "A18",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD14",
+                            "signal": "D0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD14",
+                            "signal": "DA0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD15",
+                            "signal": "D1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD15",
+                            "signal": "DA1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE0",
+                            "signal": "NBL0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE1",
+                            "signal": "NBL1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE2",
+                            "signal": "A23",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE3",
+                            "signal": "A19",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE4",
+                            "signal": "A20",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE5",
+                            "signal": "A21",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE6",
+                            "signal": "A22",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE7",
+                            "signal": "D4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE7",
+                            "signal": "DA4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE8",
+                            "signal": "D5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE8",
+                            "signal": "DA5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE9",
+                            "signal": "D6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE9",
+                            "signal": "DA6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE10",
+                            "signal": "D7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE10",
+                            "signal": "DA7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE11",
+                            "signal": "D8",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE11",
+                            "signal": "DA8",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE12",
+                            "signal": "D9",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE12",
+                            "signal": "DA9",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE13",
+                            "signal": "D10",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE13",
+                            "signal": "DA10",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE14",
+                            "signal": "D11",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE14",
+                            "signal": "DA11",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE15",
+                            "signal": "D12",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE15",
+                            "signal": "DA12",
+                            "af": 12
+                        }
+                    ],
+                    "interrupts": [
+                        {
+                            "interrupt": "FSMC",
+                            "signal": "GLOBAL"
+                        }
+                    ]
+                },
+                {
                     "name": "GPIOA",
                     "address": 1073872896,
                     "registers": {

--- a/data/chips/STM32F217ZE.json
+++ b/data/chips/STM32F217ZE.json
@@ -1330,6 +1330,444 @@
                     ]
                 },
                 {
+                    "name": "FSMC",
+                    "address": 2684354560,
+                    "registers": {
+                        "kind": "fsmc",
+                        "version": "v1",
+                        "block": "FSMC"
+                    },
+                    "rcc": {
+                        "clock": "AHB3",
+                        "enable": {
+                            "register": "AHB3ENR",
+                            "field": "FSMCEN"
+                        },
+                        "reset": {
+                            "register": "AHB3RSTR",
+                            "field": "FSMCRST"
+                        }
+                    },
+                    "pins": [
+                        {
+                            "pin": "PB7",
+                            "signal": "NL",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD0",
+                            "signal": "D2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD0",
+                            "signal": "DA2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD1",
+                            "signal": "D3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD1",
+                            "signal": "DA3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD3",
+                            "signal": "CLK",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD4",
+                            "signal": "NOE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD5",
+                            "signal": "NWE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD6",
+                            "signal": "NWAIT",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD7",
+                            "signal": "NCE2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD7",
+                            "signal": "NE1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD8",
+                            "signal": "D13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD8",
+                            "signal": "DA13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD9",
+                            "signal": "D14",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD9",
+                            "signal": "DA14",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD10",
+                            "signal": "D15",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD10",
+                            "signal": "DA15",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD11",
+                            "signal": "A16",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD11",
+                            "signal": "CLE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD12",
+                            "signal": "A17",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD12",
+                            "signal": "ALE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD13",
+                            "signal": "A18",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD14",
+                            "signal": "D0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD14",
+                            "signal": "DA0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD15",
+                            "signal": "D1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD15",
+                            "signal": "DA1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE0",
+                            "signal": "NBL0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE1",
+                            "signal": "NBL1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE2",
+                            "signal": "A23",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE3",
+                            "signal": "A19",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE4",
+                            "signal": "A20",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE5",
+                            "signal": "A21",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE6",
+                            "signal": "A22",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE7",
+                            "signal": "D4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE7",
+                            "signal": "DA4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE8",
+                            "signal": "D5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE8",
+                            "signal": "DA5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE9",
+                            "signal": "D6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE9",
+                            "signal": "DA6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE10",
+                            "signal": "D7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE10",
+                            "signal": "DA7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE11",
+                            "signal": "D8",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE11",
+                            "signal": "DA8",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE12",
+                            "signal": "D9",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE12",
+                            "signal": "DA9",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE13",
+                            "signal": "D10",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE13",
+                            "signal": "DA10",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE14",
+                            "signal": "D11",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE14",
+                            "signal": "DA11",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE15",
+                            "signal": "D12",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE15",
+                            "signal": "DA12",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF0",
+                            "signal": "A0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF1",
+                            "signal": "A1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF2",
+                            "signal": "A2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF3",
+                            "signal": "A3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF4",
+                            "signal": "A4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF5",
+                            "signal": "A5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF6",
+                            "signal": "NIORD",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF7",
+                            "signal": "NREG",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF8",
+                            "signal": "NIOWR",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF9",
+                            "signal": "CD",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF10",
+                            "signal": "INTR",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF12",
+                            "signal": "A6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF13",
+                            "signal": "A7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF14",
+                            "signal": "A8",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF15",
+                            "signal": "A9",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG0",
+                            "signal": "A10",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG1",
+                            "signal": "A11",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG2",
+                            "signal": "A12",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG3",
+                            "signal": "A13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG4",
+                            "signal": "A14",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG5",
+                            "signal": "A15",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG6",
+                            "signal": "INT2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG7",
+                            "signal": "INT3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG9",
+                            "signal": "NCE3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG9",
+                            "signal": "NE2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG10",
+                            "signal": "NCE4_1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG10",
+                            "signal": "NE3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG11",
+                            "signal": "NCE4_2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG12",
+                            "signal": "NE4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG13",
+                            "signal": "A24",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG14",
+                            "signal": "A25",
+                            "af": 12
+                        }
+                    ],
+                    "interrupts": [
+                        {
+                            "interrupt": "FSMC",
+                            "signal": "GLOBAL"
+                        }
+                    ]
+                },
+                {
                     "name": "GPIOA",
                     "address": 1073872896,
                     "registers": {

--- a/data/chips/STM32F217ZG.json
+++ b/data/chips/STM32F217ZG.json
@@ -1330,6 +1330,444 @@
                     ]
                 },
                 {
+                    "name": "FSMC",
+                    "address": 2684354560,
+                    "registers": {
+                        "kind": "fsmc",
+                        "version": "v1",
+                        "block": "FSMC"
+                    },
+                    "rcc": {
+                        "clock": "AHB3",
+                        "enable": {
+                            "register": "AHB3ENR",
+                            "field": "FSMCEN"
+                        },
+                        "reset": {
+                            "register": "AHB3RSTR",
+                            "field": "FSMCRST"
+                        }
+                    },
+                    "pins": [
+                        {
+                            "pin": "PB7",
+                            "signal": "NL",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD0",
+                            "signal": "D2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD0",
+                            "signal": "DA2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD1",
+                            "signal": "D3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD1",
+                            "signal": "DA3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD3",
+                            "signal": "CLK",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD4",
+                            "signal": "NOE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD5",
+                            "signal": "NWE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD6",
+                            "signal": "NWAIT",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD7",
+                            "signal": "NCE2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD7",
+                            "signal": "NE1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD8",
+                            "signal": "D13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD8",
+                            "signal": "DA13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD9",
+                            "signal": "D14",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD9",
+                            "signal": "DA14",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD10",
+                            "signal": "D15",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD10",
+                            "signal": "DA15",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD11",
+                            "signal": "A16",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD11",
+                            "signal": "CLE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD12",
+                            "signal": "A17",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD12",
+                            "signal": "ALE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD13",
+                            "signal": "A18",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD14",
+                            "signal": "D0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD14",
+                            "signal": "DA0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD15",
+                            "signal": "D1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD15",
+                            "signal": "DA1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE0",
+                            "signal": "NBL0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE1",
+                            "signal": "NBL1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE2",
+                            "signal": "A23",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE3",
+                            "signal": "A19",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE4",
+                            "signal": "A20",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE5",
+                            "signal": "A21",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE6",
+                            "signal": "A22",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE7",
+                            "signal": "D4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE7",
+                            "signal": "DA4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE8",
+                            "signal": "D5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE8",
+                            "signal": "DA5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE9",
+                            "signal": "D6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE9",
+                            "signal": "DA6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE10",
+                            "signal": "D7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE10",
+                            "signal": "DA7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE11",
+                            "signal": "D8",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE11",
+                            "signal": "DA8",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE12",
+                            "signal": "D9",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE12",
+                            "signal": "DA9",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE13",
+                            "signal": "D10",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE13",
+                            "signal": "DA10",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE14",
+                            "signal": "D11",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE14",
+                            "signal": "DA11",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE15",
+                            "signal": "D12",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE15",
+                            "signal": "DA12",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF0",
+                            "signal": "A0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF1",
+                            "signal": "A1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF2",
+                            "signal": "A2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF3",
+                            "signal": "A3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF4",
+                            "signal": "A4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF5",
+                            "signal": "A5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF6",
+                            "signal": "NIORD",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF7",
+                            "signal": "NREG",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF8",
+                            "signal": "NIOWR",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF9",
+                            "signal": "CD",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF10",
+                            "signal": "INTR",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF12",
+                            "signal": "A6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF13",
+                            "signal": "A7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF14",
+                            "signal": "A8",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF15",
+                            "signal": "A9",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG0",
+                            "signal": "A10",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG1",
+                            "signal": "A11",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG2",
+                            "signal": "A12",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG3",
+                            "signal": "A13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG4",
+                            "signal": "A14",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG5",
+                            "signal": "A15",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG6",
+                            "signal": "INT2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG7",
+                            "signal": "INT3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG9",
+                            "signal": "NCE3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG9",
+                            "signal": "NE2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG10",
+                            "signal": "NCE4_1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG10",
+                            "signal": "NE3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG11",
+                            "signal": "NCE4_2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG12",
+                            "signal": "NE4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG13",
+                            "signal": "A24",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG14",
+                            "signal": "A25",
+                            "af": 12
+                        }
+                    ],
+                    "interrupts": [
+                        {
+                            "interrupt": "FSMC",
+                            "signal": "GLOBAL"
+                        }
+                    ]
+                },
+                {
                     "name": "GPIOA",
                     "address": 1073872896,
                     "registers": {

--- a/data/chips/STM32F405OE.json
+++ b/data/chips/STM32F405OE.json
@@ -949,6 +949,244 @@
                     ]
                 },
                 {
+                    "name": "FSMC",
+                    "address": 2684354560,
+                    "registers": {
+                        "kind": "fsmc",
+                        "version": "v1",
+                        "block": "FSMC"
+                    },
+                    "rcc": {
+                        "clock": "AHB3",
+                        "enable": {
+                            "register": "AHB3ENR",
+                            "field": "FSMCEN"
+                        },
+                        "reset": {
+                            "register": "AHB3RSTR",
+                            "field": "FSMCRST"
+                        }
+                    },
+                    "pins": [
+                        {
+                            "pin": "PB7",
+                            "signal": "NL",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD0",
+                            "signal": "D2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD0",
+                            "signal": "DA2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD1",
+                            "signal": "D3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD1",
+                            "signal": "DA3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD4",
+                            "signal": "NOE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD5",
+                            "signal": "NWE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD6",
+                            "signal": "NWAIT",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD7",
+                            "signal": "NCE2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD7",
+                            "signal": "NE1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD8",
+                            "signal": "D13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD8",
+                            "signal": "DA13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD9",
+                            "signal": "D14",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD9",
+                            "signal": "DA14",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD10",
+                            "signal": "D15",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD10",
+                            "signal": "DA15",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD11",
+                            "signal": "A16",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD11",
+                            "signal": "CLE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD12",
+                            "signal": "A17",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD12",
+                            "signal": "ALE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD14",
+                            "signal": "D0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD14",
+                            "signal": "DA0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD15",
+                            "signal": "D1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD15",
+                            "signal": "DA1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE7",
+                            "signal": "D4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE7",
+                            "signal": "DA4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE8",
+                            "signal": "D5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE8",
+                            "signal": "DA5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE9",
+                            "signal": "D6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE9",
+                            "signal": "DA6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE10",
+                            "signal": "D7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE10",
+                            "signal": "DA7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE11",
+                            "signal": "D8",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE11",
+                            "signal": "DA8",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE12",
+                            "signal": "D9",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE12",
+                            "signal": "DA9",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE13",
+                            "signal": "D10",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE13",
+                            "signal": "DA10",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE14",
+                            "signal": "D11",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE14",
+                            "signal": "DA11",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE15",
+                            "signal": "D12",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE15",
+                            "signal": "DA12",
+                            "af": 12
+                        }
+                    ],
+                    "interrupts": [
+                        {
+                            "interrupt": "FSMC",
+                            "signal": "GLOBAL"
+                        }
+                    ]
+                },
+                {
                     "name": "GPIOA",
                     "address": 1073872896,
                     "registers": {

--- a/data/chips/STM32F405OG.json
+++ b/data/chips/STM32F405OG.json
@@ -949,6 +949,244 @@
                     ]
                 },
                 {
+                    "name": "FSMC",
+                    "address": 2684354560,
+                    "registers": {
+                        "kind": "fsmc",
+                        "version": "v1",
+                        "block": "FSMC"
+                    },
+                    "rcc": {
+                        "clock": "AHB3",
+                        "enable": {
+                            "register": "AHB3ENR",
+                            "field": "FSMCEN"
+                        },
+                        "reset": {
+                            "register": "AHB3RSTR",
+                            "field": "FSMCRST"
+                        }
+                    },
+                    "pins": [
+                        {
+                            "pin": "PB7",
+                            "signal": "NL",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD0",
+                            "signal": "D2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD0",
+                            "signal": "DA2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD1",
+                            "signal": "D3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD1",
+                            "signal": "DA3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD4",
+                            "signal": "NOE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD5",
+                            "signal": "NWE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD6",
+                            "signal": "NWAIT",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD7",
+                            "signal": "NCE2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD7",
+                            "signal": "NE1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD8",
+                            "signal": "D13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD8",
+                            "signal": "DA13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD9",
+                            "signal": "D14",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD9",
+                            "signal": "DA14",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD10",
+                            "signal": "D15",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD10",
+                            "signal": "DA15",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD11",
+                            "signal": "A16",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD11",
+                            "signal": "CLE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD12",
+                            "signal": "A17",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD12",
+                            "signal": "ALE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD14",
+                            "signal": "D0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD14",
+                            "signal": "DA0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD15",
+                            "signal": "D1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD15",
+                            "signal": "DA1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE7",
+                            "signal": "D4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE7",
+                            "signal": "DA4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE8",
+                            "signal": "D5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE8",
+                            "signal": "DA5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE9",
+                            "signal": "D6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE9",
+                            "signal": "DA6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE10",
+                            "signal": "D7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE10",
+                            "signal": "DA7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE11",
+                            "signal": "D8",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE11",
+                            "signal": "DA8",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE12",
+                            "signal": "D9",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE12",
+                            "signal": "DA9",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE13",
+                            "signal": "D10",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE13",
+                            "signal": "DA10",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE14",
+                            "signal": "D11",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE14",
+                            "signal": "DA11",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE15",
+                            "signal": "D12",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE15",
+                            "signal": "DA12",
+                            "af": 12
+                        }
+                    ],
+                    "interrupts": [
+                        {
+                            "interrupt": "FSMC",
+                            "signal": "GLOBAL"
+                        }
+                    ]
+                },
+                {
                     "name": "GPIOA",
                     "address": 1073872896,
                     "registers": {

--- a/data/chips/STM32F405VG.json
+++ b/data/chips/STM32F405VG.json
@@ -977,6 +977,289 @@
                     ]
                 },
                 {
+                    "name": "FSMC",
+                    "address": 2684354560,
+                    "registers": {
+                        "kind": "fsmc",
+                        "version": "v1",
+                        "block": "FSMC"
+                    },
+                    "rcc": {
+                        "clock": "AHB3",
+                        "enable": {
+                            "register": "AHB3ENR",
+                            "field": "FSMCEN"
+                        },
+                        "reset": {
+                            "register": "AHB3RSTR",
+                            "field": "FSMCRST"
+                        }
+                    },
+                    "pins": [
+                        {
+                            "pin": "PB7",
+                            "signal": "NL",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD0",
+                            "signal": "D2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD0",
+                            "signal": "DA2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD1",
+                            "signal": "D3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD1",
+                            "signal": "DA3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD3",
+                            "signal": "CLK",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD4",
+                            "signal": "NOE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD5",
+                            "signal": "NWE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD6",
+                            "signal": "NWAIT",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD7",
+                            "signal": "NCE2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD7",
+                            "signal": "NE1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD8",
+                            "signal": "D13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD8",
+                            "signal": "DA13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD9",
+                            "signal": "D14",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD9",
+                            "signal": "DA14",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD10",
+                            "signal": "D15",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD10",
+                            "signal": "DA15",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD11",
+                            "signal": "A16",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD11",
+                            "signal": "CLE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD12",
+                            "signal": "A17",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD12",
+                            "signal": "ALE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD13",
+                            "signal": "A18",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD14",
+                            "signal": "D0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD14",
+                            "signal": "DA0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD15",
+                            "signal": "D1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD15",
+                            "signal": "DA1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE0",
+                            "signal": "NBL0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE1",
+                            "signal": "NBL1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE2",
+                            "signal": "A23",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE3",
+                            "signal": "A19",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE4",
+                            "signal": "A20",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE5",
+                            "signal": "A21",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE6",
+                            "signal": "A22",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE7",
+                            "signal": "D4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE7",
+                            "signal": "DA4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE8",
+                            "signal": "D5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE8",
+                            "signal": "DA5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE9",
+                            "signal": "D6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE9",
+                            "signal": "DA6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE10",
+                            "signal": "D7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE10",
+                            "signal": "DA7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE11",
+                            "signal": "D8",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE11",
+                            "signal": "DA8",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE12",
+                            "signal": "D9",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE12",
+                            "signal": "DA9",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE13",
+                            "signal": "D10",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE13",
+                            "signal": "DA10",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE14",
+                            "signal": "D11",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE14",
+                            "signal": "DA11",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE15",
+                            "signal": "D12",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE15",
+                            "signal": "DA12",
+                            "af": 12
+                        }
+                    ],
+                    "interrupts": [
+                        {
+                            "interrupt": "FSMC",
+                            "signal": "GLOBAL"
+                        }
+                    ]
+                },
+                {
                     "name": "GPIOA",
                     "address": 1073872896,
                     "registers": {

--- a/data/chips/STM32F405ZG.json
+++ b/data/chips/STM32F405ZG.json
@@ -1009,6 +1009,444 @@
                     ]
                 },
                 {
+                    "name": "FSMC",
+                    "address": 2684354560,
+                    "registers": {
+                        "kind": "fsmc",
+                        "version": "v1",
+                        "block": "FSMC"
+                    },
+                    "rcc": {
+                        "clock": "AHB3",
+                        "enable": {
+                            "register": "AHB3ENR",
+                            "field": "FSMCEN"
+                        },
+                        "reset": {
+                            "register": "AHB3RSTR",
+                            "field": "FSMCRST"
+                        }
+                    },
+                    "pins": [
+                        {
+                            "pin": "PB7",
+                            "signal": "NL",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD0",
+                            "signal": "D2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD0",
+                            "signal": "DA2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD1",
+                            "signal": "D3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD1",
+                            "signal": "DA3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD3",
+                            "signal": "CLK",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD4",
+                            "signal": "NOE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD5",
+                            "signal": "NWE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD6",
+                            "signal": "NWAIT",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD7",
+                            "signal": "NCE2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD7",
+                            "signal": "NE1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD8",
+                            "signal": "D13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD8",
+                            "signal": "DA13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD9",
+                            "signal": "D14",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD9",
+                            "signal": "DA14",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD10",
+                            "signal": "D15",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD10",
+                            "signal": "DA15",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD11",
+                            "signal": "A16",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD11",
+                            "signal": "CLE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD12",
+                            "signal": "A17",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD12",
+                            "signal": "ALE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD13",
+                            "signal": "A18",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD14",
+                            "signal": "D0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD14",
+                            "signal": "DA0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD15",
+                            "signal": "D1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD15",
+                            "signal": "DA1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE0",
+                            "signal": "NBL0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE1",
+                            "signal": "NBL1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE2",
+                            "signal": "A23",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE3",
+                            "signal": "A19",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE4",
+                            "signal": "A20",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE5",
+                            "signal": "A21",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE6",
+                            "signal": "A22",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE7",
+                            "signal": "D4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE7",
+                            "signal": "DA4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE8",
+                            "signal": "D5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE8",
+                            "signal": "DA5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE9",
+                            "signal": "D6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE9",
+                            "signal": "DA6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE10",
+                            "signal": "D7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE10",
+                            "signal": "DA7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE11",
+                            "signal": "D8",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE11",
+                            "signal": "DA8",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE12",
+                            "signal": "D9",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE12",
+                            "signal": "DA9",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE13",
+                            "signal": "D10",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE13",
+                            "signal": "DA10",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE14",
+                            "signal": "D11",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE14",
+                            "signal": "DA11",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE15",
+                            "signal": "D12",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE15",
+                            "signal": "DA12",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF0",
+                            "signal": "A0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF1",
+                            "signal": "A1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF2",
+                            "signal": "A2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF3",
+                            "signal": "A3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF4",
+                            "signal": "A4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF5",
+                            "signal": "A5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF6",
+                            "signal": "NIORD",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF7",
+                            "signal": "NREG",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF8",
+                            "signal": "NIOWR",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF9",
+                            "signal": "CD",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF10",
+                            "signal": "INTR",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF12",
+                            "signal": "A6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF13",
+                            "signal": "A7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF14",
+                            "signal": "A8",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF15",
+                            "signal": "A9",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG0",
+                            "signal": "A10",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG1",
+                            "signal": "A11",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG2",
+                            "signal": "A12",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG3",
+                            "signal": "A13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG4",
+                            "signal": "A14",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG5",
+                            "signal": "A15",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG6",
+                            "signal": "INT2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG7",
+                            "signal": "INT3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG9",
+                            "signal": "NCE3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG9",
+                            "signal": "NE2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG10",
+                            "signal": "NCE4_1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG10",
+                            "signal": "NE3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG11",
+                            "signal": "NCE4_2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG12",
+                            "signal": "NE4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG13",
+                            "signal": "A24",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG14",
+                            "signal": "A25",
+                            "af": 12
+                        }
+                    ],
+                    "interrupts": [
+                        {
+                            "interrupt": "FSMC",
+                            "signal": "GLOBAL"
+                        }
+                    ]
+                },
+                {
                     "name": "GPIOA",
                     "address": 1073872896,
                     "registers": {

--- a/data/chips/STM32F407IE.json
+++ b/data/chips/STM32F407IE.json
@@ -1440,6 +1440,444 @@
                     ]
                 },
                 {
+                    "name": "FSMC",
+                    "address": 2684354560,
+                    "registers": {
+                        "kind": "fsmc",
+                        "version": "v1",
+                        "block": "FSMC"
+                    },
+                    "rcc": {
+                        "clock": "AHB3",
+                        "enable": {
+                            "register": "AHB3ENR",
+                            "field": "FSMCEN"
+                        },
+                        "reset": {
+                            "register": "AHB3RSTR",
+                            "field": "FSMCRST"
+                        }
+                    },
+                    "pins": [
+                        {
+                            "pin": "PB7",
+                            "signal": "NL",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD0",
+                            "signal": "D2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD0",
+                            "signal": "DA2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD1",
+                            "signal": "D3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD1",
+                            "signal": "DA3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD3",
+                            "signal": "CLK",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD4",
+                            "signal": "NOE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD5",
+                            "signal": "NWE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD6",
+                            "signal": "NWAIT",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD7",
+                            "signal": "NCE2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD7",
+                            "signal": "NE1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD8",
+                            "signal": "D13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD8",
+                            "signal": "DA13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD9",
+                            "signal": "D14",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD9",
+                            "signal": "DA14",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD10",
+                            "signal": "D15",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD10",
+                            "signal": "DA15",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD11",
+                            "signal": "A16",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD11",
+                            "signal": "CLE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD12",
+                            "signal": "A17",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD12",
+                            "signal": "ALE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD13",
+                            "signal": "A18",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD14",
+                            "signal": "D0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD14",
+                            "signal": "DA0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD15",
+                            "signal": "D1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD15",
+                            "signal": "DA1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE0",
+                            "signal": "NBL0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE1",
+                            "signal": "NBL1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE2",
+                            "signal": "A23",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE3",
+                            "signal": "A19",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE4",
+                            "signal": "A20",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE5",
+                            "signal": "A21",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE6",
+                            "signal": "A22",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE7",
+                            "signal": "D4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE7",
+                            "signal": "DA4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE8",
+                            "signal": "D5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE8",
+                            "signal": "DA5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE9",
+                            "signal": "D6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE9",
+                            "signal": "DA6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE10",
+                            "signal": "D7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE10",
+                            "signal": "DA7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE11",
+                            "signal": "D8",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE11",
+                            "signal": "DA8",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE12",
+                            "signal": "D9",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE12",
+                            "signal": "DA9",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE13",
+                            "signal": "D10",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE13",
+                            "signal": "DA10",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE14",
+                            "signal": "D11",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE14",
+                            "signal": "DA11",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE15",
+                            "signal": "D12",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE15",
+                            "signal": "DA12",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF0",
+                            "signal": "A0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF1",
+                            "signal": "A1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF2",
+                            "signal": "A2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF3",
+                            "signal": "A3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF4",
+                            "signal": "A4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF5",
+                            "signal": "A5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF6",
+                            "signal": "NIORD",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF7",
+                            "signal": "NREG",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF8",
+                            "signal": "NIOWR",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF9",
+                            "signal": "CD",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF10",
+                            "signal": "INTR",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF12",
+                            "signal": "A6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF13",
+                            "signal": "A7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF14",
+                            "signal": "A8",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF15",
+                            "signal": "A9",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG0",
+                            "signal": "A10",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG1",
+                            "signal": "A11",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG2",
+                            "signal": "A12",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG3",
+                            "signal": "A13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG4",
+                            "signal": "A14",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG5",
+                            "signal": "A15",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG6",
+                            "signal": "INT2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG7",
+                            "signal": "INT3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG9",
+                            "signal": "NCE3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG9",
+                            "signal": "NE2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG10",
+                            "signal": "NCE4_1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG10",
+                            "signal": "NE3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG11",
+                            "signal": "NCE4_2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG12",
+                            "signal": "NE4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG13",
+                            "signal": "A24",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG14",
+                            "signal": "A25",
+                            "af": 12
+                        }
+                    ],
+                    "interrupts": [
+                        {
+                            "interrupt": "FSMC",
+                            "signal": "GLOBAL"
+                        }
+                    ]
+                },
+                {
                     "name": "GPIOA",
                     "address": 1073872896,
                     "registers": {

--- a/data/chips/STM32F407IG.json
+++ b/data/chips/STM32F407IG.json
@@ -1440,6 +1440,444 @@
                     ]
                 },
                 {
+                    "name": "FSMC",
+                    "address": 2684354560,
+                    "registers": {
+                        "kind": "fsmc",
+                        "version": "v1",
+                        "block": "FSMC"
+                    },
+                    "rcc": {
+                        "clock": "AHB3",
+                        "enable": {
+                            "register": "AHB3ENR",
+                            "field": "FSMCEN"
+                        },
+                        "reset": {
+                            "register": "AHB3RSTR",
+                            "field": "FSMCRST"
+                        }
+                    },
+                    "pins": [
+                        {
+                            "pin": "PB7",
+                            "signal": "NL",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD0",
+                            "signal": "D2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD0",
+                            "signal": "DA2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD1",
+                            "signal": "D3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD1",
+                            "signal": "DA3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD3",
+                            "signal": "CLK",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD4",
+                            "signal": "NOE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD5",
+                            "signal": "NWE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD6",
+                            "signal": "NWAIT",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD7",
+                            "signal": "NCE2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD7",
+                            "signal": "NE1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD8",
+                            "signal": "D13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD8",
+                            "signal": "DA13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD9",
+                            "signal": "D14",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD9",
+                            "signal": "DA14",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD10",
+                            "signal": "D15",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD10",
+                            "signal": "DA15",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD11",
+                            "signal": "A16",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD11",
+                            "signal": "CLE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD12",
+                            "signal": "A17",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD12",
+                            "signal": "ALE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD13",
+                            "signal": "A18",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD14",
+                            "signal": "D0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD14",
+                            "signal": "DA0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD15",
+                            "signal": "D1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD15",
+                            "signal": "DA1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE0",
+                            "signal": "NBL0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE1",
+                            "signal": "NBL1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE2",
+                            "signal": "A23",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE3",
+                            "signal": "A19",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE4",
+                            "signal": "A20",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE5",
+                            "signal": "A21",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE6",
+                            "signal": "A22",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE7",
+                            "signal": "D4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE7",
+                            "signal": "DA4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE8",
+                            "signal": "D5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE8",
+                            "signal": "DA5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE9",
+                            "signal": "D6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE9",
+                            "signal": "DA6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE10",
+                            "signal": "D7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE10",
+                            "signal": "DA7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE11",
+                            "signal": "D8",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE11",
+                            "signal": "DA8",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE12",
+                            "signal": "D9",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE12",
+                            "signal": "DA9",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE13",
+                            "signal": "D10",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE13",
+                            "signal": "DA10",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE14",
+                            "signal": "D11",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE14",
+                            "signal": "DA11",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE15",
+                            "signal": "D12",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE15",
+                            "signal": "DA12",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF0",
+                            "signal": "A0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF1",
+                            "signal": "A1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF2",
+                            "signal": "A2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF3",
+                            "signal": "A3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF4",
+                            "signal": "A4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF5",
+                            "signal": "A5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF6",
+                            "signal": "NIORD",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF7",
+                            "signal": "NREG",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF8",
+                            "signal": "NIOWR",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF9",
+                            "signal": "CD",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF10",
+                            "signal": "INTR",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF12",
+                            "signal": "A6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF13",
+                            "signal": "A7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF14",
+                            "signal": "A8",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF15",
+                            "signal": "A9",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG0",
+                            "signal": "A10",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG1",
+                            "signal": "A11",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG2",
+                            "signal": "A12",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG3",
+                            "signal": "A13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG4",
+                            "signal": "A14",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG5",
+                            "signal": "A15",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG6",
+                            "signal": "INT2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG7",
+                            "signal": "INT3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG9",
+                            "signal": "NCE3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG9",
+                            "signal": "NE2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG10",
+                            "signal": "NCE4_1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG10",
+                            "signal": "NE3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG11",
+                            "signal": "NCE4_2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG12",
+                            "signal": "NE4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG13",
+                            "signal": "A24",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG14",
+                            "signal": "A25",
+                            "af": 12
+                        }
+                    ],
+                    "interrupts": [
+                        {
+                            "interrupt": "FSMC",
+                            "signal": "GLOBAL"
+                        }
+                    ]
+                },
+                {
                     "name": "GPIOA",
                     "address": 1073872896,
                     "registers": {

--- a/data/chips/STM32F407VE.json
+++ b/data/chips/STM32F407VE.json
@@ -1264,6 +1264,289 @@
                     ]
                 },
                 {
+                    "name": "FSMC",
+                    "address": 2684354560,
+                    "registers": {
+                        "kind": "fsmc",
+                        "version": "v1",
+                        "block": "FSMC"
+                    },
+                    "rcc": {
+                        "clock": "AHB3",
+                        "enable": {
+                            "register": "AHB3ENR",
+                            "field": "FSMCEN"
+                        },
+                        "reset": {
+                            "register": "AHB3RSTR",
+                            "field": "FSMCRST"
+                        }
+                    },
+                    "pins": [
+                        {
+                            "pin": "PB7",
+                            "signal": "NL",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD0",
+                            "signal": "D2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD0",
+                            "signal": "DA2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD1",
+                            "signal": "D3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD1",
+                            "signal": "DA3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD3",
+                            "signal": "CLK",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD4",
+                            "signal": "NOE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD5",
+                            "signal": "NWE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD6",
+                            "signal": "NWAIT",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD7",
+                            "signal": "NCE2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD7",
+                            "signal": "NE1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD8",
+                            "signal": "D13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD8",
+                            "signal": "DA13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD9",
+                            "signal": "D14",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD9",
+                            "signal": "DA14",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD10",
+                            "signal": "D15",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD10",
+                            "signal": "DA15",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD11",
+                            "signal": "A16",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD11",
+                            "signal": "CLE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD12",
+                            "signal": "A17",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD12",
+                            "signal": "ALE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD13",
+                            "signal": "A18",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD14",
+                            "signal": "D0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD14",
+                            "signal": "DA0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD15",
+                            "signal": "D1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD15",
+                            "signal": "DA1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE0",
+                            "signal": "NBL0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE1",
+                            "signal": "NBL1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE2",
+                            "signal": "A23",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE3",
+                            "signal": "A19",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE4",
+                            "signal": "A20",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE5",
+                            "signal": "A21",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE6",
+                            "signal": "A22",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE7",
+                            "signal": "D4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE7",
+                            "signal": "DA4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE8",
+                            "signal": "D5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE8",
+                            "signal": "DA5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE9",
+                            "signal": "D6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE9",
+                            "signal": "DA6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE10",
+                            "signal": "D7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE10",
+                            "signal": "DA7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE11",
+                            "signal": "D8",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE11",
+                            "signal": "DA8",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE12",
+                            "signal": "D9",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE12",
+                            "signal": "DA9",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE13",
+                            "signal": "D10",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE13",
+                            "signal": "DA10",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE14",
+                            "signal": "D11",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE14",
+                            "signal": "DA11",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE15",
+                            "signal": "D12",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE15",
+                            "signal": "DA12",
+                            "af": 12
+                        }
+                    ],
+                    "interrupts": [
+                        {
+                            "interrupt": "FSMC",
+                            "signal": "GLOBAL"
+                        }
+                    ]
+                },
+                {
                     "name": "GPIOA",
                     "address": 1073872896,
                     "registers": {

--- a/data/chips/STM32F407VG.json
+++ b/data/chips/STM32F407VG.json
@@ -1264,6 +1264,289 @@
                     ]
                 },
                 {
+                    "name": "FSMC",
+                    "address": 2684354560,
+                    "registers": {
+                        "kind": "fsmc",
+                        "version": "v1",
+                        "block": "FSMC"
+                    },
+                    "rcc": {
+                        "clock": "AHB3",
+                        "enable": {
+                            "register": "AHB3ENR",
+                            "field": "FSMCEN"
+                        },
+                        "reset": {
+                            "register": "AHB3RSTR",
+                            "field": "FSMCRST"
+                        }
+                    },
+                    "pins": [
+                        {
+                            "pin": "PB7",
+                            "signal": "NL",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD0",
+                            "signal": "D2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD0",
+                            "signal": "DA2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD1",
+                            "signal": "D3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD1",
+                            "signal": "DA3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD3",
+                            "signal": "CLK",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD4",
+                            "signal": "NOE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD5",
+                            "signal": "NWE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD6",
+                            "signal": "NWAIT",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD7",
+                            "signal": "NCE2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD7",
+                            "signal": "NE1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD8",
+                            "signal": "D13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD8",
+                            "signal": "DA13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD9",
+                            "signal": "D14",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD9",
+                            "signal": "DA14",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD10",
+                            "signal": "D15",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD10",
+                            "signal": "DA15",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD11",
+                            "signal": "A16",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD11",
+                            "signal": "CLE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD12",
+                            "signal": "A17",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD12",
+                            "signal": "ALE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD13",
+                            "signal": "A18",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD14",
+                            "signal": "D0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD14",
+                            "signal": "DA0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD15",
+                            "signal": "D1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD15",
+                            "signal": "DA1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE0",
+                            "signal": "NBL0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE1",
+                            "signal": "NBL1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE2",
+                            "signal": "A23",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE3",
+                            "signal": "A19",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE4",
+                            "signal": "A20",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE5",
+                            "signal": "A21",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE6",
+                            "signal": "A22",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE7",
+                            "signal": "D4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE7",
+                            "signal": "DA4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE8",
+                            "signal": "D5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE8",
+                            "signal": "DA5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE9",
+                            "signal": "D6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE9",
+                            "signal": "DA6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE10",
+                            "signal": "D7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE10",
+                            "signal": "DA7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE11",
+                            "signal": "D8",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE11",
+                            "signal": "DA8",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE12",
+                            "signal": "D9",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE12",
+                            "signal": "DA9",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE13",
+                            "signal": "D10",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE13",
+                            "signal": "DA10",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE14",
+                            "signal": "D11",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE14",
+                            "signal": "DA11",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE15",
+                            "signal": "D12",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE15",
+                            "signal": "DA12",
+                            "af": 12
+                        }
+                    ],
+                    "interrupts": [
+                        {
+                            "interrupt": "FSMC",
+                            "signal": "GLOBAL"
+                        }
+                    ]
+                },
+                {
                     "name": "GPIOA",
                     "address": 1073872896,
                     "registers": {

--- a/data/chips/STM32F407ZE.json
+++ b/data/chips/STM32F407ZE.json
@@ -1326,6 +1326,444 @@
                     ]
                 },
                 {
+                    "name": "FSMC",
+                    "address": 2684354560,
+                    "registers": {
+                        "kind": "fsmc",
+                        "version": "v1",
+                        "block": "FSMC"
+                    },
+                    "rcc": {
+                        "clock": "AHB3",
+                        "enable": {
+                            "register": "AHB3ENR",
+                            "field": "FSMCEN"
+                        },
+                        "reset": {
+                            "register": "AHB3RSTR",
+                            "field": "FSMCRST"
+                        }
+                    },
+                    "pins": [
+                        {
+                            "pin": "PB7",
+                            "signal": "NL",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD0",
+                            "signal": "D2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD0",
+                            "signal": "DA2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD1",
+                            "signal": "D3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD1",
+                            "signal": "DA3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD3",
+                            "signal": "CLK",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD4",
+                            "signal": "NOE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD5",
+                            "signal": "NWE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD6",
+                            "signal": "NWAIT",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD7",
+                            "signal": "NCE2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD7",
+                            "signal": "NE1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD8",
+                            "signal": "D13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD8",
+                            "signal": "DA13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD9",
+                            "signal": "D14",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD9",
+                            "signal": "DA14",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD10",
+                            "signal": "D15",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD10",
+                            "signal": "DA15",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD11",
+                            "signal": "A16",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD11",
+                            "signal": "CLE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD12",
+                            "signal": "A17",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD12",
+                            "signal": "ALE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD13",
+                            "signal": "A18",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD14",
+                            "signal": "D0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD14",
+                            "signal": "DA0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD15",
+                            "signal": "D1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD15",
+                            "signal": "DA1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE0",
+                            "signal": "NBL0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE1",
+                            "signal": "NBL1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE2",
+                            "signal": "A23",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE3",
+                            "signal": "A19",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE4",
+                            "signal": "A20",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE5",
+                            "signal": "A21",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE6",
+                            "signal": "A22",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE7",
+                            "signal": "D4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE7",
+                            "signal": "DA4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE8",
+                            "signal": "D5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE8",
+                            "signal": "DA5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE9",
+                            "signal": "D6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE9",
+                            "signal": "DA6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE10",
+                            "signal": "D7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE10",
+                            "signal": "DA7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE11",
+                            "signal": "D8",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE11",
+                            "signal": "DA8",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE12",
+                            "signal": "D9",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE12",
+                            "signal": "DA9",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE13",
+                            "signal": "D10",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE13",
+                            "signal": "DA10",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE14",
+                            "signal": "D11",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE14",
+                            "signal": "DA11",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE15",
+                            "signal": "D12",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE15",
+                            "signal": "DA12",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF0",
+                            "signal": "A0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF1",
+                            "signal": "A1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF2",
+                            "signal": "A2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF3",
+                            "signal": "A3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF4",
+                            "signal": "A4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF5",
+                            "signal": "A5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF6",
+                            "signal": "NIORD",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF7",
+                            "signal": "NREG",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF8",
+                            "signal": "NIOWR",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF9",
+                            "signal": "CD",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF10",
+                            "signal": "INTR",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF12",
+                            "signal": "A6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF13",
+                            "signal": "A7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF14",
+                            "signal": "A8",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF15",
+                            "signal": "A9",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG0",
+                            "signal": "A10",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG1",
+                            "signal": "A11",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG2",
+                            "signal": "A12",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG3",
+                            "signal": "A13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG4",
+                            "signal": "A14",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG5",
+                            "signal": "A15",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG6",
+                            "signal": "INT2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG7",
+                            "signal": "INT3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG9",
+                            "signal": "NCE3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG9",
+                            "signal": "NE2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG10",
+                            "signal": "NCE4_1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG10",
+                            "signal": "NE3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG11",
+                            "signal": "NCE4_2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG12",
+                            "signal": "NE4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG13",
+                            "signal": "A24",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG14",
+                            "signal": "A25",
+                            "af": 12
+                        }
+                    ],
+                    "interrupts": [
+                        {
+                            "interrupt": "FSMC",
+                            "signal": "GLOBAL"
+                        }
+                    ]
+                },
+                {
                     "name": "GPIOA",
                     "address": 1073872896,
                     "registers": {

--- a/data/chips/STM32F407ZG.json
+++ b/data/chips/STM32F407ZG.json
@@ -1326,6 +1326,444 @@
                     ]
                 },
                 {
+                    "name": "FSMC",
+                    "address": 2684354560,
+                    "registers": {
+                        "kind": "fsmc",
+                        "version": "v1",
+                        "block": "FSMC"
+                    },
+                    "rcc": {
+                        "clock": "AHB3",
+                        "enable": {
+                            "register": "AHB3ENR",
+                            "field": "FSMCEN"
+                        },
+                        "reset": {
+                            "register": "AHB3RSTR",
+                            "field": "FSMCRST"
+                        }
+                    },
+                    "pins": [
+                        {
+                            "pin": "PB7",
+                            "signal": "NL",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD0",
+                            "signal": "D2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD0",
+                            "signal": "DA2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD1",
+                            "signal": "D3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD1",
+                            "signal": "DA3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD3",
+                            "signal": "CLK",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD4",
+                            "signal": "NOE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD5",
+                            "signal": "NWE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD6",
+                            "signal": "NWAIT",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD7",
+                            "signal": "NCE2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD7",
+                            "signal": "NE1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD8",
+                            "signal": "D13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD8",
+                            "signal": "DA13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD9",
+                            "signal": "D14",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD9",
+                            "signal": "DA14",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD10",
+                            "signal": "D15",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD10",
+                            "signal": "DA15",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD11",
+                            "signal": "A16",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD11",
+                            "signal": "CLE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD12",
+                            "signal": "A17",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD12",
+                            "signal": "ALE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD13",
+                            "signal": "A18",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD14",
+                            "signal": "D0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD14",
+                            "signal": "DA0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD15",
+                            "signal": "D1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD15",
+                            "signal": "DA1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE0",
+                            "signal": "NBL0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE1",
+                            "signal": "NBL1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE2",
+                            "signal": "A23",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE3",
+                            "signal": "A19",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE4",
+                            "signal": "A20",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE5",
+                            "signal": "A21",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE6",
+                            "signal": "A22",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE7",
+                            "signal": "D4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE7",
+                            "signal": "DA4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE8",
+                            "signal": "D5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE8",
+                            "signal": "DA5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE9",
+                            "signal": "D6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE9",
+                            "signal": "DA6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE10",
+                            "signal": "D7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE10",
+                            "signal": "DA7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE11",
+                            "signal": "D8",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE11",
+                            "signal": "DA8",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE12",
+                            "signal": "D9",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE12",
+                            "signal": "DA9",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE13",
+                            "signal": "D10",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE13",
+                            "signal": "DA10",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE14",
+                            "signal": "D11",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE14",
+                            "signal": "DA11",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE15",
+                            "signal": "D12",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE15",
+                            "signal": "DA12",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF0",
+                            "signal": "A0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF1",
+                            "signal": "A1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF2",
+                            "signal": "A2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF3",
+                            "signal": "A3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF4",
+                            "signal": "A4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF5",
+                            "signal": "A5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF6",
+                            "signal": "NIORD",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF7",
+                            "signal": "NREG",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF8",
+                            "signal": "NIOWR",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF9",
+                            "signal": "CD",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF10",
+                            "signal": "INTR",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF12",
+                            "signal": "A6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF13",
+                            "signal": "A7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF14",
+                            "signal": "A8",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF15",
+                            "signal": "A9",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG0",
+                            "signal": "A10",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG1",
+                            "signal": "A11",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG2",
+                            "signal": "A12",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG3",
+                            "signal": "A13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG4",
+                            "signal": "A14",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG5",
+                            "signal": "A15",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG6",
+                            "signal": "INT2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG7",
+                            "signal": "INT3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG9",
+                            "signal": "NCE3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG9",
+                            "signal": "NE2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG10",
+                            "signal": "NCE4_1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG10",
+                            "signal": "NE3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG11",
+                            "signal": "NCE4_2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG12",
+                            "signal": "NE4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG13",
+                            "signal": "A24",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG14",
+                            "signal": "A25",
+                            "af": 12
+                        }
+                    ],
+                    "interrupts": [
+                        {
+                            "interrupt": "FSMC",
+                            "signal": "GLOBAL"
+                        }
+                    ]
+                },
+                {
                     "name": "GPIOA",
                     "address": 1073872896,
                     "registers": {

--- a/data/chips/STM32F412RE.json
+++ b/data/chips/STM32F412RE.json
@@ -952,6 +952,139 @@
                     ]
                 },
                 {
+                    "name": "FSMC",
+                    "address": 2684354560,
+                    "registers": {
+                        "kind": "fsmc",
+                        "version": "v1",
+                        "block": "FSMC"
+                    },
+                    "rcc": {
+                        "clock": "AHB3",
+                        "enable": {
+                            "register": "AHB3ENR",
+                            "field": "FSMCEN"
+                        },
+                        "reset": {
+                            "register": "AHB3RSTR",
+                            "field": "FSMCRST"
+                        }
+                    },
+                    "pins": [
+                        {
+                            "pin": "PA2",
+                            "signal": "D4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PA2",
+                            "signal": "DA4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PA3",
+                            "signal": "D5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PA3",
+                            "signal": "DA5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PA4",
+                            "signal": "D6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PA4",
+                            "signal": "DA6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PA5",
+                            "signal": "D7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PA5",
+                            "signal": "DA7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PB7",
+                            "signal": "NL",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PB14",
+                            "signal": "D0",
+                            "af": 10
+                        },
+                        {
+                            "pin": "PB14",
+                            "signal": "DA0",
+                            "af": 10
+                        },
+                        {
+                            "pin": "PC2",
+                            "signal": "NWE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PC3",
+                            "signal": "A0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PC4",
+                            "signal": "NE4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PC5",
+                            "signal": "NOE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PC6",
+                            "signal": "D1",
+                            "af": 10
+                        },
+                        {
+                            "pin": "PC6",
+                            "signal": "DA1",
+                            "af": 10
+                        },
+                        {
+                            "pin": "PC11",
+                            "signal": "D2",
+                            "af": 10
+                        },
+                        {
+                            "pin": "PC11",
+                            "signal": "DA2",
+                            "af": 10
+                        },
+                        {
+                            "pin": "PC12",
+                            "signal": "D3",
+                            "af": 10
+                        },
+                        {
+                            "pin": "PC12",
+                            "signal": "DA3",
+                            "af": 10
+                        },
+                        {
+                            "pin": "PD2",
+                            "signal": "NWE",
+                            "af": 10
+                        }
+                    ],
+                    "interrupts": []
+                },
+                {
                     "name": "GPIOA",
                     "address": 1073872896,
                     "registers": {

--- a/data/chips/STM32F412RG.json
+++ b/data/chips/STM32F412RG.json
@@ -952,6 +952,139 @@
                     ]
                 },
                 {
+                    "name": "FSMC",
+                    "address": 2684354560,
+                    "registers": {
+                        "kind": "fsmc",
+                        "version": "v1",
+                        "block": "FSMC"
+                    },
+                    "rcc": {
+                        "clock": "AHB3",
+                        "enable": {
+                            "register": "AHB3ENR",
+                            "field": "FSMCEN"
+                        },
+                        "reset": {
+                            "register": "AHB3RSTR",
+                            "field": "FSMCRST"
+                        }
+                    },
+                    "pins": [
+                        {
+                            "pin": "PA2",
+                            "signal": "D4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PA2",
+                            "signal": "DA4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PA3",
+                            "signal": "D5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PA3",
+                            "signal": "DA5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PA4",
+                            "signal": "D6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PA4",
+                            "signal": "DA6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PA5",
+                            "signal": "D7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PA5",
+                            "signal": "DA7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PB7",
+                            "signal": "NL",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PB14",
+                            "signal": "D0",
+                            "af": 10
+                        },
+                        {
+                            "pin": "PB14",
+                            "signal": "DA0",
+                            "af": 10
+                        },
+                        {
+                            "pin": "PC2",
+                            "signal": "NWE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PC3",
+                            "signal": "A0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PC4",
+                            "signal": "NE4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PC5",
+                            "signal": "NOE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PC6",
+                            "signal": "D1",
+                            "af": 10
+                        },
+                        {
+                            "pin": "PC6",
+                            "signal": "DA1",
+                            "af": 10
+                        },
+                        {
+                            "pin": "PC11",
+                            "signal": "D2",
+                            "af": 10
+                        },
+                        {
+                            "pin": "PC11",
+                            "signal": "DA2",
+                            "af": 10
+                        },
+                        {
+                            "pin": "PC12",
+                            "signal": "D3",
+                            "af": 10
+                        },
+                        {
+                            "pin": "PC12",
+                            "signal": "DA3",
+                            "af": 10
+                        },
+                        {
+                            "pin": "PD2",
+                            "signal": "NWE",
+                            "af": 10
+                        }
+                    ],
+                    "interrupts": []
+                },
+                {
                     "name": "GPIOA",
                     "address": 1073872896,
                     "registers": {

--- a/data/chips/STM32F412VE.json
+++ b/data/chips/STM32F412VE.json
@@ -1028,6 +1028,384 @@
                     ]
                 },
                 {
+                    "name": "FSMC",
+                    "address": 2684354560,
+                    "registers": {
+                        "kind": "fsmc",
+                        "version": "v1",
+                        "block": "FSMC"
+                    },
+                    "rcc": {
+                        "clock": "AHB3",
+                        "enable": {
+                            "register": "AHB3ENR",
+                            "field": "FSMCEN"
+                        },
+                        "reset": {
+                            "register": "AHB3RSTR",
+                            "field": "FSMCRST"
+                        }
+                    },
+                    "pins": [
+                        {
+                            "pin": "PA2",
+                            "signal": "D4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PA2",
+                            "signal": "DA4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PA3",
+                            "signal": "D5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PA3",
+                            "signal": "DA5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PA4",
+                            "signal": "D6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PA4",
+                            "signal": "DA6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PA5",
+                            "signal": "D7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PA5",
+                            "signal": "DA7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PB7",
+                            "signal": "NL",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PB12",
+                            "signal": "D13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PB12",
+                            "signal": "DA13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PB14",
+                            "signal": "D0",
+                            "af": 10
+                        },
+                        {
+                            "pin": "PB14",
+                            "signal": "DA0",
+                            "af": 10
+                        },
+                        {
+                            "pin": "PC2",
+                            "signal": "NWE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PC3",
+                            "signal": "A0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PC4",
+                            "signal": "NE4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PC5",
+                            "signal": "NOE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PC6",
+                            "signal": "D1",
+                            "af": 10
+                        },
+                        {
+                            "pin": "PC6",
+                            "signal": "DA1",
+                            "af": 10
+                        },
+                        {
+                            "pin": "PC11",
+                            "signal": "D2",
+                            "af": 10
+                        },
+                        {
+                            "pin": "PC11",
+                            "signal": "DA2",
+                            "af": 10
+                        },
+                        {
+                            "pin": "PC12",
+                            "signal": "D3",
+                            "af": 10
+                        },
+                        {
+                            "pin": "PC12",
+                            "signal": "DA3",
+                            "af": 10
+                        },
+                        {
+                            "pin": "PD0",
+                            "signal": "D2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD0",
+                            "signal": "DA2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD1",
+                            "signal": "D3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD1",
+                            "signal": "DA3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD2",
+                            "signal": "NWE",
+                            "af": 10
+                        },
+                        {
+                            "pin": "PD3",
+                            "signal": "CLK",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD4",
+                            "signal": "NOE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD5",
+                            "signal": "NWE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD6",
+                            "signal": "NWAIT",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD7",
+                            "signal": "NE1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD8",
+                            "signal": "D13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD8",
+                            "signal": "DA13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD9",
+                            "signal": "D14",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD9",
+                            "signal": "DA14",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD10",
+                            "signal": "D15",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD10",
+                            "signal": "DA15",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD11",
+                            "signal": "A16",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD12",
+                            "signal": "A17",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD13",
+                            "signal": "A18",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD14",
+                            "signal": "D0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD14",
+                            "signal": "DA0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD15",
+                            "signal": "D1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD15",
+                            "signal": "DA1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE0",
+                            "signal": "NBL0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE1",
+                            "signal": "NBL1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE2",
+                            "signal": "A23",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE3",
+                            "signal": "A19",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE4",
+                            "signal": "A20",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE5",
+                            "signal": "A21",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE6",
+                            "signal": "A22",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE7",
+                            "signal": "D4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE7",
+                            "signal": "DA4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE8",
+                            "signal": "D5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE8",
+                            "signal": "DA5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE9",
+                            "signal": "D6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE9",
+                            "signal": "DA6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE10",
+                            "signal": "D7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE10",
+                            "signal": "DA7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE11",
+                            "signal": "D8",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE11",
+                            "signal": "DA8",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE12",
+                            "signal": "D9",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE12",
+                            "signal": "DA9",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE13",
+                            "signal": "D10",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE13",
+                            "signal": "DA10",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE14",
+                            "signal": "D11",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE14",
+                            "signal": "DA11",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE15",
+                            "signal": "D12",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE15",
+                            "signal": "DA12",
+                            "af": 12
+                        }
+                    ],
+                    "interrupts": []
+                },
+                {
                     "name": "GPIOA",
                     "address": 1073872896,
                     "registers": {

--- a/data/chips/STM32F412VG.json
+++ b/data/chips/STM32F412VG.json
@@ -1028,6 +1028,384 @@
                     ]
                 },
                 {
+                    "name": "FSMC",
+                    "address": 2684354560,
+                    "registers": {
+                        "kind": "fsmc",
+                        "version": "v1",
+                        "block": "FSMC"
+                    },
+                    "rcc": {
+                        "clock": "AHB3",
+                        "enable": {
+                            "register": "AHB3ENR",
+                            "field": "FSMCEN"
+                        },
+                        "reset": {
+                            "register": "AHB3RSTR",
+                            "field": "FSMCRST"
+                        }
+                    },
+                    "pins": [
+                        {
+                            "pin": "PA2",
+                            "signal": "D4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PA2",
+                            "signal": "DA4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PA3",
+                            "signal": "D5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PA3",
+                            "signal": "DA5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PA4",
+                            "signal": "D6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PA4",
+                            "signal": "DA6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PA5",
+                            "signal": "D7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PA5",
+                            "signal": "DA7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PB7",
+                            "signal": "NL",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PB12",
+                            "signal": "D13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PB12",
+                            "signal": "DA13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PB14",
+                            "signal": "D0",
+                            "af": 10
+                        },
+                        {
+                            "pin": "PB14",
+                            "signal": "DA0",
+                            "af": 10
+                        },
+                        {
+                            "pin": "PC2",
+                            "signal": "NWE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PC3",
+                            "signal": "A0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PC4",
+                            "signal": "NE4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PC5",
+                            "signal": "NOE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PC6",
+                            "signal": "D1",
+                            "af": 10
+                        },
+                        {
+                            "pin": "PC6",
+                            "signal": "DA1",
+                            "af": 10
+                        },
+                        {
+                            "pin": "PC11",
+                            "signal": "D2",
+                            "af": 10
+                        },
+                        {
+                            "pin": "PC11",
+                            "signal": "DA2",
+                            "af": 10
+                        },
+                        {
+                            "pin": "PC12",
+                            "signal": "D3",
+                            "af": 10
+                        },
+                        {
+                            "pin": "PC12",
+                            "signal": "DA3",
+                            "af": 10
+                        },
+                        {
+                            "pin": "PD0",
+                            "signal": "D2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD0",
+                            "signal": "DA2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD1",
+                            "signal": "D3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD1",
+                            "signal": "DA3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD2",
+                            "signal": "NWE",
+                            "af": 10
+                        },
+                        {
+                            "pin": "PD3",
+                            "signal": "CLK",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD4",
+                            "signal": "NOE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD5",
+                            "signal": "NWE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD6",
+                            "signal": "NWAIT",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD7",
+                            "signal": "NE1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD8",
+                            "signal": "D13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD8",
+                            "signal": "DA13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD9",
+                            "signal": "D14",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD9",
+                            "signal": "DA14",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD10",
+                            "signal": "D15",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD10",
+                            "signal": "DA15",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD11",
+                            "signal": "A16",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD12",
+                            "signal": "A17",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD13",
+                            "signal": "A18",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD14",
+                            "signal": "D0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD14",
+                            "signal": "DA0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD15",
+                            "signal": "D1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD15",
+                            "signal": "DA1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE0",
+                            "signal": "NBL0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE1",
+                            "signal": "NBL1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE2",
+                            "signal": "A23",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE3",
+                            "signal": "A19",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE4",
+                            "signal": "A20",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE5",
+                            "signal": "A21",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE6",
+                            "signal": "A22",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE7",
+                            "signal": "D4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE7",
+                            "signal": "DA4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE8",
+                            "signal": "D5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE8",
+                            "signal": "DA5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE9",
+                            "signal": "D6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE9",
+                            "signal": "DA6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE10",
+                            "signal": "D7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE10",
+                            "signal": "DA7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE11",
+                            "signal": "D8",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE11",
+                            "signal": "DA8",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE12",
+                            "signal": "D9",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE12",
+                            "signal": "DA9",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE13",
+                            "signal": "D10",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE13",
+                            "signal": "DA10",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE14",
+                            "signal": "D11",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE14",
+                            "signal": "DA11",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE15",
+                            "signal": "D12",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE15",
+                            "signal": "DA12",
+                            "af": 12
+                        }
+                    ],
+                    "interrupts": []
+                },
+                {
                     "name": "GPIOA",
                     "address": 1073872896,
                     "registers": {

--- a/data/chips/STM32F412ZE.json
+++ b/data/chips/STM32F412ZE.json
@@ -1063,6 +1063,489 @@
                     ]
                 },
                 {
+                    "name": "FSMC",
+                    "address": 2684354560,
+                    "registers": {
+                        "kind": "fsmc",
+                        "version": "v1",
+                        "block": "FSMC"
+                    },
+                    "rcc": {
+                        "clock": "AHB3",
+                        "enable": {
+                            "register": "AHB3ENR",
+                            "field": "FSMCEN"
+                        },
+                        "reset": {
+                            "register": "AHB3RSTR",
+                            "field": "FSMCRST"
+                        }
+                    },
+                    "pins": [
+                        {
+                            "pin": "PA2",
+                            "signal": "D4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PA2",
+                            "signal": "DA4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PA3",
+                            "signal": "D5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PA3",
+                            "signal": "DA5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PA4",
+                            "signal": "D6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PA4",
+                            "signal": "DA6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PA5",
+                            "signal": "D7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PA5",
+                            "signal": "DA7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PB7",
+                            "signal": "NL",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PB12",
+                            "signal": "D13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PB12",
+                            "signal": "DA13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PB14",
+                            "signal": "D0",
+                            "af": 10
+                        },
+                        {
+                            "pin": "PB14",
+                            "signal": "DA0",
+                            "af": 10
+                        },
+                        {
+                            "pin": "PC2",
+                            "signal": "NWE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PC3",
+                            "signal": "A0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PC4",
+                            "signal": "NE4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PC5",
+                            "signal": "NOE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PC6",
+                            "signal": "D1",
+                            "af": 10
+                        },
+                        {
+                            "pin": "PC6",
+                            "signal": "DA1",
+                            "af": 10
+                        },
+                        {
+                            "pin": "PC11",
+                            "signal": "D2",
+                            "af": 10
+                        },
+                        {
+                            "pin": "PC11",
+                            "signal": "DA2",
+                            "af": 10
+                        },
+                        {
+                            "pin": "PC12",
+                            "signal": "D3",
+                            "af": 10
+                        },
+                        {
+                            "pin": "PC12",
+                            "signal": "DA3",
+                            "af": 10
+                        },
+                        {
+                            "pin": "PD0",
+                            "signal": "D2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD0",
+                            "signal": "DA2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD1",
+                            "signal": "D3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD1",
+                            "signal": "DA3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD2",
+                            "signal": "NWE",
+                            "af": 10
+                        },
+                        {
+                            "pin": "PD3",
+                            "signal": "CLK",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD4",
+                            "signal": "NOE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD5",
+                            "signal": "NWE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD6",
+                            "signal": "NWAIT",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD7",
+                            "signal": "NE1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD8",
+                            "signal": "D13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD8",
+                            "signal": "DA13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD9",
+                            "signal": "D14",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD9",
+                            "signal": "DA14",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD10",
+                            "signal": "D15",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD10",
+                            "signal": "DA15",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD11",
+                            "signal": "A16",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD12",
+                            "signal": "A17",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD13",
+                            "signal": "A18",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD14",
+                            "signal": "D0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD14",
+                            "signal": "DA0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD15",
+                            "signal": "D1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD15",
+                            "signal": "DA1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE0",
+                            "signal": "NBL0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE1",
+                            "signal": "NBL1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE2",
+                            "signal": "A23",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE3",
+                            "signal": "A19",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE4",
+                            "signal": "A20",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE5",
+                            "signal": "A21",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE6",
+                            "signal": "A22",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE7",
+                            "signal": "D4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE7",
+                            "signal": "DA4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE8",
+                            "signal": "D5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE8",
+                            "signal": "DA5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE9",
+                            "signal": "D6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE9",
+                            "signal": "DA6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE10",
+                            "signal": "D7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE10",
+                            "signal": "DA7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE11",
+                            "signal": "D8",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE11",
+                            "signal": "DA8",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE12",
+                            "signal": "D9",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE12",
+                            "signal": "DA9",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE13",
+                            "signal": "D10",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE13",
+                            "signal": "DA10",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE14",
+                            "signal": "D11",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE14",
+                            "signal": "DA11",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE15",
+                            "signal": "D12",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE15",
+                            "signal": "DA12",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF0",
+                            "signal": "A0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF1",
+                            "signal": "A1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF2",
+                            "signal": "A2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF3",
+                            "signal": "A3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF4",
+                            "signal": "A4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF5",
+                            "signal": "A5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF12",
+                            "signal": "A6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF13",
+                            "signal": "A7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF14",
+                            "signal": "A8",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF15",
+                            "signal": "A9",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG0",
+                            "signal": "A10",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG1",
+                            "signal": "A11",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG2",
+                            "signal": "A12",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG3",
+                            "signal": "A13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG4",
+                            "signal": "A14",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG5",
+                            "signal": "A15",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG9",
+                            "signal": "NE2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG10",
+                            "signal": "NE3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG12",
+                            "signal": "NE4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG13",
+                            "signal": "A24",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG14",
+                            "signal": "A25",
+                            "af": 12
+                        }
+                    ],
+                    "interrupts": []
+                },
+                {
                     "name": "GPIOA",
                     "address": 1073872896,
                     "registers": {

--- a/data/chips/STM32F412ZG.json
+++ b/data/chips/STM32F412ZG.json
@@ -1063,6 +1063,489 @@
                     ]
                 },
                 {
+                    "name": "FSMC",
+                    "address": 2684354560,
+                    "registers": {
+                        "kind": "fsmc",
+                        "version": "v1",
+                        "block": "FSMC"
+                    },
+                    "rcc": {
+                        "clock": "AHB3",
+                        "enable": {
+                            "register": "AHB3ENR",
+                            "field": "FSMCEN"
+                        },
+                        "reset": {
+                            "register": "AHB3RSTR",
+                            "field": "FSMCRST"
+                        }
+                    },
+                    "pins": [
+                        {
+                            "pin": "PA2",
+                            "signal": "D4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PA2",
+                            "signal": "DA4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PA3",
+                            "signal": "D5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PA3",
+                            "signal": "DA5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PA4",
+                            "signal": "D6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PA4",
+                            "signal": "DA6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PA5",
+                            "signal": "D7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PA5",
+                            "signal": "DA7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PB7",
+                            "signal": "NL",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PB12",
+                            "signal": "D13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PB12",
+                            "signal": "DA13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PB14",
+                            "signal": "D0",
+                            "af": 10
+                        },
+                        {
+                            "pin": "PB14",
+                            "signal": "DA0",
+                            "af": 10
+                        },
+                        {
+                            "pin": "PC2",
+                            "signal": "NWE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PC3",
+                            "signal": "A0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PC4",
+                            "signal": "NE4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PC5",
+                            "signal": "NOE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PC6",
+                            "signal": "D1",
+                            "af": 10
+                        },
+                        {
+                            "pin": "PC6",
+                            "signal": "DA1",
+                            "af": 10
+                        },
+                        {
+                            "pin": "PC11",
+                            "signal": "D2",
+                            "af": 10
+                        },
+                        {
+                            "pin": "PC11",
+                            "signal": "DA2",
+                            "af": 10
+                        },
+                        {
+                            "pin": "PC12",
+                            "signal": "D3",
+                            "af": 10
+                        },
+                        {
+                            "pin": "PC12",
+                            "signal": "DA3",
+                            "af": 10
+                        },
+                        {
+                            "pin": "PD0",
+                            "signal": "D2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD0",
+                            "signal": "DA2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD1",
+                            "signal": "D3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD1",
+                            "signal": "DA3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD2",
+                            "signal": "NWE",
+                            "af": 10
+                        },
+                        {
+                            "pin": "PD3",
+                            "signal": "CLK",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD4",
+                            "signal": "NOE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD5",
+                            "signal": "NWE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD6",
+                            "signal": "NWAIT",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD7",
+                            "signal": "NE1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD8",
+                            "signal": "D13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD8",
+                            "signal": "DA13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD9",
+                            "signal": "D14",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD9",
+                            "signal": "DA14",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD10",
+                            "signal": "D15",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD10",
+                            "signal": "DA15",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD11",
+                            "signal": "A16",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD12",
+                            "signal": "A17",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD13",
+                            "signal": "A18",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD14",
+                            "signal": "D0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD14",
+                            "signal": "DA0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD15",
+                            "signal": "D1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD15",
+                            "signal": "DA1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE0",
+                            "signal": "NBL0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE1",
+                            "signal": "NBL1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE2",
+                            "signal": "A23",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE3",
+                            "signal": "A19",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE4",
+                            "signal": "A20",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE5",
+                            "signal": "A21",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE6",
+                            "signal": "A22",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE7",
+                            "signal": "D4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE7",
+                            "signal": "DA4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE8",
+                            "signal": "D5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE8",
+                            "signal": "DA5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE9",
+                            "signal": "D6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE9",
+                            "signal": "DA6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE10",
+                            "signal": "D7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE10",
+                            "signal": "DA7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE11",
+                            "signal": "D8",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE11",
+                            "signal": "DA8",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE12",
+                            "signal": "D9",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE12",
+                            "signal": "DA9",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE13",
+                            "signal": "D10",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE13",
+                            "signal": "DA10",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE14",
+                            "signal": "D11",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE14",
+                            "signal": "DA11",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE15",
+                            "signal": "D12",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE15",
+                            "signal": "DA12",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF0",
+                            "signal": "A0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF1",
+                            "signal": "A1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF2",
+                            "signal": "A2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF3",
+                            "signal": "A3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF4",
+                            "signal": "A4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF5",
+                            "signal": "A5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF12",
+                            "signal": "A6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF13",
+                            "signal": "A7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF14",
+                            "signal": "A8",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF15",
+                            "signal": "A9",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG0",
+                            "signal": "A10",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG1",
+                            "signal": "A11",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG2",
+                            "signal": "A12",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG3",
+                            "signal": "A13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG4",
+                            "signal": "A14",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG5",
+                            "signal": "A15",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG9",
+                            "signal": "NE2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG10",
+                            "signal": "NE3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG12",
+                            "signal": "NE4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG13",
+                            "signal": "A24",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG14",
+                            "signal": "A25",
+                            "af": 12
+                        }
+                    ],
+                    "interrupts": []
+                },
+                {
                     "name": "GPIOA",
                     "address": 1073872896,
                     "registers": {

--- a/data/chips/STM32F413MG.json
+++ b/data/chips/STM32F413MG.json
@@ -1305,6 +1305,248 @@
                     ]
                 },
                 {
+                    "name": "FSMC",
+                    "address": 2684354560,
+                    "registers": {
+                        "kind": "fsmc",
+                        "version": "v1",
+                        "block": "FSMC"
+                    },
+                    "rcc": {
+                        "clock": "AHB3",
+                        "enable": {
+                            "register": "AHB3ENR",
+                            "field": "FSMCEN"
+                        },
+                        "reset": {
+                            "register": "AHB3RSTR",
+                            "field": "FSMCRST"
+                        }
+                    },
+                    "pins": [
+                        {
+                            "pin": "PA2",
+                            "signal": "D4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PA2",
+                            "signal": "DA4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PA3",
+                            "signal": "D5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PA3",
+                            "signal": "DA5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PA4",
+                            "signal": "D6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PA4",
+                            "signal": "DA6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PA5",
+                            "signal": "D7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PA5",
+                            "signal": "DA7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PB7",
+                            "signal": "NL",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PB12",
+                            "signal": "D13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PB12",
+                            "signal": "DA13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PB14",
+                            "signal": "D0",
+                            "af": 10
+                        },
+                        {
+                            "pin": "PB14",
+                            "signal": "DA0",
+                            "af": 10
+                        },
+                        {
+                            "pin": "PC2",
+                            "signal": "NWE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PC3",
+                            "signal": "A0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PC4",
+                            "signal": "NE4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PC5",
+                            "signal": "NOE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PC6",
+                            "signal": "D1",
+                            "af": 10
+                        },
+                        {
+                            "pin": "PC6",
+                            "signal": "DA1",
+                            "af": 10
+                        },
+                        {
+                            "pin": "PC11",
+                            "signal": "D2",
+                            "af": 10
+                        },
+                        {
+                            "pin": "PC11",
+                            "signal": "DA2",
+                            "af": 10
+                        },
+                        {
+                            "pin": "PC12",
+                            "signal": "D3",
+                            "af": 10
+                        },
+                        {
+                            "pin": "PC12",
+                            "signal": "DA3",
+                            "af": 10
+                        },
+                        {
+                            "pin": "PD0",
+                            "signal": "D2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD0",
+                            "signal": "DA2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD2",
+                            "signal": "NWE",
+                            "af": 10
+                        },
+                        {
+                            "pin": "PD9",
+                            "signal": "D14",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD9",
+                            "signal": "DA14",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD10",
+                            "signal": "D15",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD10",
+                            "signal": "DA15",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE9",
+                            "signal": "D6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE9",
+                            "signal": "DA6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE10",
+                            "signal": "D7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE10",
+                            "signal": "DA7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE11",
+                            "signal": "D8",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE11",
+                            "signal": "DA8",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE12",
+                            "signal": "D9",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE12",
+                            "signal": "DA9",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE13",
+                            "signal": "D10",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE13",
+                            "signal": "DA10",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE14",
+                            "signal": "D11",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE14",
+                            "signal": "DA11",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE15",
+                            "signal": "D12",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE15",
+                            "signal": "DA12",
+                            "af": 12
+                        }
+                    ]
+                },
+                {
                     "name": "GPIOA",
                     "address": 1073872896,
                     "registers": {

--- a/data/chips/STM32F413MH.json
+++ b/data/chips/STM32F413MH.json
@@ -1305,6 +1305,248 @@
                     ]
                 },
                 {
+                    "name": "FSMC",
+                    "address": 2684354560,
+                    "registers": {
+                        "kind": "fsmc",
+                        "version": "v1",
+                        "block": "FSMC"
+                    },
+                    "rcc": {
+                        "clock": "AHB3",
+                        "enable": {
+                            "register": "AHB3ENR",
+                            "field": "FSMCEN"
+                        },
+                        "reset": {
+                            "register": "AHB3RSTR",
+                            "field": "FSMCRST"
+                        }
+                    },
+                    "pins": [
+                        {
+                            "pin": "PA2",
+                            "signal": "D4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PA2",
+                            "signal": "DA4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PA3",
+                            "signal": "D5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PA3",
+                            "signal": "DA5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PA4",
+                            "signal": "D6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PA4",
+                            "signal": "DA6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PA5",
+                            "signal": "D7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PA5",
+                            "signal": "DA7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PB7",
+                            "signal": "NL",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PB12",
+                            "signal": "D13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PB12",
+                            "signal": "DA13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PB14",
+                            "signal": "D0",
+                            "af": 10
+                        },
+                        {
+                            "pin": "PB14",
+                            "signal": "DA0",
+                            "af": 10
+                        },
+                        {
+                            "pin": "PC2",
+                            "signal": "NWE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PC3",
+                            "signal": "A0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PC4",
+                            "signal": "NE4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PC5",
+                            "signal": "NOE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PC6",
+                            "signal": "D1",
+                            "af": 10
+                        },
+                        {
+                            "pin": "PC6",
+                            "signal": "DA1",
+                            "af": 10
+                        },
+                        {
+                            "pin": "PC11",
+                            "signal": "D2",
+                            "af": 10
+                        },
+                        {
+                            "pin": "PC11",
+                            "signal": "DA2",
+                            "af": 10
+                        },
+                        {
+                            "pin": "PC12",
+                            "signal": "D3",
+                            "af": 10
+                        },
+                        {
+                            "pin": "PC12",
+                            "signal": "DA3",
+                            "af": 10
+                        },
+                        {
+                            "pin": "PD0",
+                            "signal": "D2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD0",
+                            "signal": "DA2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD2",
+                            "signal": "NWE",
+                            "af": 10
+                        },
+                        {
+                            "pin": "PD9",
+                            "signal": "D14",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD9",
+                            "signal": "DA14",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD10",
+                            "signal": "D15",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD10",
+                            "signal": "DA15",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE9",
+                            "signal": "D6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE9",
+                            "signal": "DA6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE10",
+                            "signal": "D7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE10",
+                            "signal": "DA7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE11",
+                            "signal": "D8",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE11",
+                            "signal": "DA8",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE12",
+                            "signal": "D9",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE12",
+                            "signal": "DA9",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE13",
+                            "signal": "D10",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE13",
+                            "signal": "DA10",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE14",
+                            "signal": "D11",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE14",
+                            "signal": "DA11",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE15",
+                            "signal": "D12",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE15",
+                            "signal": "DA12",
+                            "af": 12
+                        }
+                    ]
+                },
+                {
                     "name": "GPIOA",
                     "address": 1073872896,
                     "registers": {

--- a/data/chips/STM32F413RG.json
+++ b/data/chips/STM32F413RG.json
@@ -1260,6 +1260,138 @@
                     ]
                 },
                 {
+                    "name": "FSMC",
+                    "address": 2684354560,
+                    "registers": {
+                        "kind": "fsmc",
+                        "version": "v1",
+                        "block": "FSMC"
+                    },
+                    "rcc": {
+                        "clock": "AHB3",
+                        "enable": {
+                            "register": "AHB3ENR",
+                            "field": "FSMCEN"
+                        },
+                        "reset": {
+                            "register": "AHB3RSTR",
+                            "field": "FSMCRST"
+                        }
+                    },
+                    "pins": [
+                        {
+                            "pin": "PA2",
+                            "signal": "D4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PA2",
+                            "signal": "DA4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PA3",
+                            "signal": "D5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PA3",
+                            "signal": "DA5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PA4",
+                            "signal": "D6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PA4",
+                            "signal": "DA6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PA5",
+                            "signal": "D7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PA5",
+                            "signal": "DA7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PB7",
+                            "signal": "NL",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PB14",
+                            "signal": "D0",
+                            "af": 10
+                        },
+                        {
+                            "pin": "PB14",
+                            "signal": "DA0",
+                            "af": 10
+                        },
+                        {
+                            "pin": "PC2",
+                            "signal": "NWE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PC3",
+                            "signal": "A0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PC4",
+                            "signal": "NE4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PC5",
+                            "signal": "NOE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PC6",
+                            "signal": "D1",
+                            "af": 10
+                        },
+                        {
+                            "pin": "PC6",
+                            "signal": "DA1",
+                            "af": 10
+                        },
+                        {
+                            "pin": "PC11",
+                            "signal": "D2",
+                            "af": 10
+                        },
+                        {
+                            "pin": "PC11",
+                            "signal": "DA2",
+                            "af": 10
+                        },
+                        {
+                            "pin": "PC12",
+                            "signal": "D3",
+                            "af": 10
+                        },
+                        {
+                            "pin": "PC12",
+                            "signal": "DA3",
+                            "af": 10
+                        },
+                        {
+                            "pin": "PD2",
+                            "signal": "NWE",
+                            "af": 10
+                        }
+                    ]
+                },
+                {
                     "name": "GPIOA",
                     "address": 1073872896,
                     "registers": {

--- a/data/chips/STM32F413RH.json
+++ b/data/chips/STM32F413RH.json
@@ -1260,6 +1260,138 @@
                     ]
                 },
                 {
+                    "name": "FSMC",
+                    "address": 2684354560,
+                    "registers": {
+                        "kind": "fsmc",
+                        "version": "v1",
+                        "block": "FSMC"
+                    },
+                    "rcc": {
+                        "clock": "AHB3",
+                        "enable": {
+                            "register": "AHB3ENR",
+                            "field": "FSMCEN"
+                        },
+                        "reset": {
+                            "register": "AHB3RSTR",
+                            "field": "FSMCRST"
+                        }
+                    },
+                    "pins": [
+                        {
+                            "pin": "PA2",
+                            "signal": "D4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PA2",
+                            "signal": "DA4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PA3",
+                            "signal": "D5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PA3",
+                            "signal": "DA5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PA4",
+                            "signal": "D6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PA4",
+                            "signal": "DA6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PA5",
+                            "signal": "D7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PA5",
+                            "signal": "DA7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PB7",
+                            "signal": "NL",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PB14",
+                            "signal": "D0",
+                            "af": 10
+                        },
+                        {
+                            "pin": "PB14",
+                            "signal": "DA0",
+                            "af": 10
+                        },
+                        {
+                            "pin": "PC2",
+                            "signal": "NWE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PC3",
+                            "signal": "A0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PC4",
+                            "signal": "NE4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PC5",
+                            "signal": "NOE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PC6",
+                            "signal": "D1",
+                            "af": 10
+                        },
+                        {
+                            "pin": "PC6",
+                            "signal": "DA1",
+                            "af": 10
+                        },
+                        {
+                            "pin": "PC11",
+                            "signal": "D2",
+                            "af": 10
+                        },
+                        {
+                            "pin": "PC11",
+                            "signal": "DA2",
+                            "af": 10
+                        },
+                        {
+                            "pin": "PC12",
+                            "signal": "D3",
+                            "af": 10
+                        },
+                        {
+                            "pin": "PC12",
+                            "signal": "DA3",
+                            "af": 10
+                        },
+                        {
+                            "pin": "PD2",
+                            "signal": "NWE",
+                            "af": 10
+                        }
+                    ]
+                },
+                {
                     "name": "GPIOA",
                     "address": 1073872896,
                     "registers": {

--- a/data/chips/STM32F413VG.json
+++ b/data/chips/STM32F413VG.json
@@ -1419,6 +1419,383 @@
                     ]
                 },
                 {
+                    "name": "FSMC",
+                    "address": 2684354560,
+                    "registers": {
+                        "kind": "fsmc",
+                        "version": "v1",
+                        "block": "FSMC"
+                    },
+                    "rcc": {
+                        "clock": "AHB3",
+                        "enable": {
+                            "register": "AHB3ENR",
+                            "field": "FSMCEN"
+                        },
+                        "reset": {
+                            "register": "AHB3RSTR",
+                            "field": "FSMCRST"
+                        }
+                    },
+                    "pins": [
+                        {
+                            "pin": "PA2",
+                            "signal": "D4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PA2",
+                            "signal": "DA4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PA3",
+                            "signal": "D5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PA3",
+                            "signal": "DA5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PA4",
+                            "signal": "D6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PA4",
+                            "signal": "DA6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PA5",
+                            "signal": "D7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PA5",
+                            "signal": "DA7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PB7",
+                            "signal": "NL",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PB12",
+                            "signal": "D13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PB12",
+                            "signal": "DA13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PB14",
+                            "signal": "D0",
+                            "af": 10
+                        },
+                        {
+                            "pin": "PB14",
+                            "signal": "DA0",
+                            "af": 10
+                        },
+                        {
+                            "pin": "PC2",
+                            "signal": "NWE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PC3",
+                            "signal": "A0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PC4",
+                            "signal": "NE4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PC5",
+                            "signal": "NOE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PC6",
+                            "signal": "D1",
+                            "af": 10
+                        },
+                        {
+                            "pin": "PC6",
+                            "signal": "DA1",
+                            "af": 10
+                        },
+                        {
+                            "pin": "PC11",
+                            "signal": "D2",
+                            "af": 10
+                        },
+                        {
+                            "pin": "PC11",
+                            "signal": "DA2",
+                            "af": 10
+                        },
+                        {
+                            "pin": "PC12",
+                            "signal": "D3",
+                            "af": 10
+                        },
+                        {
+                            "pin": "PC12",
+                            "signal": "DA3",
+                            "af": 10
+                        },
+                        {
+                            "pin": "PD0",
+                            "signal": "D2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD0",
+                            "signal": "DA2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD1",
+                            "signal": "D3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD1",
+                            "signal": "DA3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD2",
+                            "signal": "NWE",
+                            "af": 10
+                        },
+                        {
+                            "pin": "PD3",
+                            "signal": "CLK",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD4",
+                            "signal": "NOE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD5",
+                            "signal": "NWE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD6",
+                            "signal": "NWAIT",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD7",
+                            "signal": "NE1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD8",
+                            "signal": "D13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD8",
+                            "signal": "DA13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD9",
+                            "signal": "D14",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD9",
+                            "signal": "DA14",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD10",
+                            "signal": "D15",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD10",
+                            "signal": "DA15",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD11",
+                            "signal": "A16",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD12",
+                            "signal": "A17",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD13",
+                            "signal": "A18",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD14",
+                            "signal": "D0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD14",
+                            "signal": "DA0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD15",
+                            "signal": "D1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD15",
+                            "signal": "DA1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE0",
+                            "signal": "NBL0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE1",
+                            "signal": "NBL1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE2",
+                            "signal": "A23",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE3",
+                            "signal": "A19",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE4",
+                            "signal": "A20",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE5",
+                            "signal": "A21",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE6",
+                            "signal": "A22",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE7",
+                            "signal": "D4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE7",
+                            "signal": "DA4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE8",
+                            "signal": "D5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE8",
+                            "signal": "DA5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE9",
+                            "signal": "D6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE9",
+                            "signal": "DA6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE10",
+                            "signal": "D7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE10",
+                            "signal": "DA7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE11",
+                            "signal": "D8",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE11",
+                            "signal": "DA8",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE12",
+                            "signal": "D9",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE12",
+                            "signal": "DA9",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE13",
+                            "signal": "D10",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE13",
+                            "signal": "DA10",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE14",
+                            "signal": "D11",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE14",
+                            "signal": "DA11",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE15",
+                            "signal": "D12",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE15",
+                            "signal": "DA12",
+                            "af": 12
+                        }
+                    ]
+                },
+                {
                     "name": "GPIOA",
                     "address": 1073872896,
                     "registers": {

--- a/data/chips/STM32F413VH.json
+++ b/data/chips/STM32F413VH.json
@@ -1419,6 +1419,383 @@
                     ]
                 },
                 {
+                    "name": "FSMC",
+                    "address": 2684354560,
+                    "registers": {
+                        "kind": "fsmc",
+                        "version": "v1",
+                        "block": "FSMC"
+                    },
+                    "rcc": {
+                        "clock": "AHB3",
+                        "enable": {
+                            "register": "AHB3ENR",
+                            "field": "FSMCEN"
+                        },
+                        "reset": {
+                            "register": "AHB3RSTR",
+                            "field": "FSMCRST"
+                        }
+                    },
+                    "pins": [
+                        {
+                            "pin": "PA2",
+                            "signal": "D4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PA2",
+                            "signal": "DA4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PA3",
+                            "signal": "D5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PA3",
+                            "signal": "DA5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PA4",
+                            "signal": "D6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PA4",
+                            "signal": "DA6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PA5",
+                            "signal": "D7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PA5",
+                            "signal": "DA7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PB7",
+                            "signal": "NL",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PB12",
+                            "signal": "D13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PB12",
+                            "signal": "DA13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PB14",
+                            "signal": "D0",
+                            "af": 10
+                        },
+                        {
+                            "pin": "PB14",
+                            "signal": "DA0",
+                            "af": 10
+                        },
+                        {
+                            "pin": "PC2",
+                            "signal": "NWE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PC3",
+                            "signal": "A0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PC4",
+                            "signal": "NE4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PC5",
+                            "signal": "NOE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PC6",
+                            "signal": "D1",
+                            "af": 10
+                        },
+                        {
+                            "pin": "PC6",
+                            "signal": "DA1",
+                            "af": 10
+                        },
+                        {
+                            "pin": "PC11",
+                            "signal": "D2",
+                            "af": 10
+                        },
+                        {
+                            "pin": "PC11",
+                            "signal": "DA2",
+                            "af": 10
+                        },
+                        {
+                            "pin": "PC12",
+                            "signal": "D3",
+                            "af": 10
+                        },
+                        {
+                            "pin": "PC12",
+                            "signal": "DA3",
+                            "af": 10
+                        },
+                        {
+                            "pin": "PD0",
+                            "signal": "D2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD0",
+                            "signal": "DA2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD1",
+                            "signal": "D3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD1",
+                            "signal": "DA3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD2",
+                            "signal": "NWE",
+                            "af": 10
+                        },
+                        {
+                            "pin": "PD3",
+                            "signal": "CLK",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD4",
+                            "signal": "NOE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD5",
+                            "signal": "NWE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD6",
+                            "signal": "NWAIT",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD7",
+                            "signal": "NE1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD8",
+                            "signal": "D13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD8",
+                            "signal": "DA13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD9",
+                            "signal": "D14",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD9",
+                            "signal": "DA14",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD10",
+                            "signal": "D15",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD10",
+                            "signal": "DA15",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD11",
+                            "signal": "A16",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD12",
+                            "signal": "A17",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD13",
+                            "signal": "A18",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD14",
+                            "signal": "D0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD14",
+                            "signal": "DA0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD15",
+                            "signal": "D1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD15",
+                            "signal": "DA1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE0",
+                            "signal": "NBL0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE1",
+                            "signal": "NBL1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE2",
+                            "signal": "A23",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE3",
+                            "signal": "A19",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE4",
+                            "signal": "A20",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE5",
+                            "signal": "A21",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE6",
+                            "signal": "A22",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE7",
+                            "signal": "D4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE7",
+                            "signal": "DA4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE8",
+                            "signal": "D5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE8",
+                            "signal": "DA5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE9",
+                            "signal": "D6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE9",
+                            "signal": "DA6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE10",
+                            "signal": "D7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE10",
+                            "signal": "DA7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE11",
+                            "signal": "D8",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE11",
+                            "signal": "DA8",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE12",
+                            "signal": "D9",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE12",
+                            "signal": "DA9",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE13",
+                            "signal": "D10",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE13",
+                            "signal": "DA10",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE14",
+                            "signal": "D11",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE14",
+                            "signal": "DA11",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE15",
+                            "signal": "D12",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE15",
+                            "signal": "DA12",
+                            "af": 12
+                        }
+                    ]
+                },
+                {
                     "name": "GPIOA",
                     "address": 1073872896,
                     "registers": {

--- a/data/chips/STM32F413ZG.json
+++ b/data/chips/STM32F413ZG.json
@@ -1454,6 +1454,488 @@
                     ]
                 },
                 {
+                    "name": "FSMC",
+                    "address": 2684354560,
+                    "registers": {
+                        "kind": "fsmc",
+                        "version": "v1",
+                        "block": "FSMC"
+                    },
+                    "rcc": {
+                        "clock": "AHB3",
+                        "enable": {
+                            "register": "AHB3ENR",
+                            "field": "FSMCEN"
+                        },
+                        "reset": {
+                            "register": "AHB3RSTR",
+                            "field": "FSMCRST"
+                        }
+                    },
+                    "pins": [
+                        {
+                            "pin": "PA2",
+                            "signal": "D4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PA2",
+                            "signal": "DA4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PA3",
+                            "signal": "D5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PA3",
+                            "signal": "DA5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PA4",
+                            "signal": "D6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PA4",
+                            "signal": "DA6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PA5",
+                            "signal": "D7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PA5",
+                            "signal": "DA7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PB7",
+                            "signal": "NL",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PB12",
+                            "signal": "D13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PB12",
+                            "signal": "DA13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PB14",
+                            "signal": "D0",
+                            "af": 10
+                        },
+                        {
+                            "pin": "PB14",
+                            "signal": "DA0",
+                            "af": 10
+                        },
+                        {
+                            "pin": "PC2",
+                            "signal": "NWE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PC3",
+                            "signal": "A0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PC4",
+                            "signal": "NE4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PC5",
+                            "signal": "NOE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PC6",
+                            "signal": "D1",
+                            "af": 10
+                        },
+                        {
+                            "pin": "PC6",
+                            "signal": "DA1",
+                            "af": 10
+                        },
+                        {
+                            "pin": "PC11",
+                            "signal": "D2",
+                            "af": 10
+                        },
+                        {
+                            "pin": "PC11",
+                            "signal": "DA2",
+                            "af": 10
+                        },
+                        {
+                            "pin": "PC12",
+                            "signal": "D3",
+                            "af": 10
+                        },
+                        {
+                            "pin": "PC12",
+                            "signal": "DA3",
+                            "af": 10
+                        },
+                        {
+                            "pin": "PD0",
+                            "signal": "D2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD0",
+                            "signal": "DA2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD1",
+                            "signal": "D3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD1",
+                            "signal": "DA3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD2",
+                            "signal": "NWE",
+                            "af": 10
+                        },
+                        {
+                            "pin": "PD3",
+                            "signal": "CLK",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD4",
+                            "signal": "NOE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD5",
+                            "signal": "NWE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD6",
+                            "signal": "NWAIT",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD7",
+                            "signal": "NE1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD8",
+                            "signal": "D13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD8",
+                            "signal": "DA13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD9",
+                            "signal": "D14",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD9",
+                            "signal": "DA14",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD10",
+                            "signal": "D15",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD10",
+                            "signal": "DA15",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD11",
+                            "signal": "A16",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD12",
+                            "signal": "A17",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD13",
+                            "signal": "A18",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD14",
+                            "signal": "D0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD14",
+                            "signal": "DA0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD15",
+                            "signal": "D1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD15",
+                            "signal": "DA1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE0",
+                            "signal": "NBL0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE1",
+                            "signal": "NBL1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE2",
+                            "signal": "A23",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE3",
+                            "signal": "A19",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE4",
+                            "signal": "A20",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE5",
+                            "signal": "A21",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE6",
+                            "signal": "A22",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE7",
+                            "signal": "D4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE7",
+                            "signal": "DA4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE8",
+                            "signal": "D5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE8",
+                            "signal": "DA5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE9",
+                            "signal": "D6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE9",
+                            "signal": "DA6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE10",
+                            "signal": "D7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE10",
+                            "signal": "DA7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE11",
+                            "signal": "D8",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE11",
+                            "signal": "DA8",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE12",
+                            "signal": "D9",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE12",
+                            "signal": "DA9",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE13",
+                            "signal": "D10",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE13",
+                            "signal": "DA10",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE14",
+                            "signal": "D11",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE14",
+                            "signal": "DA11",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE15",
+                            "signal": "D12",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE15",
+                            "signal": "DA12",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF0",
+                            "signal": "A0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF1",
+                            "signal": "A1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF2",
+                            "signal": "A2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF3",
+                            "signal": "A3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF4",
+                            "signal": "A4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF5",
+                            "signal": "A5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF12",
+                            "signal": "A6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF13",
+                            "signal": "A7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF14",
+                            "signal": "A8",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF15",
+                            "signal": "A9",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG0",
+                            "signal": "A10",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG1",
+                            "signal": "A11",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG2",
+                            "signal": "A12",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG3",
+                            "signal": "A13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG4",
+                            "signal": "A14",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG5",
+                            "signal": "A15",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG9",
+                            "signal": "NE2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG10",
+                            "signal": "NE3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG12",
+                            "signal": "NE4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG13",
+                            "signal": "A24",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG14",
+                            "signal": "A25",
+                            "af": 12
+                        }
+                    ]
+                },
+                {
                     "name": "GPIOA",
                     "address": 1073872896,
                     "registers": {

--- a/data/chips/STM32F413ZH.json
+++ b/data/chips/STM32F413ZH.json
@@ -1454,6 +1454,488 @@
                     ]
                 },
                 {
+                    "name": "FSMC",
+                    "address": 2684354560,
+                    "registers": {
+                        "kind": "fsmc",
+                        "version": "v1",
+                        "block": "FSMC"
+                    },
+                    "rcc": {
+                        "clock": "AHB3",
+                        "enable": {
+                            "register": "AHB3ENR",
+                            "field": "FSMCEN"
+                        },
+                        "reset": {
+                            "register": "AHB3RSTR",
+                            "field": "FSMCRST"
+                        }
+                    },
+                    "pins": [
+                        {
+                            "pin": "PA2",
+                            "signal": "D4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PA2",
+                            "signal": "DA4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PA3",
+                            "signal": "D5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PA3",
+                            "signal": "DA5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PA4",
+                            "signal": "D6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PA4",
+                            "signal": "DA6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PA5",
+                            "signal": "D7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PA5",
+                            "signal": "DA7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PB7",
+                            "signal": "NL",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PB12",
+                            "signal": "D13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PB12",
+                            "signal": "DA13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PB14",
+                            "signal": "D0",
+                            "af": 10
+                        },
+                        {
+                            "pin": "PB14",
+                            "signal": "DA0",
+                            "af": 10
+                        },
+                        {
+                            "pin": "PC2",
+                            "signal": "NWE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PC3",
+                            "signal": "A0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PC4",
+                            "signal": "NE4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PC5",
+                            "signal": "NOE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PC6",
+                            "signal": "D1",
+                            "af": 10
+                        },
+                        {
+                            "pin": "PC6",
+                            "signal": "DA1",
+                            "af": 10
+                        },
+                        {
+                            "pin": "PC11",
+                            "signal": "D2",
+                            "af": 10
+                        },
+                        {
+                            "pin": "PC11",
+                            "signal": "DA2",
+                            "af": 10
+                        },
+                        {
+                            "pin": "PC12",
+                            "signal": "D3",
+                            "af": 10
+                        },
+                        {
+                            "pin": "PC12",
+                            "signal": "DA3",
+                            "af": 10
+                        },
+                        {
+                            "pin": "PD0",
+                            "signal": "D2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD0",
+                            "signal": "DA2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD1",
+                            "signal": "D3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD1",
+                            "signal": "DA3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD2",
+                            "signal": "NWE",
+                            "af": 10
+                        },
+                        {
+                            "pin": "PD3",
+                            "signal": "CLK",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD4",
+                            "signal": "NOE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD5",
+                            "signal": "NWE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD6",
+                            "signal": "NWAIT",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD7",
+                            "signal": "NE1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD8",
+                            "signal": "D13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD8",
+                            "signal": "DA13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD9",
+                            "signal": "D14",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD9",
+                            "signal": "DA14",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD10",
+                            "signal": "D15",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD10",
+                            "signal": "DA15",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD11",
+                            "signal": "A16",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD12",
+                            "signal": "A17",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD13",
+                            "signal": "A18",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD14",
+                            "signal": "D0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD14",
+                            "signal": "DA0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD15",
+                            "signal": "D1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD15",
+                            "signal": "DA1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE0",
+                            "signal": "NBL0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE1",
+                            "signal": "NBL1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE2",
+                            "signal": "A23",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE3",
+                            "signal": "A19",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE4",
+                            "signal": "A20",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE5",
+                            "signal": "A21",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE6",
+                            "signal": "A22",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE7",
+                            "signal": "D4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE7",
+                            "signal": "DA4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE8",
+                            "signal": "D5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE8",
+                            "signal": "DA5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE9",
+                            "signal": "D6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE9",
+                            "signal": "DA6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE10",
+                            "signal": "D7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE10",
+                            "signal": "DA7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE11",
+                            "signal": "D8",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE11",
+                            "signal": "DA8",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE12",
+                            "signal": "D9",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE12",
+                            "signal": "DA9",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE13",
+                            "signal": "D10",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE13",
+                            "signal": "DA10",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE14",
+                            "signal": "D11",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE14",
+                            "signal": "DA11",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE15",
+                            "signal": "D12",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE15",
+                            "signal": "DA12",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF0",
+                            "signal": "A0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF1",
+                            "signal": "A1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF2",
+                            "signal": "A2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF3",
+                            "signal": "A3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF4",
+                            "signal": "A4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF5",
+                            "signal": "A5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF12",
+                            "signal": "A6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF13",
+                            "signal": "A7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF14",
+                            "signal": "A8",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF15",
+                            "signal": "A9",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG0",
+                            "signal": "A10",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG1",
+                            "signal": "A11",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG2",
+                            "signal": "A12",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG3",
+                            "signal": "A13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG4",
+                            "signal": "A14",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG5",
+                            "signal": "A15",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG9",
+                            "signal": "NE2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG10",
+                            "signal": "NE3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG12",
+                            "signal": "NE4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG13",
+                            "signal": "A24",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG14",
+                            "signal": "A25",
+                            "af": 12
+                        }
+                    ]
+                },
+                {
                     "name": "GPIOA",
                     "address": 1073872896,
                     "registers": {

--- a/data/chips/STM32F415OG.json
+++ b/data/chips/STM32F415OG.json
@@ -982,6 +982,244 @@
                     ]
                 },
                 {
+                    "name": "FSMC",
+                    "address": 2684354560,
+                    "registers": {
+                        "kind": "fsmc",
+                        "version": "v1",
+                        "block": "FSMC"
+                    },
+                    "rcc": {
+                        "clock": "AHB3",
+                        "enable": {
+                            "register": "AHB3ENR",
+                            "field": "FSMCEN"
+                        },
+                        "reset": {
+                            "register": "AHB3RSTR",
+                            "field": "FSMCRST"
+                        }
+                    },
+                    "pins": [
+                        {
+                            "pin": "PB7",
+                            "signal": "NL",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD0",
+                            "signal": "D2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD0",
+                            "signal": "DA2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD1",
+                            "signal": "D3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD1",
+                            "signal": "DA3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD4",
+                            "signal": "NOE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD5",
+                            "signal": "NWE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD6",
+                            "signal": "NWAIT",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD7",
+                            "signal": "NCE2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD7",
+                            "signal": "NE1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD8",
+                            "signal": "D13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD8",
+                            "signal": "DA13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD9",
+                            "signal": "D14",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD9",
+                            "signal": "DA14",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD10",
+                            "signal": "D15",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD10",
+                            "signal": "DA15",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD11",
+                            "signal": "A16",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD11",
+                            "signal": "CLE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD12",
+                            "signal": "A17",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD12",
+                            "signal": "ALE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD14",
+                            "signal": "D0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD14",
+                            "signal": "DA0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD15",
+                            "signal": "D1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD15",
+                            "signal": "DA1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE7",
+                            "signal": "D4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE7",
+                            "signal": "DA4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE8",
+                            "signal": "D5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE8",
+                            "signal": "DA5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE9",
+                            "signal": "D6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE9",
+                            "signal": "DA6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE10",
+                            "signal": "D7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE10",
+                            "signal": "DA7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE11",
+                            "signal": "D8",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE11",
+                            "signal": "DA8",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE12",
+                            "signal": "D9",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE12",
+                            "signal": "DA9",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE13",
+                            "signal": "D10",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE13",
+                            "signal": "DA10",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE14",
+                            "signal": "D11",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE14",
+                            "signal": "DA11",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE15",
+                            "signal": "D12",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE15",
+                            "signal": "DA12",
+                            "af": 12
+                        }
+                    ],
+                    "interrupts": [
+                        {
+                            "interrupt": "FSMC",
+                            "signal": "GLOBAL"
+                        }
+                    ]
+                },
+                {
                     "name": "GPIOA",
                     "address": 1073872896,
                     "registers": {

--- a/data/chips/STM32F415VG.json
+++ b/data/chips/STM32F415VG.json
@@ -1010,6 +1010,289 @@
                     ]
                 },
                 {
+                    "name": "FSMC",
+                    "address": 2684354560,
+                    "registers": {
+                        "kind": "fsmc",
+                        "version": "v1",
+                        "block": "FSMC"
+                    },
+                    "rcc": {
+                        "clock": "AHB3",
+                        "enable": {
+                            "register": "AHB3ENR",
+                            "field": "FSMCEN"
+                        },
+                        "reset": {
+                            "register": "AHB3RSTR",
+                            "field": "FSMCRST"
+                        }
+                    },
+                    "pins": [
+                        {
+                            "pin": "PB7",
+                            "signal": "NL",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD0",
+                            "signal": "D2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD0",
+                            "signal": "DA2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD1",
+                            "signal": "D3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD1",
+                            "signal": "DA3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD3",
+                            "signal": "CLK",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD4",
+                            "signal": "NOE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD5",
+                            "signal": "NWE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD6",
+                            "signal": "NWAIT",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD7",
+                            "signal": "NCE2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD7",
+                            "signal": "NE1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD8",
+                            "signal": "D13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD8",
+                            "signal": "DA13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD9",
+                            "signal": "D14",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD9",
+                            "signal": "DA14",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD10",
+                            "signal": "D15",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD10",
+                            "signal": "DA15",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD11",
+                            "signal": "A16",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD11",
+                            "signal": "CLE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD12",
+                            "signal": "A17",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD12",
+                            "signal": "ALE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD13",
+                            "signal": "A18",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD14",
+                            "signal": "D0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD14",
+                            "signal": "DA0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD15",
+                            "signal": "D1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD15",
+                            "signal": "DA1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE0",
+                            "signal": "NBL0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE1",
+                            "signal": "NBL1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE2",
+                            "signal": "A23",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE3",
+                            "signal": "A19",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE4",
+                            "signal": "A20",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE5",
+                            "signal": "A21",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE6",
+                            "signal": "A22",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE7",
+                            "signal": "D4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE7",
+                            "signal": "DA4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE8",
+                            "signal": "D5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE8",
+                            "signal": "DA5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE9",
+                            "signal": "D6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE9",
+                            "signal": "DA6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE10",
+                            "signal": "D7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE10",
+                            "signal": "DA7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE11",
+                            "signal": "D8",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE11",
+                            "signal": "DA8",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE12",
+                            "signal": "D9",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE12",
+                            "signal": "DA9",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE13",
+                            "signal": "D10",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE13",
+                            "signal": "DA10",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE14",
+                            "signal": "D11",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE14",
+                            "signal": "DA11",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE15",
+                            "signal": "D12",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE15",
+                            "signal": "DA12",
+                            "af": 12
+                        }
+                    ],
+                    "interrupts": [
+                        {
+                            "interrupt": "FSMC",
+                            "signal": "GLOBAL"
+                        }
+                    ]
+                },
+                {
                     "name": "GPIOA",
                     "address": 1073872896,
                     "registers": {

--- a/data/chips/STM32F415ZG.json
+++ b/data/chips/STM32F415ZG.json
@@ -1042,6 +1042,444 @@
                     ]
                 },
                 {
+                    "name": "FSMC",
+                    "address": 2684354560,
+                    "registers": {
+                        "kind": "fsmc",
+                        "version": "v1",
+                        "block": "FSMC"
+                    },
+                    "rcc": {
+                        "clock": "AHB3",
+                        "enable": {
+                            "register": "AHB3ENR",
+                            "field": "FSMCEN"
+                        },
+                        "reset": {
+                            "register": "AHB3RSTR",
+                            "field": "FSMCRST"
+                        }
+                    },
+                    "pins": [
+                        {
+                            "pin": "PB7",
+                            "signal": "NL",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD0",
+                            "signal": "D2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD0",
+                            "signal": "DA2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD1",
+                            "signal": "D3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD1",
+                            "signal": "DA3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD3",
+                            "signal": "CLK",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD4",
+                            "signal": "NOE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD5",
+                            "signal": "NWE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD6",
+                            "signal": "NWAIT",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD7",
+                            "signal": "NCE2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD7",
+                            "signal": "NE1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD8",
+                            "signal": "D13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD8",
+                            "signal": "DA13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD9",
+                            "signal": "D14",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD9",
+                            "signal": "DA14",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD10",
+                            "signal": "D15",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD10",
+                            "signal": "DA15",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD11",
+                            "signal": "A16",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD11",
+                            "signal": "CLE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD12",
+                            "signal": "A17",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD12",
+                            "signal": "ALE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD13",
+                            "signal": "A18",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD14",
+                            "signal": "D0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD14",
+                            "signal": "DA0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD15",
+                            "signal": "D1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD15",
+                            "signal": "DA1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE0",
+                            "signal": "NBL0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE1",
+                            "signal": "NBL1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE2",
+                            "signal": "A23",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE3",
+                            "signal": "A19",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE4",
+                            "signal": "A20",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE5",
+                            "signal": "A21",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE6",
+                            "signal": "A22",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE7",
+                            "signal": "D4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE7",
+                            "signal": "DA4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE8",
+                            "signal": "D5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE8",
+                            "signal": "DA5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE9",
+                            "signal": "D6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE9",
+                            "signal": "DA6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE10",
+                            "signal": "D7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE10",
+                            "signal": "DA7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE11",
+                            "signal": "D8",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE11",
+                            "signal": "DA8",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE12",
+                            "signal": "D9",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE12",
+                            "signal": "DA9",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE13",
+                            "signal": "D10",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE13",
+                            "signal": "DA10",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE14",
+                            "signal": "D11",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE14",
+                            "signal": "DA11",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE15",
+                            "signal": "D12",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE15",
+                            "signal": "DA12",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF0",
+                            "signal": "A0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF1",
+                            "signal": "A1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF2",
+                            "signal": "A2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF3",
+                            "signal": "A3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF4",
+                            "signal": "A4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF5",
+                            "signal": "A5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF6",
+                            "signal": "NIORD",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF7",
+                            "signal": "NREG",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF8",
+                            "signal": "NIOWR",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF9",
+                            "signal": "CD",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF10",
+                            "signal": "INTR",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF12",
+                            "signal": "A6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF13",
+                            "signal": "A7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF14",
+                            "signal": "A8",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF15",
+                            "signal": "A9",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG0",
+                            "signal": "A10",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG1",
+                            "signal": "A11",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG2",
+                            "signal": "A12",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG3",
+                            "signal": "A13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG4",
+                            "signal": "A14",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG5",
+                            "signal": "A15",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG6",
+                            "signal": "INT2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG7",
+                            "signal": "INT3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG9",
+                            "signal": "NCE3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG9",
+                            "signal": "NE2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG10",
+                            "signal": "NCE4_1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG10",
+                            "signal": "NE3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG11",
+                            "signal": "NCE4_2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG12",
+                            "signal": "NE4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG13",
+                            "signal": "A24",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG14",
+                            "signal": "A25",
+                            "af": 12
+                        }
+                    ],
+                    "interrupts": [
+                        {
+                            "interrupt": "FSMC",
+                            "signal": "GLOBAL"
+                        }
+                    ]
+                },
+                {
                     "name": "GPIOA",
                     "address": 1073872896,
                     "registers": {

--- a/data/chips/STM32F417IE.json
+++ b/data/chips/STM32F417IE.json
@@ -1473,6 +1473,444 @@
                     ]
                 },
                 {
+                    "name": "FSMC",
+                    "address": 2684354560,
+                    "registers": {
+                        "kind": "fsmc",
+                        "version": "v1",
+                        "block": "FSMC"
+                    },
+                    "rcc": {
+                        "clock": "AHB3",
+                        "enable": {
+                            "register": "AHB3ENR",
+                            "field": "FSMCEN"
+                        },
+                        "reset": {
+                            "register": "AHB3RSTR",
+                            "field": "FSMCRST"
+                        }
+                    },
+                    "pins": [
+                        {
+                            "pin": "PB7",
+                            "signal": "NL",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD0",
+                            "signal": "D2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD0",
+                            "signal": "DA2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD1",
+                            "signal": "D3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD1",
+                            "signal": "DA3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD3",
+                            "signal": "CLK",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD4",
+                            "signal": "NOE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD5",
+                            "signal": "NWE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD6",
+                            "signal": "NWAIT",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD7",
+                            "signal": "NCE2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD7",
+                            "signal": "NE1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD8",
+                            "signal": "D13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD8",
+                            "signal": "DA13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD9",
+                            "signal": "D14",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD9",
+                            "signal": "DA14",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD10",
+                            "signal": "D15",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD10",
+                            "signal": "DA15",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD11",
+                            "signal": "A16",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD11",
+                            "signal": "CLE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD12",
+                            "signal": "A17",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD12",
+                            "signal": "ALE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD13",
+                            "signal": "A18",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD14",
+                            "signal": "D0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD14",
+                            "signal": "DA0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD15",
+                            "signal": "D1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD15",
+                            "signal": "DA1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE0",
+                            "signal": "NBL0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE1",
+                            "signal": "NBL1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE2",
+                            "signal": "A23",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE3",
+                            "signal": "A19",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE4",
+                            "signal": "A20",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE5",
+                            "signal": "A21",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE6",
+                            "signal": "A22",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE7",
+                            "signal": "D4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE7",
+                            "signal": "DA4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE8",
+                            "signal": "D5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE8",
+                            "signal": "DA5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE9",
+                            "signal": "D6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE9",
+                            "signal": "DA6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE10",
+                            "signal": "D7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE10",
+                            "signal": "DA7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE11",
+                            "signal": "D8",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE11",
+                            "signal": "DA8",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE12",
+                            "signal": "D9",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE12",
+                            "signal": "DA9",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE13",
+                            "signal": "D10",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE13",
+                            "signal": "DA10",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE14",
+                            "signal": "D11",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE14",
+                            "signal": "DA11",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE15",
+                            "signal": "D12",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE15",
+                            "signal": "DA12",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF0",
+                            "signal": "A0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF1",
+                            "signal": "A1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF2",
+                            "signal": "A2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF3",
+                            "signal": "A3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF4",
+                            "signal": "A4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF5",
+                            "signal": "A5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF6",
+                            "signal": "NIORD",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF7",
+                            "signal": "NREG",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF8",
+                            "signal": "NIOWR",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF9",
+                            "signal": "CD",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF10",
+                            "signal": "INTR",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF12",
+                            "signal": "A6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF13",
+                            "signal": "A7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF14",
+                            "signal": "A8",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF15",
+                            "signal": "A9",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG0",
+                            "signal": "A10",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG1",
+                            "signal": "A11",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG2",
+                            "signal": "A12",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG3",
+                            "signal": "A13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG4",
+                            "signal": "A14",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG5",
+                            "signal": "A15",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG6",
+                            "signal": "INT2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG7",
+                            "signal": "INT3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG9",
+                            "signal": "NCE3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG9",
+                            "signal": "NE2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG10",
+                            "signal": "NCE4_1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG10",
+                            "signal": "NE3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG11",
+                            "signal": "NCE4_2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG12",
+                            "signal": "NE4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG13",
+                            "signal": "A24",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG14",
+                            "signal": "A25",
+                            "af": 12
+                        }
+                    ],
+                    "interrupts": [
+                        {
+                            "interrupt": "FSMC",
+                            "signal": "GLOBAL"
+                        }
+                    ]
+                },
+                {
                     "name": "GPIOA",
                     "address": 1073872896,
                     "registers": {

--- a/data/chips/STM32F417IG.json
+++ b/data/chips/STM32F417IG.json
@@ -1473,6 +1473,444 @@
                     ]
                 },
                 {
+                    "name": "FSMC",
+                    "address": 2684354560,
+                    "registers": {
+                        "kind": "fsmc",
+                        "version": "v1",
+                        "block": "FSMC"
+                    },
+                    "rcc": {
+                        "clock": "AHB3",
+                        "enable": {
+                            "register": "AHB3ENR",
+                            "field": "FSMCEN"
+                        },
+                        "reset": {
+                            "register": "AHB3RSTR",
+                            "field": "FSMCRST"
+                        }
+                    },
+                    "pins": [
+                        {
+                            "pin": "PB7",
+                            "signal": "NL",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD0",
+                            "signal": "D2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD0",
+                            "signal": "DA2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD1",
+                            "signal": "D3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD1",
+                            "signal": "DA3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD3",
+                            "signal": "CLK",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD4",
+                            "signal": "NOE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD5",
+                            "signal": "NWE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD6",
+                            "signal": "NWAIT",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD7",
+                            "signal": "NCE2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD7",
+                            "signal": "NE1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD8",
+                            "signal": "D13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD8",
+                            "signal": "DA13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD9",
+                            "signal": "D14",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD9",
+                            "signal": "DA14",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD10",
+                            "signal": "D15",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD10",
+                            "signal": "DA15",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD11",
+                            "signal": "A16",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD11",
+                            "signal": "CLE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD12",
+                            "signal": "A17",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD12",
+                            "signal": "ALE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD13",
+                            "signal": "A18",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD14",
+                            "signal": "D0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD14",
+                            "signal": "DA0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD15",
+                            "signal": "D1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD15",
+                            "signal": "DA1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE0",
+                            "signal": "NBL0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE1",
+                            "signal": "NBL1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE2",
+                            "signal": "A23",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE3",
+                            "signal": "A19",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE4",
+                            "signal": "A20",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE5",
+                            "signal": "A21",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE6",
+                            "signal": "A22",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE7",
+                            "signal": "D4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE7",
+                            "signal": "DA4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE8",
+                            "signal": "D5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE8",
+                            "signal": "DA5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE9",
+                            "signal": "D6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE9",
+                            "signal": "DA6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE10",
+                            "signal": "D7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE10",
+                            "signal": "DA7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE11",
+                            "signal": "D8",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE11",
+                            "signal": "DA8",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE12",
+                            "signal": "D9",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE12",
+                            "signal": "DA9",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE13",
+                            "signal": "D10",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE13",
+                            "signal": "DA10",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE14",
+                            "signal": "D11",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE14",
+                            "signal": "DA11",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE15",
+                            "signal": "D12",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE15",
+                            "signal": "DA12",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF0",
+                            "signal": "A0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF1",
+                            "signal": "A1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF2",
+                            "signal": "A2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF3",
+                            "signal": "A3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF4",
+                            "signal": "A4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF5",
+                            "signal": "A5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF6",
+                            "signal": "NIORD",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF7",
+                            "signal": "NREG",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF8",
+                            "signal": "NIOWR",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF9",
+                            "signal": "CD",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF10",
+                            "signal": "INTR",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF12",
+                            "signal": "A6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF13",
+                            "signal": "A7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF14",
+                            "signal": "A8",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF15",
+                            "signal": "A9",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG0",
+                            "signal": "A10",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG1",
+                            "signal": "A11",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG2",
+                            "signal": "A12",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG3",
+                            "signal": "A13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG4",
+                            "signal": "A14",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG5",
+                            "signal": "A15",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG6",
+                            "signal": "INT2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG7",
+                            "signal": "INT3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG9",
+                            "signal": "NCE3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG9",
+                            "signal": "NE2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG10",
+                            "signal": "NCE4_1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG10",
+                            "signal": "NE3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG11",
+                            "signal": "NCE4_2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG12",
+                            "signal": "NE4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG13",
+                            "signal": "A24",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG14",
+                            "signal": "A25",
+                            "af": 12
+                        }
+                    ],
+                    "interrupts": [
+                        {
+                            "interrupt": "FSMC",
+                            "signal": "GLOBAL"
+                        }
+                    ]
+                },
+                {
                     "name": "GPIOA",
                     "address": 1073872896,
                     "registers": {

--- a/data/chips/STM32F417VE.json
+++ b/data/chips/STM32F417VE.json
@@ -1297,6 +1297,289 @@
                     ]
                 },
                 {
+                    "name": "FSMC",
+                    "address": 2684354560,
+                    "registers": {
+                        "kind": "fsmc",
+                        "version": "v1",
+                        "block": "FSMC"
+                    },
+                    "rcc": {
+                        "clock": "AHB3",
+                        "enable": {
+                            "register": "AHB3ENR",
+                            "field": "FSMCEN"
+                        },
+                        "reset": {
+                            "register": "AHB3RSTR",
+                            "field": "FSMCRST"
+                        }
+                    },
+                    "pins": [
+                        {
+                            "pin": "PB7",
+                            "signal": "NL",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD0",
+                            "signal": "D2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD0",
+                            "signal": "DA2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD1",
+                            "signal": "D3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD1",
+                            "signal": "DA3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD3",
+                            "signal": "CLK",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD4",
+                            "signal": "NOE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD5",
+                            "signal": "NWE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD6",
+                            "signal": "NWAIT",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD7",
+                            "signal": "NCE2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD7",
+                            "signal": "NE1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD8",
+                            "signal": "D13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD8",
+                            "signal": "DA13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD9",
+                            "signal": "D14",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD9",
+                            "signal": "DA14",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD10",
+                            "signal": "D15",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD10",
+                            "signal": "DA15",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD11",
+                            "signal": "A16",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD11",
+                            "signal": "CLE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD12",
+                            "signal": "A17",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD12",
+                            "signal": "ALE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD13",
+                            "signal": "A18",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD14",
+                            "signal": "D0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD14",
+                            "signal": "DA0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD15",
+                            "signal": "D1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD15",
+                            "signal": "DA1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE0",
+                            "signal": "NBL0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE1",
+                            "signal": "NBL1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE2",
+                            "signal": "A23",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE3",
+                            "signal": "A19",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE4",
+                            "signal": "A20",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE5",
+                            "signal": "A21",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE6",
+                            "signal": "A22",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE7",
+                            "signal": "D4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE7",
+                            "signal": "DA4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE8",
+                            "signal": "D5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE8",
+                            "signal": "DA5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE9",
+                            "signal": "D6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE9",
+                            "signal": "DA6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE10",
+                            "signal": "D7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE10",
+                            "signal": "DA7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE11",
+                            "signal": "D8",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE11",
+                            "signal": "DA8",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE12",
+                            "signal": "D9",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE12",
+                            "signal": "DA9",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE13",
+                            "signal": "D10",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE13",
+                            "signal": "DA10",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE14",
+                            "signal": "D11",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE14",
+                            "signal": "DA11",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE15",
+                            "signal": "D12",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE15",
+                            "signal": "DA12",
+                            "af": 12
+                        }
+                    ],
+                    "interrupts": [
+                        {
+                            "interrupt": "FSMC",
+                            "signal": "GLOBAL"
+                        }
+                    ]
+                },
+                {
                     "name": "GPIOA",
                     "address": 1073872896,
                     "registers": {

--- a/data/chips/STM32F417VG.json
+++ b/data/chips/STM32F417VG.json
@@ -1297,6 +1297,289 @@
                     ]
                 },
                 {
+                    "name": "FSMC",
+                    "address": 2684354560,
+                    "registers": {
+                        "kind": "fsmc",
+                        "version": "v1",
+                        "block": "FSMC"
+                    },
+                    "rcc": {
+                        "clock": "AHB3",
+                        "enable": {
+                            "register": "AHB3ENR",
+                            "field": "FSMCEN"
+                        },
+                        "reset": {
+                            "register": "AHB3RSTR",
+                            "field": "FSMCRST"
+                        }
+                    },
+                    "pins": [
+                        {
+                            "pin": "PB7",
+                            "signal": "NL",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD0",
+                            "signal": "D2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD0",
+                            "signal": "DA2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD1",
+                            "signal": "D3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD1",
+                            "signal": "DA3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD3",
+                            "signal": "CLK",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD4",
+                            "signal": "NOE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD5",
+                            "signal": "NWE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD6",
+                            "signal": "NWAIT",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD7",
+                            "signal": "NCE2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD7",
+                            "signal": "NE1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD8",
+                            "signal": "D13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD8",
+                            "signal": "DA13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD9",
+                            "signal": "D14",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD9",
+                            "signal": "DA14",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD10",
+                            "signal": "D15",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD10",
+                            "signal": "DA15",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD11",
+                            "signal": "A16",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD11",
+                            "signal": "CLE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD12",
+                            "signal": "A17",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD12",
+                            "signal": "ALE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD13",
+                            "signal": "A18",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD14",
+                            "signal": "D0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD14",
+                            "signal": "DA0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD15",
+                            "signal": "D1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD15",
+                            "signal": "DA1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE0",
+                            "signal": "NBL0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE1",
+                            "signal": "NBL1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE2",
+                            "signal": "A23",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE3",
+                            "signal": "A19",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE4",
+                            "signal": "A20",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE5",
+                            "signal": "A21",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE6",
+                            "signal": "A22",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE7",
+                            "signal": "D4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE7",
+                            "signal": "DA4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE8",
+                            "signal": "D5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE8",
+                            "signal": "DA5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE9",
+                            "signal": "D6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE9",
+                            "signal": "DA6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE10",
+                            "signal": "D7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE10",
+                            "signal": "DA7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE11",
+                            "signal": "D8",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE11",
+                            "signal": "DA8",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE12",
+                            "signal": "D9",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE12",
+                            "signal": "DA9",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE13",
+                            "signal": "D10",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE13",
+                            "signal": "DA10",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE14",
+                            "signal": "D11",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE14",
+                            "signal": "DA11",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE15",
+                            "signal": "D12",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE15",
+                            "signal": "DA12",
+                            "af": 12
+                        }
+                    ],
+                    "interrupts": [
+                        {
+                            "interrupt": "FSMC",
+                            "signal": "GLOBAL"
+                        }
+                    ]
+                },
+                {
                     "name": "GPIOA",
                     "address": 1073872896,
                     "registers": {

--- a/data/chips/STM32F417ZE.json
+++ b/data/chips/STM32F417ZE.json
@@ -1359,6 +1359,444 @@
                     ]
                 },
                 {
+                    "name": "FSMC",
+                    "address": 2684354560,
+                    "registers": {
+                        "kind": "fsmc",
+                        "version": "v1",
+                        "block": "FSMC"
+                    },
+                    "rcc": {
+                        "clock": "AHB3",
+                        "enable": {
+                            "register": "AHB3ENR",
+                            "field": "FSMCEN"
+                        },
+                        "reset": {
+                            "register": "AHB3RSTR",
+                            "field": "FSMCRST"
+                        }
+                    },
+                    "pins": [
+                        {
+                            "pin": "PB7",
+                            "signal": "NL",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD0",
+                            "signal": "D2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD0",
+                            "signal": "DA2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD1",
+                            "signal": "D3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD1",
+                            "signal": "DA3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD3",
+                            "signal": "CLK",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD4",
+                            "signal": "NOE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD5",
+                            "signal": "NWE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD6",
+                            "signal": "NWAIT",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD7",
+                            "signal": "NCE2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD7",
+                            "signal": "NE1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD8",
+                            "signal": "D13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD8",
+                            "signal": "DA13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD9",
+                            "signal": "D14",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD9",
+                            "signal": "DA14",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD10",
+                            "signal": "D15",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD10",
+                            "signal": "DA15",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD11",
+                            "signal": "A16",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD11",
+                            "signal": "CLE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD12",
+                            "signal": "A17",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD12",
+                            "signal": "ALE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD13",
+                            "signal": "A18",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD14",
+                            "signal": "D0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD14",
+                            "signal": "DA0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD15",
+                            "signal": "D1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD15",
+                            "signal": "DA1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE0",
+                            "signal": "NBL0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE1",
+                            "signal": "NBL1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE2",
+                            "signal": "A23",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE3",
+                            "signal": "A19",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE4",
+                            "signal": "A20",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE5",
+                            "signal": "A21",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE6",
+                            "signal": "A22",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE7",
+                            "signal": "D4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE7",
+                            "signal": "DA4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE8",
+                            "signal": "D5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE8",
+                            "signal": "DA5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE9",
+                            "signal": "D6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE9",
+                            "signal": "DA6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE10",
+                            "signal": "D7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE10",
+                            "signal": "DA7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE11",
+                            "signal": "D8",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE11",
+                            "signal": "DA8",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE12",
+                            "signal": "D9",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE12",
+                            "signal": "DA9",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE13",
+                            "signal": "D10",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE13",
+                            "signal": "DA10",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE14",
+                            "signal": "D11",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE14",
+                            "signal": "DA11",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE15",
+                            "signal": "D12",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE15",
+                            "signal": "DA12",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF0",
+                            "signal": "A0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF1",
+                            "signal": "A1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF2",
+                            "signal": "A2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF3",
+                            "signal": "A3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF4",
+                            "signal": "A4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF5",
+                            "signal": "A5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF6",
+                            "signal": "NIORD",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF7",
+                            "signal": "NREG",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF8",
+                            "signal": "NIOWR",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF9",
+                            "signal": "CD",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF10",
+                            "signal": "INTR",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF12",
+                            "signal": "A6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF13",
+                            "signal": "A7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF14",
+                            "signal": "A8",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF15",
+                            "signal": "A9",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG0",
+                            "signal": "A10",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG1",
+                            "signal": "A11",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG2",
+                            "signal": "A12",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG3",
+                            "signal": "A13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG4",
+                            "signal": "A14",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG5",
+                            "signal": "A15",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG6",
+                            "signal": "INT2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG7",
+                            "signal": "INT3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG9",
+                            "signal": "NCE3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG9",
+                            "signal": "NE2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG10",
+                            "signal": "NCE4_1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG10",
+                            "signal": "NE3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG11",
+                            "signal": "NCE4_2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG12",
+                            "signal": "NE4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG13",
+                            "signal": "A24",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG14",
+                            "signal": "A25",
+                            "af": 12
+                        }
+                    ],
+                    "interrupts": [
+                        {
+                            "interrupt": "FSMC",
+                            "signal": "GLOBAL"
+                        }
+                    ]
+                },
+                {
                     "name": "GPIOA",
                     "address": 1073872896,
                     "registers": {

--- a/data/chips/STM32F417ZG.json
+++ b/data/chips/STM32F417ZG.json
@@ -1359,6 +1359,444 @@
                     ]
                 },
                 {
+                    "name": "FSMC",
+                    "address": 2684354560,
+                    "registers": {
+                        "kind": "fsmc",
+                        "version": "v1",
+                        "block": "FSMC"
+                    },
+                    "rcc": {
+                        "clock": "AHB3",
+                        "enable": {
+                            "register": "AHB3ENR",
+                            "field": "FSMCEN"
+                        },
+                        "reset": {
+                            "register": "AHB3RSTR",
+                            "field": "FSMCRST"
+                        }
+                    },
+                    "pins": [
+                        {
+                            "pin": "PB7",
+                            "signal": "NL",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD0",
+                            "signal": "D2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD0",
+                            "signal": "DA2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD1",
+                            "signal": "D3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD1",
+                            "signal": "DA3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD3",
+                            "signal": "CLK",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD4",
+                            "signal": "NOE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD5",
+                            "signal": "NWE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD6",
+                            "signal": "NWAIT",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD7",
+                            "signal": "NCE2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD7",
+                            "signal": "NE1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD8",
+                            "signal": "D13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD8",
+                            "signal": "DA13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD9",
+                            "signal": "D14",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD9",
+                            "signal": "DA14",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD10",
+                            "signal": "D15",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD10",
+                            "signal": "DA15",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD11",
+                            "signal": "A16",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD11",
+                            "signal": "CLE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD12",
+                            "signal": "A17",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD12",
+                            "signal": "ALE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD13",
+                            "signal": "A18",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD14",
+                            "signal": "D0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD14",
+                            "signal": "DA0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD15",
+                            "signal": "D1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD15",
+                            "signal": "DA1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE0",
+                            "signal": "NBL0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE1",
+                            "signal": "NBL1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE2",
+                            "signal": "A23",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE3",
+                            "signal": "A19",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE4",
+                            "signal": "A20",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE5",
+                            "signal": "A21",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE6",
+                            "signal": "A22",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE7",
+                            "signal": "D4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE7",
+                            "signal": "DA4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE8",
+                            "signal": "D5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE8",
+                            "signal": "DA5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE9",
+                            "signal": "D6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE9",
+                            "signal": "DA6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE10",
+                            "signal": "D7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE10",
+                            "signal": "DA7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE11",
+                            "signal": "D8",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE11",
+                            "signal": "DA8",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE12",
+                            "signal": "D9",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE12",
+                            "signal": "DA9",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE13",
+                            "signal": "D10",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE13",
+                            "signal": "DA10",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE14",
+                            "signal": "D11",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE14",
+                            "signal": "DA11",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE15",
+                            "signal": "D12",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE15",
+                            "signal": "DA12",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF0",
+                            "signal": "A0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF1",
+                            "signal": "A1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF2",
+                            "signal": "A2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF3",
+                            "signal": "A3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF4",
+                            "signal": "A4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF5",
+                            "signal": "A5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF6",
+                            "signal": "NIORD",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF7",
+                            "signal": "NREG",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF8",
+                            "signal": "NIOWR",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF9",
+                            "signal": "CD",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF10",
+                            "signal": "INTR",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF12",
+                            "signal": "A6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF13",
+                            "signal": "A7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF14",
+                            "signal": "A8",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF15",
+                            "signal": "A9",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG0",
+                            "signal": "A10",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG1",
+                            "signal": "A11",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG2",
+                            "signal": "A12",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG3",
+                            "signal": "A13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG4",
+                            "signal": "A14",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG5",
+                            "signal": "A15",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG6",
+                            "signal": "INT2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG7",
+                            "signal": "INT3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG9",
+                            "signal": "NCE3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG9",
+                            "signal": "NE2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG10",
+                            "signal": "NCE4_1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG10",
+                            "signal": "NE3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG11",
+                            "signal": "NCE4_2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG12",
+                            "signal": "NE4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG13",
+                            "signal": "A24",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG14",
+                            "signal": "A25",
+                            "af": 12
+                        }
+                    ],
+                    "interrupts": [
+                        {
+                            "interrupt": "FSMC",
+                            "signal": "GLOBAL"
+                        }
+                    ]
+                },
+                {
                     "name": "GPIOA",
                     "address": 1073872896,
                     "registers": {

--- a/data/chips/STM32F423MH.json
+++ b/data/chips/STM32F423MH.json
@@ -1327,6 +1327,248 @@
                     ]
                 },
                 {
+                    "name": "FSMC",
+                    "address": 2684354560,
+                    "registers": {
+                        "kind": "fsmc",
+                        "version": "v1",
+                        "block": "FSMC"
+                    },
+                    "rcc": {
+                        "clock": "AHB3",
+                        "enable": {
+                            "register": "AHB3ENR",
+                            "field": "FSMCEN"
+                        },
+                        "reset": {
+                            "register": "AHB3RSTR",
+                            "field": "FSMCRST"
+                        }
+                    },
+                    "pins": [
+                        {
+                            "pin": "PA2",
+                            "signal": "D4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PA2",
+                            "signal": "DA4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PA3",
+                            "signal": "D5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PA3",
+                            "signal": "DA5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PA4",
+                            "signal": "D6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PA4",
+                            "signal": "DA6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PA5",
+                            "signal": "D7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PA5",
+                            "signal": "DA7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PB7",
+                            "signal": "NL",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PB12",
+                            "signal": "D13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PB12",
+                            "signal": "DA13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PB14",
+                            "signal": "D0",
+                            "af": 10
+                        },
+                        {
+                            "pin": "PB14",
+                            "signal": "DA0",
+                            "af": 10
+                        },
+                        {
+                            "pin": "PC2",
+                            "signal": "NWE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PC3",
+                            "signal": "A0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PC4",
+                            "signal": "NE4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PC5",
+                            "signal": "NOE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PC6",
+                            "signal": "D1",
+                            "af": 10
+                        },
+                        {
+                            "pin": "PC6",
+                            "signal": "DA1",
+                            "af": 10
+                        },
+                        {
+                            "pin": "PC11",
+                            "signal": "D2",
+                            "af": 10
+                        },
+                        {
+                            "pin": "PC11",
+                            "signal": "DA2",
+                            "af": 10
+                        },
+                        {
+                            "pin": "PC12",
+                            "signal": "D3",
+                            "af": 10
+                        },
+                        {
+                            "pin": "PC12",
+                            "signal": "DA3",
+                            "af": 10
+                        },
+                        {
+                            "pin": "PD0",
+                            "signal": "D2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD0",
+                            "signal": "DA2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD2",
+                            "signal": "NWE",
+                            "af": 10
+                        },
+                        {
+                            "pin": "PD9",
+                            "signal": "D14",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD9",
+                            "signal": "DA14",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD10",
+                            "signal": "D15",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD10",
+                            "signal": "DA15",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE9",
+                            "signal": "D6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE9",
+                            "signal": "DA6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE10",
+                            "signal": "D7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE10",
+                            "signal": "DA7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE11",
+                            "signal": "D8",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE11",
+                            "signal": "DA8",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE12",
+                            "signal": "D9",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE12",
+                            "signal": "DA9",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE13",
+                            "signal": "D10",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE13",
+                            "signal": "DA10",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE14",
+                            "signal": "D11",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE14",
+                            "signal": "DA11",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE15",
+                            "signal": "D12",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE15",
+                            "signal": "DA12",
+                            "af": 12
+                        }
+                    ]
+                },
+                {
                     "name": "GPIOA",
                     "address": 1073872896,
                     "registers": {

--- a/data/chips/STM32F423RH.json
+++ b/data/chips/STM32F423RH.json
@@ -1282,6 +1282,138 @@
                     ]
                 },
                 {
+                    "name": "FSMC",
+                    "address": 2684354560,
+                    "registers": {
+                        "kind": "fsmc",
+                        "version": "v1",
+                        "block": "FSMC"
+                    },
+                    "rcc": {
+                        "clock": "AHB3",
+                        "enable": {
+                            "register": "AHB3ENR",
+                            "field": "FSMCEN"
+                        },
+                        "reset": {
+                            "register": "AHB3RSTR",
+                            "field": "FSMCRST"
+                        }
+                    },
+                    "pins": [
+                        {
+                            "pin": "PA2",
+                            "signal": "D4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PA2",
+                            "signal": "DA4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PA3",
+                            "signal": "D5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PA3",
+                            "signal": "DA5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PA4",
+                            "signal": "D6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PA4",
+                            "signal": "DA6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PA5",
+                            "signal": "D7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PA5",
+                            "signal": "DA7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PB7",
+                            "signal": "NL",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PB14",
+                            "signal": "D0",
+                            "af": 10
+                        },
+                        {
+                            "pin": "PB14",
+                            "signal": "DA0",
+                            "af": 10
+                        },
+                        {
+                            "pin": "PC2",
+                            "signal": "NWE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PC3",
+                            "signal": "A0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PC4",
+                            "signal": "NE4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PC5",
+                            "signal": "NOE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PC6",
+                            "signal": "D1",
+                            "af": 10
+                        },
+                        {
+                            "pin": "PC6",
+                            "signal": "DA1",
+                            "af": 10
+                        },
+                        {
+                            "pin": "PC11",
+                            "signal": "D2",
+                            "af": 10
+                        },
+                        {
+                            "pin": "PC11",
+                            "signal": "DA2",
+                            "af": 10
+                        },
+                        {
+                            "pin": "PC12",
+                            "signal": "D3",
+                            "af": 10
+                        },
+                        {
+                            "pin": "PC12",
+                            "signal": "DA3",
+                            "af": 10
+                        },
+                        {
+                            "pin": "PD2",
+                            "signal": "NWE",
+                            "af": 10
+                        }
+                    ]
+                },
+                {
                     "name": "GPIOA",
                     "address": 1073872896,
                     "registers": {

--- a/data/chips/STM32F423VH.json
+++ b/data/chips/STM32F423VH.json
@@ -1441,6 +1441,383 @@
                     ]
                 },
                 {
+                    "name": "FSMC",
+                    "address": 2684354560,
+                    "registers": {
+                        "kind": "fsmc",
+                        "version": "v1",
+                        "block": "FSMC"
+                    },
+                    "rcc": {
+                        "clock": "AHB3",
+                        "enable": {
+                            "register": "AHB3ENR",
+                            "field": "FSMCEN"
+                        },
+                        "reset": {
+                            "register": "AHB3RSTR",
+                            "field": "FSMCRST"
+                        }
+                    },
+                    "pins": [
+                        {
+                            "pin": "PA2",
+                            "signal": "D4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PA2",
+                            "signal": "DA4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PA3",
+                            "signal": "D5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PA3",
+                            "signal": "DA5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PA4",
+                            "signal": "D6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PA4",
+                            "signal": "DA6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PA5",
+                            "signal": "D7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PA5",
+                            "signal": "DA7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PB7",
+                            "signal": "NL",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PB12",
+                            "signal": "D13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PB12",
+                            "signal": "DA13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PB14",
+                            "signal": "D0",
+                            "af": 10
+                        },
+                        {
+                            "pin": "PB14",
+                            "signal": "DA0",
+                            "af": 10
+                        },
+                        {
+                            "pin": "PC2",
+                            "signal": "NWE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PC3",
+                            "signal": "A0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PC4",
+                            "signal": "NE4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PC5",
+                            "signal": "NOE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PC6",
+                            "signal": "D1",
+                            "af": 10
+                        },
+                        {
+                            "pin": "PC6",
+                            "signal": "DA1",
+                            "af": 10
+                        },
+                        {
+                            "pin": "PC11",
+                            "signal": "D2",
+                            "af": 10
+                        },
+                        {
+                            "pin": "PC11",
+                            "signal": "DA2",
+                            "af": 10
+                        },
+                        {
+                            "pin": "PC12",
+                            "signal": "D3",
+                            "af": 10
+                        },
+                        {
+                            "pin": "PC12",
+                            "signal": "DA3",
+                            "af": 10
+                        },
+                        {
+                            "pin": "PD0",
+                            "signal": "D2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD0",
+                            "signal": "DA2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD1",
+                            "signal": "D3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD1",
+                            "signal": "DA3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD2",
+                            "signal": "NWE",
+                            "af": 10
+                        },
+                        {
+                            "pin": "PD3",
+                            "signal": "CLK",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD4",
+                            "signal": "NOE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD5",
+                            "signal": "NWE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD6",
+                            "signal": "NWAIT",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD7",
+                            "signal": "NE1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD8",
+                            "signal": "D13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD8",
+                            "signal": "DA13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD9",
+                            "signal": "D14",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD9",
+                            "signal": "DA14",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD10",
+                            "signal": "D15",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD10",
+                            "signal": "DA15",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD11",
+                            "signal": "A16",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD12",
+                            "signal": "A17",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD13",
+                            "signal": "A18",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD14",
+                            "signal": "D0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD14",
+                            "signal": "DA0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD15",
+                            "signal": "D1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD15",
+                            "signal": "DA1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE0",
+                            "signal": "NBL0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE1",
+                            "signal": "NBL1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE2",
+                            "signal": "A23",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE3",
+                            "signal": "A19",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE4",
+                            "signal": "A20",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE5",
+                            "signal": "A21",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE6",
+                            "signal": "A22",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE7",
+                            "signal": "D4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE7",
+                            "signal": "DA4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE8",
+                            "signal": "D5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE8",
+                            "signal": "DA5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE9",
+                            "signal": "D6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE9",
+                            "signal": "DA6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE10",
+                            "signal": "D7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE10",
+                            "signal": "DA7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE11",
+                            "signal": "D8",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE11",
+                            "signal": "DA8",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE12",
+                            "signal": "D9",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE12",
+                            "signal": "DA9",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE13",
+                            "signal": "D10",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE13",
+                            "signal": "DA10",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE14",
+                            "signal": "D11",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE14",
+                            "signal": "DA11",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE15",
+                            "signal": "D12",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE15",
+                            "signal": "DA12",
+                            "af": 12
+                        }
+                    ]
+                },
+                {
                     "name": "GPIOA",
                     "address": 1073872896,
                     "registers": {

--- a/data/chips/STM32F423ZH.json
+++ b/data/chips/STM32F423ZH.json
@@ -1476,6 +1476,488 @@
                     ]
                 },
                 {
+                    "name": "FSMC",
+                    "address": 2684354560,
+                    "registers": {
+                        "kind": "fsmc",
+                        "version": "v1",
+                        "block": "FSMC"
+                    },
+                    "rcc": {
+                        "clock": "AHB3",
+                        "enable": {
+                            "register": "AHB3ENR",
+                            "field": "FSMCEN"
+                        },
+                        "reset": {
+                            "register": "AHB3RSTR",
+                            "field": "FSMCRST"
+                        }
+                    },
+                    "pins": [
+                        {
+                            "pin": "PA2",
+                            "signal": "D4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PA2",
+                            "signal": "DA4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PA3",
+                            "signal": "D5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PA3",
+                            "signal": "DA5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PA4",
+                            "signal": "D6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PA4",
+                            "signal": "DA6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PA5",
+                            "signal": "D7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PA5",
+                            "signal": "DA7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PB7",
+                            "signal": "NL",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PB12",
+                            "signal": "D13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PB12",
+                            "signal": "DA13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PB14",
+                            "signal": "D0",
+                            "af": 10
+                        },
+                        {
+                            "pin": "PB14",
+                            "signal": "DA0",
+                            "af": 10
+                        },
+                        {
+                            "pin": "PC2",
+                            "signal": "NWE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PC3",
+                            "signal": "A0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PC4",
+                            "signal": "NE4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PC5",
+                            "signal": "NOE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PC6",
+                            "signal": "D1",
+                            "af": 10
+                        },
+                        {
+                            "pin": "PC6",
+                            "signal": "DA1",
+                            "af": 10
+                        },
+                        {
+                            "pin": "PC11",
+                            "signal": "D2",
+                            "af": 10
+                        },
+                        {
+                            "pin": "PC11",
+                            "signal": "DA2",
+                            "af": 10
+                        },
+                        {
+                            "pin": "PC12",
+                            "signal": "D3",
+                            "af": 10
+                        },
+                        {
+                            "pin": "PC12",
+                            "signal": "DA3",
+                            "af": 10
+                        },
+                        {
+                            "pin": "PD0",
+                            "signal": "D2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD0",
+                            "signal": "DA2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD1",
+                            "signal": "D3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD1",
+                            "signal": "DA3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD2",
+                            "signal": "NWE",
+                            "af": 10
+                        },
+                        {
+                            "pin": "PD3",
+                            "signal": "CLK",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD4",
+                            "signal": "NOE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD5",
+                            "signal": "NWE",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD6",
+                            "signal": "NWAIT",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD7",
+                            "signal": "NE1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD8",
+                            "signal": "D13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD8",
+                            "signal": "DA13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD9",
+                            "signal": "D14",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD9",
+                            "signal": "DA14",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD10",
+                            "signal": "D15",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD10",
+                            "signal": "DA15",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD11",
+                            "signal": "A16",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD12",
+                            "signal": "A17",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD13",
+                            "signal": "A18",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD14",
+                            "signal": "D0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD14",
+                            "signal": "DA0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD15",
+                            "signal": "D1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PD15",
+                            "signal": "DA1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE0",
+                            "signal": "NBL0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE1",
+                            "signal": "NBL1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE2",
+                            "signal": "A23",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE3",
+                            "signal": "A19",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE4",
+                            "signal": "A20",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE5",
+                            "signal": "A21",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE6",
+                            "signal": "A22",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE7",
+                            "signal": "D4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE7",
+                            "signal": "DA4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE8",
+                            "signal": "D5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE8",
+                            "signal": "DA5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE9",
+                            "signal": "D6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE9",
+                            "signal": "DA6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE10",
+                            "signal": "D7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE10",
+                            "signal": "DA7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE11",
+                            "signal": "D8",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE11",
+                            "signal": "DA8",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE12",
+                            "signal": "D9",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE12",
+                            "signal": "DA9",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE13",
+                            "signal": "D10",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE13",
+                            "signal": "DA10",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE14",
+                            "signal": "D11",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE14",
+                            "signal": "DA11",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE15",
+                            "signal": "D12",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PE15",
+                            "signal": "DA12",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF0",
+                            "signal": "A0",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF1",
+                            "signal": "A1",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF2",
+                            "signal": "A2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF3",
+                            "signal": "A3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF4",
+                            "signal": "A4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF5",
+                            "signal": "A5",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF12",
+                            "signal": "A6",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF13",
+                            "signal": "A7",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF14",
+                            "signal": "A8",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PF15",
+                            "signal": "A9",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG0",
+                            "signal": "A10",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG1",
+                            "signal": "A11",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG2",
+                            "signal": "A12",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG3",
+                            "signal": "A13",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG4",
+                            "signal": "A14",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG5",
+                            "signal": "A15",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG9",
+                            "signal": "NE2",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG10",
+                            "signal": "NE3",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG12",
+                            "signal": "NE4",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG13",
+                            "signal": "A24",
+                            "af": 12
+                        },
+                        {
+                            "pin": "PG14",
+                            "signal": "A25",
+                            "af": 12
+                        }
+                    ]
+                },
+                {
                     "name": "GPIOA",
                     "address": 1073872896,
                     "registers": {

--- a/data/chips/STM32L151QD.json
+++ b/data/chips/STM32L151QD.json
@@ -919,7 +919,12 @@
                 },
                 {
                     "name": "FSMC",
-                    "address": 1610612736,
+                    "address": 2684354560,
+                    "registers": {
+                        "kind": "fsmc",
+                        "version": "v1",
+                        "block": "FSMC"
+                    },
                     "rcc": {
                         "clock": "AHB1",
                         "enable": {

--- a/data/chips/STM32L151VD.json
+++ b/data/chips/STM32L151VD.json
@@ -847,7 +847,12 @@
                 },
                 {
                     "name": "FSMC",
-                    "address": 1610612736,
+                    "address": 2684354560,
+                    "registers": {
+                        "kind": "fsmc",
+                        "version": "v1",
+                        "block": "FSMC"
+                    },
                     "rcc": {
                         "clock": "AHB1",
                         "enable": {

--- a/data/chips/STM32L151ZD.json
+++ b/data/chips/STM32L151ZD.json
@@ -927,7 +927,12 @@
                 },
                 {
                     "name": "FSMC",
-                    "address": 1610612736,
+                    "address": 2684354560,
+                    "registers": {
+                        "kind": "fsmc",
+                        "version": "v1",
+                        "block": "FSMC"
+                    },
                     "rcc": {
                         "clock": "AHB1",
                         "enable": {

--- a/data/chips/STM32L152QD.json
+++ b/data/chips/STM32L152QD.json
@@ -919,7 +919,12 @@
                 },
                 {
                     "name": "FSMC",
-                    "address": 1610612736,
+                    "address": 2684354560,
+                    "registers": {
+                        "kind": "fsmc",
+                        "version": "v1",
+                        "block": "FSMC"
+                    },
                     "rcc": {
                         "clock": "AHB1",
                         "enable": {

--- a/data/chips/STM32L152VD.json
+++ b/data/chips/STM32L152VD.json
@@ -847,7 +847,12 @@
                 },
                 {
                     "name": "FSMC",
-                    "address": 1610612736,
+                    "address": 2684354560,
+                    "registers": {
+                        "kind": "fsmc",
+                        "version": "v1",
+                        "block": "FSMC"
+                    },
                     "rcc": {
                         "clock": "AHB1",
                         "enable": {

--- a/data/chips/STM32L152ZD.json
+++ b/data/chips/STM32L152ZD.json
@@ -927,7 +927,12 @@
                 },
                 {
                     "name": "FSMC",
-                    "address": 1610612736,
+                    "address": 2684354560,
+                    "registers": {
+                        "kind": "fsmc",
+                        "version": "v1",
+                        "block": "FSMC"
+                    },
                     "rcc": {
                         "clock": "AHB1",
                         "enable": {

--- a/data/chips/STM32L162QD.json
+++ b/data/chips/STM32L162QD.json
@@ -939,7 +939,12 @@
                 },
                 {
                     "name": "FSMC",
-                    "address": 1610612736,
+                    "address": 2684354560,
+                    "registers": {
+                        "kind": "fsmc",
+                        "version": "v1",
+                        "block": "FSMC"
+                    },
                     "rcc": {
                         "clock": "AHB1",
                         "enable": {

--- a/data/chips/STM32L162VD.json
+++ b/data/chips/STM32L162VD.json
@@ -867,7 +867,12 @@
                 },
                 {
                     "name": "FSMC",
-                    "address": 1610612736,
+                    "address": 2684354560,
+                    "registers": {
+                        "kind": "fsmc",
+                        "version": "v1",
+                        "block": "FSMC"
+                    },
                     "rcc": {
                         "clock": "AHB1",
                         "enable": {

--- a/data/chips/STM32L162ZD.json
+++ b/data/chips/STM32L162ZD.json
@@ -947,7 +947,12 @@
                 },
                 {
                     "name": "FSMC",
-                    "address": 1610612736,
+                    "address": 2684354560,
+                    "registers": {
+                        "kind": "fsmc",
+                        "version": "v1",
+                        "block": "FSMC"
+                    },
                     "rcc": {
                         "clock": "AHB1",
                         "enable": {

--- a/data/registers/fsmc_v1.yaml
+++ b/data/registers/fsmc_v1.yaml
@@ -1,0 +1,1191 @@
+---
+block/FSMC:
+  description: Flexible memory controller
+  items:
+    - name: BCR1
+      description: SRAM/NOR-Flash chip-select control register 1
+      byte_offset: 0
+      fieldset: BCR
+    - name: BTR1
+      description: SRAM/NOR-Flash chip-select timing register 1
+      byte_offset: 4
+      fieldset: BTR
+    - name: BCR2
+      description: SRAM/NOR-Flash chip-select control register 2
+      byte_offset: 8
+      fieldset: BCR
+    - name: BTR2
+      description: SRAM/NOR-Flash chip-select timing register 2
+      byte_offset: 12
+      fieldset: BTR
+    - name: BCR3
+      description: SRAM/NOR-Flash chip-select control register 3
+      byte_offset: 16
+      fieldset: BCR
+    - name: BTR3
+      description: SRAM/NOR-Flash chip-select timing register 3
+      byte_offset: 20
+      fieldset: BTR
+    - name: BCR4
+      description: SRAM/NOR-Flash chip-select control register 4
+      byte_offset: 24
+      fieldset: BCR
+    - name: BTR4
+      description: SRAM/NOR-Flash chip-select timing register 4
+      byte_offset: 28
+      fieldset: BTR
+    - name: PCR2
+      description: PC Card/NAND Flash control register 2
+      byte_offset: 96
+      fieldset: PCR
+    - name: PCR3
+      description: PC Card/NAND Flash control register 3
+      byte_offset: 128
+      fieldset: PCR
+    - name: PCR4
+      description: PC Card/NAND Flash control register 4
+      byte_offset: 160
+      fieldset: PCR
+    - name: SR2
+      description: FIFO status and interrupt register 2
+      byte_offset: 100
+      fieldset: SR
+    - name: SR3
+      description: FIFO status and interrupt register 3
+      byte_offset: 132
+      fieldset: SR
+    - name: SR4
+      description: FIFO status and interrupt register 4
+      byte_offset: 164
+      fieldset: SR
+    - name: PMEM2
+      description: Common memory space timing register 2
+      byte_offset: 104
+      fieldset: PMEM
+    - name: PATT2
+      description: Attribute memory space timing register 2
+      byte_offset: 108
+      fieldset: PATT
+    - name: ECCR2
+      description: ECC result register 2
+      byte_offset: 116
+      access: Read
+      fieldset: ECCR
+    - name: PMEM3
+      description: Common memory space timing register 3
+      byte_offset: 136
+      fieldset: PMEM
+    - name: PATT3
+      description: Attribute memory space timing register 3
+      byte_offset: 140
+      fieldset: PATT
+    - name: ECCR3
+      description: ECC result register 3
+      byte_offset: 148
+      access: Read
+      fieldset: ECCR
+    - name: PMEM4
+      description: Common memory space timing register 4
+      byte_offset: 168
+      fieldset: PMEM
+    - name: PATT4
+      description: Attribute memory space timing register 4
+      byte_offset: 172
+      fieldset: PATT
+    - name: PIO4
+      description: I/O space timing register 4
+      byte_offset: 176
+      fieldset: PIO
+    - name: BWTR1
+      description: SRAM/NOR-Flash write timing registers 1
+      byte_offset: 260
+      fieldset: BWTR
+    - name: BWTR2
+      description: SRAM/NOR-Flash write timing registers 2
+      byte_offset: 268
+      fieldset: BWTR
+    - name: BWTR3
+      description: SRAM/NOR-Flash write timing registers 3
+      byte_offset: 276
+      fieldset: BWTR
+    - name: BWTR4
+      description: SRAM/NOR-Flash write timing registers 4
+      byte_offset: 284
+      fieldset: BWTR
+    - name: SDCR1
+      description: SDRAM Control Register 1
+      byte_offset: 320
+      fieldset: SDCR
+    - name: SDCR2
+      description: SDRAM Control Register 2
+      byte_offset: 324
+      fieldset: SDCR
+    - name: SDTR1
+      description: SDRAM Timing register 1
+      byte_offset: 328
+      fieldset: SDTR
+    - name: SDTR2
+      description: SDRAM Timing register 2
+      byte_offset: 332
+      fieldset: SDTR
+    - name: SDCMR
+      description: SDRAM Command Mode register
+      byte_offset: 336
+      fieldset: SDCMR
+    - name: SDRTR
+      description: SDRAM Refresh Timer register
+      byte_offset: 340
+      fieldset: SDRTR
+    - name: SDSR
+      description: SDRAM Status register
+      byte_offset: 344
+      access: Read
+      fieldset: SDSR
+
+fieldset/BCR:
+  description: SRAM/NOR-Flash chip-select control register
+  fields:
+    - name: MBKEN
+      description: MBKEN
+      bit_offset: 0
+      bit_size: 1
+      enum: BCR_MBKEN
+    - name: MUXEN
+      description: MUXEN
+      bit_offset: 1
+      bit_size: 1
+      enum: BCR_MUXEN
+    - name: MTYP
+      description: MTYP
+      bit_offset: 2
+      bit_size: 2
+      enum: BCR_MTYP
+    - name: MWID
+      description: MWID
+      bit_offset: 4
+      bit_size: 2
+      enum: BCR_MWID
+    - name: FACCEN
+      description: FACCEN
+      bit_offset: 6
+      bit_size: 1
+      enum: BCR_FACCEN
+    - name: BURSTEN
+      description: BURSTEN
+      bit_offset: 8
+      bit_size: 1
+      enum: BCR_BURSTEN
+    - name: WAITPOL
+      description: WAITPOL
+      bit_offset: 9
+      bit_size: 1
+      enum: BCR_WAITPOL
+    - name: WRAPMOD
+      description: WRAPMOD
+      bit_offset: 10
+      bit_size: 1
+    - name: WAITCFG
+      description: WAITCFG
+      bit_offset: 11
+      bit_size: 1
+      enum: BCR_WAITCFG
+    - name: WREN
+      description: WREN
+      bit_offset: 12
+      bit_size: 1
+      enum: BCR_WREN
+    - name: WAITEN
+      description: WAITEN
+      bit_offset: 13
+      bit_size: 1
+      enum: BCR_WAITEN
+    - name: EXTMOD
+      description: EXTMOD
+      bit_offset: 14
+      bit_size: 1
+      enum: BCR_EXTMOD
+    - name: ASYNCWAIT
+      description: ASYNCWAIT
+      bit_offset: 15
+      bit_size: 1
+      enum: BCR_ASYNCWAIT
+    - name: CPSIZE
+      description: CPSIZE
+      bit_offset: 16
+      bit_size: 3
+      enum: BCR_CPSIZE
+    - name: CBURSTRW
+      description: CBURSTRW
+      bit_offset: 19
+      bit_size: 1
+      enum: BCR_CBURSTRW
+    - name: CCLKEN
+      description: CCLKEN
+      bit_offset: 20
+      bit_size: 1
+fieldset/BTR:
+  description: SRAM/NOR-Flash chip-select timing register
+  fields:
+    - name: ADDSET
+      description: ADDSET
+      bit_offset: 0
+      bit_size: 4
+    - name: ADDHLD
+      description: ADDHLD
+      bit_offset: 4
+      bit_size: 4
+    - name: DATAST
+      description: DATAST
+      bit_offset: 8
+      bit_size: 8
+    - name: BUSTURN
+      description: BUSTURN
+      bit_offset: 16
+      bit_size: 4
+    - name: CLKDIV
+      description: CLKDIV
+      bit_offset: 20
+      bit_size: 4
+    - name: DATLAT
+      description: DATLAT
+      bit_offset: 24
+      bit_size: 4
+    - name: ACCMOD
+      description: ACCMOD
+      bit_offset: 28
+      bit_size: 2
+      enum: BTR_ACCMOD
+fieldset/BWTR:
+  description: SRAM/NOR-Flash write timing register
+  fields:
+    - name: ADDSET
+      description: ADDSET
+      bit_offset: 0
+      bit_size: 4
+    - name: ADDHLD
+      description: ADDHLD
+      bit_offset: 4
+      bit_size: 4
+    - name: DATAST
+      description: DATAST
+      bit_offset: 8
+      bit_size: 8
+    - name: BUSTURN
+      description: BUSTURN
+      bit_offset: 16
+      bit_size: 4
+    - name: CLKDIV
+      description: CLKDIV
+      bit_offset: 20
+      bit_size: 4
+    - name: ACCMOD
+      description: ACCMOD
+      bit_offset: 28
+      bit_size: 2
+      enum: BWTR_ACCMOD
+fieldset/ECCR:
+  description: ECC result register
+  fields:
+    - name: ECC
+      description: ECCx
+      bit_offset: 0
+      bit_size: 32
+fieldset/PATT:
+  description: Attribute memory space timing register
+  fields:
+    - name: ATTSET
+      description: ATTSETx
+      bit_offset: 0
+      bit_size: 8
+    - name: ATTWAIT
+      description: ATTWAITx
+      bit_offset: 8
+      bit_size: 8
+    - name: ATTHOLD
+      description: ATTHOLDx
+      bit_offset: 16
+      bit_size: 8
+    - name: ATTHIZ
+      description: ATTHIZx
+      bit_offset: 24
+      bit_size: 8
+fieldset/PCR:
+  description: PC Card/NAND Flash control register
+  fields:
+    - name: PWAITEN
+      description: PWAITEN
+      bit_offset: 1
+      bit_size: 1
+      enum: PWAITEN
+    - name: PBKEN
+      description: PBKEN
+      bit_offset: 2
+      bit_size: 1
+      enum: PBKEN
+    - name: PTYP
+      description: PTYP
+      bit_offset: 3
+      bit_size: 1
+      enum: PTYP
+    - name: PWID
+      description: PWID
+      bit_offset: 4
+      bit_size: 2
+      enum: PWID
+    - name: ECCEN
+      description: ECCEN
+      bit_offset: 6
+      bit_size: 1
+      enum: ECCEN
+    - name: TCLR
+      description: TCLR
+      bit_offset: 9
+      bit_size: 4
+    - name: TAR
+      description: TAR
+      bit_offset: 13
+      bit_size: 4
+    - name: ECCPS
+      description: ECCPS
+      bit_offset: 17
+      bit_size: 3
+      enum: ECCPS
+fieldset/PIO:
+  description: I/O space timing register
+  fields:
+    - name: IOSETx
+      description: IOSETx
+      bit_offset: 0
+      bit_size: 8
+    - name: IOWAITx
+      description: IOWAITx
+      bit_offset: 8
+      bit_size: 8
+    - name: IOHOLDx
+      description: IOHOLDx
+      bit_offset: 16
+      bit_size: 8
+    - name: IOHIZx
+      description: IOHIZx
+      bit_offset: 24
+      bit_size: 8
+fieldset/PMEM:
+  description: Common memory space timing register
+  fields:
+    - name: MEMSET
+      description: MEMSETx
+      bit_offset: 0
+      bit_size: 8
+    - name: MEMWAIT
+      description: MEMWAITx
+      bit_offset: 8
+      bit_size: 8
+    - name: MEMHOLD
+      description: MEMHOLDx
+      bit_offset: 16
+      bit_size: 8
+    - name: MEMHIZ
+      description: MEMHIZx
+      bit_offset: 24
+      bit_size: 8
+fieldset/SDCMR:
+  description: SDRAM Command Mode register
+  fields:
+    - name: MODE
+      description: Command mode
+      bit_offset: 0
+      bit_size: 3
+      enum: MODE
+    - name: CTB2
+      description: Command target bank 2
+      bit_offset: 3
+      bit_size: 1
+      enum: CTB2
+    - name: CTB1
+      description: Command target bank 1
+      bit_offset: 4
+      bit_size: 1
+      enum: CTB2
+    - name: NRFS
+      description: Number of Auto-refresh
+      bit_offset: 5
+      bit_size: 4
+    - name: MRD
+      description: Mode Register definition
+      bit_offset: 9
+      bit_size: 13
+fieldset/SDCR:
+  description: SDRAM Control Register
+  fields:
+    - name: NC
+      description: Number of column address bits
+      bit_offset: 0
+      bit_size: 2
+      enum: NC
+    - name: NR
+      description: Number of row address bits
+      bit_offset: 2
+      bit_size: 2
+      enum: NR
+    - name: MWID
+      description: Memory data bus width
+      bit_offset: 4
+      bit_size: 2
+      enum: SDCR_MWID
+    - name: NB
+      description: Number of internal banks
+      bit_offset: 6
+      bit_size: 1
+      enum: NB
+    - name: CAS
+      description: CAS latency
+      bit_offset: 7
+      bit_size: 2
+      enum: CAS
+    - name: WP
+      description: Write protection
+      bit_offset: 9
+      bit_size: 1
+      enum: WP
+    - name: SDCLK
+      description: SDRAM clock configuration
+      bit_offset: 10
+      bit_size: 2
+      enum: SDCLK
+    - name: RBURST
+      description: Burst read
+      bit_offset: 12
+      bit_size: 1
+      enum: RBURST
+    - name: RPIPE
+      description: Read pipe
+      bit_offset: 13
+      bit_size: 2
+      enum: RPIPE
+fieldset/SDRTR:
+  description: SDRAM Refresh Timer register
+  fields:
+    - name: CRE
+      description: Clear Refresh error flag
+      bit_offset: 0
+      bit_size: 1
+      enum: CRE
+    - name: COUNT
+      description: Refresh Timer Count
+      bit_offset: 1
+      bit_size: 13
+    - name: REIE
+      description: RES Interrupt Enable
+      bit_offset: 14
+      bit_size: 1
+      enum: REIE
+fieldset/SDSR:
+  description: SDRAM Status register
+  fields:
+    - name: RE
+      description: Refresh error flag
+      bit_offset: 0
+      bit_size: 1
+      enum: RE
+    - name: MODES1
+      description: Status Mode for Bank 1
+      bit_offset: 1
+      bit_size: 2
+      enum: MODES1
+    - name: MODES2
+      description: Status Mode for Bank 2
+      bit_offset: 3
+      bit_size: 2
+      enum: MODES1
+    - name: BUSY
+      description: Busy status
+      bit_offset: 5
+      bit_size: 1
+      enum: BUSY
+fieldset/SDTR:
+  description: SDRAM Timing register
+  fields:
+    - name: TMRD
+      description: Load Mode Register to Active
+      bit_offset: 0
+      bit_size: 4
+    - name: TXSR
+      description: Exit self-refresh delay
+      bit_offset: 4
+      bit_size: 4
+    - name: TRAS
+      description: Self refresh time
+      bit_offset: 8
+      bit_size: 4
+    - name: TRC
+      description: Row cycle delay
+      bit_offset: 12
+      bit_size: 4
+    - name: TWR
+      description: Recovery delay
+      bit_offset: 16
+      bit_size: 4
+    - name: TRP
+      description: Row precharge delay
+      bit_offset: 20
+      bit_size: 4
+    - name: TRCD
+      description: Row to column delay
+      bit_offset: 24
+      bit_size: 4
+fieldset/SR:
+  description: FIFO status and interrupt register
+  fields:
+    - name: IRS
+      description: IRS
+      bit_offset: 0
+      bit_size: 1
+      enum: IRS
+    - name: ILS
+      description: ILS
+      bit_offset: 1
+      bit_size: 1
+      enum: ILS
+    - name: IFS
+      description: IFS
+      bit_offset: 2
+      bit_size: 1
+      enum: IFS
+    - name: IREN
+      description: IREN
+      bit_offset: 3
+      bit_size: 1
+      enum: IREN
+    - name: ILEN
+      description: ILEN
+      bit_offset: 4
+      bit_size: 1
+      enum: ILEN
+    - name: IFEN
+      description: IFEN
+      bit_offset: 5
+      bit_size: 1
+      enum: IFEN
+    - name: FEMPT
+      description: FEMPT
+      bit_offset: 6
+      bit_size: 1
+      enum: FEMPT
+enum/BCR1_ASYNCWAIT:
+  bit_size: 1
+  variants:
+    - name: Disabled
+      description: Wait signal not used in asynchronous mode
+      value: 0
+    - name: Enabled
+      description: Wait signal used even in asynchronous mode
+      value: 1
+enum/BCR1_BURSTEN:
+  bit_size: 1
+  variants:
+    - name: Disabled
+      description: Burst mode disabled
+      value: 0
+    - name: Enabled
+      description: Burst mode enabled
+      value: 1
+enum/BCR1_CBURSTRW:
+  bit_size: 1
+  variants:
+    - name: Disabled
+      description: Write operations are always performed in asynchronous mode
+      value: 0
+    - name: Enabled
+      description: Write operations are performed in synchronous mode
+      value: 1
+enum/BCR1_CPSIZE:
+  bit_size: 3
+  variants:
+    - name: NoBurstSplit
+      description: No burst split when crossing page boundary
+      value: 0
+    - name: Bytes128
+      description: 128 bytes CRAM page size
+      value: 1
+    - name: Bytes256
+      description: 256 bytes CRAM page size
+      value: 2
+    - name: Bytes512
+      description: 512 bytes CRAM page size
+      value: 3
+    - name: Bytes1024
+      description: 1024 bytes CRAM page size
+      value: 4
+enum/BCR1_EXTMOD:
+  bit_size: 1
+  variants:
+    - name: Disabled
+      description: Values inside the FMC_BWTR are not taken into account
+      value: 0
+    - name: Enabled
+      description: Values inside the FMC_BWTR are taken into account
+      value: 1
+enum/BCR1_FACCEN:
+  bit_size: 1
+  variants:
+    - name: Disabled
+      description: Corresponding NOR Flash memory access is disabled
+      value: 0
+    - name: Enabled
+      description: Corresponding NOR Flash memory access is enabled
+      value: 1
+enum/BCR1_MBKEN:
+  bit_size: 1
+  variants:
+    - name: Disabled
+      description: Corresponding memory bank is disabled
+      value: 0
+    - name: Enabled
+      description: Corresponding memory bank is enabled
+      value: 1
+enum/BCR1_MTYP:
+  bit_size: 2
+  variants:
+    - name: SRAM
+      description: SRAM memory type
+      value: 0
+    - name: PSRAM
+      description: PSRAM (CRAM) memory type
+      value: 1
+    - name: Flash
+      description: NOR Flash/OneNAND Flash
+      value: 2
+enum/BCR1_MUXEN:
+  bit_size: 1
+  variants:
+    - name: Disabled
+      description: Address/Data non-multiplexed
+      value: 0
+    - name: Enabled
+      description: Address/Data multiplexed on databus
+      value: 1
+enum/BCR1_MWID:
+  bit_size: 2
+  variants:
+    - name: Bits8
+      description: Memory data bus width 8 bits
+      value: 0
+    - name: Bits16
+      description: Memory data bus width 16 bits
+      value: 1
+    - name: Bits32
+      description: Memory data bus width 32 bits
+      value: 2
+enum/BCR1_WAITCFG:
+  bit_size: 1
+  variants:
+    - name: BeforeWaitState
+      description: NWAIT signal is active one data cycle before wait state
+      value: 0
+    - name: DuringWaitState
+      description: NWAIT signal is active during wait state
+      value: 1
+enum/BCR1_WAITEN:
+  bit_size: 1
+  variants:
+    - name: Disabled
+      description: Values inside the FMC_BWTR are taken into account
+      value: 0
+    - name: Enabled
+      description: NWAIT signal enabled
+      value: 1
+enum/BCR1_WAITPOL:
+  bit_size: 1
+  variants:
+    - name: ActiveLow
+      description: NWAIT active low
+      value: 0
+    - name: ActiveHigh
+      description: NWAIT active high
+      value: 1
+enum/BCR1_WREN:
+  bit_size: 1
+  variants:
+    - name: Disabled
+      description: Write operations disabled for the bank by the FMC
+      value: 0
+    - name: Enabled
+      description: Write operations enabled for the bank by the FMC
+      value: 1
+enum/BCR_ASYNCWAIT:
+  bit_size: 1
+  variants:
+    - name: Disabled
+      description: Wait signal not used in asynchronous mode
+      value: 0
+    - name: Enabled
+      description: Wait signal used even in asynchronous mode
+      value: 1
+enum/BCR_BURSTEN:
+  bit_size: 1
+  variants:
+    - name: Disabled
+      description: Burst mode disabled
+      value: 0
+    - name: Enabled
+      description: Burst mode enabled
+      value: 1
+enum/BCR_CBURSTRW:
+  bit_size: 1
+  variants:
+    - name: Disabled
+      description: Write operations are always performed in asynchronous mode
+      value: 0
+    - name: Enabled
+      description: Write operations are performed in synchronous mode
+      value: 1
+enum/BCR_CPSIZE:
+  bit_size: 3
+  variants:
+    - name: NoBurstSplit
+      description: No burst split when crossing page boundary
+      value: 0
+    - name: Bytes128
+      description: 128 bytes CRAM page size
+      value: 1
+    - name: Bytes256
+      description: 256 bytes CRAM page size
+      value: 2
+    - name: Bytes512
+      description: 512 bytes CRAM page size
+      value: 3
+    - name: Bytes1024
+      description: 1024 bytes CRAM page size
+      value: 4
+enum/BCR_EXTMOD:
+  bit_size: 1
+  variants:
+    - name: Disabled
+      description: Values inside the FMC_BWTR are not taken into account
+      value: 0
+    - name: Enabled
+      description: Values inside the FMC_BWTR are taken into account
+      value: 1
+enum/BCR_FACCEN:
+  bit_size: 1
+  variants:
+    - name: Disabled
+      description: Corresponding NOR Flash memory access is disabled
+      value: 0
+    - name: Enabled
+      description: Corresponding NOR Flash memory access is enabled
+      value: 1
+enum/BCR_MBKEN:
+  bit_size: 1
+  variants:
+    - name: Disabled
+      description: Corresponding memory bank is disabled
+      value: 0
+    - name: Enabled
+      description: Corresponding memory bank is enabled
+      value: 1
+enum/BCR_MTYP:
+  bit_size: 2
+  variants:
+    - name: SRAM
+      description: SRAM memory type
+      value: 0
+    - name: PSRAM
+      description: PSRAM (CRAM) memory type
+      value: 1
+    - name: Flash
+      description: NOR Flash/OneNAND Flash
+      value: 2
+enum/BCR_MUXEN:
+  bit_size: 1
+  variants:
+    - name: Disabled
+      description: Address/Data non-multiplexed
+      value: 0
+    - name: Enabled
+      description: Address/Data multiplexed on databus
+      value: 1
+enum/BCR_MWID:
+  bit_size: 2
+  variants:
+    - name: Bits8
+      description: Memory data bus width 8 bits
+      value: 0
+    - name: Bits16
+      description: Memory data bus width 16 bits
+      value: 1
+    - name: Bits32
+      description: Memory data bus width 32 bits
+      value: 2
+enum/BCR_WAITCFG:
+  bit_size: 1
+  variants:
+    - name: BeforeWaitState
+      description: NWAIT signal is active one data cycle before wait state
+      value: 0
+    - name: DuringWaitState
+      description: NWAIT signal is active during wait state
+      value: 1
+enum/BCR_WAITEN:
+  bit_size: 1
+  variants:
+    - name: Disabled
+      description: Values inside the FMC_BWTR are taken into account
+      value: 0
+    - name: Enabled
+      description: NWAIT signal enabled
+      value: 1
+enum/BCR_WAITPOL:
+  bit_size: 1
+  variants:
+    - name: ActiveLow
+      description: NWAIT active low
+      value: 0
+    - name: ActiveHigh
+      description: NWAIT active high
+      value: 1
+enum/BCR_WREN:
+  bit_size: 1
+  variants:
+    - name: Disabled
+      description: Write operations disabled for the bank by the FMC
+      value: 0
+    - name: Enabled
+      description: Write operations enabled for the bank by the FMC
+      value: 1
+enum/BTR_ACCMOD:
+  bit_size: 2
+  variants:
+    - name: A
+      description: Access mode A
+      value: 0
+    - name: B
+      description: Access mode B
+      value: 1
+    - name: C
+      description: Access mode C
+      value: 2
+    - name: D
+      description: Access mode D
+      value: 3
+enum/BUSY:
+  bit_size: 1
+  variants:
+    - name: NotBusy
+      description: SDRAM Controller is ready to accept a new request
+      value: 0
+    - name: Busy
+      description: SDRAM Controller is not ready to accept a new request
+      value: 1
+enum/BWTR_ACCMOD:
+  bit_size: 2
+  variants:
+    - name: A
+      description: Access mode A
+      value: 0
+    - name: B
+      description: Access mode B
+      value: 1
+    - name: C
+      description: Access mode C
+      value: 2
+    - name: D
+      description: Access mode D
+      value: 3
+enum/CAS:
+  bit_size: 2
+  variants:
+    - name: Clocks1
+      description: 1 cycle
+      value: 1
+    - name: Clocks2
+      description: 2 cycles
+      value: 2
+    - name: Clocks3
+      description: 3 cycles
+      value: 3
+enum/CRE:
+  bit_size: 1
+  variants:
+    - name: Clear
+      description: Refresh Error Flag is cleared
+      value: 1
+enum/CTB2:
+  bit_size: 1
+  variants:
+    - name: NotIssued
+      description: Command not issued to SDRAM Bank 1
+      value: 0
+    - name: Issued
+      description: Command issued to SDRAM Bank 1
+      value: 1
+enum/ECCEN:
+  bit_size: 1
+  variants:
+    - name: Disabled
+      description: ECC logic is disabled and reset
+      value: 0
+    - name: Enabled
+      description: ECC logic is enabled
+      value: 1
+enum/ECCPS:
+  bit_size: 3
+  variants:
+    - name: Bytes256
+      description: ECC page size 256 bytes
+      value: 0
+    - name: Bytes512
+      description: ECC page size 512 bytes
+      value: 1
+    - name: Bytes1024
+      description: ECC page size 1024 bytes
+      value: 2
+    - name: Bytes2048
+      description: ECC page size 2048 bytes
+      value: 3
+    - name: Bytes4096
+      description: ECC page size 4096 bytes
+      value: 4
+    - name: Bytes8192
+      description: ECC page size 8192 bytes
+      value: 5
+enum/FEMPT:
+  bit_size: 1
+  variants:
+    - name: NotEmpty
+      description: FIFO not empty
+      value: 0
+    - name: Empty
+      description: FIFO empty
+      value: 1
+enum/IFEN:
+  bit_size: 1
+  variants:
+    - name: Disabled
+      description: Interrupt falling edge detection request disabled
+      value: 0
+    - name: Enabled
+      description: Interrupt falling edge detection request enabled
+      value: 1
+enum/IFS:
+  bit_size: 1
+  variants:
+    - name: DidNotOccur
+      description: Interrupt falling edge did not occur
+      value: 0
+    - name: Occurred
+      description: Interrupt falling edge occurred
+      value: 1
+enum/ILEN:
+  bit_size: 1
+  variants:
+    - name: Disabled
+      description: Interrupt high-level detection request disabled
+      value: 0
+    - name: Enabled
+      description: Interrupt high-level detection request enabled
+      value: 1
+enum/ILS:
+  bit_size: 1
+  variants:
+    - name: DidNotOccur
+      description: Interrupt high-level did not occur
+      value: 0
+    - name: Occurred
+      description: Interrupt high-level occurred
+      value: 1
+enum/IREN:
+  bit_size: 1
+  variants:
+    - name: Disabled
+      description: Interrupt rising edge detection request disabled
+      value: 0
+    - name: Enabled
+      description: Interrupt rising edge detection request enabled
+      value: 1
+enum/IRS:
+  bit_size: 1
+  variants:
+    - name: DidNotOccur
+      description: Interrupt rising edge did not occur
+      value: 0
+    - name: Occurred
+      description: Interrupt rising edge occurred
+      value: 1
+enum/MODE:
+  bit_size: 3
+  variants:
+    - name: Normal
+      description: Normal Mode
+      value: 0
+    - name: ClockConfigurationEnable
+      description: Clock Configuration Enable
+      value: 1
+    - name: PALL
+      description: PALL (All Bank Precharge) command
+      value: 2
+    - name: AutoRefreshCommand
+      description: Auto-refresh command
+      value: 3
+    - name: LoadModeRegister
+      description: Load Mode Resgier
+      value: 4
+    - name: SelfRefreshCommand
+      description: Self-refresh command
+      value: 5
+    - name: PowerDownCommand
+      description: Power-down command
+      value: 6
+enum/MODES1:
+  bit_size: 2
+  variants:
+    - name: Normal
+      description: Normal Mode
+      value: 0
+    - name: SelfRefresh
+      description: Self-refresh mode
+      value: 1
+    - name: PowerDown
+      description: Power-down mode
+      value: 2
+enum/NB:
+  bit_size: 1
+  variants:
+    - name: NB2
+      description: Two internal Banks
+      value: 0
+    - name: NB4
+      description: Four internal Banks
+      value: 1
+enum/NC:
+  bit_size: 2
+  variants:
+    - name: Bits8
+      description: 8 bits
+      value: 0
+    - name: Bits9
+      description: 9 bits
+      value: 1
+    - name: Bits10
+      description: 10 bits
+      value: 2
+    - name: Bits11
+      description: 11 bits
+      value: 3
+enum/NR:
+  bit_size: 2
+  variants:
+    - name: Bits11
+      description: 11 bits
+      value: 0
+    - name: Bits12
+      description: 12 bits
+      value: 1
+    - name: Bits13
+      description: 13 bits
+      value: 2
+enum/PBKEN:
+  bit_size: 1
+  variants:
+    - name: Disabled
+      description: Corresponding memory bank is disabled
+      value: 0
+    - name: Enabled
+      description: Corresponding memory bank is enabled
+      value: 1
+enum/PTYP:
+  bit_size: 1
+  variants:
+    - name: NANDFlash
+      description: NAND Flash
+      value: 1
+enum/PWAITEN:
+  bit_size: 1
+  variants:
+    - name: Disabled
+      description: Wait feature disabled
+      value: 0
+    - name: Enabled
+      description: Wait feature enabled
+      value: 1
+enum/PWID:
+  bit_size: 2
+  variants:
+    - name: Bits8
+      description: External memory device width 8 bits
+      value: 0
+    - name: Bits16
+      description: External memory device width 16 bits
+      value: 1
+enum/RBURST:
+  bit_size: 1
+  variants:
+    - name: Disabled
+      description: Single read requests are not managed as bursts
+      value: 0
+    - name: Enabled
+      description: Single read requests are always managed as bursts
+      value: 1
+enum/RE:
+  bit_size: 1
+  variants:
+    - name: NoError
+      description: No refresh error has been detected
+      value: 0
+    - name: Error
+      description: A refresh error has been detected
+      value: 1
+enum/REIE:
+  bit_size: 1
+  variants:
+    - name: Disabled
+      description: Interrupt is disabled
+      value: 0
+    - name: Enabled
+      description: Interrupt is generated if RE = 1
+      value: 1
+enum/RPIPE:
+  bit_size: 2
+  variants:
+    - name: NoDelay
+      description: No clock cycle delay
+      value: 0
+    - name: Clocks1
+      description: One clock cycle delay
+      value: 1
+    - name: Clocks2
+      description: Two clock cycles delay
+      value: 2
+enum/SDCLK:
+  bit_size: 2
+  variants:
+    - name: Disabled
+      description: SDCLK clock disabled
+      value: 0
+    - name: Div2
+      description: SDCLK period = 2 x HCLK period
+      value: 2
+    - name: Div3
+      description: SDCLK period = 3 x HCLK period
+      value: 3
+enum/SDCR_MWID:
+  bit_size: 2
+  variants:
+    - name: Bits8
+      description: Memory data bus width 8 bits
+      value: 0
+    - name: Bits16
+      description: Memory data bus width 16 bits
+      value: 1
+    - name: Bits32
+      description: Memory data bus width 32 bits
+      value: 2
+enum/WP:
+  bit_size: 1
+  variants:
+    - name: Disabled
+      description: Write accesses allowed
+      value: 0
+    - name: Enabled
+      description: Write accesses ignored
+      value: 1

--- a/stm32data/__main__.py
+++ b/stm32data/__main__.py
@@ -219,6 +219,7 @@ perimap = [
     ('STM32F7.*:ETH:ETH:ethermac110_v2_0', ('eth', 'v1c', 'ETH')),
     ('.*ETH:ethermac110_v3_0', ('eth', 'v2', 'ETH')),
 
+    ('.*:FSMC:.*', ('fsmc', 'v1', 'FSMC')),
     ('STM32H7.*:FMC:.*', ('fmc', 'h7', 'FMC')),
 
     ('.*LPTIM\d.*:G0xx_lptimer1_v1_4', ('lptim', 'g0', 'LPTIM')),
@@ -300,7 +301,8 @@ alt_peri_defines = {
     'FLASH': ['FLASH_R_BASE', 'FLASH_REG_BASE'],
     'ADC_COMMON': ['ADC_COMMON', 'ADC1_COMMON', 'ADC12_COMMON', 'ADC123_COMMON'],
     'CAN': ['CAN_BASE', 'CAN1_BASE'],
-    'FMC': ['FMC_BASE', 'FMC_R_BASE']
+    'FMC': ['FMC_BASE', 'FMC_R_BASE'],
+    'FSMC': ['FSMC_R_BASE']
 }
 
 # Device address overrides, in case of missing from headers


### PR DESCRIPTION
The current v1 yaml has a few extra registers defined that don't belong to some of the chips out there (the ones at byte_offset 320 and above), but the rest of registers are identical.