### PR TITLE
Generate support for ethernet v1a and v1b

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ In order to run the generator, you will need to install the following tools:
 * `git`
 * `jq`
 * `svd` – `pip3 install svdtools` 
+* `xmltodict` - `pip3 install xmltodict`
 
 ## Generating the YAMLs
 

--- a/data/chips/STM32F105R8.json
+++ b/data/chips/STM32F105R8.json
@@ -1069,7 +1069,7 @@
                     "address": 1073876992,
                     "registers": {
                         "kind": "rcc",
-                        "version": "f1",
+                        "version": "f1cl",
                         "block": "RCC"
                     },
                     "pins": [

--- a/data/chips/STM32F105RB.json
+++ b/data/chips/STM32F105RB.json
@@ -1069,7 +1069,7 @@
                     "address": 1073876992,
                     "registers": {
                         "kind": "rcc",
-                        "version": "f1",
+                        "version": "f1cl",
                         "block": "RCC"
                     },
                     "pins": [

--- a/data/chips/STM32F105RC.json
+++ b/data/chips/STM32F105RC.json
@@ -1069,7 +1069,7 @@
                     "address": 1073876992,
                     "registers": {
                         "kind": "rcc",
-                        "version": "f1",
+                        "version": "f1cl",
                         "block": "RCC"
                     },
                     "pins": [

--- a/data/chips/STM32F105V8.json
+++ b/data/chips/STM32F105V8.json
@@ -1081,7 +1081,7 @@
                     "address": 1073876992,
                     "registers": {
                         "kind": "rcc",
-                        "version": "f1",
+                        "version": "f1cl",
                         "block": "RCC"
                     },
                     "pins": [

--- a/data/chips/STM32F105VB.json
+++ b/data/chips/STM32F105VB.json
@@ -1081,7 +1081,7 @@
                     "address": 1073876992,
                     "registers": {
                         "kind": "rcc",
-                        "version": "f1",
+                        "version": "f1cl",
                         "block": "RCC"
                     },
                     "pins": [

--- a/data/chips/STM32F105VC.json
+++ b/data/chips/STM32F105VC.json
@@ -1077,7 +1077,7 @@
                     "address": 1073876992,
                     "registers": {
                         "kind": "rcc",
-                        "version": "f1",
+                        "version": "f1cl",
                         "block": "RCC"
                     },
                     "pins": [

--- a/data/chips/STM32F107RB.json
+++ b/data/chips/STM32F107RB.json
@@ -735,6 +735,11 @@
                 {
                     "name": "ETH",
                     "address": 1073905664,
+                    "registers": {
+                        "kind": "eth",
+                        "version": "v1a",
+                        "block": "ETH"
+                    },
                     "pins": [
                         {
                             "pin": "PA0",

--- a/data/chips/STM32F107RB.json
+++ b/data/chips/STM32F107RB.json
@@ -1120,7 +1120,7 @@
                     "address": 1073876992,
                     "registers": {
                         "kind": "rcc",
-                        "version": "f1",
+                        "version": "f1cl",
                         "block": "RCC"
                     },
                     "pins": [

--- a/data/chips/STM32F107RC.json
+++ b/data/chips/STM32F107RC.json
@@ -735,6 +735,11 @@
                 {
                     "name": "ETH",
                     "address": 1073905664,
+                    "registers": {
+                        "kind": "eth",
+                        "version": "v1a",
+                        "block": "ETH"
+                    },
                     "pins": [
                         {
                             "pin": "PA0",

--- a/data/chips/STM32F107RC.json
+++ b/data/chips/STM32F107RC.json
@@ -1120,7 +1120,7 @@
                     "address": 1073876992,
                     "registers": {
                         "kind": "rcc",
-                        "version": "f1",
+                        "version": "f1cl",
                         "block": "RCC"
                     },
                     "pins": [

--- a/data/chips/STM32F107VB.json
+++ b/data/chips/STM32F107VB.json
@@ -743,6 +743,11 @@
                 {
                     "name": "ETH",
                     "address": 1073905664,
+                    "registers": {
+                        "kind": "eth",
+                        "version": "v1a",
+                        "block": "ETH"
+                    },
                     "pins": [
                         {
                             "pin": "PA0",

--- a/data/chips/STM32F107VB.json
+++ b/data/chips/STM32F107VB.json
@@ -1152,7 +1152,7 @@
                     "address": 1073876992,
                     "registers": {
                         "kind": "rcc",
-                        "version": "f1",
+                        "version": "f1cl",
                         "block": "RCC"
                     },
                     "pins": [

--- a/data/chips/STM32F107VC.json
+++ b/data/chips/STM32F107VC.json
@@ -747,6 +747,11 @@
                 {
                     "name": "ETH",
                     "address": 1073905664,
+                    "registers": {
+                        "kind": "eth",
+                        "version": "v1a",
+                        "block": "ETH"
+                    },
                     "pins": [
                         {
                             "pin": "PA0",

--- a/data/chips/STM32F107VC.json
+++ b/data/chips/STM32F107VC.json
@@ -1156,7 +1156,7 @@
                     "address": 1073876992,
                     "registers": {
                         "kind": "rcc",
-                        "version": "f1",
+                        "version": "f1cl",
                         "block": "RCC"
                     },
                     "pins": [

--- a/data/chips/STM32F207IC.json
+++ b/data/chips/STM32F207IC.json
@@ -1158,6 +1158,11 @@
                 {
                     "name": "ETH",
                     "address": 1073905664,
+                    "registers": {
+                        "kind": "eth",
+                        "version": "v1b",
+                        "block": "ETH"
+                    },
                     "pins": [
                         {
                             "pin": "PA0",

--- a/data/chips/STM32F207IE.json
+++ b/data/chips/STM32F207IE.json
@@ -1158,6 +1158,11 @@
                 {
                     "name": "ETH",
                     "address": 1073905664,
+                    "registers": {
+                        "kind": "eth",
+                        "version": "v1b",
+                        "block": "ETH"
+                    },
                     "pins": [
                         {
                             "pin": "PA0",

--- a/data/chips/STM32F207IF.json
+++ b/data/chips/STM32F207IF.json
@@ -1158,6 +1158,11 @@
                 {
                     "name": "ETH",
                     "address": 1073905664,
+                    "registers": {
+                        "kind": "eth",
+                        "version": "v1b",
+                        "block": "ETH"
+                    },
                     "pins": [
                         {
                             "pin": "PA0",

--- a/data/chips/STM32F207IG.json
+++ b/data/chips/STM32F207IG.json
@@ -1158,6 +1158,11 @@
                 {
                     "name": "ETH",
                     "address": 1073905664,
+                    "registers": {
+                        "kind": "eth",
+                        "version": "v1b",
+                        "block": "ETH"
+                    },
                     "pins": [
                         {
                             "pin": "PA0",

--- a/data/chips/STM32F207VC.json
+++ b/data/chips/STM32F207VC.json
@@ -1027,6 +1027,11 @@
                 {
                     "name": "ETH",
                     "address": 1073905664,
+                    "registers": {
+                        "kind": "eth",
+                        "version": "v1b",
+                        "block": "ETH"
+                    },
                     "pins": [
                         {
                             "pin": "PA0",

--- a/data/chips/STM32F207VE.json
+++ b/data/chips/STM32F207VE.json
@@ -1027,6 +1027,11 @@
                 {
                     "name": "ETH",
                     "address": 1073905664,
+                    "registers": {
+                        "kind": "eth",
+                        "version": "v1b",
+                        "block": "ETH"
+                    },
                     "pins": [
                         {
                             "pin": "PA0",

--- a/data/chips/STM32F207VF.json
+++ b/data/chips/STM32F207VF.json
@@ -1027,6 +1027,11 @@
                 {
                     "name": "ETH",
                     "address": 1073905664,
+                    "registers": {
+                        "kind": "eth",
+                        "version": "v1b",
+                        "block": "ETH"
+                    },
                     "pins": [
                         {
                             "pin": "PA0",

--- a/data/chips/STM32F207VG.json
+++ b/data/chips/STM32F207VG.json
@@ -1027,6 +1027,11 @@
                 {
                     "name": "ETH",
                     "address": 1073905664,
+                    "registers": {
+                        "kind": "eth",
+                        "version": "v1b",
+                        "block": "ETH"
+                    },
                     "pins": [
                         {
                             "pin": "PA0",

--- a/data/chips/STM32F207ZC.json
+++ b/data/chips/STM32F207ZC.json
@@ -1069,6 +1069,11 @@
                 {
                     "name": "ETH",
                     "address": 1073905664,
+                    "registers": {
+                        "kind": "eth",
+                        "version": "v1b",
+                        "block": "ETH"
+                    },
                     "pins": [
                         {
                             "pin": "PA0",

--- a/data/chips/STM32F207ZE.json
+++ b/data/chips/STM32F207ZE.json
@@ -1069,6 +1069,11 @@
                 {
                     "name": "ETH",
                     "address": 1073905664,
+                    "registers": {
+                        "kind": "eth",
+                        "version": "v1b",
+                        "block": "ETH"
+                    },
                     "pins": [
                         {
                             "pin": "PA0",

--- a/data/chips/STM32F207ZF.json
+++ b/data/chips/STM32F207ZF.json
@@ -1069,6 +1069,11 @@
                 {
                     "name": "ETH",
                     "address": 1073905664,
+                    "registers": {
+                        "kind": "eth",
+                        "version": "v1b",
+                        "block": "ETH"
+                    },
                     "pins": [
                         {
                             "pin": "PA0",

--- a/data/chips/STM32F207ZG.json
+++ b/data/chips/STM32F207ZG.json
@@ -1069,6 +1069,11 @@
                 {
                     "name": "ETH",
                     "address": 1073905664,
+                    "registers": {
+                        "kind": "eth",
+                        "version": "v1b",
+                        "block": "ETH"
+                    },
                     "pins": [
                         {
                             "pin": "PA0",

--- a/data/chips/STM32F217IE.json
+++ b/data/chips/STM32F217IE.json
@@ -1191,6 +1191,11 @@
                 {
                     "name": "ETH",
                     "address": 1073905664,
+                    "registers": {
+                        "kind": "eth",
+                        "version": "v1b",
+                        "block": "ETH"
+                    },
                     "pins": [
                         {
                             "pin": "PA0",

--- a/data/chips/STM32F217IG.json
+++ b/data/chips/STM32F217IG.json
@@ -1191,6 +1191,11 @@
                 {
                     "name": "ETH",
                     "address": 1073905664,
+                    "registers": {
+                        "kind": "eth",
+                        "version": "v1b",
+                        "block": "ETH"
+                    },
                     "pins": [
                         {
                             "pin": "PA0",

--- a/data/chips/STM32F217VE.json
+++ b/data/chips/STM32F217VE.json
@@ -1060,6 +1060,11 @@
                 {
                     "name": "ETH",
                     "address": 1073905664,
+                    "registers": {
+                        "kind": "eth",
+                        "version": "v1b",
+                        "block": "ETH"
+                    },
                     "pins": [
                         {
                             "pin": "PA0",

--- a/data/chips/STM32F217VG.json
+++ b/data/chips/STM32F217VG.json
@@ -1060,6 +1060,11 @@
                 {
                     "name": "ETH",
                     "address": 1073905664,
+                    "registers": {
+                        "kind": "eth",
+                        "version": "v1b",
+                        "block": "ETH"
+                    },
                     "pins": [
                         {
                             "pin": "PA0",

--- a/data/chips/STM32F217ZE.json
+++ b/data/chips/STM32F217ZE.json
@@ -1102,6 +1102,11 @@
                 {
                     "name": "ETH",
                     "address": 1073905664,
+                    "registers": {
+                        "kind": "eth",
+                        "version": "v1b",
+                        "block": "ETH"
+                    },
                     "pins": [
                         {
                             "pin": "PA0",

--- a/data/chips/STM32F217ZG.json
+++ b/data/chips/STM32F217ZG.json
@@ -1102,6 +1102,11 @@
                 {
                     "name": "ETH",
                     "address": 1073905664,
+                    "registers": {
+                        "kind": "eth",
+                        "version": "v1b",
+                        "block": "ETH"
+                    },
                     "pins": [
                         {
                             "pin": "PA0",

--- a/data/chips/STM32F407IE.json
+++ b/data/chips/STM32F407IE.json
@@ -1182,6 +1182,11 @@
                 {
                     "name": "ETH",
                     "address": 1073905664,
+                    "registers": {
+                        "kind": "eth",
+                        "version": "v1b",
+                        "block": "ETH"
+                    },
                     "pins": [
                         {
                             "pin": "PA0",

--- a/data/chips/STM32F407IG.json
+++ b/data/chips/STM32F407IG.json
@@ -1182,6 +1182,11 @@
                 {
                     "name": "ETH",
                     "address": 1073905664,
+                    "registers": {
+                        "kind": "eth",
+                        "version": "v1b",
+                        "block": "ETH"
+                    },
                     "pins": [
                         {
                             "pin": "PA0",

--- a/data/chips/STM32F407VE.json
+++ b/data/chips/STM32F407VE.json
@@ -1051,6 +1051,11 @@
                 {
                     "name": "ETH",
                     "address": 1073905664,
+                    "registers": {
+                        "kind": "eth",
+                        "version": "v1b",
+                        "block": "ETH"
+                    },
                     "pins": [
                         {
                             "pin": "PA0",

--- a/data/chips/STM32F407VG.json
+++ b/data/chips/STM32F407VG.json
@@ -1051,6 +1051,11 @@
                 {
                     "name": "ETH",
                     "address": 1073905664,
+                    "registers": {
+                        "kind": "eth",
+                        "version": "v1b",
+                        "block": "ETH"
+                    },
                     "pins": [
                         {
                             "pin": "PA0",

--- a/data/chips/STM32F407ZE.json
+++ b/data/chips/STM32F407ZE.json
@@ -1093,6 +1093,11 @@
                 {
                     "name": "ETH",
                     "address": 1073905664,
+                    "registers": {
+                        "kind": "eth",
+                        "version": "v1b",
+                        "block": "ETH"
+                    },
                     "pins": [
                         {
                             "pin": "PA0",

--- a/data/chips/STM32F407ZG.json
+++ b/data/chips/STM32F407ZG.json
@@ -1093,6 +1093,11 @@
                 {
                     "name": "ETH",
                     "address": 1073905664,
+                    "registers": {
+                        "kind": "eth",
+                        "version": "v1b",
+                        "block": "ETH"
+                    },
                     "pins": [
                         {
                             "pin": "PA0",

--- a/data/chips/STM32F417IE.json
+++ b/data/chips/STM32F417IE.json
@@ -1215,6 +1215,11 @@
                 {
                     "name": "ETH",
                     "address": 1073905664,
+                    "registers": {
+                        "kind": "eth",
+                        "version": "v1b",
+                        "block": "ETH"
+                    },
                     "pins": [
                         {
                             "pin": "PA0",

--- a/data/chips/STM32F417IG.json
+++ b/data/chips/STM32F417IG.json
@@ -1215,6 +1215,11 @@
                 {
                     "name": "ETH",
                     "address": 1073905664,
+                    "registers": {
+                        "kind": "eth",
+                        "version": "v1b",
+                        "block": "ETH"
+                    },
                     "pins": [
                         {
                             "pin": "PA0",

--- a/data/chips/STM32F417VE.json
+++ b/data/chips/STM32F417VE.json
@@ -1084,6 +1084,11 @@
                 {
                     "name": "ETH",
                     "address": 1073905664,
+                    "registers": {
+                        "kind": "eth",
+                        "version": "v1b",
+                        "block": "ETH"
+                    },
                     "pins": [
                         {
                             "pin": "PA0",

--- a/data/chips/STM32F417VG.json
+++ b/data/chips/STM32F417VG.json
@@ -1084,6 +1084,11 @@
                 {
                     "name": "ETH",
                     "address": 1073905664,
+                    "registers": {
+                        "kind": "eth",
+                        "version": "v1b",
+                        "block": "ETH"
+                    },
                     "pins": [
                         {
                             "pin": "PA0",

--- a/data/chips/STM32F417ZE.json
+++ b/data/chips/STM32F417ZE.json
@@ -1126,6 +1126,11 @@
                 {
                     "name": "ETH",
                     "address": 1073905664,
+                    "registers": {
+                        "kind": "eth",
+                        "version": "v1b",
+                        "block": "ETH"
+                    },
                     "pins": [
                         {
                             "pin": "PA0",

--- a/data/chips/STM32F417ZG.json
+++ b/data/chips/STM32F417ZG.json
@@ -1126,6 +1126,11 @@
                 {
                     "name": "ETH",
                     "address": 1073905664,
+                    "registers": {
+                        "kind": "eth",
+                        "version": "v1b",
+                        "block": "ETH"
+                    },
                     "pins": [
                         {
                             "pin": "PA0",

--- a/data/chips/STM32F427AG.json
+++ b/data/chips/STM32F427AG.json
@@ -1227,6 +1227,11 @@
                 {
                     "name": "ETH",
                     "address": 1073905664,
+                    "registers": {
+                        "kind": "eth",
+                        "version": "v1b",
+                        "block": "ETH"
+                    },
                     "pins": [
                         {
                             "pin": "PA0",

--- a/data/chips/STM32F427AI.json
+++ b/data/chips/STM32F427AI.json
@@ -1227,6 +1227,11 @@
                 {
                     "name": "ETH",
                     "address": 1073905664,
+                    "registers": {
+                        "kind": "eth",
+                        "version": "v1b",
+                        "block": "ETH"
+                    },
                     "pins": [
                         {
                             "pin": "PA0",

--- a/data/chips/STM32F427IG.json
+++ b/data/chips/STM32F427IG.json
@@ -1264,6 +1264,11 @@
                 {
                     "name": "ETH",
                     "address": 1073905664,
+                    "registers": {
+                        "kind": "eth",
+                        "version": "v1b",
+                        "block": "ETH"
+                    },
                     "pins": [
                         {
                             "pin": "PA0",

--- a/data/chips/STM32F427II.json
+++ b/data/chips/STM32F427II.json
@@ -1264,6 +1264,11 @@
                 {
                     "name": "ETH",
                     "address": 1073905664,
+                    "registers": {
+                        "kind": "eth",
+                        "version": "v1b",
+                        "block": "ETH"
+                    },
                     "pins": [
                         {
                             "pin": "PA0",

--- a/data/chips/STM32F427VG.json
+++ b/data/chips/STM32F427VG.json
@@ -1093,6 +1093,11 @@
                 {
                     "name": "ETH",
                     "address": 1073905664,
+                    "registers": {
+                        "kind": "eth",
+                        "version": "v1b",
+                        "block": "ETH"
+                    },
                     "pins": [
                         {
                             "pin": "PA0",

--- a/data/chips/STM32F427VI.json
+++ b/data/chips/STM32F427VI.json
@@ -1093,6 +1093,11 @@
                 {
                     "name": "ETH",
                     "address": 1073905664,
+                    "registers": {
+                        "kind": "eth",
+                        "version": "v1b",
+                        "block": "ETH"
+                    },
                     "pins": [
                         {
                             "pin": "PA0",

--- a/data/chips/STM32F427ZG.json
+++ b/data/chips/STM32F427ZG.json
@@ -1165,6 +1165,11 @@
                 {
                     "name": "ETH",
                     "address": 1073905664,
+                    "registers": {
+                        "kind": "eth",
+                        "version": "v1b",
+                        "block": "ETH"
+                    },
                     "pins": [
                         {
                             "pin": "PA0",

--- a/data/chips/STM32F427ZI.json
+++ b/data/chips/STM32F427ZI.json
@@ -1165,6 +1165,11 @@
                 {
                     "name": "ETH",
                     "address": 1073905664,
+                    "registers": {
+                        "kind": "eth",
+                        "version": "v1b",
+                        "block": "ETH"
+                    },
                     "pins": [
                         {
                             "pin": "PA0",

--- a/data/chips/STM32F429AG.json
+++ b/data/chips/STM32F429AG.json
@@ -1239,6 +1239,11 @@
                 {
                     "name": "ETH",
                     "address": 1073905664,
+                    "registers": {
+                        "kind": "eth",
+                        "version": "v1b",
+                        "block": "ETH"
+                    },
                     "pins": [
                         {
                             "pin": "PA0",

--- a/data/chips/STM32F429AI.json
+++ b/data/chips/STM32F429AI.json
@@ -1239,6 +1239,11 @@
                 {
                     "name": "ETH",
                     "address": 1073905664,
+                    "registers": {
+                        "kind": "eth",
+                        "version": "v1b",
+                        "block": "ETH"
+                    },
                     "pins": [
                         {
                             "pin": "PA0",

--- a/data/chips/STM32F429BE.json
+++ b/data/chips/STM32F429BE.json
@@ -1260,6 +1260,11 @@
                 {
                     "name": "ETH",
                     "address": 1073905664,
+                    "registers": {
+                        "kind": "eth",
+                        "version": "v1b",
+                        "block": "ETH"
+                    },
                     "pins": [
                         {
                             "pin": "PA0",

--- a/data/chips/STM32F429BG.json
+++ b/data/chips/STM32F429BG.json
@@ -1266,6 +1266,11 @@
                 {
                     "name": "ETH",
                     "address": 1073905664,
+                    "registers": {
+                        "kind": "eth",
+                        "version": "v1b",
+                        "block": "ETH"
+                    },
                     "pins": [
                         {
                             "pin": "PA0",

--- a/data/chips/STM32F429BI.json
+++ b/data/chips/STM32F429BI.json
@@ -1266,6 +1266,11 @@
                 {
                     "name": "ETH",
                     "address": 1073905664,
+                    "registers": {
+                        "kind": "eth",
+                        "version": "v1b",
+                        "block": "ETH"
+                    },
                     "pins": [
                         {
                             "pin": "PA0",

--- a/data/chips/STM32F429IE.json
+++ b/data/chips/STM32F429IE.json
@@ -1264,6 +1264,11 @@
                 {
                     "name": "ETH",
                     "address": 1073905664,
+                    "registers": {
+                        "kind": "eth",
+                        "version": "v1b",
+                        "block": "ETH"
+                    },
                     "pins": [
                         {
                             "pin": "PA0",

--- a/data/chips/STM32F429IG.json
+++ b/data/chips/STM32F429IG.json
@@ -1276,6 +1276,11 @@
                 {
                     "name": "ETH",
                     "address": 1073905664,
+                    "registers": {
+                        "kind": "eth",
+                        "version": "v1b",
+                        "block": "ETH"
+                    },
                     "pins": [
                         {
                             "pin": "PA0",

--- a/data/chips/STM32F429II.json
+++ b/data/chips/STM32F429II.json
@@ -1276,6 +1276,11 @@
                 {
                     "name": "ETH",
                     "address": 1073905664,
+                    "registers": {
+                        "kind": "eth",
+                        "version": "v1b",
+                        "block": "ETH"
+                    },
                     "pins": [
                         {
                             "pin": "PA0",

--- a/data/chips/STM32F429NE.json
+++ b/data/chips/STM32F429NE.json
@@ -1260,6 +1260,11 @@
                 {
                     "name": "ETH",
                     "address": 1073905664,
+                    "registers": {
+                        "kind": "eth",
+                        "version": "v1b",
+                        "block": "ETH"
+                    },
                     "pins": [
                         {
                             "pin": "PA0",

--- a/data/chips/STM32F429NG.json
+++ b/data/chips/STM32F429NG.json
@@ -1266,6 +1266,11 @@
                 {
                     "name": "ETH",
                     "address": 1073905664,
+                    "registers": {
+                        "kind": "eth",
+                        "version": "v1b",
+                        "block": "ETH"
+                    },
                     "pins": [
                         {
                             "pin": "PA0",

--- a/data/chips/STM32F429NI.json
+++ b/data/chips/STM32F429NI.json
@@ -1266,6 +1266,11 @@
                 {
                     "name": "ETH",
                     "address": 1073905664,
+                    "registers": {
+                        "kind": "eth",
+                        "version": "v1b",
+                        "block": "ETH"
+                    },
                     "pins": [
                         {
                             "pin": "PA0",

--- a/data/chips/STM32F429VE.json
+++ b/data/chips/STM32F429VE.json
@@ -1093,6 +1093,11 @@
                 {
                     "name": "ETH",
                     "address": 1073905664,
+                    "registers": {
+                        "kind": "eth",
+                        "version": "v1b",
+                        "block": "ETH"
+                    },
                     "pins": [
                         {
                             "pin": "PA0",

--- a/data/chips/STM32F429VG.json
+++ b/data/chips/STM32F429VG.json
@@ -1099,6 +1099,11 @@
                 {
                     "name": "ETH",
                     "address": 1073905664,
+                    "registers": {
+                        "kind": "eth",
+                        "version": "v1b",
+                        "block": "ETH"
+                    },
                     "pins": [
                         {
                             "pin": "PA0",

--- a/data/chips/STM32F429VI.json
+++ b/data/chips/STM32F429VI.json
@@ -1099,6 +1099,11 @@
                 {
                     "name": "ETH",
                     "address": 1073905664,
+                    "registers": {
+                        "kind": "eth",
+                        "version": "v1b",
+                        "block": "ETH"
+                    },
                     "pins": [
                         {
                             "pin": "PA0",

--- a/data/chips/STM32F429ZE.json
+++ b/data/chips/STM32F429ZE.json
@@ -1165,6 +1165,11 @@
                 {
                     "name": "ETH",
                     "address": 1073905664,
+                    "registers": {
+                        "kind": "eth",
+                        "version": "v1b",
+                        "block": "ETH"
+                    },
                     "pins": [
                         {
                             "pin": "PA0",

--- a/data/chips/STM32F429ZG.json
+++ b/data/chips/STM32F429ZG.json
@@ -1175,6 +1175,11 @@
                 {
                     "name": "ETH",
                     "address": 1073905664,
+                    "registers": {
+                        "kind": "eth",
+                        "version": "v1b",
+                        "block": "ETH"
+                    },
                     "pins": [
                         {
                             "pin": "PA0",

--- a/data/chips/STM32F429ZI.json
+++ b/data/chips/STM32F429ZI.json
@@ -1175,6 +1175,11 @@
                 {
                     "name": "ETH",
                     "address": 1073905664,
+                    "registers": {
+                        "kind": "eth",
+                        "version": "v1b",
+                        "block": "ETH"
+                    },
                     "pins": [
                         {
                             "pin": "PA0",

--- a/data/chips/STM32F437AI.json
+++ b/data/chips/STM32F437AI.json
@@ -1260,6 +1260,11 @@
                 {
                     "name": "ETH",
                     "address": 1073905664,
+                    "registers": {
+                        "kind": "eth",
+                        "version": "v1b",
+                        "block": "ETH"
+                    },
                     "pins": [
                         {
                             "pin": "PA0",

--- a/data/chips/STM32F437IG.json
+++ b/data/chips/STM32F437IG.json
@@ -1297,6 +1297,11 @@
                 {
                     "name": "ETH",
                     "address": 1073905664,
+                    "registers": {
+                        "kind": "eth",
+                        "version": "v1b",
+                        "block": "ETH"
+                    },
                     "pins": [
                         {
                             "pin": "PA0",

--- a/data/chips/STM32F437II.json
+++ b/data/chips/STM32F437II.json
@@ -1297,6 +1297,11 @@
                 {
                     "name": "ETH",
                     "address": 1073905664,
+                    "registers": {
+                        "kind": "eth",
+                        "version": "v1b",
+                        "block": "ETH"
+                    },
                     "pins": [
                         {
                             "pin": "PA0",

--- a/data/chips/STM32F437VG.json
+++ b/data/chips/STM32F437VG.json
@@ -1126,6 +1126,11 @@
                 {
                     "name": "ETH",
                     "address": 1073905664,
+                    "registers": {
+                        "kind": "eth",
+                        "version": "v1b",
+                        "block": "ETH"
+                    },
                     "pins": [
                         {
                             "pin": "PA0",

--- a/data/chips/STM32F437VI.json
+++ b/data/chips/STM32F437VI.json
@@ -1126,6 +1126,11 @@
                 {
                     "name": "ETH",
                     "address": 1073905664,
+                    "registers": {
+                        "kind": "eth",
+                        "version": "v1b",
+                        "block": "ETH"
+                    },
                     "pins": [
                         {
                             "pin": "PA0",

--- a/data/chips/STM32F437ZG.json
+++ b/data/chips/STM32F437ZG.json
@@ -1198,6 +1198,11 @@
                 {
                     "name": "ETH",
                     "address": 1073905664,
+                    "registers": {
+                        "kind": "eth",
+                        "version": "v1b",
+                        "block": "ETH"
+                    },
                     "pins": [
                         {
                             "pin": "PA0",

--- a/data/chips/STM32F437ZI.json
+++ b/data/chips/STM32F437ZI.json
@@ -1198,6 +1198,11 @@
                 {
                     "name": "ETH",
                     "address": 1073905664,
+                    "registers": {
+                        "kind": "eth",
+                        "version": "v1b",
+                        "block": "ETH"
+                    },
                     "pins": [
                         {
                             "pin": "PA0",

--- a/data/chips/STM32F439AI.json
+++ b/data/chips/STM32F439AI.json
@@ -1272,6 +1272,11 @@
                 {
                     "name": "ETH",
                     "address": 1073905664,
+                    "registers": {
+                        "kind": "eth",
+                        "version": "v1b",
+                        "block": "ETH"
+                    },
                     "pins": [
                         {
                             "pin": "PA0",

--- a/data/chips/STM32F439BG.json
+++ b/data/chips/STM32F439BG.json
@@ -1299,6 +1299,11 @@
                 {
                     "name": "ETH",
                     "address": 1073905664,
+                    "registers": {
+                        "kind": "eth",
+                        "version": "v1b",
+                        "block": "ETH"
+                    },
                     "pins": [
                         {
                             "pin": "PA0",

--- a/data/chips/STM32F439BI.json
+++ b/data/chips/STM32F439BI.json
@@ -1299,6 +1299,11 @@
                 {
                     "name": "ETH",
                     "address": 1073905664,
+                    "registers": {
+                        "kind": "eth",
+                        "version": "v1b",
+                        "block": "ETH"
+                    },
                     "pins": [
                         {
                             "pin": "PA0",

--- a/data/chips/STM32F439IG.json
+++ b/data/chips/STM32F439IG.json
@@ -1309,6 +1309,11 @@
                 {
                     "name": "ETH",
                     "address": 1073905664,
+                    "registers": {
+                        "kind": "eth",
+                        "version": "v1b",
+                        "block": "ETH"
+                    },
                     "pins": [
                         {
                             "pin": "PA0",

--- a/data/chips/STM32F439II.json
+++ b/data/chips/STM32F439II.json
@@ -1309,6 +1309,11 @@
                 {
                     "name": "ETH",
                     "address": 1073905664,
+                    "registers": {
+                        "kind": "eth",
+                        "version": "v1b",
+                        "block": "ETH"
+                    },
                     "pins": [
                         {
                             "pin": "PA0",

--- a/data/chips/STM32F439NG.json
+++ b/data/chips/STM32F439NG.json
@@ -1299,6 +1299,11 @@
                 {
                     "name": "ETH",
                     "address": 1073905664,
+                    "registers": {
+                        "kind": "eth",
+                        "version": "v1b",
+                        "block": "ETH"
+                    },
                     "pins": [
                         {
                             "pin": "PA0",

--- a/data/chips/STM32F439NI.json
+++ b/data/chips/STM32F439NI.json
@@ -1299,6 +1299,11 @@
                 {
                     "name": "ETH",
                     "address": 1073905664,
+                    "registers": {
+                        "kind": "eth",
+                        "version": "v1b",
+                        "block": "ETH"
+                    },
                     "pins": [
                         {
                             "pin": "PA0",

--- a/data/chips/STM32F439VG.json
+++ b/data/chips/STM32F439VG.json
@@ -1132,6 +1132,11 @@
                 {
                     "name": "ETH",
                     "address": 1073905664,
+                    "registers": {
+                        "kind": "eth",
+                        "version": "v1b",
+                        "block": "ETH"
+                    },
                     "pins": [
                         {
                             "pin": "PA0",

--- a/data/chips/STM32F439VI.json
+++ b/data/chips/STM32F439VI.json
@@ -1132,6 +1132,11 @@
                 {
                     "name": "ETH",
                     "address": 1073905664,
+                    "registers": {
+                        "kind": "eth",
+                        "version": "v1b",
+                        "block": "ETH"
+                    },
                     "pins": [
                         {
                             "pin": "PA0",

--- a/data/chips/STM32F439ZG.json
+++ b/data/chips/STM32F439ZG.json
@@ -1208,6 +1208,11 @@
                 {
                     "name": "ETH",
                     "address": 1073905664,
+                    "registers": {
+                        "kind": "eth",
+                        "version": "v1b",
+                        "block": "ETH"
+                    },
                     "pins": [
                         {
                             "pin": "PA0",

--- a/data/chips/STM32F439ZI.json
+++ b/data/chips/STM32F439ZI.json
@@ -1208,6 +1208,11 @@
                 {
                     "name": "ETH",
                     "address": 1073905664,
+                    "registers": {
+                        "kind": "eth",
+                        "version": "v1b",
+                        "block": "ETH"
+                    },
                     "pins": [
                         {
                             "pin": "PA0",

--- a/data/chips/STM32F469BE.json
+++ b/data/chips/STM32F469BE.json
@@ -1260,6 +1260,11 @@
                 {
                     "name": "ETH",
                     "address": 1073905664,
+                    "registers": {
+                        "kind": "eth",
+                        "version": "v1b",
+                        "block": "ETH"
+                    },
                     "pins": [
                         {
                             "pin": "PA0",

--- a/data/chips/STM32F469BG.json
+++ b/data/chips/STM32F469BG.json
@@ -1260,6 +1260,11 @@
                 {
                     "name": "ETH",
                     "address": 1073905664,
+                    "registers": {
+                        "kind": "eth",
+                        "version": "v1b",
+                        "block": "ETH"
+                    },
                     "pins": [
                         {
                             "pin": "PA0",

--- a/data/chips/STM32F469BI.json
+++ b/data/chips/STM32F469BI.json
@@ -1260,6 +1260,11 @@
                 {
                     "name": "ETH",
                     "address": 1073905664,
+                    "registers": {
+                        "kind": "eth",
+                        "version": "v1b",
+                        "block": "ETH"
+                    },
                     "pins": [
                         {
                             "pin": "PA0",

--- a/data/chips/STM32F469IE.json
+++ b/data/chips/STM32F469IE.json
@@ -1219,6 +1219,11 @@
                 {
                     "name": "ETH",
                     "address": 1073905664,
+                    "registers": {
+                        "kind": "eth",
+                        "version": "v1b",
+                        "block": "ETH"
+                    },
                     "pins": [
                         {
                             "pin": "PA0",

--- a/data/chips/STM32F469IG.json
+++ b/data/chips/STM32F469IG.json
@@ -1219,6 +1219,11 @@
                 {
                     "name": "ETH",
                     "address": 1073905664,
+                    "registers": {
+                        "kind": "eth",
+                        "version": "v1b",
+                        "block": "ETH"
+                    },
                     "pins": [
                         {
                             "pin": "PA0",

--- a/data/chips/STM32F469II.json
+++ b/data/chips/STM32F469II.json
@@ -1219,6 +1219,11 @@
                 {
                     "name": "ETH",
                     "address": 1073905664,
+                    "registers": {
+                        "kind": "eth",
+                        "version": "v1b",
+                        "block": "ETH"
+                    },
                     "pins": [
                         {
                             "pin": "PA0",

--- a/data/chips/STM32F469NE.json
+++ b/data/chips/STM32F469NE.json
@@ -1260,6 +1260,11 @@
                 {
                     "name": "ETH",
                     "address": 1073905664,
+                    "registers": {
+                        "kind": "eth",
+                        "version": "v1b",
+                        "block": "ETH"
+                    },
                     "pins": [
                         {
                             "pin": "PA0",

--- a/data/chips/STM32F469NG.json
+++ b/data/chips/STM32F469NG.json
@@ -1260,6 +1260,11 @@
                 {
                     "name": "ETH",
                     "address": 1073905664,
+                    "registers": {
+                        "kind": "eth",
+                        "version": "v1b",
+                        "block": "ETH"
+                    },
                     "pins": [
                         {
                             "pin": "PA0",

--- a/data/chips/STM32F469NI.json
+++ b/data/chips/STM32F469NI.json
@@ -1260,6 +1260,11 @@
                 {
                     "name": "ETH",
                     "address": 1073905664,
+                    "registers": {
+                        "kind": "eth",
+                        "version": "v1b",
+                        "block": "ETH"
+                    },
                     "pins": [
                         {
                             "pin": "PA0",

--- a/data/chips/STM32F479BG.json
+++ b/data/chips/STM32F479BG.json
@@ -1293,6 +1293,11 @@
                 {
                     "name": "ETH",
                     "address": 1073905664,
+                    "registers": {
+                        "kind": "eth",
+                        "version": "v1b",
+                        "block": "ETH"
+                    },
                     "pins": [
                         {
                             "pin": "PA0",

--- a/data/chips/STM32F479BI.json
+++ b/data/chips/STM32F479BI.json
@@ -1293,6 +1293,11 @@
                 {
                     "name": "ETH",
                     "address": 1073905664,
+                    "registers": {
+                        "kind": "eth",
+                        "version": "v1b",
+                        "block": "ETH"
+                    },
                     "pins": [
                         {
                             "pin": "PA0",

--- a/data/chips/STM32F479IG.json
+++ b/data/chips/STM32F479IG.json
@@ -1252,6 +1252,11 @@
                 {
                     "name": "ETH",
                     "address": 1073905664,
+                    "registers": {
+                        "kind": "eth",
+                        "version": "v1b",
+                        "block": "ETH"
+                    },
                     "pins": [
                         {
                             "pin": "PA0",

--- a/data/chips/STM32F479II.json
+++ b/data/chips/STM32F479II.json
@@ -1252,6 +1252,11 @@
                 {
                     "name": "ETH",
                     "address": 1073905664,
+                    "registers": {
+                        "kind": "eth",
+                        "version": "v1b",
+                        "block": "ETH"
+                    },
                     "pins": [
                         {
                             "pin": "PA0",

--- a/data/chips/STM32F479NG.json
+++ b/data/chips/STM32F479NG.json
@@ -1293,6 +1293,11 @@
                 {
                     "name": "ETH",
                     "address": 1073905664,
+                    "registers": {
+                        "kind": "eth",
+                        "version": "v1b",
+                        "block": "ETH"
+                    },
                     "pins": [
                         {
                             "pin": "PA0",

--- a/data/chips/STM32F479NI.json
+++ b/data/chips/STM32F479NI.json
@@ -1293,6 +1293,11 @@
                 {
                     "name": "ETH",
                     "address": 1073905664,
+                    "registers": {
+                        "kind": "eth",
+                        "version": "v1b",
+                        "block": "ETH"
+                    },
                     "pins": [
                         {
                             "pin": "PA0",

--- a/data/registers/eth_v1a.yaml
+++ b/data/registers/eth_v1a.yaml
@@ -1,0 +1,2142 @@
+---
+block/ETH:
+  description: Ethernet Peripheral
+  items:
+    - name: ETHERNET_MAC
+      description: "Ethernet: media access control (MAC)"
+      byte_offset: 0
+      block: ETHERNET_MAC
+    - name: ETHERNET_PTP
+      description: "Ethernet: Precision Time Protocol (PTP)"
+      byte_offset: 1792
+      block: ETHERNET_PTP
+    - name: ETHERNET_DMA
+      description: "Ethernet: DMA mode register (DMA)"
+      byte_offset: 4096
+      block: ETHERNET_DMA
+block/ETHERNET_DMA:
+  description: "Ethernet: DMA controller operation"
+  items:
+    - name: DMABMR
+      description: Ethernet DMA bus mode register
+      byte_offset: 0
+      fieldset: DMABMR
+    - name: DMATPDR
+      description: Ethernet DMA transmit poll demand register
+      byte_offset: 4
+      fieldset: DMATPDR
+    - name: DMARPDR
+      description: EHERNET DMA receive poll demand register
+      byte_offset: 8
+      fieldset: DMARPDR
+    - name: DMARDLAR
+      description: Ethernet DMA receive descriptor list address register
+      byte_offset: 12
+      fieldset: DMARDLAR
+    - name: DMATDLAR
+      description: Ethernet DMA transmit descriptor list address register
+      byte_offset: 16
+      fieldset: DMATDLAR
+    - name: DMASR
+      description: Ethernet DMA status register
+      byte_offset: 20
+      fieldset: DMASR
+    - name: DMAOMR
+      description: Ethernet DMA operation mode register
+      byte_offset: 24
+      fieldset: DMAOMR
+    - name: DMAIER
+      description: Ethernet DMA interrupt enable register
+      byte_offset: 28
+      fieldset: DMAIER
+    - name: DMAMFBOCR
+      description: Ethernet DMA missed frame and buffer overflow counter register
+      byte_offset: 32
+      fieldset: DMAMFBOCR
+    - name: DMACHTDR
+      description: Ethernet DMA current host transmit descriptor register
+      byte_offset: 72
+      access: Read
+      fieldset: DMACHTDR
+    - name: DMACHRDR
+      description: Ethernet DMA current host receive descriptor register
+      byte_offset: 76
+      access: Read
+      fieldset: DMACHRDR
+    - name: DMACHTBAR
+      description: Ethernet DMA current host transmit buffer address register
+      byte_offset: 80
+      access: Read
+      fieldset: DMACHTBAR
+    - name: DMACHRBAR
+      description: Ethernet DMA current host receive buffer address register
+      byte_offset: 84
+      access: Read
+      fieldset: DMACHRBAR
+block/ETHERNET_MAC:
+  description: "Ethernet: media access control (MAC)"
+  items:
+    - name: MACCR
+      description: Ethernet MAC configuration register
+      byte_offset: 0
+      fieldset: MACCR
+    - name: MACFFR
+      description: Ethernet MAC frame filter register
+      byte_offset: 4
+      fieldset: MACFFR
+    - name: MACHTHR
+      description: Ethernet MAC hash table high register
+      byte_offset: 8
+      fieldset: MACHTHR
+    - name: MACHTLR
+      description: Ethernet MAC hash table low register
+      byte_offset: 12
+      fieldset: MACHTLR
+    - name: MACMIIAR
+      description: Ethernet MAC MII address register
+      byte_offset: 16
+      fieldset: MACMIIAR
+    - name: MACMIIDR
+      description: Ethernet MAC MII data register
+      byte_offset: 20
+      fieldset: MACMIIDR
+    - name: MACFCR
+      description: Ethernet MAC flow control register
+      byte_offset: 24
+      fieldset: MACFCR
+    - name: MACVLANTR
+      description: Ethernet MAC VLAN tag register
+      byte_offset: 28
+      fieldset: MACVLANTR
+    - name: MACRWUFFR
+      description: Ethernet MAC remote wakeup frame filter register
+      byte_offset: 40
+    - name: MACPMTCSR
+      description: Ethernet MAC PMT control and status register
+      byte_offset: 44
+      fieldset: MACPMTCSR
+    - name: MACDBGR
+      description: Ethernet MAC debug register
+      byte_offset: 52
+      access: Read
+      fieldset: MACDBGR
+    - name: MACSR
+      description: Ethernet MAC interrupt status register
+      byte_offset: 56
+      fieldset: MACSR
+    - name: MACIMR
+      description: Ethernet MAC interrupt mask register
+      byte_offset: 60
+      fieldset: MACIMR
+    - name: MACA0HR
+      description: Ethernet MAC address 0 high register
+      byte_offset: 64
+      fieldset: MACA0HR
+    - name: MACA0LR
+      description: Ethernet MAC address 0 low register
+      byte_offset: 68
+      fieldset: MACA0LR
+    - name: MACA1HR
+      description: Ethernet MAC address 1 high register
+      byte_offset: 72
+      fieldset: MACA1HR
+    - name: MACA1LR
+      description: Ethernet MAC address1 low register
+      byte_offset: 76
+      fieldset: MACA1LR
+    - name: MACA2HR
+      description: Ethernet MAC address 2 high register
+      byte_offset: 80
+      fieldset: MACA2HR
+    - name: MACA2LR
+      description: Ethernet MAC address 2 low register
+      byte_offset: 84
+      fieldset: MACA2LR
+    - name: MACA3HR
+      description: Ethernet MAC address 3 high register
+      byte_offset: 88
+      fieldset: MACA3HR
+    - name: MACA3LR
+      description: Ethernet MAC address 3 low register
+      byte_offset: 92
+      fieldset: MACA3LR
+    - name: MMCCR
+      description: Ethernet MMC control register
+      byte_offset: 256
+      fieldset: MMCCR
+    - name: MMCRIR
+      description: Ethernet MMC receive interrupt register
+      byte_offset: 260
+      fieldset: MMCRIR
+    - name: MMCTIR
+      description: Ethernet MMC transmit interrupt register
+      byte_offset: 264
+      access: Read
+      fieldset: MMCTIR
+    - name: MMCRIMR
+      description: Ethernet MMC receive interrupt mask register
+      byte_offset: 268
+      fieldset: MMCRIMR
+    - name: MMCTIMR
+      description: Ethernet MMC transmit interrupt mask register
+      byte_offset: 272
+      fieldset: MMCTIMR
+    - name: MMCTGFSCCR
+      description: Ethernet MMC transmitted good frames after a single collision counter
+      byte_offset: 332
+      access: Read
+      fieldset: MMCTGFSCCR
+    - name: MMCTGFMSCCR
+      description: Ethernet MMC transmitted good frames after more than a single collision
+      byte_offset: 336
+      access: Read
+      fieldset: MMCTGFMSCCR
+    - name: MMCTGFCR
+      description: Ethernet MMC transmitted good frames counter register
+      byte_offset: 360
+      access: Read
+      fieldset: MMCTGFCR
+    - name: MMCRFCECR
+      description: Ethernet MMC received frames with CRC error counter register
+      byte_offset: 404
+      access: Read
+      fieldset: MMCRFCECR
+    - name: MMCRFAECR
+      description: Ethernet MMC received frames with alignment error counter register
+      byte_offset: 408
+      access: Read
+      fieldset: MMCRFAECR
+    - name: MMCRGUFCR
+      description: MMC received good unicast frames counter register
+      byte_offset: 452
+      access: Read
+      fieldset: MMCRGUFCR
+block/ETHERNET_PTP:
+  description: "Ethernet: Precision time protocol"
+  items:
+    - name: PTPTSCR
+      description: Ethernet PTP time stamp control register
+      byte_offset: 0
+      fieldset: PTPTSCR
+    - name: PTPSSIR
+      description: Ethernet PTP subsecond increment register
+      byte_offset: 4
+      fieldset: PTPSSIR
+    - name: PTPTSHR
+      description: Ethernet PTP time stamp high register
+      byte_offset: 8
+      access: Read
+      fieldset: PTPTSHR
+    - name: PTPTSLR
+      description: Ethernet PTP time stamp low register
+      byte_offset: 12
+      access: Read
+      fieldset: PTPTSLR
+    - name: PTPTSHUR
+      description: Ethernet PTP time stamp high update register
+      byte_offset: 16
+      fieldset: PTPTSHUR
+    - name: PTPTSLUR
+      description: Ethernet PTP time stamp low update register
+      byte_offset: 20
+      fieldset: PTPTSLUR
+    - name: PTPTSAR
+      description: Ethernet PTP time stamp addend register
+      byte_offset: 24
+      fieldset: PTPTSAR
+    - name: PTPTTHR
+      description: Ethernet PTP target time high register
+      byte_offset: 28
+      fieldset: PTPTTHR
+    - name: PTPTTLR
+      description: Ethernet PTP target time low register
+      byte_offset: 32
+      fieldset: PTPTTLR
+    - name: PTPTSSR
+      description: Ethernet PTP time stamp status register
+      byte_offset: 40
+      access: Read
+      fieldset: PTPTSSR
+    - name: PTPPPSCR
+      description: Ethernet PTP PPS control register
+      byte_offset: 44
+      access: Read
+      fieldset: PTPPPSCR
+fieldset/DMABMR:
+  description: Ethernet DMA bus mode register
+  fields:
+    - name: SR
+      description: Software reset
+      bit_offset: 0
+      bit_size: 1
+    - name: DA
+      description: DMA arbitration
+      bit_offset: 1
+      bit_size: 1
+      enum: DA
+    - name: DSL
+      description: Descriptor skip length
+      bit_offset: 2
+      bit_size: 5
+    - name: PBL
+      description: Programmable burst length
+      bit_offset: 8
+      bit_size: 6
+      enum: PBL
+    - name: PM
+      description: Rx-Tx priority ratio
+      bit_offset: 14
+      bit_size: 2
+      enum: PriorityRxOverTx
+    - name: FB
+      description: Fixed burst
+      bit_offset: 16
+      bit_size: 1
+      enum: FB
+    - name: RDP
+      description: Rx DMA PBL
+      bit_offset: 17
+      bit_size: 6
+      enum: RDP
+    - name: USP
+      description: Use separate PBL
+      bit_offset: 23
+      bit_size: 1
+      enum: USP
+    - name: FPM
+      description: 4xPBL mode
+      bit_offset: 24
+      bit_size: 1
+      enum: FPM
+    - name: AAB
+      description: Address-aligned beats
+      bit_offset: 25
+      bit_size: 1
+      enum: AAB
+fieldset/DMACHRBAR:
+  description: Ethernet DMA current host receive buffer address register
+  fields:
+    - name: HRBAP
+      description: Host receive buffer address pointer
+      bit_offset: 0
+      bit_size: 32
+fieldset/DMACHRDR:
+  description: Ethernet DMA current host receive descriptor register
+  fields:
+    - name: HRDAP
+      description: Host receive descriptor address pointer
+      bit_offset: 0
+      bit_size: 32
+fieldset/DMACHTBAR:
+  description: Ethernet DMA current host transmit buffer address register
+  fields:
+    - name: HTBAP
+      description: Host transmit buffer address pointer
+      bit_offset: 0
+      bit_size: 32
+fieldset/DMACHTDR:
+  description: Ethernet DMA current host transmit descriptor register
+  fields:
+    - name: HTDAP
+      description: Host transmit descriptor address pointer
+      bit_offset: 0
+      bit_size: 32
+fieldset/DMAIER:
+  description: Ethernet DMA interrupt enable register
+  fields:
+    - name: TIE
+      description: Transmit interrupt enable
+      bit_offset: 0
+      bit_size: 1
+    - name: TPSIE
+      description: Transmit process stopped interrupt enable
+      bit_offset: 1
+      bit_size: 1
+    - name: TBUIE
+      description: Transmit buffer unavailable interrupt enable
+      bit_offset: 2
+      bit_size: 1
+    - name: TJTIE
+      description: Transmit jabber timeout interrupt enable
+      bit_offset: 3
+      bit_size: 1
+    - name: ROIE
+      description: Receive overflow interrupt enable
+      bit_offset: 4
+      bit_size: 1
+    - name: TUIE
+      description: Transmit underflow interrupt enable
+      bit_offset: 5
+      bit_size: 1
+    - name: RIE
+      description: Receive interrupt enable
+      bit_offset: 6
+      bit_size: 1
+    - name: RBUIE
+      description: Receive buffer unavailable interrupt enable
+      bit_offset: 7
+      bit_size: 1
+    - name: RPSIE
+      description: Receive process stopped interrupt enable
+      bit_offset: 8
+      bit_size: 1
+    - name: RWTIE
+      description: Receive watchdog timeout interrupt enable
+      bit_offset: 9
+      bit_size: 1
+    - name: ETIE
+      description: Early transmit interrupt enable
+      bit_offset: 10
+      bit_size: 1
+    - name: FBEIE
+      description: Fatal bus error interrupt enable
+      bit_offset: 13
+      bit_size: 1
+    - name: ERIE
+      description: Early receive interrupt enable
+      bit_offset: 14
+      bit_size: 1
+    - name: AISE
+      description: Abnormal interrupt summary enable
+      bit_offset: 15
+      bit_size: 1
+    - name: NISE
+      description: Normal interrupt summary enable
+      bit_offset: 16
+      bit_size: 1
+fieldset/DMAMFBOCR:
+  description: Ethernet DMA missed frame and buffer overflow counter register
+  fields:
+    - name: MFC
+      description: Missed frames by the controller
+      bit_offset: 0
+      bit_size: 16
+    - name: OMFC
+      description: Overflow bit for missed frame counter
+      bit_offset: 16
+      bit_size: 1
+    - name: MFA
+      description: Missed frames by the application
+      bit_offset: 17
+      bit_size: 11
+    - name: OFOC
+      description: Overflow bit for FIFO overflow counter
+      bit_offset: 28
+      bit_size: 1
+fieldset/DMAOMR:
+  description: Ethernet DMA operation mode register
+  fields:
+    - name: SR
+      description: Start/stop receive
+      bit_offset: 1
+      bit_size: 1
+      enum: DMAOMR_SR
+    - name: OSF
+      description: Operate on second frame
+      bit_offset: 2
+      bit_size: 1
+    - name: RTC
+      description: Receive threshold control
+      bit_offset: 3
+      bit_size: 2
+      enum: RTC
+    - name: FUGF
+      description: Forward undersized good frames
+      bit_offset: 6
+      bit_size: 1
+      enum: FUGF
+    - name: FEF
+      description: Forward error frames
+      bit_offset: 7
+      bit_size: 1
+      enum: FEF
+    - name: ST
+      description: Start/stop transmission
+      bit_offset: 13
+      bit_size: 1
+      enum: ST
+    - name: TTC
+      description: Transmit threshold control
+      bit_offset: 14
+      bit_size: 3
+      enum: TTC
+    - name: FTF
+      description: Flush transmit FIFO
+      bit_offset: 20
+      bit_size: 1
+      enum: FTF
+    - name: TSF
+      description: Transmit store and forward
+      bit_offset: 21
+      bit_size: 1
+      enum: TSF
+    - name: DFRF
+      description: Disable flushing of received frames
+      bit_offset: 24
+      bit_size: 1
+    - name: RSF
+      description: Receive store and forward
+      bit_offset: 25
+      bit_size: 1
+      enum: RSF
+    - name: DTCEFD
+      description: Dropping of TCP/IP checksum error frames disable
+      bit_offset: 26
+      bit_size: 1
+      enum: DTCEFD
+fieldset/DMARDLAR:
+  description: Ethernet DMA receive descriptor list address register
+  fields:
+    - name: SRL
+      description: Start of receive list
+      bit_offset: 0
+      bit_size: 32
+fieldset/DMARPDR:
+  description: EHERNET DMA receive poll demand register
+  fields:
+    - name: RPD
+      description: Receive poll demand
+      bit_offset: 0
+      bit_size: 32
+      enum: RPD
+fieldset/DMASR:
+  description: Ethernet DMA status register
+  fields:
+    - name: TS
+      description: Transmit status
+      bit_offset: 0
+      bit_size: 1
+    - name: TPSS
+      description: Transmit process stopped status
+      bit_offset: 1
+      bit_size: 1
+    - name: TBUS
+      description: Transmit buffer unavailable status
+      bit_offset: 2
+      bit_size: 1
+    - name: TJTS
+      description: Transmit jabber timeout status
+      bit_offset: 3
+      bit_size: 1
+    - name: ROS
+      description: Receive overflow status
+      bit_offset: 4
+      bit_size: 1
+    - name: TUS
+      description: Transmit underflow status
+      bit_offset: 5
+      bit_size: 1
+    - name: RS
+      description: Receive status
+      bit_offset: 6
+      bit_size: 1
+    - name: RBUS
+      description: Receive buffer unavailable status
+      bit_offset: 7
+      bit_size: 1
+    - name: RPSS
+      description: Receive process stopped status
+      bit_offset: 8
+      bit_size: 1
+    - name: PWTS
+      description: PWTS
+      bit_offset: 9
+      bit_size: 1
+    - name: ETS
+      description: Early transmit status
+      bit_offset: 10
+      bit_size: 1
+    - name: FBES
+      description: Fatal bus error status
+      bit_offset: 13
+      bit_size: 1
+    - name: ERS
+      description: Early receive status
+      bit_offset: 14
+      bit_size: 1
+    - name: AIS
+      description: Abnormal interrupt summary
+      bit_offset: 15
+      bit_size: 1
+    - name: NIS
+      description: Normal interrupt summary
+      bit_offset: 16
+      bit_size: 1
+    - name: RPS
+      description: Receive process state
+      bit_offset: 17
+      bit_size: 3
+      enum: RPS
+    - name: TPS
+      description: Transmit process state
+      bit_offset: 20
+      bit_size: 3
+      enum: TPS
+    - name: EBS
+      description: Error bits status
+      bit_offset: 23
+      bit_size: 3
+    - name: MMCS
+      description: MMC status
+      bit_offset: 27
+      bit_size: 1
+    - name: PMTS
+      description: PMT status
+      bit_offset: 28
+      bit_size: 1
+    - name: TSTS
+      description: Time stamp trigger status
+      bit_offset: 29
+      bit_size: 1
+fieldset/DMATDLAR:
+  description: Ethernet DMA transmit descriptor list address register
+  fields:
+    - name: STL
+      description: Start of transmit list
+      bit_offset: 0
+      bit_size: 32
+fieldset/DMATPDR:
+  description: Ethernet DMA transmit poll demand register
+  fields:
+    - name: TPD
+      description: Transmit poll demand
+      bit_offset: 0
+      bit_size: 32
+      enum: TPD
+fieldset/MACA0HR:
+  description: Ethernet MAC address 0 high register
+  fields:
+    - name: MACA0H
+      description: MAC address0 high
+      bit_offset: 0
+      bit_size: 16
+    - name: MO
+      description: Always 1
+      bit_offset: 31
+      bit_size: 1
+fieldset/MACA0LR:
+  description: Ethernet MAC address 0 low register
+  fields:
+    - name: MACA0L
+      description: "0"
+      bit_offset: 0
+      bit_size: 32
+fieldset/MACA1HR:
+  description: Ethernet MAC address 1 high register
+  fields:
+    - name: MACA1H
+      description: MACA1H
+      bit_offset: 0
+      bit_size: 16
+    - name: MBC
+      description: MBC
+      bit_offset: 24
+      bit_size: 6
+    - name: SA
+      description: SA
+      bit_offset: 30
+      bit_size: 1
+      enum: MACAHR_SA
+    - name: AE
+      description: AE
+      bit_offset: 31
+      bit_size: 1
+      enum: MACAHR_AE
+fieldset/MACA1LR:
+  description: Ethernet MAC address1 low register
+  fields:
+    - name: MACA1L
+      description: MACA1LR
+      bit_offset: 0
+      bit_size: 32
+fieldset/MACA2HR:
+  description: Ethernet MAC address 2 high register
+  fields:
+    - name: MACA2H
+      description: MAC2AH
+      bit_offset: 0
+      bit_size: 16
+    - name: MBC
+      description: MBC
+      bit_offset: 24
+      bit_size: 6
+    - name: SA
+      description: SA
+      bit_offset: 30
+      bit_size: 1
+      enum: MACAHR_SA
+    - name: AE
+      description: AE
+      bit_offset: 31
+      bit_size: 1
+      enum: MACAHR_AE
+fieldset/MACA2LR:
+  description: Ethernet MAC address 2 low register
+  fields:
+    - name: MACA2L
+      description: MACA2L
+      bit_offset: 0
+      bit_size: 32
+fieldset/MACA3HR:
+  description: Ethernet MAC address 3 high register
+  fields:
+    - name: MACA3H
+      description: MACA3H
+      bit_offset: 0
+      bit_size: 16
+    - name: MBC
+      description: MBC
+      bit_offset: 24
+      bit_size: 6
+    - name: SA
+      description: SA
+      bit_offset: 30
+      bit_size: 1
+      enum: MACAHR_SA
+    - name: AE
+      description: AE
+      bit_offset: 31
+      bit_size: 1
+      enum: MACAHR_AE
+fieldset/MACA3LR:
+  description: Ethernet MAC address 3 low register
+  fields:
+    - name: MACA3L
+      description: MBCA3L
+      bit_offset: 0
+      bit_size: 32
+fieldset/MACCR:
+  description: Ethernet MAC configuration register
+  fields:
+    - name: RE
+      description: Receiver enable
+      bit_offset: 2
+      bit_size: 1
+    - name: TE
+      description: Transmitter enable
+      bit_offset: 3
+      bit_size: 1
+    - name: DC
+      description: Deferral check
+      bit_offset: 4
+      bit_size: 1
+      enum: DC
+    - name: BL
+      description: Back-off limit
+      bit_offset: 5
+      bit_size: 2
+      enum: BL
+    - name: APCS
+      description: Automatic pad/CRC stripping
+      bit_offset: 7
+      bit_size: 1
+      enum: APCS
+    - name: RD
+      description: Retry disable
+      bit_offset: 9
+      bit_size: 1
+      enum: RD
+    - name: IPCO
+      description: IPv4 checksum offload
+      bit_offset: 10
+      bit_size: 1
+      enum: IPCO
+    - name: DM
+      description: Duplex mode
+      bit_offset: 11
+      bit_size: 1
+      enum: DM
+    - name: LM
+      description: Loopback mode
+      bit_offset: 12
+      bit_size: 1
+      enum: LM
+    - name: ROD
+      description: Receive own disable
+      bit_offset: 13
+      bit_size: 1
+      enum: ROD
+    - name: FES
+      description: Fast Ethernet speed
+      bit_offset: 14
+      bit_size: 1
+      enum: FES
+    - name: CSD
+      description: Carrier sense disable
+      bit_offset: 16
+      bit_size: 1
+      enum: CSD
+    - name: IFG
+      description: Interframe gap
+      bit_offset: 17
+      bit_size: 3
+      enum: IFG
+    - name: JD
+      description: Jabber disable
+      bit_offset: 22
+      bit_size: 1
+      enum: JD
+    - name: WD
+      description: Watchdog disable
+      bit_offset: 23
+      bit_size: 1
+      enum: WD
+fieldset/MACDBGR:
+  description: Ethernet MAC debug register
+  fields:
+    - name: MMRPEA
+      description: MAC MII receive protocol engine active
+      bit_offset: 0
+      bit_size: 1
+    - name: MSFRWCS
+      description: MAC small FIFO read/write controllers status
+      bit_offset: 1
+      bit_size: 2
+    - name: RFWRA
+      description: Rx FIFO write controller active
+      bit_offset: 4
+      bit_size: 1
+    - name: RFRCS
+      description: Rx FIFO read controller status
+      bit_offset: 5
+      bit_size: 2
+    - name: RFFL
+      description: Rx FIFO fill level
+      bit_offset: 8
+      bit_size: 2
+    - name: MMTEA
+      description: MAC MII transmit engine active
+      bit_offset: 16
+      bit_size: 1
+    - name: MTFCS
+      description: MAC transmit frame controller status
+      bit_offset: 17
+      bit_size: 2
+    - name: MTP
+      description: MAC transmitter in pause
+      bit_offset: 19
+      bit_size: 1
+    - name: TFRS
+      description: Tx FIFO read status
+      bit_offset: 20
+      bit_size: 2
+    - name: TFWA
+      description: Tx FIFO write active
+      bit_offset: 22
+      bit_size: 1
+    - name: TFNE
+      description: Tx FIFO not empty
+      bit_offset: 24
+      bit_size: 1
+    - name: TFF
+      description: Tx FIFO full
+      bit_offset: 25
+      bit_size: 1
+fieldset/MACFCR:
+  description: Ethernet MAC flow control register
+  fields:
+    - name: FCB
+      description: Flow control busy/back pressure activate
+      bit_offset: 0
+      bit_size: 1
+      enum: FCB
+    - name: TFCE
+      description: Transmit flow control enable
+      bit_offset: 1
+      bit_size: 1
+      enum: TFCE
+    - name: RFCE
+      description: Receive flow control enable
+      bit_offset: 2
+      bit_size: 1
+      enum: RFCE
+    - name: UPFD
+      description: Unicast pause frame detect
+      bit_offset: 3
+      bit_size: 1
+      enum: UPFD
+    - name: PLT
+      description: Pause low threshold
+      bit_offset: 4
+      bit_size: 2
+      enum: PLT
+    - name: ZQPD
+      description: Zero-quanta pause disable
+      bit_offset: 7
+      bit_size: 1
+      enum: ZQPD
+    - name: PT
+      description: Pause time
+      bit_offset: 16
+      bit_size: 16
+fieldset/MACFFR:
+  description: Ethernet MAC frame filter register
+  fields:
+    - name: PM
+      description: Promiscuous mode
+      bit_offset: 0
+      bit_size: 1
+      enum: PM
+    - name: HU
+      description: Hash unicast
+      bit_offset: 1
+      bit_size: 1
+      enum: HU
+    - name: HM
+      description: Hash multicast
+      bit_offset: 2
+      bit_size: 1
+      enum: HM
+    - name: DAIF
+      description: Destination address unique filtering
+      bit_offset: 3
+      bit_size: 1
+      enum: DAIF
+    - name: PAM
+      description: Pass all multicast
+      bit_offset: 4
+      bit_size: 1
+      enum: PAM
+    - name: BFD
+      description: Broadcast frames disable
+      bit_offset: 5
+      bit_size: 1
+      enum: BFD
+    - name: PCF
+      description: Pass control frames
+      bit_offset: 6
+      bit_size: 2
+      enum: PCF
+    - name: SAIF
+      description: Source address inverse filtering
+      bit_offset: 7
+      bit_size: 1
+      enum: SAIF
+    - name: SAF
+      description: Source address filter
+      bit_offset: 8
+      bit_size: 1
+      enum: SAF
+    - name: HPF
+      description: Hash or perfect filter
+      bit_offset: 9
+      bit_size: 1
+      enum: HPF
+    - name: RA
+      description: Receive all
+      bit_offset: 31
+      bit_size: 1
+      enum: RA
+fieldset/MACHTHR:
+  description: Ethernet MAC hash table high register
+  fields:
+    - name: HTH
+      description: Upper 32 bits of hash table
+      bit_offset: 0
+      bit_size: 32
+fieldset/MACHTLR:
+  description: Ethernet MAC hash table low register
+  fields:
+    - name: HTL
+      description: Lower 32 bits of hash table
+      bit_offset: 0
+      bit_size: 32
+fieldset/MACIMR:
+  description: Ethernet MAC interrupt mask register
+  fields:
+    - name: PMTIM
+      description: PMT interrupt mask
+      bit_offset: 3
+      bit_size: 1
+      enum: PMTIM
+    - name: TSTIM
+      description: Time stamp trigger interrupt mask
+      bit_offset: 9
+      bit_size: 1
+      enum: TSTIM
+fieldset/MACMIIAR:
+  description: Ethernet MAC MII address register
+  fields:
+    - name: MB
+      description: MII busy
+      bit_offset: 0
+      bit_size: 1
+      enum: MB_progress
+    - name: MW
+      description: MII write
+      bit_offset: 1
+      bit_size: 1
+      enum: MW
+    - name: CR
+      description: Clock range
+      bit_offset: 2
+      bit_size: 3
+      enum: CR
+    - name: MR
+      description: MII register - select the desired MII register in the PHY device
+      bit_offset: 6
+      bit_size: 5
+    - name: PA
+      description: PHY address - select which of possible 32 PHYs is being accessed
+      bit_offset: 11
+      bit_size: 5
+fieldset/MACMIIDR:
+  description: Ethernet MAC MII data register
+  fields:
+    - name: MD
+      description: MII data read from/written to the PHY
+      bit_offset: 0
+      bit_size: 16
+fieldset/MACPMTCSR:
+  description: Ethernet MAC PMT control and status register
+  fields:
+    - name: PD
+      description: Power down
+      bit_offset: 0
+      bit_size: 1
+      enum: PD
+    - name: MPE
+      description: Magic packet enable
+      bit_offset: 1
+      bit_size: 1
+      enum: MPE
+    - name: WFE
+      description: Wakeup frame enable
+      bit_offset: 2
+      bit_size: 1
+      enum: WFE
+    - name: MPR
+      description: Magic packet received
+      bit_offset: 5
+      bit_size: 1
+    - name: WFR
+      description: Wakeup frame received
+      bit_offset: 6
+      bit_size: 1
+    - name: GU
+      description: Global unicast
+      bit_offset: 9
+      bit_size: 1
+      enum: GU
+    - name: WFFRPR
+      description: Wakeup frame filter register pointer reset
+      bit_offset: 31
+      bit_size: 1
+      enum: WFFRPR
+fieldset/MACSR:
+  description: Ethernet MAC interrupt status register
+  fields:
+    - name: PMTS
+      description: PMT status
+      bit_offset: 3
+      bit_size: 1
+    - name: MMCS
+      description: MMC status
+      bit_offset: 4
+      bit_size: 1
+    - name: MMCRS
+      description: MMC receive status
+      bit_offset: 5
+      bit_size: 1
+    - name: MMCTS
+      description: MMC transmit status
+      bit_offset: 6
+      bit_size: 1
+    - name: TSTS
+      description: Time stamp trigger status
+      bit_offset: 9
+      bit_size: 1
+fieldset/MACVLANTR:
+  description: Ethernet MAC VLAN tag register
+  fields:
+    - name: VLANTI
+      description: VLAN tag identifier (for receive frames)
+      bit_offset: 0
+      bit_size: 16
+    - name: VLANTC
+      description: 12-bit VLAN tag comparison
+      bit_offset: 16
+      bit_size: 1
+      enum: VLANTC
+fieldset/MMCCR:
+  description: Ethernet MMC control register
+  fields:
+    - name: CR
+      description: Counter reset
+      bit_offset: 0
+      bit_size: 1
+      enum: CounterReset
+    - name: CSR
+      description: Counter stop rollover
+      bit_offset: 1
+      bit_size: 1
+      enum: CSR
+    - name: ROR
+      description: Reset on read
+      bit_offset: 2
+      bit_size: 1
+      enum: ROR
+    - name: MCF
+      description: MMC counter freeze
+      bit_offset: 3
+      bit_size: 1
+      enum: MCF
+fieldset/MMCRFAECR:
+  description: Ethernet MMC received frames with alignment error counter register
+  fields:
+    - name: RFAEC
+      description: RFAEC
+      bit_offset: 0
+      bit_size: 32
+fieldset/MMCRFCECR:
+  description: Ethernet MMC received frames with CRC error counter register
+  fields:
+    - name: RFCFC
+      description: RFCFC
+      bit_offset: 0
+      bit_size: 32
+fieldset/MMCRGUFCR:
+  description: MMC received good unicast frames counter register
+  fields:
+    - name: RGUFC
+      description: RGUFC
+      bit_offset: 0
+      bit_size: 32
+fieldset/MMCRIMR:
+  description: Ethernet MMC receive interrupt mask register
+  fields:
+    - name: RFCEM
+      description: Received frame CRC error mask
+      bit_offset: 5
+      bit_size: 1
+      enum: RFCEM
+    - name: RFAEM
+      description: Received frames alignment error mask
+      bit_offset: 6
+      bit_size: 1
+      enum: RFAEM
+    - name: RGUFM
+      description: Received good Unicast frames mask
+      bit_offset: 17
+      bit_size: 1
+      enum: RGUFM
+fieldset/MMCRIR:
+  description: Ethernet MMC receive interrupt register
+  fields:
+    - name: RFCES
+      description: Received frames CRC error status
+      bit_offset: 5
+      bit_size: 1
+    - name: RFAES
+      description: Received frames alignment error status
+      bit_offset: 6
+      bit_size: 1
+    - name: RGUFS
+      description: Received good Unicast frames status
+      bit_offset: 17
+      bit_size: 1
+fieldset/MMCTGFCR:
+  description: Ethernet MMC transmitted good frames counter register
+  fields:
+    - name: TGFC
+      description: HTL
+      bit_offset: 0
+      bit_size: 32
+fieldset/MMCTGFMSCCR:
+  description: Ethernet MMC transmitted good frames after more than a single collision
+  fields:
+    - name: TGFMSCC
+      description: TGFMSCC
+      bit_offset: 0
+      bit_size: 32
+fieldset/MMCTGFSCCR:
+  description: Ethernet MMC transmitted good frames after a single collision counter
+  fields:
+    - name: TGFSCC
+      description: Transmitted good frames single collision counter
+      bit_offset: 0
+      bit_size: 32
+fieldset/MMCTIMR:
+  description: Ethernet MMC transmit interrupt mask register
+  fields:
+    - name: TGFSCM
+      description: Transmitted good frames single collision mask
+      bit_offset: 14
+      bit_size: 1
+      enum: TGFSCM
+    - name: TGFMSCM
+      description: Transmitted good frames more than single collision mask
+      bit_offset: 15
+      bit_size: 1
+      enum: TGFMSCM
+    - name: TGFM
+      description: Transmitted good frames mask
+      bit_offset: 16
+      bit_size: 1
+      enum: TGFM
+fieldset/MMCTIR:
+  description: Ethernet MMC transmit interrupt register
+  fields:
+    - name: TGFSCS
+      description: Transmitted good frames single collision status
+      bit_offset: 14
+      bit_size: 1
+    - name: TGFMSCS
+      description: Transmitted good frames more than single collision status
+      bit_offset: 15
+      bit_size: 1
+    - name: TGFS
+      description: Transmitted good frames status
+      bit_offset: 21
+      bit_size: 1
+fieldset/PTPPPSCR:
+  description: Ethernet PTP PPS control register
+  fields:
+    - name: TSSO
+      description: TSSO
+      bit_offset: 0
+      bit_size: 1
+    - name: TSTTR
+      description: TSTTR
+      bit_offset: 1
+      bit_size: 1
+fieldset/PTPSSIR:
+  description: Ethernet PTP subsecond increment register
+  fields:
+    - name: STSSI
+      description: STSSI
+      bit_offset: 0
+      bit_size: 8
+fieldset/PTPTSAR:
+  description: Ethernet PTP time stamp addend register
+  fields:
+    - name: TSA
+      description: TSA
+      bit_offset: 0
+      bit_size: 32
+fieldset/PTPTSCR:
+  description: Ethernet PTP time stamp control register
+  fields:
+    - name: TSE
+      description: TSE
+      bit_offset: 0
+      bit_size: 1
+    - name: TSFCU
+      description: TSFCU
+      bit_offset: 1
+      bit_size: 1
+    - name: TSSTI
+      description: TSSTI
+      bit_offset: 2
+      bit_size: 1
+    - name: TSSTU
+      description: TSSTU
+      bit_offset: 3
+      bit_size: 1
+    - name: TSITE
+      description: TSITE
+      bit_offset: 4
+      bit_size: 1
+    - name: TTSARU
+      description: TTSARU
+      bit_offset: 5
+      bit_size: 1
+    - name: TSSARFE
+      description: TSSARFE
+      bit_offset: 8
+      bit_size: 1
+    - name: TSSSR
+      description: TSSSR
+      bit_offset: 9
+      bit_size: 1
+    - name: TSPTPPSV2E
+      description: TSPTPPSV2E
+      bit_offset: 10
+      bit_size: 1
+    - name: TSSPTPOEFE
+      description: TSSPTPOEFE
+      bit_offset: 11
+      bit_size: 1
+    - name: TSSIPV6FE
+      description: TSSIPV6FE
+      bit_offset: 12
+      bit_size: 1
+    - name: TSSIPV4FE
+      description: TSSIPV4FE
+      bit_offset: 13
+      bit_size: 1
+    - name: TSSEME
+      description: TSSEME
+      bit_offset: 14
+      bit_size: 1
+    - name: TSSMRME
+      description: TSSMRME
+      bit_offset: 15
+      bit_size: 1
+    - name: TSCNT
+      description: TSCNT
+      bit_offset: 16
+      bit_size: 2
+    - name: TSPFFMAE
+      description: TSPFFMAE
+      bit_offset: 18
+      bit_size: 1
+fieldset/PTPTSHR:
+  description: Ethernet PTP time stamp high register
+  fields:
+    - name: STS
+      description: STS
+      bit_offset: 0
+      bit_size: 32
+fieldset/PTPTSHUR:
+  description: Ethernet PTP time stamp high update register
+  fields:
+    - name: TSUS
+      description: TSUS
+      bit_offset: 0
+      bit_size: 32
+fieldset/PTPTSLR:
+  description: Ethernet PTP time stamp low register
+  fields:
+    - name: STSS
+      description: STSS
+      bit_offset: 0
+      bit_size: 31
+    - name: STPNS
+      description: STPNS
+      bit_offset: 31
+      bit_size: 1
+fieldset/PTPTSLUR:
+  description: Ethernet PTP time stamp low update register
+  fields:
+    - name: TSUSS
+      description: TSUSS
+      bit_offset: 0
+      bit_size: 31
+    - name: TSUPNS
+      description: TSUPNS
+      bit_offset: 31
+      bit_size: 1
+fieldset/PTPTSSR:
+  description: Ethernet PTP time stamp status register
+  fields:
+    - name: TSSO
+      description: TSSO
+      bit_offset: 0
+      bit_size: 1
+    - name: TSTTR
+      description: TSSO
+      bit_offset: 1
+      bit_size: 1
+fieldset/PTPTTHR:
+  description: Ethernet PTP target time high register
+  fields:
+    - name: TTSH
+      description: "0"
+      bit_offset: 0
+      bit_size: 32
+fieldset/PTPTTLR:
+  description: Ethernet PTP target time low register
+  fields:
+    - name: TTSL
+      description: TTSL
+      bit_offset: 0
+      bit_size: 32
+enum/AAB:
+  bit_size: 1
+  variants:
+    - name: Unaligned
+      description: Bursts are not aligned
+      value: 0
+    - name: Aligned
+      description: Align bursts to start address LS bits. First burst alignment depends on FB bit
+      value: 1
+enum/APCS:
+  bit_size: 1
+  variants:
+    - name: Disabled
+      description: MAC passes all incoming frames unmodified
+      value: 0
+    - name: Strip
+      description: MAC strips the Pad/FCS field on incoming frames only for lengths less than or equal to 1500 bytes
+      value: 1
+enum/BFD:
+  bit_size: 1
+  variants:
+    - name: Enabled
+      description: Address filters pass all received broadcast frames
+      value: 0
+    - name: Disabled
+      description: Address filters filter all incoming broadcast frames
+      value: 1
+enum/BL:
+  bit_size: 2
+  variants:
+    - name: BL10
+      description: "For retransmission n, wait up to 2^min(n, 10) time slots"
+      value: 0
+    - name: BL8
+      description: "For retransmission n, wait up to 2^min(n, 8) time slots"
+      value: 1
+    - name: BL4
+      description: "For retransmission n, wait up to 2^min(n, 4) time slots"
+      value: 2
+    - name: BL1
+      description: "For retransmission n, wait up to 2^min(n, 1) time slots"
+      value: 3
+enum/CR:
+  bit_size: 3
+  variants:
+    - name: CR_60_100
+      description: 60-100MHz HCLK/42
+      value: 0
+    - name: CR_100_150
+      description: 100-150 MHz HCLK/62
+      value: 1
+    - name: CR_20_35
+      description: 20-35MHz HCLK/16
+      value: 2
+    - name: CR_35_60
+      description: 35-60MHz HCLK/16
+      value: 3
+    - name: CR_150_168
+      description: 150-168MHz HCLK/102
+      value: 4
+enum/CSD:
+  bit_size: 1
+  variants:
+    - name: Enabled
+      description: Errors generated due to loss of carrier
+      value: 0
+    - name: Disabled
+      description: No error generated due to loss of carrier
+      value: 1
+enum/CSR:
+  bit_size: 1
+  variants:
+    - name: Disabled
+      description: Counters roll over to zero after reaching the maximum value
+      value: 0
+    - name: Enabled
+      description: Counters do not roll over to zero after reaching the maximum value
+      value: 1
+enum/CounterReset:
+  bit_size: 1
+  variants:
+    - name: Reset
+      description: Reset all counters. Cleared automatically
+      value: 1
+enum/DA:
+  bit_size: 1
+  variants:
+    - name: RoundRobin
+      description: "Round-robin with Rx:Tx priority given by PM"
+      value: 0
+    - name: RxPriority
+      description: Rx has priority over Tx
+      value: 1
+enum/DAIF:
+  bit_size: 1
+  variants:
+    - name: Normal
+      description: Normal filtering of frames
+      value: 0
+    - name: Invert
+      description: Address check block operates in inverse filtering mode for the DA address comparison
+      value: 1
+enum/DC:
+  bit_size: 1
+  variants:
+    - name: Disabled
+      description: MAC defers until CRS signal goes inactive
+      value: 0
+    - name: Enabled
+      description: Deferral check function enabled
+      value: 1
+enum/DM:
+  bit_size: 1
+  variants:
+    - name: HalfDuplex
+      description: MAC operates in half-duplex mode
+      value: 0
+    - name: FullDuplex
+      description: MAC operates in full-duplex mode
+      value: 1
+enum/DMABMR_SR:
+  bit_size: 1
+  variants:
+    - name: Reset
+      description: Reset all MAC subsystem internal registers and logic. Cleared automatically
+      value: 1
+enum/DMAOMR_SR:
+  bit_size: 1
+  variants:
+    - name: Stopped
+      description: Reception is stopped after transfer of the current frame
+      value: 0
+    - name: Started
+      description: Reception is placed in the Running state
+      value: 1
+enum/DTCEFD:
+  bit_size: 1
+  variants:
+    - name: Enabled
+      description: Drop frames with errors only in the receive checksum offload engine
+      value: 0
+    - name: Disabled
+      description: Do not drop frames that only have errors in the receive checksum offload engine
+      value: 1
+enum/FB:
+  bit_size: 1
+  variants:
+    - name: Variable
+      description: AHB uses SINGLE and INCR burst transfers
+      value: 0
+    - name: Fixed
+      description: AHB uses only fixed burst transfers
+      value: 1
+enum/FCB:
+  bit_size: 1
+  variants:
+    - name: DisableBackPressure
+      description: "In half duplex only, deasserts back pressure"
+      value: 0
+    - name: PauseOrBackPressure
+      description: "In full duplex, initiate a Pause control frame. In half duplex, assert back pressure"
+      value: 1
+enum/FEF:
+  bit_size: 1
+  variants:
+    - name: Drop
+      description: Rx FIFO drops frames with error status
+      value: 0
+    - name: Forward
+      description: All frames except runt error frames are forwarded to the DMA
+      value: 1
+enum/FES:
+  bit_size: 1
+  variants:
+    - name: FES10
+      description: 10 Mbit/s
+      value: 0
+    - name: FES100
+      description: 100 Mbit/s
+      value: 1
+enum/FPM:
+  bit_size: 1
+  variants:
+    - name: x1
+      description: PBL values used as-is
+      value: 0
+    - name: x4
+      description: PBL values multiplied by 4
+      value: 1
+enum/FTF:
+  bit_size: 1
+  variants:
+    - name: Flush
+      description: Transmit FIFO controller logic is reset to its default values. Cleared automatically
+      value: 1
+enum/FUGF:
+  bit_size: 1
+  variants:
+    - name: Drop
+      description: Rx FIFO drops all frames of less than 64 bytes
+      value: 0
+    - name: Forward
+      description: Rx FIFO forwards undersized frames
+      value: 1
+enum/GU:
+  bit_size: 1
+  variants:
+    - name: Disabled
+      description: Normal operation
+      value: 0
+    - name: Enabled
+      description: Any unicast packet filtered by the MAC address recognition may be a wakeup frame
+      value: 1
+enum/HM:
+  bit_size: 1
+  variants:
+    - name: Perfect
+      description: MAC performs a perfect destination address filtering for multicast frames
+      value: 0
+    - name: Hash
+      description: MAC performs destination address filtering of received multicast frames according to the hash table
+      value: 1
+enum/HPF:
+  bit_size: 1
+  variants:
+    - name: HashOnly
+      description: "If HM or HU is set, only frames that match the Hash filter are passed"
+      value: 0
+    - name: HashOrPerfect
+      description: "If HM or HU is set, frames that match either the perfect filter or the hash filter are passed"
+      value: 1
+enum/HU:
+  bit_size: 1
+  variants:
+    - name: Perfect
+      description: MAC performs a perfect destination address filtering for unicast frames
+      value: 0
+    - name: Hash
+      description: MAC performs destination address filtering of received unicast frames according to the hash table
+      value: 1
+enum/IFG:
+  bit_size: 3
+  variants:
+    - name: IFG96
+      description: 96 bit times
+      value: 0
+    - name: IFG88
+      description: 88 bit times
+      value: 1
+    - name: IFG80
+      description: 80 bit times
+      value: 2
+    - name: IFG72
+      description: 72 bit times
+      value: 3
+    - name: IFG64
+      description: 64 bit times
+      value: 4
+    - name: IFG56
+      description: 56 bit times
+      value: 5
+    - name: IFG48
+      description: 48 bit times
+      value: 6
+    - name: IFG40
+      description: 40 bit times
+      value: 7
+enum/IPCO:
+  bit_size: 1
+  variants:
+    - name: Disabled
+      description: IPv4 checksum offload disabled
+      value: 0
+    - name: Offload
+      description: IPv4 checksums are checked in received frames
+      value: 1
+enum/JD:
+  bit_size: 1
+  variants:
+    - name: Enabled
+      description: "Jabber enabled, transmit frames up to 2048 bytes"
+      value: 0
+    - name: Disabled
+      description: "Jabber disabled, transmit frames up to 16384 bytes"
+      value: 1
+enum/LM:
+  bit_size: 1
+  variants:
+    - name: Normal
+      description: Normal mode
+      value: 0
+    - name: Loopback
+      description: MAC operates in loopback mode at the MII
+      value: 1
+enum/MACAHR_AE:
+  bit_size: 1
+  variants:
+    - name: Disabled
+      description: Address filters ignore this address
+      value: 0
+    - name: Enabled
+      description: Address filters use this address
+      value: 1
+enum/MACAHR_SA:
+  bit_size: 1
+  variants:
+    - name: Destination
+      description: This address is used for comparison with DA fields of the received frame
+      value: 0
+    - name: Source
+      description: This address is used for comparison with SA fields of received frames
+      value: 1
+enum/MB_progress:
+  bit_size: 1
+  variants:
+    - name: Busy
+      description: This bit is set to 1 by the application to indicate that a read or write access is in progress
+      value: 1
+enum/MCF:
+  bit_size: 1
+  variants:
+    - name: Unfrozen
+      description: All MMC counters update normally
+      value: 0
+    - name: Frozen
+      description: All MMC counters frozen to their current value
+      value: 1
+enum/MPE:
+  bit_size: 1
+  variants:
+    - name: Disabled
+      description: No power management event generated due to Magic Packet reception
+      value: 0
+    - name: Enabled
+      description: Enable generation of a power management event due to Magic Packet reception
+      value: 1
+enum/MW:
+  bit_size: 1
+  variants:
+    - name: Read
+      description: Read operation
+      value: 0
+    - name: Write
+      description: Write operation
+      value: 1
+enum/PAM:
+  bit_size: 1
+  variants:
+    - name: Disabled
+      description: Filtering of multicast frames depends on HM
+      value: 0
+    - name: Enabled
+      description: All received frames with a multicast destination address are passed
+      value: 1
+enum/PBL:
+  bit_size: 6
+  variants:
+    - name: PBL1
+      description: Maximum of 1 beat per DMA transaction
+      value: 1
+    - name: PBL2
+      description: Maximum of 2 beats per DMA transaction
+      value: 2
+    - name: PBL4
+      description: Maximum of 4 beats per DMA transaction
+      value: 4
+    - name: PBL8
+      description: Maximum of 8 beats per DMA transaction
+      value: 8
+    - name: PBL16
+      description: Maximum of 16 beats per DMA transaction
+      value: 16
+    - name: PBL32
+      description: Maximum of 32 beats per DMA transaction
+      value: 32
+enum/PCF:
+  bit_size: 2
+  variants:
+    - name: PreventAll
+      description: MAC prevents all control frames from reaching the application
+      value: 0
+    - name: ForwardAllExceptPause
+      description: MAC forwards all control frames to application except Pause
+      value: 1
+    - name: ForwardAll
+      description: MAC forwards all control frames to application even if they fail the address filter
+      value: 2
+    - name: ForwardAllFiltered
+      description: MAC forwards control frames that pass the address filter
+      value: 3
+enum/PD:
+  bit_size: 1
+  variants:
+    - name: Enabled
+      description: All received frames will be dropped. Cleared automatically when a magic packet or wakeup frame is received
+      value: 1
+enum/PLT:
+  bit_size: 2
+  variants:
+    - name: PLT4
+      description: Pause time minus 4 slot times
+      value: 0
+    - name: PLT28
+      description: Pause time minus 28 slot times
+      value: 1
+    - name: PLT144
+      description: Pause time minus 144 slot times
+      value: 2
+    - name: PLT256
+      description: Pause time minus 256 slot times
+      value: 3
+enum/PM:
+  bit_size: 1
+  variants:
+    - name: Disabled
+      description: Normal address filtering
+      value: 0
+    - name: Enabled
+      description: Address filters pass all incoming frames regardless of their destination or source address
+      value: 1
+enum/PMTIM:
+  bit_size: 1
+  variants:
+    - name: Unmasked
+      description: PMT Status interrupt generation enabled
+      value: 0
+    - name: Masked
+      description: PMT Status interrupt generation disabled
+      value: 1
+enum/PriorityRxOverTx:
+  bit_size: 2
+  variants:
+    - name: OneToOne
+      description: "RxDMA priority over TxDMA is 1:1"
+      value: 0
+    - name: TwoToOne
+      description: "RxDMA priority over TxDMA is 2:1"
+      value: 1
+    - name: ThreeToOne
+      description: "RxDMA priority over TxDMA is 3:1"
+      value: 2
+    - name: FourToOne
+      description: "RxDMA priority over TxDMA is 4:1"
+      value: 3
+enum/RA:
+  bit_size: 1
+  variants:
+    - name: Disabled
+      description: MAC receiver passes on to the application only those frames that have passed the SA/DA address file
+      value: 0
+    - name: Enabled
+      description: MAC receiver passes oll received frames on to the application
+      value: 1
+enum/RD:
+  bit_size: 1
+  variants:
+    - name: Enabled
+      description: MAC attempts retries based on the settings of BL
+      value: 0
+    - name: Disabled
+      description: MAC attempts only 1 transmission
+      value: 1
+enum/RDP:
+  bit_size: 6
+  variants:
+    - name: RDP1
+      description: 1 beat per RxDMA transaction
+      value: 1
+    - name: RDP2
+      description: 2 beats per RxDMA transaction
+      value: 2
+    - name: RDP4
+      description: 4 beats per RxDMA transaction
+      value: 4
+    - name: RDP8
+      description: 8 beats per RxDMA transaction
+      value: 8
+    - name: RDP16
+      description: 16 beats per RxDMA transaction
+      value: 16
+    - name: RDP32
+      description: 32 beats per RxDMA transaction
+      value: 32
+enum/RE:
+  bit_size: 1
+  variants:
+    - name: Disabled
+      description: MAC receive state machine is disabled after the completion of the reception of the current frame
+      value: 0
+    - name: Enabled
+      description: MAC receive state machine is enabled
+      value: 1
+enum/RFAEM:
+  bit_size: 1
+  variants:
+    - name: Unmasked
+      description: Received-alignment-error counter half-full interrupt enabled
+      value: 0
+    - name: Masked
+      description: Received-alignment-error counter half-full interrupt disabled
+      value: 1
+enum/RFCE:
+  bit_size: 1
+  variants:
+    - name: Disabled
+      description: Pause frames are not decoded
+      value: 0
+    - name: Enabled
+      description: MAC decodes received Pause frames and disables its transmitted for a specified time
+      value: 1
+enum/RFCEM:
+  bit_size: 1
+  variants:
+    - name: Unmasked
+      description: Received-crc-error counter half-full interrupt enabled
+      value: 0
+    - name: Masked
+      description: Received-crc-error counter half-full interrupt disabled
+      value: 1
+enum/RGUFM:
+  bit_size: 1
+  variants:
+    - name: Unmasked
+      description: Received-good-unicast counter half-full interrupt enabled
+      value: 0
+    - name: Masked
+      description: Received-good-unicast counter half-full interrupt disabled
+      value: 1
+enum/ROD:
+  bit_size: 1
+  variants:
+    - name: Enabled
+      description: MAC receives all packets from PHY while transmitting
+      value: 0
+    - name: Disabled
+      description: MAC disables reception of frames in half-duplex mode
+      value: 1
+enum/ROR:
+  bit_size: 1
+  variants:
+    - name: Disabled
+      description: MMC counters do not reset on read
+      value: 0
+    - name: Enabled
+      description: MMC counters reset to zero after read
+      value: 1
+enum/RPD:
+  bit_size: 32
+  variants:
+    - name: Poll
+      description: Poll the receive descriptor list
+      value: 0
+enum/RPS:
+  bit_size: 3
+  variants:
+    - name: Stopped
+      description: "Stopped, reset or Stop Receive command issued"
+      value: 0
+    - name: RunningFetching
+      description: "Running, fetching receive transfer descriptor"
+      value: 1
+    - name: RunningWaiting
+      description: "Running, waiting for receive packet"
+      value: 3
+    - name: Suspended
+      description: "Suspended, receive descriptor unavailable"
+      value: 4
+    - name: RunningWriting
+      description: "Running, writing data to host memory buffer"
+      value: 7
+enum/RSF:
+  bit_size: 1
+  variants:
+    - name: CutThrough
+      description: "Rx FIFO operates in cut-through mode, subject to RTC bits"
+      value: 0
+    - name: StoreForward
+      description: Frames are read from Rx FIFO after complete frame has been written
+      value: 1
+enum/RTC:
+  bit_size: 2
+  variants:
+    - name: RTC64
+      description: 64 bytes
+      value: 0
+    - name: RTC32
+      description: 32 bytes
+      value: 1
+    - name: RTC96
+      description: 96 bytes
+      value: 2
+    - name: RTC128
+      description: 128 bytes
+      value: 3
+enum/SAF:
+  bit_size: 1
+  variants:
+    - name: Disabled
+      description: Source address ignored
+      value: 0
+    - name: Enabled
+      description: MAC drops frames that fail the source address filter
+      value: 1
+enum/SAIF:
+  bit_size: 1
+  variants:
+    - name: Normal
+      description: Source address filter operates normally
+      value: 0
+    - name: Invert
+      description: Source address filter operation inverted
+      value: 1
+enum/ST:
+  bit_size: 1
+  variants:
+    - name: Stopped
+      description: Transmission is placed in the Stopped state
+      value: 0
+    - name: Started
+      description: Transmission is placed in Running state
+      value: 1
+enum/TE:
+  bit_size: 1
+  variants:
+    - name: Disabled
+      description: MAC transmit state machine is disabled after completion of the transmission of the current frame
+      value: 0
+    - name: Enabled
+      description: MAC transmit state machine is enabled
+      value: 1
+enum/TFCE:
+  bit_size: 1
+  variants:
+    - name: Disabled
+      description: "In full duplex, flow control is disabled. In half duplex, back pressure is disabled"
+      value: 0
+    - name: Enabled
+      description: "In full duplex, flow control is enabled. In half duplex, back pressure is enabled"
+      value: 1
+enum/TGFM:
+  bit_size: 1
+  variants:
+    - name: Unmasked
+      description: Transmitted-good counter half-full interrupt enabled
+      value: 0
+    - name: Masked
+      description: Transmitted-good counter half-full interrupt disabled
+      value: 1
+enum/TGFMSCM:
+  bit_size: 1
+  variants:
+    - name: Unmasked
+      description: Transmitted-good-multiple-collision half-full interrupt enabled
+      value: 0
+    - name: Masked
+      description: Transmitted-good-multiple-collision half-full interrupt disabled
+      value: 1
+enum/TGFSCM:
+  bit_size: 1
+  variants:
+    - name: Unmasked
+      description: Transmitted-good-single-collision half-full interrupt enabled
+      value: 0
+    - name: Masked
+      description: Transmitted-good-single-collision half-full interrupt disabled
+      value: 1
+enum/TPD:
+  bit_size: 32
+  variants:
+    - name: Poll
+      description: Poll the transmit descriptor list
+      value: 0
+enum/TPS:
+  bit_size: 3
+  variants:
+    - name: Stopped
+      description: "Stopped, Reset or Stop Transmit command issued"
+      value: 0
+    - name: RunningFetching
+      description: "Running, fetching transmit transfer descriptor"
+      value: 1
+    - name: RunningWaiting
+      description: "Running, waiting for status"
+      value: 2
+    - name: RunningReading
+      description: "Running, reading data from host memory buffer"
+      value: 3
+    - name: Suspended
+      description: "Suspended, transmit descriptor unavailable or transmit buffer underflow"
+      value: 6
+    - name: Running
+      description: "Running, closing transmit descriptor"
+      value: 7
+enum/TSF:
+  bit_size: 1
+  variants:
+    - name: CutThrough
+      description: Transmission starts when the frame size in the Tx FIFO exceeds TTC threshold
+      value: 0
+    - name: StoreForward
+      description: Transmission starts when a full frame is in the Tx FIFO
+      value: 1
+enum/TSTIM:
+  bit_size: 1
+  variants:
+    - name: Unmasked
+      description: Time stamp interrupt generation enabled
+      value: 0
+    - name: Masked
+      description: Time stamp interrupt generation disabled
+      value: 1
+enum/TTC:
+  bit_size: 3
+  variants:
+    - name: TTC64
+      description: 64 bytes
+      value: 0
+    - name: TTC128
+      description: 128 bytes
+      value: 1
+    - name: TTC192
+      description: 192 bytes
+      value: 2
+    - name: TTC256
+      description: 256 bytes
+      value: 3
+    - name: TTC40
+      description: 40 bytes
+      value: 4
+    - name: TTC32
+      description: 32 bytes
+      value: 5
+    - name: TTC24
+      description: 24 bytes
+      value: 6
+    - name: TTC16
+      description: 16 bytes
+      value: 7
+enum/UPFD:
+  bit_size: 1
+  variants:
+    - name: Disabled
+      description: MAC detects only a Pause frame with the multicast address specified in the 802.3x standard
+      value: 0
+    - name: Enabled
+      description: "MAC additionally detects Pause frames with the station's unicast address"
+      value: 1
+enum/USP:
+  bit_size: 1
+  variants:
+    - name: Combined
+      description: PBL value used for both Rx and Tx DMA
+      value: 0
+    - name: Separate
+      description: "RxDMA uses RDP value, TxDMA uses PBL value"
+      value: 1
+enum/VLANTC:
+  bit_size: 1
+  variants:
+    - name: VLANTC16
+      description: Full 16 bit VLAN identifiers are used for comparison and filtering
+      value: 0
+    - name: VLANTC12
+      description: 12 bit VLAN identifies are used for comparison and filtering
+      value: 1
+enum/WD:
+  bit_size: 1
+  variants:
+    - name: Enabled
+      description: "Watchdog enabled, receive frames limited to 2048 bytes"
+      value: 0
+    - name: Disabled
+      description: "Watchdog disabled, receive frames may be up to to 16384 bytes"
+      value: 1
+enum/WFE:
+  bit_size: 1
+  variants:
+    - name: Disabled
+      description: No power management event generated due to wakeup frame reception
+      value: 0
+    - name: Enabled
+      description: Enable generation of a power management event due to wakeup frame reception
+      value: 1
+enum/WFFRPR:
+  bit_size: 1
+  variants:
+    - name: Reset
+      description: Reset wakeup frame filter register point to 0b000. Automatically cleared
+      value: 1
+enum/ZQPD:
+  bit_size: 1
+  variants:
+    - name: Enabled
+      description: Normal operation with automatic zero-quanta pause control frame generation
+      value: 0
+    - name: Disabled
+      description: Automatic generation of zero-quanta pause control frames is disabled
+      value: 1

--- a/data/registers/eth_v1b.yaml
+++ b/data/registers/eth_v1b.yaml
@@ -1,0 +1,2220 @@
+---
+block/ETH:
+  description: Ethernet Peripheral
+  items:
+    - name: ETHERNET_MAC
+      description: "Ethernet: media access control (MAC)"
+      byte_offset: 0
+      block: ETHERNET_MAC
+    - name: ETHERNET_PTP
+      description: "Ethernet: Precision Time Protocol (PTP)"
+      byte_offset: 1792
+      block: ETHERNET_PTP
+    - name: ETHERNET_DMA
+      description: "Ethernet: DMA mode register (DMA)"
+      byte_offset: 4096
+      block: ETHERNET_DMA
+block/ETHERNET_DMA:
+  description: "Ethernet: DMA controller operation"
+  items:
+    - name: DMABMR
+      description: Ethernet DMA bus mode register
+      byte_offset: 0
+      fieldset: DMABMR
+    - name: DMATPDR
+      description: Ethernet DMA transmit poll demand register
+      byte_offset: 4
+      fieldset: DMATPDR
+    - name: DMARPDR
+      description: EHERNET DMA receive poll demand register
+      byte_offset: 8
+      fieldset: DMARPDR
+    - name: DMARDLAR
+      description: Ethernet DMA receive descriptor list address register
+      byte_offset: 12
+      fieldset: DMARDLAR
+    - name: DMATDLAR
+      description: Ethernet DMA transmit descriptor list address register
+      byte_offset: 16
+      fieldset: DMATDLAR
+    - name: DMASR
+      description: Ethernet DMA status register
+      byte_offset: 20
+      fieldset: DMASR
+    - name: DMAOMR
+      description: Ethernet DMA operation mode register
+      byte_offset: 24
+      fieldset: DMAOMR
+    - name: DMAIER
+      description: Ethernet DMA interrupt enable register
+      byte_offset: 28
+      fieldset: DMAIER
+    - name: DMAMFBOCR
+      description: Ethernet DMA missed frame and buffer overflow counter register
+      byte_offset: 32
+      fieldset: DMAMFBOCR
+    - name: DMARSWTR
+      description: Ethernet DMA receive status watchdog timer register
+      byte_offset: 36
+      fieldset: DMARSWTR
+    - name: DMACHTDR
+      description: Ethernet DMA current host transmit descriptor register
+      byte_offset: 72
+      access: Read
+      fieldset: DMACHTDR
+    - name: DMACHRDR
+      description: Ethernet DMA current host receive descriptor register
+      byte_offset: 76
+      access: Read
+      fieldset: DMACHRDR
+    - name: DMACHTBAR
+      description: Ethernet DMA current host transmit buffer address register
+      byte_offset: 80
+      access: Read
+      fieldset: DMACHTBAR
+    - name: DMACHRBAR
+      description: Ethernet DMA current host receive buffer address register
+      byte_offset: 84
+      access: Read
+      fieldset: DMACHRBAR
+block/ETHERNET_MAC:
+  description: "Ethernet: media access control (MAC)"
+  items:
+    - name: MACCR
+      description: Ethernet MAC configuration register
+      byte_offset: 0
+      fieldset: MACCR
+    - name: MACFFR
+      description: Ethernet MAC frame filter register
+      byte_offset: 4
+      fieldset: MACFFR
+    - name: MACHTHR
+      description: Ethernet MAC hash table high register
+      byte_offset: 8
+      fieldset: MACHTHR
+    - name: MACHTLR
+      description: Ethernet MAC hash table low register
+      byte_offset: 12
+      fieldset: MACHTLR
+    - name: MACMIIAR
+      description: Ethernet MAC MII address register
+      byte_offset: 16
+      fieldset: MACMIIAR
+    - name: MACMIIDR
+      description: Ethernet MAC MII data register
+      byte_offset: 20
+      fieldset: MACMIIDR
+    - name: MACFCR
+      description: Ethernet MAC flow control register
+      byte_offset: 24
+      fieldset: MACFCR
+    - name: MACVLANTR
+      description: Ethernet MAC VLAN tag register
+      byte_offset: 28
+      fieldset: MACVLANTR
+    - name: MACRWUFFR
+      description: Ethernet MAC remote wakeup frame filter register
+      byte_offset: 40
+    - name: MACPMTCSR
+      description: Ethernet MAC PMT control and status register
+      byte_offset: 44
+      fieldset: MACPMTCSR
+    - name: MACDBGR
+      description: Ethernet MAC debug register
+      byte_offset: 52
+      access: Read
+      fieldset: MACDBGR
+    - name: MACSR
+      description: Ethernet MAC interrupt status register
+      byte_offset: 56
+      fieldset: MACSR
+    - name: MACIMR
+      description: Ethernet MAC interrupt mask register
+      byte_offset: 60
+      fieldset: MACIMR
+    - name: MACA0HR
+      description: Ethernet MAC address 0 high register
+      byte_offset: 64
+      fieldset: MACA0HR
+    - name: MACA0LR
+      description: Ethernet MAC address 0 low register
+      byte_offset: 68
+      fieldset: MACA0LR
+    - name: MACA1HR
+      description: Ethernet MAC address 1 high register
+      byte_offset: 72
+      fieldset: MACA1HR
+    - name: MACA1LR
+      description: Ethernet MAC address1 low register
+      byte_offset: 76
+      fieldset: MACA1LR
+    - name: MACA2HR
+      description: Ethernet MAC address 2 high register
+      byte_offset: 80
+      fieldset: MACA2HR
+    - name: MACA2LR
+      description: Ethernet MAC address 2 low register
+      byte_offset: 84
+      fieldset: MACA2LR
+    - name: MACA3HR
+      description: Ethernet MAC address 3 high register
+      byte_offset: 88
+      fieldset: MACA3HR
+    - name: MACA3LR
+      description: Ethernet MAC address 3 low register
+      byte_offset: 92
+      fieldset: MACA3LR
+    - name: MMCCR
+      description: Ethernet MMC control register
+      byte_offset: 256
+      fieldset: MMCCR
+    - name: MMCRIR
+      description: Ethernet MMC receive interrupt register
+      byte_offset: 260
+      fieldset: MMCRIR
+    - name: MMCTIR
+      description: Ethernet MMC transmit interrupt register
+      byte_offset: 264
+      access: Read
+      fieldset: MMCTIR
+    - name: MMCRIMR
+      description: Ethernet MMC receive interrupt mask register
+      byte_offset: 268
+      fieldset: MMCRIMR
+    - name: MMCTIMR
+      description: Ethernet MMC transmit interrupt mask register
+      byte_offset: 272
+      fieldset: MMCTIMR
+    - name: MMCTGFSCCR
+      description: Ethernet MMC transmitted good frames after a single collision counter
+      byte_offset: 332
+      access: Read
+      fieldset: MMCTGFSCCR
+    - name: MMCTGFMSCCR
+      description: Ethernet MMC transmitted good frames after more than a single collision
+      byte_offset: 336
+      access: Read
+      fieldset: MMCTGFMSCCR
+    - name: MMCTGFCR
+      description: Ethernet MMC transmitted good frames counter register
+      byte_offset: 360
+      access: Read
+      fieldset: MMCTGFCR
+    - name: MMCRFCECR
+      description: Ethernet MMC received frames with CRC error counter register
+      byte_offset: 404
+      access: Read
+      fieldset: MMCRFCECR
+    - name: MMCRFAECR
+      description: Ethernet MMC received frames with alignment error counter register
+      byte_offset: 408
+      access: Read
+      fieldset: MMCRFAECR
+    - name: MMCRGUFCR
+      description: MMC received good unicast frames counter register
+      byte_offset: 452
+      access: Read
+      fieldset: MMCRGUFCR
+block/ETHERNET_PTP:
+  description: "Ethernet: Precision time protocol"
+  items:
+    - name: PTPTSCR
+      description: Ethernet PTP time stamp control register
+      byte_offset: 0
+      fieldset: PTPTSCR
+    - name: PTPSSIR
+      description: Ethernet PTP subsecond increment register
+      byte_offset: 4
+      fieldset: PTPSSIR
+    - name: PTPTSHR
+      description: Ethernet PTP time stamp high register
+      byte_offset: 8
+      access: Read
+      fieldset: PTPTSHR
+    - name: PTPTSLR
+      description: Ethernet PTP time stamp low register
+      byte_offset: 12
+      access: Read
+      fieldset: PTPTSLR
+    - name: PTPTSHUR
+      description: Ethernet PTP time stamp high update register
+      byte_offset: 16
+      fieldset: PTPTSHUR
+    - name: PTPTSLUR
+      description: Ethernet PTP time stamp low update register
+      byte_offset: 20
+      fieldset: PTPTSLUR
+    - name: PTPTSAR
+      description: Ethernet PTP time stamp addend register
+      byte_offset: 24
+      fieldset: PTPTSAR
+    - name: PTPTTHR
+      description: Ethernet PTP target time high register
+      byte_offset: 28
+      fieldset: PTPTTHR
+    - name: PTPTTLR
+      description: Ethernet PTP target time low register
+      byte_offset: 32
+      fieldset: PTPTTLR
+    - name: PTPTSSR
+      description: Ethernet PTP time stamp status register
+      byte_offset: 40
+      access: Read
+      fieldset: PTPTSSR
+    - name: PTPPPSCR
+      description: Ethernet PTP PPS control register
+      byte_offset: 44
+      access: Read
+      fieldset: PTPPPSCR
+fieldset/DMABMR:
+  description: Ethernet DMA bus mode register
+  fields:
+    - name: SR
+      description: Software reset
+      bit_offset: 0
+      bit_size: 1
+    - name: DA
+      description: DMA arbitration
+      bit_offset: 1
+      bit_size: 1
+      enum: DA
+    - name: DSL
+      description: Descriptor skip length
+      bit_offset: 2
+      bit_size: 5
+    - name: EDFE
+      description: Enhanced descriptor format enable
+      bit_offset: 7
+      bit_size: 1
+      enum: EDFE
+    - name: PBL
+      description: Programmable burst length
+      bit_offset: 8
+      bit_size: 6
+      enum: PBL
+    - name: PM
+      description: Rx-Tx priority ratio
+      bit_offset: 14
+      bit_size: 2
+      enum: PriorityRxOverTx
+    - name: FB
+      description: Fixed burst
+      bit_offset: 16
+      bit_size: 1
+      enum: FB
+    - name: RDP
+      description: Rx DMA PBL
+      bit_offset: 17
+      bit_size: 6
+      enum: RDP
+    - name: USP
+      description: Use separate PBL
+      bit_offset: 23
+      bit_size: 1
+      enum: USP
+    - name: FPM
+      description: 4xPBL mode
+      bit_offset: 24
+      bit_size: 1
+      enum: FPM
+    - name: AAB
+      description: Address-aligned beats
+      bit_offset: 25
+      bit_size: 1
+      enum: AAB
+    - name: MB
+      description: Mixed burst
+      bit_offset: 26
+      bit_size: 1
+      enum: MB
+fieldset/DMACHRBAR:
+  description: Ethernet DMA current host receive buffer address register
+  fields:
+    - name: HRBAP
+      description: Host receive buffer address pointer
+      bit_offset: 0
+      bit_size: 32
+fieldset/DMACHRDR:
+  description: Ethernet DMA current host receive descriptor register
+  fields:
+    - name: HRDAP
+      description: Host receive descriptor address pointer
+      bit_offset: 0
+      bit_size: 32
+fieldset/DMACHTBAR:
+  description: Ethernet DMA current host transmit buffer address register
+  fields:
+    - name: HTBAP
+      description: Host transmit buffer address pointer
+      bit_offset: 0
+      bit_size: 32
+fieldset/DMACHTDR:
+  description: Ethernet DMA current host transmit descriptor register
+  fields:
+    - name: HTDAP
+      description: Host transmit descriptor address pointer
+      bit_offset: 0
+      bit_size: 32
+fieldset/DMAIER:
+  description: Ethernet DMA interrupt enable register
+  fields:
+    - name: TIE
+      description: Transmit interrupt enable
+      bit_offset: 0
+      bit_size: 1
+    - name: TPSIE
+      description: Transmit process stopped interrupt enable
+      bit_offset: 1
+      bit_size: 1
+    - name: TBUIE
+      description: Transmit buffer unavailable interrupt enable
+      bit_offset: 2
+      bit_size: 1
+    - name: TJTIE
+      description: Transmit jabber timeout interrupt enable
+      bit_offset: 3
+      bit_size: 1
+    - name: ROIE
+      description: Receive overflow interrupt enable
+      bit_offset: 4
+      bit_size: 1
+    - name: TUIE
+      description: Transmit underflow interrupt enable
+      bit_offset: 5
+      bit_size: 1
+    - name: RIE
+      description: Receive interrupt enable
+      bit_offset: 6
+      bit_size: 1
+    - name: RBUIE
+      description: Receive buffer unavailable interrupt enable
+      bit_offset: 7
+      bit_size: 1
+    - name: RPSIE
+      description: Receive process stopped interrupt enable
+      bit_offset: 8
+      bit_size: 1
+    - name: RWTIE
+      description: Receive watchdog timeout interrupt enable
+      bit_offset: 9
+      bit_size: 1
+    - name: ETIE
+      description: Early transmit interrupt enable
+      bit_offset: 10
+      bit_size: 1
+    - name: FBEIE
+      description: Fatal bus error interrupt enable
+      bit_offset: 13
+      bit_size: 1
+    - name: ERIE
+      description: Early receive interrupt enable
+      bit_offset: 14
+      bit_size: 1
+    - name: AISE
+      description: Abnormal interrupt summary enable
+      bit_offset: 15
+      bit_size: 1
+    - name: NISE
+      description: Normal interrupt summary enable
+      bit_offset: 16
+      bit_size: 1
+fieldset/DMAMFBOCR:
+  description: Ethernet DMA missed frame and buffer overflow counter register
+  fields:
+    - name: MFC
+      description: Missed frames by the controller
+      bit_offset: 0
+      bit_size: 16
+    - name: OMFC
+      description: Overflow bit for missed frame counter
+      bit_offset: 16
+      bit_size: 1
+    - name: MFA
+      description: Missed frames by the application
+      bit_offset: 17
+      bit_size: 11
+    - name: OFOC
+      description: Overflow bit for FIFO overflow counter
+      bit_offset: 28
+      bit_size: 1
+fieldset/DMAOMR:
+  description: Ethernet DMA operation mode register
+  fields:
+    - name: SR
+      description: Start/stop receive
+      bit_offset: 1
+      bit_size: 1
+      enum: DMAOMR_SR
+    - name: OSF
+      description: Operate on second frame
+      bit_offset: 2
+      bit_size: 1
+    - name: RTC
+      description: Receive threshold control
+      bit_offset: 3
+      bit_size: 2
+      enum: RTC
+    - name: FUGF
+      description: Forward undersized good frames
+      bit_offset: 6
+      bit_size: 1
+      enum: FUGF
+    - name: FEF
+      description: Forward error frames
+      bit_offset: 7
+      bit_size: 1
+      enum: FEF
+    - name: ST
+      description: Start/stop transmission
+      bit_offset: 13
+      bit_size: 1
+      enum: ST
+    - name: TTC
+      description: Transmit threshold control
+      bit_offset: 14
+      bit_size: 3
+      enum: TTC
+    - name: FTF
+      description: Flush transmit FIFO
+      bit_offset: 20
+      bit_size: 1
+      enum: FTF
+    - name: TSF
+      description: Transmit store and forward
+      bit_offset: 21
+      bit_size: 1
+      enum: TSF
+    - name: DFRF
+      description: Disable flushing of received frames
+      bit_offset: 24
+      bit_size: 1
+    - name: RSF
+      description: Receive store and forward
+      bit_offset: 25
+      bit_size: 1
+      enum: RSF
+    - name: DTCEFD
+      description: Dropping of TCP/IP checksum error frames disable
+      bit_offset: 26
+      bit_size: 1
+      enum: DTCEFD
+fieldset/DMARDLAR:
+  description: Ethernet DMA receive descriptor list address register
+  fields:
+    - name: SRL
+      description: Start of receive list
+      bit_offset: 0
+      bit_size: 32
+fieldset/DMARPDR:
+  description: EHERNET DMA receive poll demand register
+  fields:
+    - name: RPD
+      description: Receive poll demand
+      bit_offset: 0
+      bit_size: 32
+      enum: RPD
+fieldset/DMARSWTR:
+  description: Ethernet DMA receive status watchdog timer register
+  fields:
+    - name: RSWTC
+      description: Receive status watchdog timer count
+      bit_offset: 0
+      bit_size: 8
+fieldset/DMASR:
+  description: Ethernet DMA status register
+  fields:
+    - name: TS
+      description: Transmit status
+      bit_offset: 0
+      bit_size: 1
+    - name: TPSS
+      description: Transmit process stopped status
+      bit_offset: 1
+      bit_size: 1
+    - name: TBUS
+      description: Transmit buffer unavailable status
+      bit_offset: 2
+      bit_size: 1
+    - name: TJTS
+      description: Transmit jabber timeout status
+      bit_offset: 3
+      bit_size: 1
+    - name: ROS
+      description: Receive overflow status
+      bit_offset: 4
+      bit_size: 1
+    - name: TUS
+      description: Transmit underflow status
+      bit_offset: 5
+      bit_size: 1
+    - name: RS
+      description: Receive status
+      bit_offset: 6
+      bit_size: 1
+    - name: RBUS
+      description: Receive buffer unavailable status
+      bit_offset: 7
+      bit_size: 1
+    - name: RPSS
+      description: Receive process stopped status
+      bit_offset: 8
+      bit_size: 1
+    - name: PWTS
+      description: PWTS
+      bit_offset: 9
+      bit_size: 1
+    - name: ETS
+      description: Early transmit status
+      bit_offset: 10
+      bit_size: 1
+    - name: FBES
+      description: Fatal bus error status
+      bit_offset: 13
+      bit_size: 1
+    - name: ERS
+      description: Early receive status
+      bit_offset: 14
+      bit_size: 1
+    - name: AIS
+      description: Abnormal interrupt summary
+      bit_offset: 15
+      bit_size: 1
+    - name: NIS
+      description: Normal interrupt summary
+      bit_offset: 16
+      bit_size: 1
+    - name: RPS
+      description: Receive process state
+      bit_offset: 17
+      bit_size: 3
+      enum: RPS
+    - name: TPS
+      description: Transmit process state
+      bit_offset: 20
+      bit_size: 3
+      enum: TPS
+    - name: EBS
+      description: Error bits status
+      bit_offset: 23
+      bit_size: 3
+    - name: MMCS
+      description: MMC status
+      bit_offset: 27
+      bit_size: 1
+    - name: PMTS
+      description: PMT status
+      bit_offset: 28
+      bit_size: 1
+    - name: TSTS
+      description: Time stamp trigger status
+      bit_offset: 29
+      bit_size: 1
+fieldset/DMATDLAR:
+  description: Ethernet DMA transmit descriptor list address register
+  fields:
+    - name: STL
+      description: Start of transmit list
+      bit_offset: 0
+      bit_size: 32
+fieldset/DMATPDR:
+  description: Ethernet DMA transmit poll demand register
+  fields:
+    - name: TPD
+      description: Transmit poll demand
+      bit_offset: 0
+      bit_size: 32
+      enum: TPD
+fieldset/MACA0HR:
+  description: Ethernet MAC address 0 high register
+  fields:
+    - name: MACA0H
+      description: MAC address0 high
+      bit_offset: 0
+      bit_size: 16
+    - name: MO
+      description: Always 1
+      bit_offset: 31
+      bit_size: 1
+fieldset/MACA0LR:
+  description: Ethernet MAC address 0 low register
+  fields:
+    - name: MACA0L
+      description: "0"
+      bit_offset: 0
+      bit_size: 32
+fieldset/MACA1HR:
+  description: Ethernet MAC address 1 high register
+  fields:
+    - name: MACA1H
+      description: MACA1H
+      bit_offset: 0
+      bit_size: 16
+    - name: MBC
+      description: MBC
+      bit_offset: 24
+      bit_size: 6
+    - name: SA
+      description: SA
+      bit_offset: 30
+      bit_size: 1
+      enum: MACAHR_SA
+    - name: AE
+      description: AE
+      bit_offset: 31
+      bit_size: 1
+      enum: MACAHR_AE
+fieldset/MACA1LR:
+  description: Ethernet MAC address1 low register
+  fields:
+    - name: MACA1L
+      description: MACA1LR
+      bit_offset: 0
+      bit_size: 32
+fieldset/MACA2HR:
+  description: Ethernet MAC address 2 high register
+  fields:
+    - name: MACA2H
+      description: MAC2AH
+      bit_offset: 0
+      bit_size: 16
+    - name: MBC
+      description: MBC
+      bit_offset: 24
+      bit_size: 6
+    - name: SA
+      description: SA
+      bit_offset: 30
+      bit_size: 1
+      enum: MACAHR_SA
+    - name: AE
+      description: AE
+      bit_offset: 31
+      bit_size: 1
+      enum: MACAHR_AE
+fieldset/MACA2LR:
+  description: Ethernet MAC address 2 low register
+  fields:
+    - name: MACA2L
+      description: MACA2L
+      bit_offset: 0
+      bit_size: 32
+fieldset/MACA3HR:
+  description: Ethernet MAC address 3 high register
+  fields:
+    - name: MACA3H
+      description: MACA3H
+      bit_offset: 0
+      bit_size: 16
+    - name: MBC
+      description: MBC
+      bit_offset: 24
+      bit_size: 6
+    - name: SA
+      description: SA
+      bit_offset: 30
+      bit_size: 1
+      enum: MACAHR_SA
+    - name: AE
+      description: AE
+      bit_offset: 31
+      bit_size: 1
+      enum: MACAHR_AE
+fieldset/MACA3LR:
+  description: Ethernet MAC address 3 low register
+  fields:
+    - name: MACA3L
+      description: MBCA3L
+      bit_offset: 0
+      bit_size: 32
+fieldset/MACCR:
+  description: Ethernet MAC configuration register
+  fields:
+    - name: RE
+      description: Receiver enable
+      bit_offset: 2
+      bit_size: 1
+    - name: TE
+      description: Transmitter enable
+      bit_offset: 3
+      bit_size: 1
+    - name: DC
+      description: Deferral check
+      bit_offset: 4
+      bit_size: 1
+      enum: DC
+    - name: BL
+      description: Back-off limit
+      bit_offset: 5
+      bit_size: 2
+      enum: BL
+    - name: APCS
+      description: Automatic pad/CRC stripping
+      bit_offset: 7
+      bit_size: 1
+      enum: APCS
+    - name: RD
+      description: Retry disable
+      bit_offset: 9
+      bit_size: 1
+      enum: RD
+    - name: IPCO
+      description: IPv4 checksum offload
+      bit_offset: 10
+      bit_size: 1
+      enum: IPCO
+    - name: DM
+      description: Duplex mode
+      bit_offset: 11
+      bit_size: 1
+      enum: DM
+    - name: LM
+      description: Loopback mode
+      bit_offset: 12
+      bit_size: 1
+      enum: LM
+    - name: ROD
+      description: Receive own disable
+      bit_offset: 13
+      bit_size: 1
+      enum: ROD
+    - name: FES
+      description: Fast Ethernet speed
+      bit_offset: 14
+      bit_size: 1
+      enum: FES
+    - name: CSD
+      description: Carrier sense disable
+      bit_offset: 16
+      bit_size: 1
+      enum: CSD
+    - name: IFG
+      description: Interframe gap
+      bit_offset: 17
+      bit_size: 3
+      enum: IFG
+    - name: JD
+      description: Jabber disable
+      bit_offset: 22
+      bit_size: 1
+      enum: JD
+    - name: WD
+      description: Watchdog disable
+      bit_offset: 23
+      bit_size: 1
+      enum: WD
+    - name: CSTF
+      description: CRC stripping for type frames
+      bit_offset: 25
+      bit_size: 1
+      enum: CSTF
+fieldset/MACDBGR:
+  description: Ethernet MAC debug register
+  fields:
+    - name: MMRPEA
+      description: MAC MII receive protocol engine active
+      bit_offset: 0
+      bit_size: 1
+    - name: MSFRWCS
+      description: MAC small FIFO read/write controllers status
+      bit_offset: 1
+      bit_size: 2
+    - name: RFWRA
+      description: Rx FIFO write controller active
+      bit_offset: 4
+      bit_size: 1
+    - name: RFRCS
+      description: Rx FIFO read controller status
+      bit_offset: 5
+      bit_size: 2
+    - name: RFFL
+      description: Rx FIFO fill level
+      bit_offset: 8
+      bit_size: 2
+    - name: MMTEA
+      description: MAC MII transmit engine active
+      bit_offset: 16
+      bit_size: 1
+    - name: MTFCS
+      description: MAC transmit frame controller status
+      bit_offset: 17
+      bit_size: 2
+    - name: MTP
+      description: MAC transmitter in pause
+      bit_offset: 19
+      bit_size: 1
+    - name: TFRS
+      description: Tx FIFO read status
+      bit_offset: 20
+      bit_size: 2
+    - name: TFWA
+      description: Tx FIFO write active
+      bit_offset: 22
+      bit_size: 1
+    - name: TFNE
+      description: Tx FIFO not empty
+      bit_offset: 24
+      bit_size: 1
+    - name: TFF
+      description: Tx FIFO full
+      bit_offset: 25
+      bit_size: 1
+fieldset/MACFCR:
+  description: Ethernet MAC flow control register
+  fields:
+    - name: FCB
+      description: Flow control busy/back pressure activate
+      bit_offset: 0
+      bit_size: 1
+      enum: FCB
+    - name: TFCE
+      description: Transmit flow control enable
+      bit_offset: 1
+      bit_size: 1
+      enum: TFCE
+    - name: RFCE
+      description: Receive flow control enable
+      bit_offset: 2
+      bit_size: 1
+      enum: RFCE
+    - name: UPFD
+      description: Unicast pause frame detect
+      bit_offset: 3
+      bit_size: 1
+      enum: UPFD
+    - name: PLT
+      description: Pause low threshold
+      bit_offset: 4
+      bit_size: 2
+      enum: PLT
+    - name: ZQPD
+      description: Zero-quanta pause disable
+      bit_offset: 7
+      bit_size: 1
+      enum: ZQPD
+    - name: PT
+      description: Pause time
+      bit_offset: 16
+      bit_size: 16
+fieldset/MACFFR:
+  description: Ethernet MAC frame filter register
+  fields:
+    - name: PM
+      description: Promiscuous mode
+      bit_offset: 0
+      bit_size: 1
+      enum: PM
+    - name: HU
+      description: Hash unicast
+      bit_offset: 1
+      bit_size: 1
+      enum: HU
+    - name: HM
+      description: Hash multicast
+      bit_offset: 2
+      bit_size: 1
+      enum: HM
+    - name: DAIF
+      description: Destination address unique filtering
+      bit_offset: 3
+      bit_size: 1
+      enum: DAIF
+    - name: PAM
+      description: Pass all multicast
+      bit_offset: 4
+      bit_size: 1
+      enum: PAM
+    - name: BFD
+      description: Broadcast frames disable
+      bit_offset: 5
+      bit_size: 1
+      enum: BFD
+    - name: PCF
+      description: Pass control frames
+      bit_offset: 6
+      bit_size: 2
+      enum: PCF
+    - name: SAIF
+      description: Source address inverse filtering
+      bit_offset: 7
+      bit_size: 1
+      enum: SAIF
+    - name: SAF
+      description: Source address filter
+      bit_offset: 8
+      bit_size: 1
+      enum: SAF
+    - name: HPF
+      description: Hash or perfect filter
+      bit_offset: 9
+      bit_size: 1
+      enum: HPF
+    - name: RA
+      description: Receive all
+      bit_offset: 31
+      bit_size: 1
+      enum: RA
+fieldset/MACHTHR:
+  description: Ethernet MAC hash table high register
+  fields:
+    - name: HTH
+      description: Upper 32 bits of hash table
+      bit_offset: 0
+      bit_size: 32
+fieldset/MACHTLR:
+  description: Ethernet MAC hash table low register
+  fields:
+    - name: HTL
+      description: Lower 32 bits of hash table
+      bit_offset: 0
+      bit_size: 32
+fieldset/MACIMR:
+  description: Ethernet MAC interrupt mask register
+  fields:
+    - name: PMTIM
+      description: PMT interrupt mask
+      bit_offset: 3
+      bit_size: 1
+      enum: PMTIM
+    - name: TSTIM
+      description: Time stamp trigger interrupt mask
+      bit_offset: 9
+      bit_size: 1
+      enum: TSTIM
+fieldset/MACMIIAR:
+  description: Ethernet MAC MII address register
+  fields:
+    - name: MB
+      description: MII busy
+      bit_offset: 0
+      bit_size: 1
+      enum: MB_progress
+    - name: MW
+      description: MII write
+      bit_offset: 1
+      bit_size: 1
+      enum: MW
+    - name: CR
+      description: Clock range
+      bit_offset: 2
+      bit_size: 3
+      enum: CR
+    - name: MR
+      description: MII register - select the desired MII register in the PHY device
+      bit_offset: 6
+      bit_size: 5
+    - name: PA
+      description: PHY address - select which of possible 32 PHYs is being accessed
+      bit_offset: 11
+      bit_size: 5
+fieldset/MACMIIDR:
+  description: Ethernet MAC MII data register
+  fields:
+    - name: MD
+      description: MII data read from/written to the PHY
+      bit_offset: 0
+      bit_size: 16
+fieldset/MACPMTCSR:
+  description: Ethernet MAC PMT control and status register
+  fields:
+    - name: PD
+      description: Power down
+      bit_offset: 0
+      bit_size: 1
+      enum: PD
+    - name: MPE
+      description: Magic packet enable
+      bit_offset: 1
+      bit_size: 1
+      enum: MPE
+    - name: WFE
+      description: Wakeup frame enable
+      bit_offset: 2
+      bit_size: 1
+      enum: WFE
+    - name: MPR
+      description: Magic packet received
+      bit_offset: 5
+      bit_size: 1
+    - name: WFR
+      description: Wakeup frame received
+      bit_offset: 6
+      bit_size: 1
+    - name: GU
+      description: Global unicast
+      bit_offset: 9
+      bit_size: 1
+      enum: GU
+    - name: WFFRPR
+      description: Wakeup frame filter register pointer reset
+      bit_offset: 31
+      bit_size: 1
+      enum: WFFRPR
+fieldset/MACSR:
+  description: Ethernet MAC interrupt status register
+  fields:
+    - name: PMTS
+      description: PMT status
+      bit_offset: 3
+      bit_size: 1
+    - name: MMCS
+      description: MMC status
+      bit_offset: 4
+      bit_size: 1
+    - name: MMCRS
+      description: MMC receive status
+      bit_offset: 5
+      bit_size: 1
+    - name: MMCTS
+      description: MMC transmit status
+      bit_offset: 6
+      bit_size: 1
+    - name: TSTS
+      description: Time stamp trigger status
+      bit_offset: 9
+      bit_size: 1
+fieldset/MACVLANTR:
+  description: Ethernet MAC VLAN tag register
+  fields:
+    - name: VLANTI
+      description: VLAN tag identifier (for receive frames)
+      bit_offset: 0
+      bit_size: 16
+    - name: VLANTC
+      description: 12-bit VLAN tag comparison
+      bit_offset: 16
+      bit_size: 1
+      enum: VLANTC
+fieldset/MMCCR:
+  description: Ethernet MMC control register
+  fields:
+    - name: CR
+      description: Counter reset
+      bit_offset: 0
+      bit_size: 1
+      enum: CounterReset
+    - name: CSR
+      description: Counter stop rollover
+      bit_offset: 1
+      bit_size: 1
+      enum: CSR
+    - name: ROR
+      description: Reset on read
+      bit_offset: 2
+      bit_size: 1
+      enum: ROR
+    - name: MCF
+      description: MMC counter freeze
+      bit_offset: 3
+      bit_size: 1
+      enum: MCF
+    - name: MCP
+      description: MMC counter preset
+      bit_offset: 4
+      bit_size: 1
+      enum: MCP
+    - name: MCFHP
+      description: MMC counter Full-Half preset
+      bit_offset: 5
+      bit_size: 1
+      enum: MCFHP
+fieldset/MMCRFAECR:
+  description: Ethernet MMC received frames with alignment error counter register
+  fields:
+    - name: RFAEC
+      description: RFAEC
+      bit_offset: 0
+      bit_size: 32
+fieldset/MMCRFCECR:
+  description: Ethernet MMC received frames with CRC error counter register
+  fields:
+    - name: RFCFC
+      description: RFCFC
+      bit_offset: 0
+      bit_size: 32
+fieldset/MMCRGUFCR:
+  description: MMC received good unicast frames counter register
+  fields:
+    - name: RGUFC
+      description: RGUFC
+      bit_offset: 0
+      bit_size: 32
+fieldset/MMCRIMR:
+  description: Ethernet MMC receive interrupt mask register
+  fields:
+    - name: RFCEM
+      description: Received frame CRC error mask
+      bit_offset: 5
+      bit_size: 1
+      enum: RFCEM
+    - name: RFAEM
+      description: Received frames alignment error mask
+      bit_offset: 6
+      bit_size: 1
+      enum: RFAEM
+    - name: RGUFM
+      description: Received good Unicast frames mask
+      bit_offset: 17
+      bit_size: 1
+      enum: RGUFM
+fieldset/MMCRIR:
+  description: Ethernet MMC receive interrupt register
+  fields:
+    - name: RFCES
+      description: Received frames CRC error status
+      bit_offset: 5
+      bit_size: 1
+    - name: RFAES
+      description: Received frames alignment error status
+      bit_offset: 6
+      bit_size: 1
+    - name: RGUFS
+      description: Received good Unicast frames status
+      bit_offset: 17
+      bit_size: 1
+fieldset/MMCTGFCR:
+  description: Ethernet MMC transmitted good frames counter register
+  fields:
+    - name: TGFC
+      description: HTL
+      bit_offset: 0
+      bit_size: 32
+fieldset/MMCTGFMSCCR:
+  description: Ethernet MMC transmitted good frames after more than a single collision
+  fields:
+    - name: TGFMSCC
+      description: TGFMSCC
+      bit_offset: 0
+      bit_size: 32
+fieldset/MMCTGFSCCR:
+  description: Ethernet MMC transmitted good frames after a single collision counter
+  fields:
+    - name: TGFSCC
+      description: Transmitted good frames single collision counter
+      bit_offset: 0
+      bit_size: 32
+fieldset/MMCTIMR:
+  description: Ethernet MMC transmit interrupt mask register
+  fields:
+    - name: TGFSCM
+      description: Transmitted good frames single collision mask
+      bit_offset: 14
+      bit_size: 1
+      enum: TGFSCM
+    - name: TGFMSCM
+      description: Transmitted good frames more than single collision mask
+      bit_offset: 15
+      bit_size: 1
+      enum: TGFMSCM
+    - name: TGFM
+      description: Transmitted good frames mask
+      bit_offset: 16
+      bit_size: 1
+      enum: TGFM
+fieldset/MMCTIR:
+  description: Ethernet MMC transmit interrupt register
+  fields:
+    - name: TGFSCS
+      description: Transmitted good frames single collision status
+      bit_offset: 14
+      bit_size: 1
+    - name: TGFMSCS
+      description: Transmitted good frames more than single collision status
+      bit_offset: 15
+      bit_size: 1
+    - name: TGFS
+      description: Transmitted good frames status
+      bit_offset: 21
+      bit_size: 1
+fieldset/PTPPPSCR:
+  description: Ethernet PTP PPS control register
+  fields:
+    - name: TSSO
+      description: TSSO
+      bit_offset: 0
+      bit_size: 1
+    - name: TSTTR
+      description: TSTTR
+      bit_offset: 1
+      bit_size: 1
+fieldset/PTPSSIR:
+  description: Ethernet PTP subsecond increment register
+  fields:
+    - name: STSSI
+      description: STSSI
+      bit_offset: 0
+      bit_size: 8
+fieldset/PTPTSAR:
+  description: Ethernet PTP time stamp addend register
+  fields:
+    - name: TSA
+      description: TSA
+      bit_offset: 0
+      bit_size: 32
+fieldset/PTPTSCR:
+  description: Ethernet PTP time stamp control register
+  fields:
+    - name: TSE
+      description: TSE
+      bit_offset: 0
+      bit_size: 1
+    - name: TSFCU
+      description: TSFCU
+      bit_offset: 1
+      bit_size: 1
+    - name: TSSTI
+      description: TSSTI
+      bit_offset: 2
+      bit_size: 1
+    - name: TSSTU
+      description: TSSTU
+      bit_offset: 3
+      bit_size: 1
+    - name: TSITE
+      description: TSITE
+      bit_offset: 4
+      bit_size: 1
+    - name: TTSARU
+      description: TTSARU
+      bit_offset: 5
+      bit_size: 1
+    - name: TSSARFE
+      description: TSSARFE
+      bit_offset: 8
+      bit_size: 1
+    - name: TSSSR
+      description: TSSSR
+      bit_offset: 9
+      bit_size: 1
+    - name: TSPTPPSV2E
+      description: TSPTPPSV2E
+      bit_offset: 10
+      bit_size: 1
+    - name: TSSPTPOEFE
+      description: TSSPTPOEFE
+      bit_offset: 11
+      bit_size: 1
+    - name: TSSIPV6FE
+      description: TSSIPV6FE
+      bit_offset: 12
+      bit_size: 1
+    - name: TSSIPV4FE
+      description: TSSIPV4FE
+      bit_offset: 13
+      bit_size: 1
+    - name: TSSEME
+      description: TSSEME
+      bit_offset: 14
+      bit_size: 1
+    - name: TSSMRME
+      description: TSSMRME
+      bit_offset: 15
+      bit_size: 1
+    - name: TSCNT
+      description: TSCNT
+      bit_offset: 16
+      bit_size: 2
+    - name: TSPFFMAE
+      description: TSPFFMAE
+      bit_offset: 18
+      bit_size: 1
+fieldset/PTPTSHR:
+  description: Ethernet PTP time stamp high register
+  fields:
+    - name: STS
+      description: STS
+      bit_offset: 0
+      bit_size: 32
+fieldset/PTPTSHUR:
+  description: Ethernet PTP time stamp high update register
+  fields:
+    - name: TSUS
+      description: TSUS
+      bit_offset: 0
+      bit_size: 32
+fieldset/PTPTSLR:
+  description: Ethernet PTP time stamp low register
+  fields:
+    - name: STSS
+      description: STSS
+      bit_offset: 0
+      bit_size: 31
+    - name: STPNS
+      description: STPNS
+      bit_offset: 31
+      bit_size: 1
+fieldset/PTPTSLUR:
+  description: Ethernet PTP time stamp low update register
+  fields:
+    - name: TSUSS
+      description: TSUSS
+      bit_offset: 0
+      bit_size: 31
+    - name: TSUPNS
+      description: TSUPNS
+      bit_offset: 31
+      bit_size: 1
+fieldset/PTPTSSR:
+  description: Ethernet PTP time stamp status register
+  fields:
+    - name: TSSO
+      description: TSSO
+      bit_offset: 0
+      bit_size: 1
+    - name: TSTTR
+      description: TSSO
+      bit_offset: 1
+      bit_size: 1
+fieldset/PTPTTHR:
+  description: Ethernet PTP target time high register
+  fields:
+    - name: TTSH
+      description: "0"
+      bit_offset: 0
+      bit_size: 32
+fieldset/PTPTTLR:
+  description: Ethernet PTP target time low register
+  fields:
+    - name: TTSL
+      description: TTSL
+      bit_offset: 0
+      bit_size: 32
+enum/AAB:
+  bit_size: 1
+  variants:
+    - name: Unaligned
+      description: Bursts are not aligned
+      value: 0
+    - name: Aligned
+      description: Align bursts to start address LS bits. First burst alignment depends on FB bit
+      value: 1
+enum/APCS:
+  bit_size: 1
+  variants:
+    - name: Disabled
+      description: MAC passes all incoming frames unmodified
+      value: 0
+    - name: Strip
+      description: MAC strips the Pad/FCS field on incoming frames only for lengths less than or equal to 1500 bytes
+      value: 1
+enum/BFD:
+  bit_size: 1
+  variants:
+    - name: Enabled
+      description: Address filters pass all received broadcast frames
+      value: 0
+    - name: Disabled
+      description: Address filters filter all incoming broadcast frames
+      value: 1
+enum/BL:
+  bit_size: 2
+  variants:
+    - name: BL10
+      description: "For retransmission n, wait up to 2^min(n, 10) time slots"
+      value: 0
+    - name: BL8
+      description: "For retransmission n, wait up to 2^min(n, 8) time slots"
+      value: 1
+    - name: BL4
+      description: "For retransmission n, wait up to 2^min(n, 4) time slots"
+      value: 2
+    - name: BL1
+      description: "For retransmission n, wait up to 2^min(n, 1) time slots"
+      value: 3
+enum/CR:
+  bit_size: 3
+  variants:
+    - name: CR_60_100
+      description: 60-100MHz HCLK/42
+      value: 0
+    - name: CR_100_150
+      description: 100-150 MHz HCLK/62
+      value: 1
+    - name: CR_20_35
+      description: 20-35MHz HCLK/16
+      value: 2
+    - name: CR_35_60
+      description: 35-60MHz HCLK/16
+      value: 3
+    - name: CR_150_168
+      description: 150-168MHz HCLK/102
+      value: 4
+enum/CSD:
+  bit_size: 1
+  variants:
+    - name: Enabled
+      description: Errors generated due to loss of carrier
+      value: 0
+    - name: Disabled
+      description: No error generated due to loss of carrier
+      value: 1
+enum/CSR:
+  bit_size: 1
+  variants:
+    - name: Disabled
+      description: Counters roll over to zero after reaching the maximum value
+      value: 0
+    - name: Enabled
+      description: Counters do not roll over to zero after reaching the maximum value
+      value: 1
+enum/CSTF:
+  bit_size: 1
+  variants:
+    - name: Disabled
+      description: CRC not stripped
+      value: 0
+    - name: Enabled
+      description: CRC stripped
+      value: 1
+enum/CounterReset:
+  bit_size: 1
+  variants:
+    - name: Reset
+      description: Reset all counters. Cleared automatically
+      value: 1
+enum/DA:
+  bit_size: 1
+  variants:
+    - name: RoundRobin
+      description: "Round-robin with Rx:Tx priority given by PM"
+      value: 0
+    - name: RxPriority
+      description: Rx has priority over Tx
+      value: 1
+enum/DAIF:
+  bit_size: 1
+  variants:
+    - name: Normal
+      description: Normal filtering of frames
+      value: 0
+    - name: Invert
+      description: Address check block operates in inverse filtering mode for the DA address comparison
+      value: 1
+enum/DC:
+  bit_size: 1
+  variants:
+    - name: Disabled
+      description: MAC defers until CRS signal goes inactive
+      value: 0
+    - name: Enabled
+      description: Deferral check function enabled
+      value: 1
+enum/DM:
+  bit_size: 1
+  variants:
+    - name: HalfDuplex
+      description: MAC operates in half-duplex mode
+      value: 0
+    - name: FullDuplex
+      description: MAC operates in full-duplex mode
+      value: 1
+enum/DMABMR_SR:
+  bit_size: 1
+  variants:
+    - name: Reset
+      description: Reset all MAC subsystem internal registers and logic. Cleared automatically
+      value: 1
+enum/DMAOMR_SR:
+  bit_size: 1
+  variants:
+    - name: Stopped
+      description: Reception is stopped after transfer of the current frame
+      value: 0
+    - name: Started
+      description: Reception is placed in the Running state
+      value: 1
+enum/DTCEFD:
+  bit_size: 1
+  variants:
+    - name: Enabled
+      description: Drop frames with errors only in the receive checksum offload engine
+      value: 0
+    - name: Disabled
+      description: Do not drop frames that only have errors in the receive checksum offload engine
+      value: 1
+enum/EDFE:
+  bit_size: 1
+  variants:
+    - name: Disabled
+      description: Normal descriptor format
+      value: 0
+    - name: Enabled
+      description: "Enhanced 32-byte descriptor format, required for timestamping and IPv4 checksum offload"
+      value: 1
+enum/FB:
+  bit_size: 1
+  variants:
+    - name: Variable
+      description: AHB uses SINGLE and INCR burst transfers
+      value: 0
+    - name: Fixed
+      description: AHB uses only fixed burst transfers
+      value: 1
+enum/FCB:
+  bit_size: 1
+  variants:
+    - name: DisableBackPressure
+      description: "In half duplex only, deasserts back pressure"
+      value: 0
+    - name: PauseOrBackPressure
+      description: "In full duplex, initiate a Pause control frame. In half duplex, assert back pressure"
+      value: 1
+enum/FEF:
+  bit_size: 1
+  variants:
+    - name: Drop
+      description: Rx FIFO drops frames with error status
+      value: 0
+    - name: Forward
+      description: All frames except runt error frames are forwarded to the DMA
+      value: 1
+enum/FES:
+  bit_size: 1
+  variants:
+    - name: FES10
+      description: 10 Mbit/s
+      value: 0
+    - name: FES100
+      description: 100 Mbit/s
+      value: 1
+enum/FPM:
+  bit_size: 1
+  variants:
+    - name: x1
+      description: PBL values used as-is
+      value: 0
+    - name: x4
+      description: PBL values multiplied by 4
+      value: 1
+enum/FTF:
+  bit_size: 1
+  variants:
+    - name: Flush
+      description: Transmit FIFO controller logic is reset to its default values. Cleared automatically
+      value: 1
+enum/FUGF:
+  bit_size: 1
+  variants:
+    - name: Drop
+      description: Rx FIFO drops all frames of less than 64 bytes
+      value: 0
+    - name: Forward
+      description: Rx FIFO forwards undersized frames
+      value: 1
+enum/GU:
+  bit_size: 1
+  variants:
+    - name: Disabled
+      description: Normal operation
+      value: 0
+    - name: Enabled
+      description: Any unicast packet filtered by the MAC address recognition may be a wakeup frame
+      value: 1
+enum/HM:
+  bit_size: 1
+  variants:
+    - name: Perfect
+      description: MAC performs a perfect destination address filtering for multicast frames
+      value: 0
+    - name: Hash
+      description: MAC performs destination address filtering of received multicast frames according to the hash table
+      value: 1
+enum/HPF:
+  bit_size: 1
+  variants:
+    - name: HashOnly
+      description: "If HM or HU is set, only frames that match the Hash filter are passed"
+      value: 0
+    - name: HashOrPerfect
+      description: "If HM or HU is set, frames that match either the perfect filter or the hash filter are passed"
+      value: 1
+enum/HU:
+  bit_size: 1
+  variants:
+    - name: Perfect
+      description: MAC performs a perfect destination address filtering for unicast frames
+      value: 0
+    - name: Hash
+      description: MAC performs destination address filtering of received unicast frames according to the hash table
+      value: 1
+enum/IFG:
+  bit_size: 3
+  variants:
+    - name: IFG96
+      description: 96 bit times
+      value: 0
+    - name: IFG88
+      description: 88 bit times
+      value: 1
+    - name: IFG80
+      description: 80 bit times
+      value: 2
+    - name: IFG72
+      description: 72 bit times
+      value: 3
+    - name: IFG64
+      description: 64 bit times
+      value: 4
+    - name: IFG56
+      description: 56 bit times
+      value: 5
+    - name: IFG48
+      description: 48 bit times
+      value: 6
+    - name: IFG40
+      description: 40 bit times
+      value: 7
+enum/IPCO:
+  bit_size: 1
+  variants:
+    - name: Disabled
+      description: IPv4 checksum offload disabled
+      value: 0
+    - name: Offload
+      description: IPv4 checksums are checked in received frames
+      value: 1
+enum/JD:
+  bit_size: 1
+  variants:
+    - name: Enabled
+      description: "Jabber enabled, transmit frames up to 2048 bytes"
+      value: 0
+    - name: Disabled
+      description: "Jabber disabled, transmit frames up to 16384 bytes"
+      value: 1
+enum/LM:
+  bit_size: 1
+  variants:
+    - name: Normal
+      description: Normal mode
+      value: 0
+    - name: Loopback
+      description: MAC operates in loopback mode at the MII
+      value: 1
+enum/MACAHR_AE:
+  bit_size: 1
+  variants:
+    - name: Disabled
+      description: Address filters ignore this address
+      value: 0
+    - name: Enabled
+      description: Address filters use this address
+      value: 1
+enum/MACAHR_SA:
+  bit_size: 1
+  variants:
+    - name: Destination
+      description: This address is used for comparison with DA fields of the received frame
+      value: 0
+    - name: Source
+      description: This address is used for comparison with SA fields of received frames
+      value: 1
+enum/MB:
+  bit_size: 1
+  variants:
+    - name: Normal
+      description: Fixed burst transfers (INCRx and SINGLE) for burst lengths of 16 and below
+      value: 0
+    - name: Mixed
+      description: "If FB is low, start all bursts greater than 16 with INCR (undefined burst)"
+      value: 1
+enum/MB_progress:
+  bit_size: 1
+  variants:
+    - name: Busy
+      description: This bit is set to 1 by the application to indicate that a read or write access is in progress
+      value: 1
+enum/MCF:
+  bit_size: 1
+  variants:
+    - name: Unfrozen
+      description: All MMC counters update normally
+      value: 0
+    - name: Frozen
+      description: All MMC counters frozen to their current value
+      value: 1
+enum/MCFHP:
+  bit_size: 1
+  variants:
+    - name: AlmostHalf
+      description: "When MCP is set, MMC counters are preset to almost-half value 0x7FFF_FFF0"
+      value: 0
+    - name: AlmostFull
+      description: "When MCP is set, MMC counters are preset to almost-full value 0xFFFF_FFF0"
+      value: 1
+enum/MCP:
+  bit_size: 1
+  variants:
+    - name: Preset
+      description: MMC counters will be preset to almost full or almost half. Cleared automatically
+      value: 1
+enum/MPE:
+  bit_size: 1
+  variants:
+    - name: Disabled
+      description: No power management event generated due to Magic Packet reception
+      value: 0
+    - name: Enabled
+      description: Enable generation of a power management event due to Magic Packet reception
+      value: 1
+enum/MW:
+  bit_size: 1
+  variants:
+    - name: Read
+      description: Read operation
+      value: 0
+    - name: Write
+      description: Write operation
+      value: 1
+enum/PAM:
+  bit_size: 1
+  variants:
+    - name: Disabled
+      description: Filtering of multicast frames depends on HM
+      value: 0
+    - name: Enabled
+      description: All received frames with a multicast destination address are passed
+      value: 1
+enum/PBL:
+  bit_size: 6
+  variants:
+    - name: PBL1
+      description: Maximum of 1 beat per DMA transaction
+      value: 1
+    - name: PBL2
+      description: Maximum of 2 beats per DMA transaction
+      value: 2
+    - name: PBL4
+      description: Maximum of 4 beats per DMA transaction
+      value: 4
+    - name: PBL8
+      description: Maximum of 8 beats per DMA transaction
+      value: 8
+    - name: PBL16
+      description: Maximum of 16 beats per DMA transaction
+      value: 16
+    - name: PBL32
+      description: Maximum of 32 beats per DMA transaction
+      value: 32
+enum/PCF:
+  bit_size: 2
+  variants:
+    - name: PreventAll
+      description: MAC prevents all control frames from reaching the application
+      value: 0
+    - name: ForwardAllExceptPause
+      description: MAC forwards all control frames to application except Pause
+      value: 1
+    - name: ForwardAll
+      description: MAC forwards all control frames to application even if they fail the address filter
+      value: 2
+    - name: ForwardAllFiltered
+      description: MAC forwards control frames that pass the address filter
+      value: 3
+enum/PD:
+  bit_size: 1
+  variants:
+    - name: Enabled
+      description: All received frames will be dropped. Cleared automatically when a magic packet or wakeup frame is received
+      value: 1
+enum/PLT:
+  bit_size: 2
+  variants:
+    - name: PLT4
+      description: Pause time minus 4 slot times
+      value: 0
+    - name: PLT28
+      description: Pause time minus 28 slot times
+      value: 1
+    - name: PLT144
+      description: Pause time minus 144 slot times
+      value: 2
+    - name: PLT256
+      description: Pause time minus 256 slot times
+      value: 3
+enum/PM:
+  bit_size: 1
+  variants:
+    - name: Disabled
+      description: Normal address filtering
+      value: 0
+    - name: Enabled
+      description: Address filters pass all incoming frames regardless of their destination or source address
+      value: 1
+enum/PMTIM:
+  bit_size: 1
+  variants:
+    - name: Unmasked
+      description: PMT Status interrupt generation enabled
+      value: 0
+    - name: Masked
+      description: PMT Status interrupt generation disabled
+      value: 1
+enum/PriorityRxOverTx:
+  bit_size: 2
+  variants:
+    - name: OneToOne
+      description: "RxDMA priority over TxDMA is 1:1"
+      value: 0
+    - name: TwoToOne
+      description: "RxDMA priority over TxDMA is 2:1"
+      value: 1
+    - name: ThreeToOne
+      description: "RxDMA priority over TxDMA is 3:1"
+      value: 2
+    - name: FourToOne
+      description: "RxDMA priority over TxDMA is 4:1"
+      value: 3
+enum/RA:
+  bit_size: 1
+  variants:
+    - name: Disabled
+      description: MAC receiver passes on to the application only those frames that have passed the SA/DA address file
+      value: 0
+    - name: Enabled
+      description: MAC receiver passes oll received frames on to the application
+      value: 1
+enum/RD:
+  bit_size: 1
+  variants:
+    - name: Enabled
+      description: MAC attempts retries based on the settings of BL
+      value: 0
+    - name: Disabled
+      description: MAC attempts only 1 transmission
+      value: 1
+enum/RDP:
+  bit_size: 6
+  variants:
+    - name: RDP1
+      description: 1 beat per RxDMA transaction
+      value: 1
+    - name: RDP2
+      description: 2 beats per RxDMA transaction
+      value: 2
+    - name: RDP4
+      description: 4 beats per RxDMA transaction
+      value: 4
+    - name: RDP8
+      description: 8 beats per RxDMA transaction
+      value: 8
+    - name: RDP16
+      description: 16 beats per RxDMA transaction
+      value: 16
+    - name: RDP32
+      description: 32 beats per RxDMA transaction
+      value: 32
+enum/RE:
+  bit_size: 1
+  variants:
+    - name: Disabled
+      description: MAC receive state machine is disabled after the completion of the reception of the current frame
+      value: 0
+    - name: Enabled
+      description: MAC receive state machine is enabled
+      value: 1
+enum/RFAEM:
+  bit_size: 1
+  variants:
+    - name: Unmasked
+      description: Received-alignment-error counter half-full interrupt enabled
+      value: 0
+    - name: Masked
+      description: Received-alignment-error counter half-full interrupt disabled
+      value: 1
+enum/RFCE:
+  bit_size: 1
+  variants:
+    - name: Disabled
+      description: Pause frames are not decoded
+      value: 0
+    - name: Enabled
+      description: MAC decodes received Pause frames and disables its transmitted for a specified time
+      value: 1
+enum/RFCEM:
+  bit_size: 1
+  variants:
+    - name: Unmasked
+      description: Received-crc-error counter half-full interrupt enabled
+      value: 0
+    - name: Masked
+      description: Received-crc-error counter half-full interrupt disabled
+      value: 1
+enum/RGUFM:
+  bit_size: 1
+  variants:
+    - name: Unmasked
+      description: Received-good-unicast counter half-full interrupt enabled
+      value: 0
+    - name: Masked
+      description: Received-good-unicast counter half-full interrupt disabled
+      value: 1
+enum/ROD:
+  bit_size: 1
+  variants:
+    - name: Enabled
+      description: MAC receives all packets from PHY while transmitting
+      value: 0
+    - name: Disabled
+      description: MAC disables reception of frames in half-duplex mode
+      value: 1
+enum/ROR:
+  bit_size: 1
+  variants:
+    - name: Disabled
+      description: MMC counters do not reset on read
+      value: 0
+    - name: Enabled
+      description: MMC counters reset to zero after read
+      value: 1
+enum/RPD:
+  bit_size: 32
+  variants:
+    - name: Poll
+      description: Poll the receive descriptor list
+      value: 0
+enum/RPS:
+  bit_size: 3
+  variants:
+    - name: Stopped
+      description: "Stopped, reset or Stop Receive command issued"
+      value: 0
+    - name: RunningFetching
+      description: "Running, fetching receive transfer descriptor"
+      value: 1
+    - name: RunningWaiting
+      description: "Running, waiting for receive packet"
+      value: 3
+    - name: Suspended
+      description: "Suspended, receive descriptor unavailable"
+      value: 4
+    - name: RunningWriting
+      description: "Running, writing data to host memory buffer"
+      value: 7
+enum/RSF:
+  bit_size: 1
+  variants:
+    - name: CutThrough
+      description: "Rx FIFO operates in cut-through mode, subject to RTC bits"
+      value: 0
+    - name: StoreForward
+      description: Frames are read from Rx FIFO after complete frame has been written
+      value: 1
+enum/RTC:
+  bit_size: 2
+  variants:
+    - name: RTC64
+      description: 64 bytes
+      value: 0
+    - name: RTC32
+      description: 32 bytes
+      value: 1
+    - name: RTC96
+      description: 96 bytes
+      value: 2
+    - name: RTC128
+      description: 128 bytes
+      value: 3
+enum/SAF:
+  bit_size: 1
+  variants:
+    - name: Disabled
+      description: Source address ignored
+      value: 0
+    - name: Enabled
+      description: MAC drops frames that fail the source address filter
+      value: 1
+enum/SAIF:
+  bit_size: 1
+  variants:
+    - name: Normal
+      description: Source address filter operates normally
+      value: 0
+    - name: Invert
+      description: Source address filter operation inverted
+      value: 1
+enum/ST:
+  bit_size: 1
+  variants:
+    - name: Stopped
+      description: Transmission is placed in the Stopped state
+      value: 0
+    - name: Started
+      description: Transmission is placed in Running state
+      value: 1
+enum/TE:
+  bit_size: 1
+  variants:
+    - name: Disabled
+      description: MAC transmit state machine is disabled after completion of the transmission of the current frame
+      value: 0
+    - name: Enabled
+      description: MAC transmit state machine is enabled
+      value: 1
+enum/TFCE:
+  bit_size: 1
+  variants:
+    - name: Disabled
+      description: "In full duplex, flow control is disabled. In half duplex, back pressure is disabled"
+      value: 0
+    - name: Enabled
+      description: "In full duplex, flow control is enabled. In half duplex, back pressure is enabled"
+      value: 1
+enum/TGFM:
+  bit_size: 1
+  variants:
+    - name: Unmasked
+      description: Transmitted-good counter half-full interrupt enabled
+      value: 0
+    - name: Masked
+      description: Transmitted-good counter half-full interrupt disabled
+      value: 1
+enum/TGFMSCM:
+  bit_size: 1
+  variants:
+    - name: Unmasked
+      description: Transmitted-good-multiple-collision half-full interrupt enabled
+      value: 0
+    - name: Masked
+      description: Transmitted-good-multiple-collision half-full interrupt disabled
+      value: 1
+enum/TGFSCM:
+  bit_size: 1
+  variants:
+    - name: Unmasked
+      description: Transmitted-good-single-collision half-full interrupt enabled
+      value: 0
+    - name: Masked
+      description: Transmitted-good-single-collision half-full interrupt disabled
+      value: 1
+enum/TPD:
+  bit_size: 32
+  variants:
+    - name: Poll
+      description: Poll the transmit descriptor list
+      value: 0
+enum/TPS:
+  bit_size: 3
+  variants:
+    - name: Stopped
+      description: "Stopped, Reset or Stop Transmit command issued"
+      value: 0
+    - name: RunningFetching
+      description: "Running, fetching transmit transfer descriptor"
+      value: 1
+    - name: RunningWaiting
+      description: "Running, waiting for status"
+      value: 2
+    - name: RunningReading
+      description: "Running, reading data from host memory buffer"
+      value: 3
+    - name: Suspended
+      description: "Suspended, transmit descriptor unavailable or transmit buffer underflow"
+      value: 6
+    - name: Running
+      description: "Running, closing transmit descriptor"
+      value: 7
+enum/TSF:
+  bit_size: 1
+  variants:
+    - name: CutThrough
+      description: Transmission starts when the frame size in the Tx FIFO exceeds TTC threshold
+      value: 0
+    - name: StoreForward
+      description: Transmission starts when a full frame is in the Tx FIFO
+      value: 1
+enum/TSTIM:
+  bit_size: 1
+  variants:
+    - name: Unmasked
+      description: Time stamp interrupt generation enabled
+      value: 0
+    - name: Masked
+      description: Time stamp interrupt generation disabled
+      value: 1
+enum/TTC:
+  bit_size: 3
+  variants:
+    - name: TTC64
+      description: 64 bytes
+      value: 0
+    - name: TTC128
+      description: 128 bytes
+      value: 1
+    - name: TTC192
+      description: 192 bytes
+      value: 2
+    - name: TTC256
+      description: 256 bytes
+      value: 3
+    - name: TTC40
+      description: 40 bytes
+      value: 4
+    - name: TTC32
+      description: 32 bytes
+      value: 5
+    - name: TTC24
+      description: 24 bytes
+      value: 6
+    - name: TTC16
+      description: 16 bytes
+      value: 7
+enum/UPFD:
+  bit_size: 1
+  variants:
+    - name: Disabled
+      description: MAC detects only a Pause frame with the multicast address specified in the 802.3x standard
+      value: 0
+    - name: Enabled
+      description: "MAC additionally detects Pause frames with the station's unicast address"
+      value: 1
+enum/USP:
+  bit_size: 1
+  variants:
+    - name: Combined
+      description: PBL value used for both Rx and Tx DMA
+      value: 0
+    - name: Separate
+      description: "RxDMA uses RDP value, TxDMA uses PBL value"
+      value: 1
+enum/VLANTC:
+  bit_size: 1
+  variants:
+    - name: VLANTC16
+      description: Full 16 bit VLAN identifiers are used for comparison and filtering
+      value: 0
+    - name: VLANTC12
+      description: 12 bit VLAN identifies are used for comparison and filtering
+      value: 1
+enum/WD:
+  bit_size: 1
+  variants:
+    - name: Enabled
+      description: "Watchdog enabled, receive frames limited to 2048 bytes"
+      value: 0
+    - name: Disabled
+      description: "Watchdog disabled, receive frames may be up to to 16384 bytes"
+      value: 1
+enum/WFE:
+  bit_size: 1
+  variants:
+    - name: Disabled
+      description: No power management event generated due to wakeup frame reception
+      value: 0
+    - name: Enabled
+      description: Enable generation of a power management event due to wakeup frame reception
+      value: 1
+enum/WFFRPR:
+  bit_size: 1
+  variants:
+    - name: Reset
+      description: Reset wakeup frame filter register point to 0b000. Automatically cleared
+      value: 1
+enum/ZQPD:
+  bit_size: 1
+  variants:
+    - name: Enabled
+      description: Normal operation with automatic zero-quanta pause control frame generation
+      value: 0
+    - name: Disabled
+      description: Automatic generation of zero-quanta pause control frames is disabled
+      value: 1

--- a/data/registers/rcc_f1cl.yaml
+++ b/data/registers/rcc_f1cl.yaml
@@ -525,7 +525,7 @@ fieldset/BDCR:
       bit_offset: 16
       bit_size: 1
 fieldset/CFGR:
-  description: Clock configuration register (RCC_CFGR)
+  description: Clock configuration register (RCC_3FGR)
   fields:
     - name: SW
       description: System clock Switch
@@ -585,7 +585,7 @@ fieldset/CFGR:
     - name: MCO
       description: Microcontroller clock output
       bit_offset: 24
-      bit_size: 3
+      bit_size: 4
       enum: MCO
 fieldset/CFGR2:
   description: Clock configuration register2 (RCC_CFGR2)
@@ -873,7 +873,7 @@ enum/I2S2SRC:
       description: PLL3 VCO clock selected as I2S clock entry
       value: 1
 enum/MCO:
-  bit_size: 3
+  bit_size: 4
   variants:
     - name: NoMCO
       description: "MCO output disabled, no clock on MCO"
@@ -890,6 +890,18 @@ enum/MCO:
     - name: PLL
       description: "PLL clock divided by 2 selected"
       value: 7
+    - name: PLL2
+      description: "PLL2 clock selected"
+      value: 8
+    - name: PLL3DIV2
+      description: "PLL3 clock divided by 2 selected"
+      value: 9
+    - name: XT1
+      description: "XT1 external oscillator selected"
+      value: 10
+    - name: PLL3
+      description: "PLL3 clock selected"
+      value: 11
 enum/OTGFSPRE:
   bit_size: 1
   variants:

--- a/stm32data/__main__.py
+++ b/stm32data/__main__.py
@@ -230,6 +230,7 @@ perimap = [
     ('STM32U5.*:FLASH:.*', ('flash', 'u5', 'FLASH')),
     ('STM32WB.*:FLASH:.*', ('flash', 'wb55', 'FLASH')),
     ('STM32G0.*:FLASH:.*', ('flash', 'g0', 'FLASH')),
+    ('STM32F107.*:ETH:.*', ('eth', 'v1a', 'ETH')),
     ('STM32F7.*:ETH:ETH:ethermac110_v2_0', ('eth', 'v1c', 'ETH')),
     ('.*ETH:ethermac110_v3_0', ('eth', 'v2', 'ETH')),
 

--- a/stm32data/__main__.py
+++ b/stm32data/__main__.py
@@ -232,6 +232,7 @@ perimap = [
     ('STM32WB.*:FLASH:.*', ('flash', 'wb55', 'FLASH')),
     ('STM32G0.*:FLASH:.*', ('flash', 'g0', 'FLASH')),
     ('STM32F107.*:ETH:.*', ('eth', 'v1a', 'ETH')),
+    ('STM32F[24].*:ETH:.*', ('eth', 'v1b', 'ETH')),
     ('STM32F7.*:ETH:ETH:ethermac110_v2_0', ('eth', 'v1c', 'ETH')),
     ('.*ETH:ethermac110_v3_0', ('eth', 'v2', 'ETH')),
 

--- a/stm32data/__main__.py
+++ b/stm32data/__main__.py
@@ -168,7 +168,8 @@ perimap = [
     ('.*:USB_OTG_HS:otghs1_v1_.*', ('otghs', 'v1', 'OTG_HS')),
 
     ('STM32F0.*:RCC:.*', ('rcc', 'f0', 'RCC')),
-    ('STM32F1.*:RCC:.*', ('rcc', 'f1', 'RCC')),
+    ('STM32F10[0123].*:RCC:.*', ('rcc', 'f1', 'RCC')),
+    ('STM32F10[57].*:RCC:.*', ('rcc', 'f1cl', 'RCC')),
     ('STM32F2.*:RCC:.*', ('rcc', 'f2', 'RCC')),
     ('STM32F3.*:RCC:.*', ('rcc', 'f3', 'RCC')),
     ('STM32F410.*:RCC:.*', ('rcc', 'f410', 'RCC')),


### PR DESCRIPTION
I pulled out what wasn't used in these two according to `stm32-rs`, haven't verified against the datasheets, but drivers relying on them aren't using any of the registers with differences and so should work for all versions.