### PR TITLE
WIP: add usb registers to l4r5

### DIFF
--- a/data/chips/STM32F722IC.json
+++ b/data/chips/STM32F722IC.json
@@ -5472,6 +5472,11 @@
                 {
                     "name": "USB_OTG_FS",
                     "address": 1342177280,
+                    "registers": {
+                        "kind": "otgfs",
+                        "version": "v3",
+                        "block": "OTG_FS"
+                    },
                     "rcc": {
                         "clock": "AHB2",
                         "enable": {

--- a/data/chips/STM32F722IE.json
+++ b/data/chips/STM32F722IE.json
@@ -5472,6 +5472,11 @@
                 {
                     "name": "USB_OTG_FS",
                     "address": 1342177280,
+                    "registers": {
+                        "kind": "otgfs",
+                        "version": "v3",
+                        "block": "OTG_FS"
+                    },
                     "rcc": {
                         "clock": "AHB2",
                         "enable": {

--- a/data/chips/STM32F722RC.json
+++ b/data/chips/STM32F722RC.json
@@ -3689,6 +3689,11 @@
                 {
                     "name": "USB_OTG_FS",
                     "address": 1342177280,
+                    "registers": {
+                        "kind": "otgfs",
+                        "version": "v3",
+                        "block": "OTG_FS"
+                    },
                     "rcc": {
                         "clock": "AHB2",
                         "enable": {

--- a/data/chips/STM32F722RE.json
+++ b/data/chips/STM32F722RE.json
@@ -3689,6 +3689,11 @@
                 {
                     "name": "USB_OTG_FS",
                     "address": 1342177280,
+                    "registers": {
+                        "kind": "otgfs",
+                        "version": "v3",
+                        "block": "OTG_FS"
+                    },
                     "rcc": {
                         "clock": "AHB2",
                         "enable": {

--- a/data/chips/STM32F722VC.json
+++ b/data/chips/STM32F722VC.json
@@ -4668,6 +4668,11 @@
                 {
                     "name": "USB_OTG_FS",
                     "address": 1342177280,
+                    "registers": {
+                        "kind": "otgfs",
+                        "version": "v3",
+                        "block": "OTG_FS"
+                    },
                     "rcc": {
                         "clock": "AHB2",
                         "enable": {

--- a/data/chips/STM32F722VE.json
+++ b/data/chips/STM32F722VE.json
@@ -4668,6 +4668,11 @@
                 {
                     "name": "USB_OTG_FS",
                     "address": 1342177280,
+                    "registers": {
+                        "kind": "otgfs",
+                        "version": "v3",
+                        "block": "OTG_FS"
+                    },
                     "rcc": {
                         "clock": "AHB2",
                         "enable": {

--- a/data/chips/STM32F722ZC.json
+++ b/data/chips/STM32F722ZC.json
@@ -5125,6 +5125,11 @@
                 {
                     "name": "USB_OTG_FS",
                     "address": 1342177280,
+                    "registers": {
+                        "kind": "otgfs",
+                        "version": "v3",
+                        "block": "OTG_FS"
+                    },
                     "rcc": {
                         "clock": "AHB2",
                         "enable": {

--- a/data/chips/STM32F722ZE.json
+++ b/data/chips/STM32F722ZE.json
@@ -5125,6 +5125,11 @@
                 {
                     "name": "USB_OTG_FS",
                     "address": 1342177280,
+                    "registers": {
+                        "kind": "otgfs",
+                        "version": "v3",
+                        "block": "OTG_FS"
+                    },
                     "rcc": {
                         "clock": "AHB2",
                         "enable": {

--- a/data/chips/STM32F723IC.json
+++ b/data/chips/STM32F723IC.json
@@ -5397,6 +5397,11 @@
                 {
                     "name": "USB_OTG_FS",
                     "address": 1342177280,
+                    "registers": {
+                        "kind": "otgfs",
+                        "version": "v3",
+                        "block": "OTG_FS"
+                    },
                     "rcc": {
                         "clock": "AHB2",
                         "enable": {

--- a/data/chips/STM32F723IE.json
+++ b/data/chips/STM32F723IE.json
@@ -5397,6 +5397,11 @@
                 {
                     "name": "USB_OTG_FS",
                     "address": 1342177280,
+                    "registers": {
+                        "kind": "otgfs",
+                        "version": "v3",
+                        "block": "OTG_FS"
+                    },
                     "rcc": {
                         "clock": "AHB2",
                         "enable": {

--- a/data/chips/STM32F723VC.json
+++ b/data/chips/STM32F723VC.json
@@ -4418,6 +4418,11 @@
                 {
                     "name": "USB_OTG_FS",
                     "address": 1342177280,
+                    "registers": {
+                        "kind": "otgfs",
+                        "version": "v3",
+                        "block": "OTG_FS"
+                    },
                     "rcc": {
                         "clock": "AHB2",
                         "enable": {

--- a/data/chips/STM32F723VE.json
+++ b/data/chips/STM32F723VE.json
@@ -4418,6 +4418,11 @@
                 {
                     "name": "USB_OTG_FS",
                     "address": 1342177280,
+                    "registers": {
+                        "kind": "otgfs",
+                        "version": "v3",
+                        "block": "OTG_FS"
+                    },
                     "rcc": {
                         "clock": "AHB2",
                         "enable": {

--- a/data/chips/STM32F723ZC.json
+++ b/data/chips/STM32F723ZC.json
@@ -5010,6 +5010,11 @@
                 {
                     "name": "USB_OTG_FS",
                     "address": 1342177280,
+                    "registers": {
+                        "kind": "otgfs",
+                        "version": "v3",
+                        "block": "OTG_FS"
+                    },
                     "rcc": {
                         "clock": "AHB2",
                         "enable": {

--- a/data/chips/STM32F723ZE.json
+++ b/data/chips/STM32F723ZE.json
@@ -5010,6 +5010,11 @@
                 {
                     "name": "USB_OTG_FS",
                     "address": 1342177280,
+                    "registers": {
+                        "kind": "otgfs",
+                        "version": "v3",
+                        "block": "OTG_FS"
+                    },
                     "rcc": {
                         "clock": "AHB2",
                         "enable": {

--- a/data/chips/STM32F730I8.json
+++ b/data/chips/STM32F730I8.json
@@ -5414,6 +5414,11 @@
                 {
                     "name": "USB_OTG_FS",
                     "address": 1342177280,
+                    "registers": {
+                        "kind": "otgfs",
+                        "version": "v3",
+                        "block": "OTG_FS"
+                    },
                     "rcc": {
                         "clock": "AHB2",
                         "enable": {

--- a/data/chips/STM32F730R8.json
+++ b/data/chips/STM32F730R8.json
@@ -3710,6 +3710,11 @@
                 {
                     "name": "USB_OTG_FS",
                     "address": 1342177280,
+                    "registers": {
+                        "kind": "otgfs",
+                        "version": "v3",
+                        "block": "OTG_FS"
+                    },
                     "rcc": {
                         "clock": "AHB2",
                         "enable": {

--- a/data/chips/STM32F730V8.json
+++ b/data/chips/STM32F730V8.json
@@ -4689,6 +4689,11 @@
                 {
                     "name": "USB_OTG_FS",
                     "address": 1342177280,
+                    "registers": {
+                        "kind": "otgfs",
+                        "version": "v3",
+                        "block": "OTG_FS"
+                    },
                     "rcc": {
                         "clock": "AHB2",
                         "enable": {

--- a/data/chips/STM32F730Z8.json
+++ b/data/chips/STM32F730Z8.json
@@ -5027,6 +5027,11 @@
                 {
                     "name": "USB_OTG_FS",
                     "address": 1342177280,
+                    "registers": {
+                        "kind": "otgfs",
+                        "version": "v3",
+                        "block": "OTG_FS"
+                    },
                     "rcc": {
                         "clock": "AHB2",
                         "enable": {

--- a/data/chips/STM32F732IE.json
+++ b/data/chips/STM32F732IE.json
@@ -5505,6 +5505,11 @@
                 {
                     "name": "USB_OTG_FS",
                     "address": 1342177280,
+                    "registers": {
+                        "kind": "otgfs",
+                        "version": "v3",
+                        "block": "OTG_FS"
+                    },
                     "rcc": {
                         "clock": "AHB2",
                         "enable": {

--- a/data/chips/STM32F732RE.json
+++ b/data/chips/STM32F732RE.json
@@ -3722,6 +3722,11 @@
                 {
                     "name": "USB_OTG_FS",
                     "address": 1342177280,
+                    "registers": {
+                        "kind": "otgfs",
+                        "version": "v3",
+                        "block": "OTG_FS"
+                    },
                     "rcc": {
                         "clock": "AHB2",
                         "enable": {

--- a/data/chips/STM32F732VE.json
+++ b/data/chips/STM32F732VE.json
@@ -4701,6 +4701,11 @@
                 {
                     "name": "USB_OTG_FS",
                     "address": 1342177280,
+                    "registers": {
+                        "kind": "otgfs",
+                        "version": "v3",
+                        "block": "OTG_FS"
+                    },
                     "rcc": {
                         "clock": "AHB2",
                         "enable": {

--- a/data/chips/STM32F732ZE.json
+++ b/data/chips/STM32F732ZE.json
@@ -5158,6 +5158,11 @@
                 {
                     "name": "USB_OTG_FS",
                     "address": 1342177280,
+                    "registers": {
+                        "kind": "otgfs",
+                        "version": "v3",
+                        "block": "OTG_FS"
+                    },
                     "rcc": {
                         "clock": "AHB2",
                         "enable": {

--- a/data/chips/STM32F733IE.json
+++ b/data/chips/STM32F733IE.json
@@ -5430,6 +5430,11 @@
                 {
                     "name": "USB_OTG_FS",
                     "address": 1342177280,
+                    "registers": {
+                        "kind": "otgfs",
+                        "version": "v3",
+                        "block": "OTG_FS"
+                    },
                     "rcc": {
                         "clock": "AHB2",
                         "enable": {

--- a/data/chips/STM32F733VE.json
+++ b/data/chips/STM32F733VE.json
@@ -4451,6 +4451,11 @@
                 {
                     "name": "USB_OTG_FS",
                     "address": 1342177280,
+                    "registers": {
+                        "kind": "otgfs",
+                        "version": "v3",
+                        "block": "OTG_FS"
+                    },
                     "rcc": {
                         "clock": "AHB2",
                         "enable": {

--- a/data/chips/STM32F733ZE.json
+++ b/data/chips/STM32F733ZE.json
@@ -5043,6 +5043,11 @@
                 {
                     "name": "USB_OTG_FS",
                     "address": 1342177280,
+                    "registers": {
+                        "kind": "otgfs",
+                        "version": "v3",
+                        "block": "OTG_FS"
+                    },
                     "rcc": {
                         "clock": "AHB2",
                         "enable": {

--- a/data/chips/STM32L4P5AE.json
+++ b/data/chips/STM32L4P5AE.json
@@ -7167,6 +7167,11 @@
                 {
                     "name": "USB_OTG_FS",
                     "address": 1342177280,
+                    "registers": {
+                        "kind": "otgfs",
+                        "version": "v3",
+                        "block": "OTG_FS"
+                    },
                     "rcc": {
                         "clock": "AHB2",
                         "enable": {

--- a/data/chips/STM32L4P5AG.json
+++ b/data/chips/STM32L4P5AG.json
@@ -7171,6 +7171,11 @@
                 {
                     "name": "USB_OTG_FS",
                     "address": 1342177280,
+                    "registers": {
+                        "kind": "otgfs",
+                        "version": "v3",
+                        "block": "OTG_FS"
+                    },
                     "rcc": {
                         "clock": "AHB2",
                         "enable": {

--- a/data/chips/STM32L4P5CE.json
+++ b/data/chips/STM32L4P5CE.json
@@ -4250,6 +4250,11 @@
                 {
                     "name": "USB_OTG_FS",
                     "address": 1342177280,
+                    "registers": {
+                        "kind": "otgfs",
+                        "version": "v3",
+                        "block": "OTG_FS"
+                    },
                     "rcc": {
                         "clock": "AHB2",
                         "enable": {

--- a/data/chips/STM32L4P5CG.json
+++ b/data/chips/STM32L4P5CG.json
@@ -4258,6 +4258,11 @@
                 {
                     "name": "USB_OTG_FS",
                     "address": 1342177280,
+                    "registers": {
+                        "kind": "otgfs",
+                        "version": "v3",
+                        "block": "OTG_FS"
+                    },
                     "rcc": {
                         "clock": "AHB2",
                         "enable": {

--- a/data/chips/STM32L4P5QE.json
+++ b/data/chips/STM32L4P5QE.json
@@ -6712,6 +6712,11 @@
                 {
                     "name": "USB_OTG_FS",
                     "address": 1342177280,
+                    "registers": {
+                        "kind": "otgfs",
+                        "version": "v3",
+                        "block": "OTG_FS"
+                    },
                     "rcc": {
                         "clock": "AHB2",
                         "enable": {

--- a/data/chips/STM32L4P5QG.json
+++ b/data/chips/STM32L4P5QG.json
@@ -6716,6 +6716,11 @@
                 {
                     "name": "USB_OTG_FS",
                     "address": 1342177280,
+                    "registers": {
+                        "kind": "otgfs",
+                        "version": "v3",
+                        "block": "OTG_FS"
+                    },
                     "rcc": {
                         "clock": "AHB2",
                         "enable": {

--- a/data/chips/STM32L4P5RE.json
+++ b/data/chips/STM32L4P5RE.json
@@ -5022,6 +5022,11 @@
                 {
                     "name": "USB_OTG_FS",
                     "address": 1342177280,
+                    "registers": {
+                        "kind": "otgfs",
+                        "version": "v3",
+                        "block": "OTG_FS"
+                    },
                     "rcc": {
                         "clock": "AHB2",
                         "enable": {

--- a/data/chips/STM32L4P5RG.json
+++ b/data/chips/STM32L4P5RG.json
@@ -5026,6 +5026,11 @@
                 {
                     "name": "USB_OTG_FS",
                     "address": 1342177280,
+                    "registers": {
+                        "kind": "otgfs",
+                        "version": "v3",
+                        "block": "OTG_FS"
+                    },
                     "rcc": {
                         "clock": "AHB2",
                         "enable": {

--- a/data/chips/STM32L4P5VE.json
+++ b/data/chips/STM32L4P5VE.json
@@ -6306,6 +6306,11 @@
                 {
                     "name": "USB_OTG_FS",
                     "address": 1342177280,
+                    "registers": {
+                        "kind": "otgfs",
+                        "version": "v3",
+                        "block": "OTG_FS"
+                    },
                     "rcc": {
                         "clock": "AHB2",
                         "enable": {

--- a/data/chips/STM32L4P5VG.json
+++ b/data/chips/STM32L4P5VG.json
@@ -6314,6 +6314,11 @@
                 {
                     "name": "USB_OTG_FS",
                     "address": 1342177280,
+                    "registers": {
+                        "kind": "otgfs",
+                        "version": "v3",
+                        "block": "OTG_FS"
+                    },
                     "rcc": {
                         "clock": "AHB2",
                         "enable": {

--- a/data/chips/STM32L4P5ZE.json
+++ b/data/chips/STM32L4P5ZE.json
@@ -6817,6 +6817,11 @@
                 {
                     "name": "USB_OTG_FS",
                     "address": 1342177280,
+                    "registers": {
+                        "kind": "otgfs",
+                        "version": "v3",
+                        "block": "OTG_FS"
+                    },
                     "rcc": {
                         "clock": "AHB2",
                         "enable": {

--- a/data/chips/STM32L4P5ZG.json
+++ b/data/chips/STM32L4P5ZG.json
@@ -6821,6 +6821,11 @@
                 {
                     "name": "USB_OTG_FS",
                     "address": 1342177280,
+                    "registers": {
+                        "kind": "otgfs",
+                        "version": "v3",
+                        "block": "OTG_FS"
+                    },
                     "rcc": {
                         "clock": "AHB2",
                         "enable": {

--- a/data/chips/STM32L4Q5AG.json
+++ b/data/chips/STM32L4Q5AG.json
@@ -7214,6 +7214,11 @@
                 {
                     "name": "USB_OTG_FS",
                     "address": 1342177280,
+                    "registers": {
+                        "kind": "otgfs",
+                        "version": "v3",
+                        "block": "OTG_FS"
+                    },
                     "rcc": {
                         "clock": "AHB2",
                         "enable": {

--- a/data/chips/STM32L4Q5CG.json
+++ b/data/chips/STM32L4Q5CG.json
@@ -4301,6 +4301,11 @@
                 {
                     "name": "USB_OTG_FS",
                     "address": 1342177280,
+                    "registers": {
+                        "kind": "otgfs",
+                        "version": "v3",
+                        "block": "OTG_FS"
+                    },
                     "rcc": {
                         "clock": "AHB2",
                         "enable": {

--- a/data/chips/STM32L4Q5QG.json
+++ b/data/chips/STM32L4Q5QG.json
@@ -6759,6 +6759,11 @@
                 {
                     "name": "USB_OTG_FS",
                     "address": 1342177280,
+                    "registers": {
+                        "kind": "otgfs",
+                        "version": "v3",
+                        "block": "OTG_FS"
+                    },
                     "rcc": {
                         "clock": "AHB2",
                         "enable": {

--- a/data/chips/STM32L4Q5RG.json
+++ b/data/chips/STM32L4Q5RG.json
@@ -5069,6 +5069,11 @@
                 {
                     "name": "USB_OTG_FS",
                     "address": 1342177280,
+                    "registers": {
+                        "kind": "otgfs",
+                        "version": "v3",
+                        "block": "OTG_FS"
+                    },
                     "rcc": {
                         "clock": "AHB2",
                         "enable": {

--- a/data/chips/STM32L4Q5VG.json
+++ b/data/chips/STM32L4Q5VG.json
@@ -6357,6 +6357,11 @@
                 {
                     "name": "USB_OTG_FS",
                     "address": 1342177280,
+                    "registers": {
+                        "kind": "otgfs",
+                        "version": "v3",
+                        "block": "OTG_FS"
+                    },
                     "rcc": {
                         "clock": "AHB2",
                         "enable": {

--- a/data/chips/STM32L4Q5ZG.json
+++ b/data/chips/STM32L4Q5ZG.json
@@ -6864,6 +6864,11 @@
                 {
                     "name": "USB_OTG_FS",
                     "address": 1342177280,
+                    "registers": {
+                        "kind": "otgfs",
+                        "version": "v3",
+                        "block": "OTG_FS"
+                    },
                     "rcc": {
                         "clock": "AHB2",
                         "enable": {

--- a/data/chips/STM32L4R5AG.json
+++ b/data/chips/STM32L4R5AG.json
@@ -6344,6 +6344,11 @@
                 {
                     "name": "USB_OTG_FS",
                     "address": 1342177280,
+                    "registers": {
+                        "kind": "otgfs",
+                        "version": "v3",
+                        "block": "OTG_FS"
+                    },
                     "rcc": {
                         "clock": "AHB2",
                         "enable": {

--- a/data/chips/STM32L4R5AI.json
+++ b/data/chips/STM32L4R5AI.json
@@ -6344,6 +6344,11 @@
                 {
                     "name": "USB_OTG_FS",
                     "address": 1342177280,
+                    "registers": {
+                        "kind": "otgfs",
+                        "version": "v3",
+                        "block": "OTG_FS"
+                    },
                     "rcc": {
                         "clock": "AHB2",
                         "enable": {

--- a/data/chips/STM32L4R5QG.json
+++ b/data/chips/STM32L4R5QG.json
@@ -6019,6 +6019,11 @@
                 {
                     "name": "USB_OTG_FS",
                     "address": 1342177280,
+                    "registers": {
+                        "kind": "otgfs",
+                        "version": "v3",
+                        "block": "OTG_FS"
+                    },
                     "rcc": {
                         "clock": "AHB2",
                         "enable": {

--- a/data/chips/STM32L4R5QI.json
+++ b/data/chips/STM32L4R5QI.json
@@ -6019,6 +6019,11 @@
                 {
                     "name": "USB_OTG_FS",
                     "address": 1342177280,
+                    "registers": {
+                        "kind": "otgfs",
+                        "version": "v3",
+                        "block": "OTG_FS"
+                    },
                     "rcc": {
                         "clock": "AHB2",
                         "enable": {

--- a/data/chips/STM32L4R5VG.json
+++ b/data/chips/STM32L4R5VG.json
@@ -5539,6 +5539,11 @@
                 {
                     "name": "USB_OTG_FS",
                     "address": 1342177280,
+                    "registers": {
+                        "kind": "otgfs",
+                        "version": "v3",
+                        "block": "OTG_FS"
+                    },
                     "rcc": {
                         "clock": "AHB2",
                         "enable": {

--- a/data/chips/STM32L4R5VI.json
+++ b/data/chips/STM32L4R5VI.json
@@ -5539,6 +5539,11 @@
                 {
                     "name": "USB_OTG_FS",
                     "address": 1342177280,
+                    "registers": {
+                        "kind": "otgfs",
+                        "version": "v3",
+                        "block": "OTG_FS"
+                    },
                     "rcc": {
                         "clock": "AHB2",
                         "enable": {

--- a/data/chips/STM32L4R5ZG.json
+++ b/data/chips/STM32L4R5ZG.json
@@ -6118,6 +6118,11 @@
                 {
                     "name": "USB_OTG_FS",
                     "address": 1342177280,
+                    "registers": {
+                        "kind": "otgfs",
+                        "version": "v3",
+                        "block": "OTG_FS"
+                    },
                     "rcc": {
                         "clock": "AHB2",
                         "enable": {

--- a/data/chips/STM32L4R5ZI.json
+++ b/data/chips/STM32L4R5ZI.json
@@ -6128,6 +6128,11 @@
                 {
                     "name": "USB_OTG_FS",
                     "address": 1342177280,
+                    "registers": {
+                        "kind": "otgfs",
+                        "version": "v3",
+                        "block": "OTG_FS"
+                    },
                     "rcc": {
                         "clock": "AHB2",
                         "enable": {

--- a/data/chips/STM32L4R7AI.json
+++ b/data/chips/STM32L4R7AI.json
@@ -6596,6 +6596,11 @@
                 {
                     "name": "USB_OTG_FS",
                     "address": 1342177280,
+                    "registers": {
+                        "kind": "otgfs",
+                        "version": "v3",
+                        "block": "OTG_FS"
+                    },
                     "rcc": {
                         "clock": "AHB2",
                         "enable": {

--- a/data/chips/STM32L4R7VI.json
+++ b/data/chips/STM32L4R7VI.json
@@ -5751,6 +5751,11 @@
                 {
                     "name": "USB_OTG_FS",
                     "address": 1342177280,
+                    "registers": {
+                        "kind": "otgfs",
+                        "version": "v3",
+                        "block": "OTG_FS"
+                    },
                     "rcc": {
                         "clock": "AHB2",
                         "enable": {

--- a/data/chips/STM32L4R7ZI.json
+++ b/data/chips/STM32L4R7ZI.json
@@ -6366,6 +6366,11 @@
                 {
                     "name": "USB_OTG_FS",
                     "address": 1342177280,
+                    "registers": {
+                        "kind": "otgfs",
+                        "version": "v3",
+                        "block": "OTG_FS"
+                    },
                     "rcc": {
                         "clock": "AHB2",
                         "enable": {

--- a/data/chips/STM32L4R9AG.json
+++ b/data/chips/STM32L4R9AG.json
@@ -6534,6 +6534,11 @@
                 {
                     "name": "USB_OTG_FS",
                     "address": 1342177280,
+                    "registers": {
+                        "kind": "otgfs",
+                        "version": "v3",
+                        "block": "OTG_FS"
+                    },
                     "rcc": {
                         "clock": "AHB2",
                         "enable": {

--- a/data/chips/STM32L4R9AI.json
+++ b/data/chips/STM32L4R9AI.json
@@ -6534,6 +6534,11 @@
                 {
                     "name": "USB_OTG_FS",
                     "address": 1342177280,
+                    "registers": {
+                        "kind": "otgfs",
+                        "version": "v3",
+                        "block": "OTG_FS"
+                    },
                     "rcc": {
                         "clock": "AHB2",
                         "enable": {

--- a/data/chips/STM32L4R9VG.json
+++ b/data/chips/STM32L4R9VG.json
@@ -5571,6 +5571,11 @@
                 {
                     "name": "USB_OTG_FS",
                     "address": 1342177280,
+                    "registers": {
+                        "kind": "otgfs",
+                        "version": "v3",
+                        "block": "OTG_FS"
+                    },
                     "rcc": {
                         "clock": "AHB2",
                         "enable": {

--- a/data/chips/STM32L4R9VI.json
+++ b/data/chips/STM32L4R9VI.json
@@ -5571,6 +5571,11 @@
                 {
                     "name": "USB_OTG_FS",
                     "address": 1342177280,
+                    "registers": {
+                        "kind": "otgfs",
+                        "version": "v3",
+                        "block": "OTG_FS"
+                    },
                     "rcc": {
                         "clock": "AHB2",
                         "enable": {

--- a/data/chips/STM32L4R9ZG.json
+++ b/data/chips/STM32L4R9ZG.json
@@ -6365,6 +6365,11 @@
                 {
                     "name": "USB_OTG_FS",
                     "address": 1342177280,
+                    "registers": {
+                        "kind": "otgfs",
+                        "version": "v3",
+                        "block": "OTG_FS"
+                    },
                     "rcc": {
                         "clock": "AHB2",
                         "enable": {

--- a/data/chips/STM32L4R9ZI.json
+++ b/data/chips/STM32L4R9ZI.json
@@ -6375,6 +6375,11 @@
                 {
                     "name": "USB_OTG_FS",
                     "address": 1342177280,
+                    "registers": {
+                        "kind": "otgfs",
+                        "version": "v3",
+                        "block": "OTG_FS"
+                    },
                     "rcc": {
                         "clock": "AHB2",
                         "enable": {

--- a/data/chips/STM32L4S5AI.json
+++ b/data/chips/STM32L4S5AI.json
@@ -6417,6 +6417,11 @@
                 {
                     "name": "USB_OTG_FS",
                     "address": 1342177280,
+                    "registers": {
+                        "kind": "otgfs",
+                        "version": "v3",
+                        "block": "OTG_FS"
+                    },
                     "rcc": {
                         "clock": "AHB2",
                         "enable": {

--- a/data/chips/STM32L4S5QI.json
+++ b/data/chips/STM32L4S5QI.json
@@ -6092,6 +6092,11 @@
                 {
                     "name": "USB_OTG_FS",
                     "address": 1342177280,
+                    "registers": {
+                        "kind": "otgfs",
+                        "version": "v3",
+                        "block": "OTG_FS"
+                    },
                     "rcc": {
                         "clock": "AHB2",
                         "enable": {

--- a/data/chips/STM32L4S5VI.json
+++ b/data/chips/STM32L4S5VI.json
@@ -5612,6 +5612,11 @@
                 {
                     "name": "USB_OTG_FS",
                     "address": 1342177280,
+                    "registers": {
+                        "kind": "otgfs",
+                        "version": "v3",
+                        "block": "OTG_FS"
+                    },
                     "rcc": {
                         "clock": "AHB2",
                         "enable": {

--- a/data/chips/STM32L4S5ZI.json
+++ b/data/chips/STM32L4S5ZI.json
@@ -6191,6 +6191,11 @@
                 {
                     "name": "USB_OTG_FS",
                     "address": 1342177280,
+                    "registers": {
+                        "kind": "otgfs",
+                        "version": "v3",
+                        "block": "OTG_FS"
+                    },
                     "rcc": {
                         "clock": "AHB2",
                         "enable": {

--- a/data/chips/STM32L4S7AI.json
+++ b/data/chips/STM32L4S7AI.json
@@ -6669,6 +6669,11 @@
                 {
                     "name": "USB_OTG_FS",
                     "address": 1342177280,
+                    "registers": {
+                        "kind": "otgfs",
+                        "version": "v3",
+                        "block": "OTG_FS"
+                    },
                     "rcc": {
                         "clock": "AHB2",
                         "enable": {

--- a/data/chips/STM32L4S7VI.json
+++ b/data/chips/STM32L4S7VI.json
@@ -5824,6 +5824,11 @@
                 {
                     "name": "USB_OTG_FS",
                     "address": 1342177280,
+                    "registers": {
+                        "kind": "otgfs",
+                        "version": "v3",
+                        "block": "OTG_FS"
+                    },
                     "rcc": {
                         "clock": "AHB2",
                         "enable": {

--- a/data/chips/STM32L4S7ZI.json
+++ b/data/chips/STM32L4S7ZI.json
@@ -6439,6 +6439,11 @@
                 {
                     "name": "USB_OTG_FS",
                     "address": 1342177280,
+                    "registers": {
+                        "kind": "otgfs",
+                        "version": "v3",
+                        "block": "OTG_FS"
+                    },
                     "rcc": {
                         "clock": "AHB2",
                         "enable": {

--- a/data/chips/STM32L4S9AI.json
+++ b/data/chips/STM32L4S9AI.json
@@ -6607,6 +6607,11 @@
                 {
                     "name": "USB_OTG_FS",
                     "address": 1342177280,
+                    "registers": {
+                        "kind": "otgfs",
+                        "version": "v3",
+                        "block": "OTG_FS"
+                    },
                     "rcc": {
                         "clock": "AHB2",
                         "enable": {

--- a/data/chips/STM32L4S9VI.json
+++ b/data/chips/STM32L4S9VI.json
@@ -5644,6 +5644,11 @@
                 {
                     "name": "USB_OTG_FS",
                     "address": 1342177280,
+                    "registers": {
+                        "kind": "otgfs",
+                        "version": "v3",
+                        "block": "OTG_FS"
+                    },
                     "rcc": {
                         "clock": "AHB2",
                         "enable": {

--- a/data/chips/STM32L4S9ZI.json
+++ b/data/chips/STM32L4S9ZI.json
@@ -6438,6 +6438,11 @@
                 {
                     "name": "USB_OTG_FS",
                     "address": 1342177280,
+                    "registers": {
+                        "kind": "otgfs",
+                        "version": "v3",
+                        "block": "OTG_FS"
+                    },
                     "rcc": {
                         "clock": "AHB2",
                         "enable": {

--- a/data/chips/STM32U575AG.json
+++ b/data/chips/STM32U575AG.json
@@ -6698,6 +6698,11 @@
                 {
                     "name": "USB_OTG_FS",
                     "address": 1107558400,
+                    "registers": {
+                        "kind": "otgfs",
+                        "version": "v3",
+                        "block": "OTG_FS"
+                    },
                     "rcc": {
                         "clock": "AHB2",
                         "enable": {

--- a/data/chips/STM32U575AI.json
+++ b/data/chips/STM32U575AI.json
@@ -6698,6 +6698,11 @@
                 {
                     "name": "USB_OTG_FS",
                     "address": 1107558400,
+                    "registers": {
+                        "kind": "otgfs",
+                        "version": "v3",
+                        "block": "OTG_FS"
+                    },
                     "rcc": {
                         "clock": "AHB2",
                         "enable": {

--- a/data/chips/STM32U575CG.json
+++ b/data/chips/STM32U575CG.json
@@ -3515,6 +3515,11 @@
                 {
                     "name": "USB_OTG_FS",
                     "address": 1107558400,
+                    "registers": {
+                        "kind": "otgfs",
+                        "version": "v3",
+                        "block": "OTG_FS"
+                    },
                     "rcc": {
                         "clock": "AHB2",
                         "enable": {

--- a/data/chips/STM32U575CI.json
+++ b/data/chips/STM32U575CI.json
@@ -3515,6 +3515,11 @@
                 {
                     "name": "USB_OTG_FS",
                     "address": 1107558400,
+                    "registers": {
+                        "kind": "otgfs",
+                        "version": "v3",
+                        "block": "OTG_FS"
+                    },
                     "rcc": {
                         "clock": "AHB2",
                         "enable": {

--- a/data/chips/STM32U575OG.json
+++ b/data/chips/STM32U575OG.json
@@ -4959,6 +4959,11 @@
                 {
                     "name": "USB_OTG_FS",
                     "address": 1107558400,
+                    "registers": {
+                        "kind": "otgfs",
+                        "version": "v3",
+                        "block": "OTG_FS"
+                    },
                     "rcc": {
                         "clock": "AHB2",
                         "enable": {

--- a/data/chips/STM32U575OI.json
+++ b/data/chips/STM32U575OI.json
@@ -4959,6 +4959,11 @@
                 {
                     "name": "USB_OTG_FS",
                     "address": 1107558400,
+                    "registers": {
+                        "kind": "otgfs",
+                        "version": "v3",
+                        "block": "OTG_FS"
+                    },
                     "rcc": {
                         "clock": "AHB2",
                         "enable": {

--- a/data/chips/STM32U575QG.json
+++ b/data/chips/STM32U575QG.json
@@ -6153,6 +6153,11 @@
                 {
                     "name": "USB_OTG_FS",
                     "address": 1107558400,
+                    "registers": {
+                        "kind": "otgfs",
+                        "version": "v3",
+                        "block": "OTG_FS"
+                    },
                     "rcc": {
                         "clock": "AHB2",
                         "enable": {

--- a/data/chips/STM32U575QI.json
+++ b/data/chips/STM32U575QI.json
@@ -6153,6 +6153,11 @@
                 {
                     "name": "USB_OTG_FS",
                     "address": 1107558400,
+                    "registers": {
+                        "kind": "otgfs",
+                        "version": "v3",
+                        "block": "OTG_FS"
+                    },
                     "rcc": {
                         "clock": "AHB2",
                         "enable": {

--- a/data/chips/STM32U575RG.json
+++ b/data/chips/STM32U575RG.json
@@ -4231,6 +4231,11 @@
                 {
                     "name": "USB_OTG_FS",
                     "address": 1107558400,
+                    "registers": {
+                        "kind": "otgfs",
+                        "version": "v3",
+                        "block": "OTG_FS"
+                    },
                     "rcc": {
                         "clock": "AHB2",
                         "enable": {

--- a/data/chips/STM32U575RI.json
+++ b/data/chips/STM32U575RI.json
@@ -4231,6 +4231,11 @@
                 {
                     "name": "USB_OTG_FS",
                     "address": 1107558400,
+                    "registers": {
+                        "kind": "otgfs",
+                        "version": "v3",
+                        "block": "OTG_FS"
+                    },
                     "rcc": {
                         "clock": "AHB2",
                         "enable": {

--- a/data/chips/STM32U575VG.json
+++ b/data/chips/STM32U575VG.json
@@ -5583,6 +5583,11 @@
                 {
                     "name": "USB_OTG_FS",
                     "address": 1107558400,
+                    "registers": {
+                        "kind": "otgfs",
+                        "version": "v3",
+                        "block": "OTG_FS"
+                    },
                     "rcc": {
                         "clock": "AHB2",
                         "enable": {

--- a/data/chips/STM32U575VI.json
+++ b/data/chips/STM32U575VI.json
@@ -5583,6 +5583,11 @@
                 {
                     "name": "USB_OTG_FS",
                     "address": 1107558400,
+                    "registers": {
+                        "kind": "otgfs",
+                        "version": "v3",
+                        "block": "OTG_FS"
+                    },
                     "rcc": {
                         "clock": "AHB2",
                         "enable": {

--- a/data/chips/STM32U575ZG.json
+++ b/data/chips/STM32U575ZG.json
@@ -6293,6 +6293,11 @@
                 {
                     "name": "USB_OTG_FS",
                     "address": 1107558400,
+                    "registers": {
+                        "kind": "otgfs",
+                        "version": "v3",
+                        "block": "OTG_FS"
+                    },
                     "rcc": {
                         "clock": "AHB2",
                         "enable": {

--- a/data/chips/STM32U575ZI.json
+++ b/data/chips/STM32U575ZI.json
@@ -6293,6 +6293,11 @@
                 {
                     "name": "USB_OTG_FS",
                     "address": 1107558400,
+                    "registers": {
+                        "kind": "otgfs",
+                        "version": "v3",
+                        "block": "OTG_FS"
+                    },
                     "rcc": {
                         "clock": "AHB2",
                         "enable": {

--- a/data/chips/STM32U585AI.json
+++ b/data/chips/STM32U585AI.json
@@ -6803,6 +6803,11 @@
                 {
                     "name": "USB_OTG_FS",
                     "address": 1107558400,
+                    "registers": {
+                        "kind": "otgfs",
+                        "version": "v3",
+                        "block": "OTG_FS"
+                    },
                     "rcc": {
                         "clock": "AHB2",
                         "enable": {

--- a/data/chips/STM32U585CI.json
+++ b/data/chips/STM32U585CI.json
@@ -3620,6 +3620,11 @@
                 {
                     "name": "USB_OTG_FS",
                     "address": 1107558400,
+                    "registers": {
+                        "kind": "otgfs",
+                        "version": "v3",
+                        "block": "OTG_FS"
+                    },
                     "rcc": {
                         "clock": "AHB2",
                         "enable": {

--- a/data/chips/STM32U585OI.json
+++ b/data/chips/STM32U585OI.json
@@ -5064,6 +5064,11 @@
                 {
                     "name": "USB_OTG_FS",
                     "address": 1107558400,
+                    "registers": {
+                        "kind": "otgfs",
+                        "version": "v3",
+                        "block": "OTG_FS"
+                    },
                     "rcc": {
                         "clock": "AHB2",
                         "enable": {

--- a/data/chips/STM32U585QE.json
+++ b/data/chips/STM32U585QE.json
@@ -6164,6 +6164,11 @@
                 {
                     "name": "USB_OTG_FS",
                     "address": 1107558400,
+                    "registers": {
+                        "kind": "otgfs",
+                        "version": "v3",
+                        "block": "OTG_FS"
+                    },
                     "rcc": {
                         "clock": "AHB2",
                         "enable": {

--- a/data/chips/STM32U585QI.json
+++ b/data/chips/STM32U585QI.json
@@ -6254,6 +6254,11 @@
                 {
                     "name": "USB_OTG_FS",
                     "address": 1107558400,
+                    "registers": {
+                        "kind": "otgfs",
+                        "version": "v3",
+                        "block": "OTG_FS"
+                    },
                     "rcc": {
                         "clock": "AHB2",
                         "enable": {

--- a/data/chips/STM32U585RI.json
+++ b/data/chips/STM32U585RI.json
@@ -4336,6 +4336,11 @@
                 {
                     "name": "USB_OTG_FS",
                     "address": 1107558400,
+                    "registers": {
+                        "kind": "otgfs",
+                        "version": "v3",
+                        "block": "OTG_FS"
+                    },
                     "rcc": {
                         "clock": "AHB2",
                         "enable": {

--- a/data/chips/STM32U585VI.json
+++ b/data/chips/STM32U585VI.json
@@ -5688,6 +5688,11 @@
                 {
                     "name": "USB_OTG_FS",
                     "address": 1107558400,
+                    "registers": {
+                        "kind": "otgfs",
+                        "version": "v3",
+                        "block": "OTG_FS"
+                    },
                     "rcc": {
                         "clock": "AHB2",
                         "enable": {

--- a/data/chips/STM32U585ZE.json
+++ b/data/chips/STM32U585ZE.json
@@ -6243,6 +6243,11 @@
                 {
                     "name": "USB_OTG_FS",
                     "address": 1107558400,
+                    "registers": {
+                        "kind": "otgfs",
+                        "version": "v3",
+                        "block": "OTG_FS"
+                    },
                     "rcc": {
                         "clock": "AHB2",
                         "enable": {

--- a/data/chips/STM32U585ZI.json
+++ b/data/chips/STM32U585ZI.json
@@ -6354,6 +6354,11 @@
                 {
                     "name": "USB_OTG_FS",
                     "address": 1107558400,
+                    "registers": {
+                        "kind": "otgfs",
+                        "version": "v3",
+                        "block": "OTG_FS"
+                    },
                     "rcc": {
                         "clock": "AHB2",
                         "enable": {

--- a/data/registers/otgfs_v3.yaml
+++ b/data/registers/otgfs_v3.yaml
@@ -1,0 +1,598 @@
+---
+block/OTG_FS:
+  description: USB on the go full speed
+  items:
+    - name: GOTGCTL
+      description: Control and status register
+      byte_offset: 0
+      fieldset: GOTGCTL
+    - name: GOTGINT
+      description: Interrupt register
+      byte_offset: 4
+      fieldset: GOTGINT
+    - name: GAHBCFG
+      description: AHB configuration register
+      byte_offset: 8
+      fieldset: GAHBCFG
+    - name: GUSBCFG
+      description: USB configuration register
+      byte_offset: 12
+      fieldset: GUSBCFG
+    - name: GRSTCTL
+      description: Reset register
+      byte_offset: 16
+      fieldset: GRSTCTL
+    - name: GINTSTS
+      description: Core interrupt register
+      byte_offset: 20
+      fieldset: GINTSTS
+    - name: GINTMSK
+      description: Interrupt mask register
+      byte_offset: 24
+      fieldset: GINTMSK
+    - name: GRXSTSR_Device
+      description: Receive status debug read (Device mode)
+      byte_offset: 28
+      access: Read
+      fieldset: GRXSTSR_Device
+    - name: GRXSTSR_Host
+      description: Receive status debug read (Host mode)
+      byte_offset: 28
+      access: Read
+      fieldset: GRXSTSR_Host
+    - name: GRXSTSP_Device
+      description: Status read and pop (Device mode)
+      byte_offset: 32
+      access: Read
+      fieldset: GRXSTSP_Device
+    - name: GRXSTSP_Host
+      description: Status read and pop (Host mode)
+      byte_offset: 32
+      access: Read
+      fieldset: GRXSTSP_Host
+    - name: GRXFSIZ
+      description: Receive FIFO size register
+      byte_offset: 36
+      fieldset: GRXFSIZ
+    - name: DIEPTXF0
+      description: Non-periodic transmit FIFO size register (Device mode)
+      byte_offset: 40
+      fieldset: DIEPTXF0
+    - name: HNPTXFSIZ
+      description: Non-periodic transmit FIFO size register (Host mode)
+      byte_offset: 40
+      fieldset: HNPTXFSIZ
+    - name: GNPTXSTS
+      description: Non-periodic transmit FIFO/queue status register
+      byte_offset: 44
+      access: Read
+      fieldset: GNPTXSTS
+    - name: GCCFG
+      description: General core configuration register
+      byte_offset: 56
+      fieldset: GCCFG
+    - name: CID
+      description: Core ID register
+      byte_offset: 60
+      fieldset: CID
+    - name: HPTXFSIZ
+      description: Host periodic transmit FIFO size register
+      byte_offset: 256
+      fieldset: HPTXFSIZ
+    - name: DIEPTXF
+      description: Device IN endpoint transmit FIFO size register
+      array:
+        len: 3
+        stride: 4
+      byte_offset: 260
+      fieldset: DIEPTXF
+fieldset/CID:
+  description: Core ID register
+  fields:
+    - name: PRODUCT_ID
+      description: Product ID field
+      bit_offset: 0
+      bit_size: 32
+fieldset/DIEPTXF:
+  description: Device IN endpoint transmit FIFO size register
+  fields:
+    - name: INEPTXSA
+      description: IN endpoint FIFO2 transmit RAM start address
+      bit_offset: 0
+      bit_size: 16
+    - name: INEPTXFD
+      description: IN endpoint TxFIFO depth
+      bit_offset: 16
+      bit_size: 16
+fieldset/DIEPTXF0:
+  description: Non-periodic transmit FIFO size register (Device mode)
+  fields:
+    - name: TX0FSA
+      description: Endpoint 0 transmit RAM start address
+      bit_offset: 0
+      bit_size: 16
+    - name: TX0FD
+      description: Endpoint 0 TxFIFO depth
+      bit_offset: 16
+      bit_size: 16
+fieldset/GAHBCFG:
+  description: AHB configuration register
+  fields:
+    - name: GINT
+      description: Global interrupt mask
+      bit_offset: 0
+      bit_size: 1
+    - name: TXFELVL
+      description: TxFIFO empty level
+      bit_offset: 7
+      bit_size: 1
+    - name: PTXFELVL
+      description: Periodic TxFIFO empty level
+      bit_offset: 8
+      bit_size: 1
+fieldset/GCCFG:
+  description: General core configuration register
+  fields:
+    - name: PWRDWN
+      description: Power down
+      bit_offset: 16
+      bit_size: 1
+    - name: VBUSASEN
+      description: Enable the VBUS sensing device
+      bit_offset: 18
+      bit_size: 1
+    - name: VBUSBSEN
+      description: Enable the VBUS sensing device
+      bit_offset: 19
+      bit_size: 1
+    - name: SOFOUTEN
+      description: SOF output enable
+      bit_offset: 20
+      bit_size: 1
+fieldset/GINTMSK:
+  description: Interrupt mask register
+  fields:
+    - name: MMISM
+      description: Mode mismatch interrupt mask
+      bit_offset: 1
+      bit_size: 1
+    - name: OTGINT
+      description: OTG interrupt mask
+      bit_offset: 2
+      bit_size: 1
+    - name: SOFM
+      description: Start of frame mask
+      bit_offset: 3
+      bit_size: 1
+    - name: RXFLVLM
+      description: Receive FIFO non-empty mask
+      bit_offset: 4
+      bit_size: 1
+    - name: NPTXFEM
+      description: Non-periodic TxFIFO empty mask
+      bit_offset: 5
+      bit_size: 1
+    - name: GINAKEFFM
+      description: Global non-periodic IN NAK effective mask
+      bit_offset: 6
+      bit_size: 1
+    - name: GONAKEFFM
+      description: Global OUT NAK effective mask
+      bit_offset: 7
+      bit_size: 1
+    - name: ESUSPM
+      description: Early suspend mask
+      bit_offset: 10
+      bit_size: 1
+    - name: USBSUSPM
+      description: USB suspend mask
+      bit_offset: 11
+      bit_size: 1
+    - name: USBRST
+      description: USB reset mask
+      bit_offset: 12
+      bit_size: 1
+    - name: ENUMDNEM
+      description: Enumeration done mask
+      bit_offset: 13
+      bit_size: 1
+    - name: ISOODRPM
+      description: Isochronous OUT packet dropped interrupt mask
+      bit_offset: 14
+      bit_size: 1
+    - name: EOPFM
+      description: End of periodic frame interrupt mask
+      bit_offset: 15
+      bit_size: 1
+    - name: IEPINT
+      description: IN endpoints interrupt mask
+      bit_offset: 18
+      bit_size: 1
+    - name: OEPINT
+      description: OUT endpoints interrupt mask
+      bit_offset: 19
+      bit_size: 1
+    - name: IISOIXFRM
+      description: Incomplete isochronous IN transfer mask
+      bit_offset: 20
+      bit_size: 1
+    - name: IPXFRM_IISOOXFRM
+      description: Incomplete periodic transfer mask(Host mode)/Incomplete isochronous OUT transfer mask(Device mode)
+      bit_offset: 21
+      bit_size: 1
+    - name: PRTIM
+      description: Host port interrupt mask
+      bit_offset: 24
+      bit_size: 1
+    - name: HCIM
+      description: Host channels interrupt mask
+      bit_offset: 25
+      bit_size: 1
+    - name: PTXFEM
+      description: Periodic TxFIFO empty mask
+      bit_offset: 26
+      bit_size: 1
+    - name: CIDSCHGM
+      description: Connector ID status change mask
+      bit_offset: 28
+      bit_size: 1
+    - name: DISCINT
+      description: Disconnect detected interrupt mask
+      bit_offset: 29
+      bit_size: 1
+    - name: SRQIM
+      description: Session request/new session detected interrupt mask
+      bit_offset: 30
+      bit_size: 1
+    - name: WUIM
+      description: Resume/remote wakeup detected interrupt mask
+      bit_offset: 31
+      bit_size: 1
+fieldset/GINTSTS:
+  description: Core interrupt register
+  fields:
+    - name: CMOD
+      description: Current mode of operation
+      bit_offset: 0
+      bit_size: 1
+    - name: MMIS
+      description: Mode mismatch interrupt
+      bit_offset: 1
+      bit_size: 1
+    - name: OTGINT
+      description: OTG interrupt
+      bit_offset: 2
+      bit_size: 1
+    - name: SOF
+      description: Start of frame
+      bit_offset: 3
+      bit_size: 1
+    - name: RXFLVL
+      description: RxFIFO non-empty
+      bit_offset: 4
+      bit_size: 1
+    - name: NPTXFE
+      description: Non-periodic TxFIFO empty
+      bit_offset: 5
+      bit_size: 1
+    - name: GINAKEFF
+      description: Global IN non-periodic NAK effective
+      bit_offset: 6
+      bit_size: 1
+    - name: GOUTNAKEFF
+      description: Global OUT NAK effective
+      bit_offset: 7
+      bit_size: 1
+    - name: ESUSP
+      description: Early suspend
+      bit_offset: 10
+      bit_size: 1
+    - name: USBSUSP
+      description: USB suspend
+      bit_offset: 11
+      bit_size: 1
+    - name: USBRST
+      description: USB reset
+      bit_offset: 12
+      bit_size: 1
+    - name: ENUMDNE
+      description: Enumeration done
+      bit_offset: 13
+      bit_size: 1
+    - name: ISOODRP
+      description: Isochronous OUT packet dropped interrupt
+      bit_offset: 14
+      bit_size: 1
+    - name: EOPF
+      description: End of periodic frame interrupt
+      bit_offset: 15
+      bit_size: 1
+    - name: IEPINT
+      description: IN endpoint interrupt
+      bit_offset: 18
+      bit_size: 1
+    - name: OEPINT
+      description: OUT endpoint interrupt
+      bit_offset: 19
+      bit_size: 1
+    - name: IISOIXFR
+      description: Incomplete isochronous IN transfer
+      bit_offset: 20
+      bit_size: 1
+    - name: IPXFR_INCOMPISOOUT
+      description: Incomplete periodic transfer(Host mode)/Incomplete isochronous OUT transfer(Device mode)
+      bit_offset: 21
+      bit_size: 1
+    - name: HPRTINT
+      description: Host port interrupt
+      bit_offset: 24
+      bit_size: 1
+    - name: HCINT
+      description: Host channels interrupt
+      bit_offset: 25
+      bit_size: 1
+    - name: PTXFE
+      description: Periodic TxFIFO empty
+      bit_offset: 26
+      bit_size: 1
+    - name: CIDSCHG
+      description: Connector ID status change
+      bit_offset: 28
+      bit_size: 1
+    - name: DISCINT
+      description: Disconnect detected interrupt
+      bit_offset: 29
+      bit_size: 1
+    - name: SRQINT
+      description: Session request/new session detected interrupt
+      bit_offset: 30
+      bit_size: 1
+    - name: WKUPINT
+      description: Resume/remote wakeup detected interrupt
+      bit_offset: 31
+      bit_size: 1
+fieldset/GOTGCTL:
+  description: Control and status register
+  fields:
+    - name: SRQSCS
+      description: Session request success
+      bit_offset: 0
+      bit_size: 1
+    - name: SRQ
+      description: Session request
+      bit_offset: 1
+      bit_size: 1
+    - name: HNGSCS
+      description: Host negotiation success
+      bit_offset: 8
+      bit_size: 1
+    - name: HNPRQ
+      description: HNP request
+      bit_offset: 9
+      bit_size: 1
+    - name: HSHNPEN
+      description: Host set HNP enable
+      bit_offset: 10
+      bit_size: 1
+    - name: DHNPEN
+      description: Device HNP enabled
+      bit_offset: 11
+      bit_size: 1
+    - name: CIDSTS
+      description: Connector ID status
+      bit_offset: 16
+      bit_size: 1
+    - name: DBCT
+      description: Long/short debounce time
+      bit_offset: 17
+      bit_size: 1
+    - name: ASVLD
+      description: A-session valid
+      bit_offset: 18
+      bit_size: 1
+    - name: BSVLD
+      description: B-session valid
+      bit_offset: 19
+      bit_size: 1
+fieldset/GOTGINT:
+  description: Interrupt register
+  fields:
+    - name: SEDET
+      description: Session end detected
+      bit_offset: 2
+      bit_size: 1
+    - name: SRSSCHG
+      description: Session request success status change
+      bit_offset: 8
+      bit_size: 1
+    - name: HNSSCHG
+      description: Host negotiation success status change
+      bit_offset: 9
+      bit_size: 1
+    - name: HNGDET
+      description: Host negotiation detected
+      bit_offset: 17
+      bit_size: 1
+    - name: ADTOCHG
+      description: A-device timeout change
+      bit_offset: 18
+      bit_size: 1
+    - name: DBCDNE
+      description: Debounce done
+      bit_offset: 19
+      bit_size: 1
+fieldset/GRSTCTL:
+  description: Reset register
+  fields:
+    - name: CSRST
+      description: Core soft reset
+      bit_offset: 0
+      bit_size: 1
+    - name: HSRST
+      description: HCLK soft reset
+      bit_offset: 1
+      bit_size: 1
+    - name: FCRST
+      description: Host frame counter reset
+      bit_offset: 2
+      bit_size: 1
+    - name: RXFFLSH
+      description: RxFIFO flush
+      bit_offset: 4
+      bit_size: 1
+    - name: TXFFLSH
+      description: TxFIFO flush
+      bit_offset: 5
+      bit_size: 1
+    - name: TXFNUM
+      description: TxFIFO number
+      bit_offset: 6
+      bit_size: 5
+    - name: AHBIDL
+      description: AHB master idle
+      bit_offset: 31
+      bit_size: 1
+fieldset/GRXFSIZ:
+  description: Receive FIFO size register
+  fields:
+    - name: RXFD
+      description: RxFIFO depth
+      bit_offset: 0
+      bit_size: 16
+fieldset/GRXSTSP_Device:
+  description: Status read and pop (Device mode)
+  fields:
+    - name: EPNUM
+      description: Endpoint number
+      bit_offset: 0
+      bit_size: 4
+    - name: BCNT
+      description: Byte count
+      bit_offset: 4
+      bit_size: 11
+    - name: DPID
+      description: Data PID
+      bit_offset: 15
+      bit_size: 2
+    - name: PKTSTS
+      description: Packet status
+      bit_offset: 17
+      bit_size: 4
+    - name: FRMNUM
+      description: Frame number
+      bit_offset: 21
+      bit_size: 4
+fieldset/GRXSTSP_Host:
+  description: Status read and pop (Host mode)
+  fields:
+    - name: CHNUM
+      description: Channel number
+      bit_offset: 0
+      bit_size: 4
+    - name: BCNT
+      description: Byte count
+      bit_offset: 4
+      bit_size: 11
+    - name: DPID
+      description: Data PID
+      bit_offset: 15
+      bit_size: 2
+    - name: PKTSTS
+      description: Packet status
+      bit_offset: 17
+      bit_size: 4
+fieldset/GRXSTSR_Device:
+  description: Receive status debug read(Device mode)
+  fields:
+    - name: EPNUM
+      description: Endpoint number
+      bit_offset: 0
+      bit_size: 4
+    - name: BCNT
+      description: Byte count
+      bit_offset: 4
+      bit_size: 11
+    - name: DPID
+      description: Data PID
+      bit_offset: 15
+      bit_size: 2
+    - name: PKTSTS
+      description: Packet status
+      bit_offset: 17
+      bit_size: 4
+    - name: FRMNUM
+      description: Frame number
+      bit_offset: 21
+      bit_size: 4
+fieldset/GRXSTSR_Host:
+  description: Receive status debug read(Host mode)
+  fields:
+    - name: EPNUM
+      description: Endpoint number
+      bit_offset: 0
+      bit_size: 4
+    - name: BCNT
+      description: Byte count
+      bit_offset: 4
+      bit_size: 11
+    - name: DPID
+      description: Data PID
+      bit_offset: 15
+      bit_size: 2
+    - name: PKTSTS
+      description: Packet status
+      bit_offset: 17
+      bit_size: 4
+fieldset/GUSBCFG:
+  description: USB configuration register
+  fields:
+    - name: TOCAL
+      description: FS timeout calibration
+      bit_offset: 0
+      bit_size: 3
+    - name: PHYSEL
+      description: Full Speed serial transceiver select
+      bit_offset: 6
+      bit_size: 1
+    - name: SRPCAP
+      description: SRP-capable
+      bit_offset: 8
+      bit_size: 1
+    - name: HNPCAP
+      description: HNP-capable
+      bit_offset: 9
+      bit_size: 1
+    - name: TRDT
+      description: USB turnaround time
+      bit_offset: 10
+      bit_size: 4
+    - name: FHMOD
+      description: Force host mode
+      bit_offset: 29
+      bit_size: 1
+    - name: FDMOD
+      description: Force device mode
+      bit_offset: 30
+      bit_size: 1
+fieldset/HNPTXFSIZ:
+  description: Non-periodic transmit FIFO size register (Host mode)
+  fields:
+    - name: NPTXFSA
+      description: Non-periodic transmit RAM start address
+      bit_offset: 0
+      bit_size: 16
+    - name: NPTXFD
+      description: Non-periodic TxFIFO depth
+      bit_offset: 16
+      bit_size: 16
+fieldset/HPTXFSIZ:
+  description: Host periodic transmit FIFO size register
+  fields:
+    - name: PTXSA
+      description: Host periodic TxFIFO start address
+      bit_offset: 0
+      bit_size: 16
+    - name: PTXFSIZ
+      description: Host periodic TxFIFO depth
+      bit_offset: 16
+      bit_size: 16

--- a/stm32data/__main__.py
+++ b/stm32data/__main__.py
@@ -159,6 +159,7 @@ perimap = [
     ('.*:SDMMC:sdmmc_v1_3', ('sdmmc', 'v1', 'SDMMC')),
     ('.*:SPDIFRX:spdifrx1_v1_0', ('spdifrx', 'v1', 'SPDIFRX')),
     ('.*:USB_OTG_FS:otgfs1_v1_.*', ('otgfs', 'v1', 'OTG_FS')),
+    ('.*:USB_OTG_FS:otgfs1_v3_.*', ('otgfs', 'v3', 'OTG_FS')),
     ('.*:USB_OTG_HS:otghs1_v1_.*', ('otghs', 'v1', 'OTG_HS')),
 
     ('STM32F0.*:RCC:.*', ('rcc', 'f0', 'RCC')),


### PR DESCRIPTION
I got usb working on STM32L4R5ZITx

I followed this example https://github.com/embassy-rs/embassy/blob/5c68f0bae7c4091ad34fb2a671e08a614d9beb9a/examples/stm32f4/src/bin/usb_uart.rs but made some changes
```rust
// USB requires at least 48 MHz clock
fn config() -> Config {
    let mut config = Config::default();
    config.rcc.mux = ClockSrc::MSI(MSIRange::Range11);
    config
}

#[embassy::main(config = "config()")]
async fn main(_spawner: Spawner, p: Peripherals) {
    // Enable PWR peripheral
    unsafe { RCC.apb1enr1().modify(|w| w.set_pwren(true)) };

    // Enable VddUSB
    let pwr_cr2 = 0x40007004 as *mut i32;
    unsafe { *pwr_cr2 |= 1 << 10 }; // USV is on bit 10;
```