### PR TITLE
Add SPI for F2 devices (spi2s1_v2_1)

### DIFF
--- a/data/chips/STM32F205RB.json
+++ b/data/chips/STM32F205RB.json
@@ -1575,6 +1575,11 @@
                 {
                     "name": "SPI1",
                     "address": 1073819648,
+                    "registers": {
+                        "kind": "spi",
+                        "version": "v1",
+                        "block": "SPI"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {
@@ -1660,6 +1665,11 @@
                 {
                     "name": "SPI2",
                     "address": 1073756160,
+                    "registers": {
+                        "kind": "spi",
+                        "version": "v1",
+                        "block": "SPI"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {
@@ -1735,6 +1745,11 @@
                 {
                     "name": "SPI3",
                     "address": 1073757184,
+                    "registers": {
+                        "kind": "spi",
+                        "version": "v1",
+                        "block": "SPI"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {

--- a/data/chips/STM32F205RC.json
+++ b/data/chips/STM32F205RC.json
@@ -1575,6 +1575,11 @@
                 {
                     "name": "SPI1",
                     "address": 1073819648,
+                    "registers": {
+                        "kind": "spi",
+                        "version": "v1",
+                        "block": "SPI"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {
@@ -1660,6 +1665,11 @@
                 {
                     "name": "SPI2",
                     "address": 1073756160,
+                    "registers": {
+                        "kind": "spi",
+                        "version": "v1",
+                        "block": "SPI"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {
@@ -1735,6 +1745,11 @@
                 {
                     "name": "SPI3",
                     "address": 1073757184,
+                    "registers": {
+                        "kind": "spi",
+                        "version": "v1",
+                        "block": "SPI"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {

--- a/data/chips/STM32F205RE.json
+++ b/data/chips/STM32F205RE.json
@@ -1579,6 +1579,11 @@
                 {
                     "name": "SPI1",
                     "address": 1073819648,
+                    "registers": {
+                        "kind": "spi",
+                        "version": "v1",
+                        "block": "SPI"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {
@@ -1664,6 +1669,11 @@
                 {
                     "name": "SPI2",
                     "address": 1073756160,
+                    "registers": {
+                        "kind": "spi",
+                        "version": "v1",
+                        "block": "SPI"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {
@@ -1739,6 +1749,11 @@
                 {
                     "name": "SPI3",
                     "address": 1073757184,
+                    "registers": {
+                        "kind": "spi",
+                        "version": "v1",
+                        "block": "SPI"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {

--- a/data/chips/STM32F205RF.json
+++ b/data/chips/STM32F205RF.json
@@ -1575,6 +1575,11 @@
                 {
                     "name": "SPI1",
                     "address": 1073819648,
+                    "registers": {
+                        "kind": "spi",
+                        "version": "v1",
+                        "block": "SPI"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {
@@ -1660,6 +1665,11 @@
                 {
                     "name": "SPI2",
                     "address": 1073756160,
+                    "registers": {
+                        "kind": "spi",
+                        "version": "v1",
+                        "block": "SPI"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {
@@ -1735,6 +1745,11 @@
                 {
                     "name": "SPI3",
                     "address": 1073757184,
+                    "registers": {
+                        "kind": "spi",
+                        "version": "v1",
+                        "block": "SPI"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {

--- a/data/chips/STM32F205RG.json
+++ b/data/chips/STM32F205RG.json
@@ -1583,6 +1583,11 @@
                 {
                     "name": "SPI1",
                     "address": 1073819648,
+                    "registers": {
+                        "kind": "spi",
+                        "version": "v1",
+                        "block": "SPI"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {
@@ -1668,6 +1673,11 @@
                 {
                     "name": "SPI2",
                     "address": 1073756160,
+                    "registers": {
+                        "kind": "spi",
+                        "version": "v1",
+                        "block": "SPI"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {
@@ -1743,6 +1753,11 @@
                 {
                     "name": "SPI3",
                     "address": 1073757184,
+                    "registers": {
+                        "kind": "spi",
+                        "version": "v1",
+                        "block": "SPI"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {

--- a/data/chips/STM32F205VB.json
+++ b/data/chips/STM32F205VB.json
@@ -1868,6 +1868,11 @@
                 {
                     "name": "SPI1",
                     "address": 1073819648,
+                    "registers": {
+                        "kind": "spi",
+                        "version": "v1",
+                        "block": "SPI"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {
@@ -1953,6 +1958,11 @@
                 {
                     "name": "SPI2",
                     "address": 1073756160,
+                    "registers": {
+                        "kind": "spi",
+                        "version": "v1",
+                        "block": "SPI"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {
@@ -2028,6 +2038,11 @@
                 {
                     "name": "SPI3",
                     "address": 1073757184,
+                    "registers": {
+                        "kind": "spi",
+                        "version": "v1",
+                        "block": "SPI"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {

--- a/data/chips/STM32F205VC.json
+++ b/data/chips/STM32F205VC.json
@@ -1868,6 +1868,11 @@
                 {
                     "name": "SPI1",
                     "address": 1073819648,
+                    "registers": {
+                        "kind": "spi",
+                        "version": "v1",
+                        "block": "SPI"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {
@@ -1953,6 +1958,11 @@
                 {
                     "name": "SPI2",
                     "address": 1073756160,
+                    "registers": {
+                        "kind": "spi",
+                        "version": "v1",
+                        "block": "SPI"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {
@@ -2028,6 +2038,11 @@
                 {
                     "name": "SPI3",
                     "address": 1073757184,
+                    "registers": {
+                        "kind": "spi",
+                        "version": "v1",
+                        "block": "SPI"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {

--- a/data/chips/STM32F205VE.json
+++ b/data/chips/STM32F205VE.json
@@ -1868,6 +1868,11 @@
                 {
                     "name": "SPI1",
                     "address": 1073819648,
+                    "registers": {
+                        "kind": "spi",
+                        "version": "v1",
+                        "block": "SPI"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {
@@ -1953,6 +1958,11 @@
                 {
                     "name": "SPI2",
                     "address": 1073756160,
+                    "registers": {
+                        "kind": "spi",
+                        "version": "v1",
+                        "block": "SPI"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {
@@ -2028,6 +2038,11 @@
                 {
                     "name": "SPI3",
                     "address": 1073757184,
+                    "registers": {
+                        "kind": "spi",
+                        "version": "v1",
+                        "block": "SPI"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {

--- a/data/chips/STM32F205VF.json
+++ b/data/chips/STM32F205VF.json
@@ -1868,6 +1868,11 @@
                 {
                     "name": "SPI1",
                     "address": 1073819648,
+                    "registers": {
+                        "kind": "spi",
+                        "version": "v1",
+                        "block": "SPI"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {
@@ -1953,6 +1958,11 @@
                 {
                     "name": "SPI2",
                     "address": 1073756160,
+                    "registers": {
+                        "kind": "spi",
+                        "version": "v1",
+                        "block": "SPI"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {
@@ -2028,6 +2038,11 @@
                 {
                     "name": "SPI3",
                     "address": 1073757184,
+                    "registers": {
+                        "kind": "spi",
+                        "version": "v1",
+                        "block": "SPI"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {

--- a/data/chips/STM32F205VG.json
+++ b/data/chips/STM32F205VG.json
@@ -1868,6 +1868,11 @@
                 {
                     "name": "SPI1",
                     "address": 1073819648,
+                    "registers": {
+                        "kind": "spi",
+                        "version": "v1",
+                        "block": "SPI"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {
@@ -1953,6 +1958,11 @@
                 {
                     "name": "SPI2",
                     "address": 1073756160,
+                    "registers": {
+                        "kind": "spi",
+                        "version": "v1",
+                        "block": "SPI"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {
@@ -2028,6 +2038,11 @@
                 {
                     "name": "SPI3",
                     "address": 1073757184,
+                    "registers": {
+                        "kind": "spi",
+                        "version": "v1",
+                        "block": "SPI"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {

--- a/data/chips/STM32F205ZC.json
+++ b/data/chips/STM32F205ZC.json
@@ -2070,6 +2070,11 @@
                 {
                     "name": "SPI1",
                     "address": 1073819648,
+                    "registers": {
+                        "kind": "spi",
+                        "version": "v1",
+                        "block": "SPI"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {
@@ -2155,6 +2160,11 @@
                 {
                     "name": "SPI2",
                     "address": 1073756160,
+                    "registers": {
+                        "kind": "spi",
+                        "version": "v1",
+                        "block": "SPI"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {
@@ -2230,6 +2240,11 @@
                 {
                     "name": "SPI3",
                     "address": 1073757184,
+                    "registers": {
+                        "kind": "spi",
+                        "version": "v1",
+                        "block": "SPI"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {

--- a/data/chips/STM32F205ZE.json
+++ b/data/chips/STM32F205ZE.json
@@ -2070,6 +2070,11 @@
                 {
                     "name": "SPI1",
                     "address": 1073819648,
+                    "registers": {
+                        "kind": "spi",
+                        "version": "v1",
+                        "block": "SPI"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {
@@ -2155,6 +2160,11 @@
                 {
                     "name": "SPI2",
                     "address": 1073756160,
+                    "registers": {
+                        "kind": "spi",
+                        "version": "v1",
+                        "block": "SPI"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {
@@ -2230,6 +2240,11 @@
                 {
                     "name": "SPI3",
                     "address": 1073757184,
+                    "registers": {
+                        "kind": "spi",
+                        "version": "v1",
+                        "block": "SPI"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {

--- a/data/chips/STM32F205ZF.json
+++ b/data/chips/STM32F205ZF.json
@@ -2070,6 +2070,11 @@
                 {
                     "name": "SPI1",
                     "address": 1073819648,
+                    "registers": {
+                        "kind": "spi",
+                        "version": "v1",
+                        "block": "SPI"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {
@@ -2155,6 +2160,11 @@
                 {
                     "name": "SPI2",
                     "address": 1073756160,
+                    "registers": {
+                        "kind": "spi",
+                        "version": "v1",
+                        "block": "SPI"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {
@@ -2230,6 +2240,11 @@
                 {
                     "name": "SPI3",
                     "address": 1073757184,
+                    "registers": {
+                        "kind": "spi",
+                        "version": "v1",
+                        "block": "SPI"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {

--- a/data/chips/STM32F205ZG.json
+++ b/data/chips/STM32F205ZG.json
@@ -2070,6 +2070,11 @@
                 {
                     "name": "SPI1",
                     "address": 1073819648,
+                    "registers": {
+                        "kind": "spi",
+                        "version": "v1",
+                        "block": "SPI"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {
@@ -2155,6 +2160,11 @@
                 {
                     "name": "SPI2",
                     "address": 1073756160,
+                    "registers": {
+                        "kind": "spi",
+                        "version": "v1",
+                        "block": "SPI"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {
@@ -2230,6 +2240,11 @@
                 {
                     "name": "SPI3",
                     "address": 1073757184,
+                    "registers": {
+                        "kind": "spi",
+                        "version": "v1",
+                        "block": "SPI"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {

--- a/data/chips/STM32F207IC.json
+++ b/data/chips/STM32F207IC.json
@@ -2529,6 +2529,11 @@
                 {
                     "name": "SPI1",
                     "address": 1073819648,
+                    "registers": {
+                        "kind": "spi",
+                        "version": "v1",
+                        "block": "SPI"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {
@@ -2614,6 +2619,11 @@
                 {
                     "name": "SPI2",
                     "address": 1073756160,
+                    "registers": {
+                        "kind": "spi",
+                        "version": "v1",
+                        "block": "SPI"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {
@@ -2709,6 +2719,11 @@
                 {
                     "name": "SPI3",
                     "address": 1073757184,
+                    "registers": {
+                        "kind": "spi",
+                        "version": "v1",
+                        "block": "SPI"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {

--- a/data/chips/STM32F207IE.json
+++ b/data/chips/STM32F207IE.json
@@ -2529,6 +2529,11 @@
                 {
                     "name": "SPI1",
                     "address": 1073819648,
+                    "registers": {
+                        "kind": "spi",
+                        "version": "v1",
+                        "block": "SPI"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {
@@ -2614,6 +2619,11 @@
                 {
                     "name": "SPI2",
                     "address": 1073756160,
+                    "registers": {
+                        "kind": "spi",
+                        "version": "v1",
+                        "block": "SPI"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {
@@ -2709,6 +2719,11 @@
                 {
                     "name": "SPI3",
                     "address": 1073757184,
+                    "registers": {
+                        "kind": "spi",
+                        "version": "v1",
+                        "block": "SPI"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {

--- a/data/chips/STM32F207IF.json
+++ b/data/chips/STM32F207IF.json
@@ -2529,6 +2529,11 @@
                 {
                     "name": "SPI1",
                     "address": 1073819648,
+                    "registers": {
+                        "kind": "spi",
+                        "version": "v1",
+                        "block": "SPI"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {
@@ -2614,6 +2619,11 @@
                 {
                     "name": "SPI2",
                     "address": 1073756160,
+                    "registers": {
+                        "kind": "spi",
+                        "version": "v1",
+                        "block": "SPI"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {
@@ -2709,6 +2719,11 @@
                 {
                     "name": "SPI3",
                     "address": 1073757184,
+                    "registers": {
+                        "kind": "spi",
+                        "version": "v1",
+                        "block": "SPI"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {

--- a/data/chips/STM32F207IG.json
+++ b/data/chips/STM32F207IG.json
@@ -2529,6 +2529,11 @@
                 {
                     "name": "SPI1",
                     "address": 1073819648,
+                    "registers": {
+                        "kind": "spi",
+                        "version": "v1",
+                        "block": "SPI"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {
@@ -2614,6 +2619,11 @@
                 {
                     "name": "SPI2",
                     "address": 1073756160,
+                    "registers": {
+                        "kind": "spi",
+                        "version": "v1",
+                        "block": "SPI"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {
@@ -2709,6 +2719,11 @@
                 {
                     "name": "SPI3",
                     "address": 1073757184,
+                    "registers": {
+                        "kind": "spi",
+                        "version": "v1",
+                        "block": "SPI"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {

--- a/data/chips/STM32F207VC.json
+++ b/data/chips/STM32F207VC.json
@@ -2148,6 +2148,11 @@
                 {
                     "name": "SPI1",
                     "address": 1073819648,
+                    "registers": {
+                        "kind": "spi",
+                        "version": "v1",
+                        "block": "SPI"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {
@@ -2233,6 +2238,11 @@
                 {
                     "name": "SPI2",
                     "address": 1073756160,
+                    "registers": {
+                        "kind": "spi",
+                        "version": "v1",
+                        "block": "SPI"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {
@@ -2308,6 +2318,11 @@
                 {
                     "name": "SPI3",
                     "address": 1073757184,
+                    "registers": {
+                        "kind": "spi",
+                        "version": "v1",
+                        "block": "SPI"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {

--- a/data/chips/STM32F207VE.json
+++ b/data/chips/STM32F207VE.json
@@ -2148,6 +2148,11 @@
                 {
                     "name": "SPI1",
                     "address": 1073819648,
+                    "registers": {
+                        "kind": "spi",
+                        "version": "v1",
+                        "block": "SPI"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {
@@ -2233,6 +2238,11 @@
                 {
                     "name": "SPI2",
                     "address": 1073756160,
+                    "registers": {
+                        "kind": "spi",
+                        "version": "v1",
+                        "block": "SPI"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {
@@ -2308,6 +2318,11 @@
                 {
                     "name": "SPI3",
                     "address": 1073757184,
+                    "registers": {
+                        "kind": "spi",
+                        "version": "v1",
+                        "block": "SPI"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {

--- a/data/chips/STM32F207VF.json
+++ b/data/chips/STM32F207VF.json
@@ -2148,6 +2148,11 @@
                 {
                     "name": "SPI1",
                     "address": 1073819648,
+                    "registers": {
+                        "kind": "spi",
+                        "version": "v1",
+                        "block": "SPI"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {
@@ -2233,6 +2238,11 @@
                 {
                     "name": "SPI2",
                     "address": 1073756160,
+                    "registers": {
+                        "kind": "spi",
+                        "version": "v1",
+                        "block": "SPI"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {
@@ -2308,6 +2318,11 @@
                 {
                     "name": "SPI3",
                     "address": 1073757184,
+                    "registers": {
+                        "kind": "spi",
+                        "version": "v1",
+                        "block": "SPI"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {

--- a/data/chips/STM32F207VG.json
+++ b/data/chips/STM32F207VG.json
@@ -2148,6 +2148,11 @@
                 {
                     "name": "SPI1",
                     "address": 1073819648,
+                    "registers": {
+                        "kind": "spi",
+                        "version": "v1",
+                        "block": "SPI"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {
@@ -2233,6 +2238,11 @@
                 {
                     "name": "SPI2",
                     "address": 1073756160,
+                    "registers": {
+                        "kind": "spi",
+                        "version": "v1",
+                        "block": "SPI"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {
@@ -2308,6 +2318,11 @@
                 {
                     "name": "SPI3",
                     "address": 1073757184,
+                    "registers": {
+                        "kind": "spi",
+                        "version": "v1",
+                        "block": "SPI"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {

--- a/data/chips/STM32F207ZC.json
+++ b/data/chips/STM32F207ZC.json
@@ -2380,6 +2380,11 @@
                 {
                     "name": "SPI1",
                     "address": 1073819648,
+                    "registers": {
+                        "kind": "spi",
+                        "version": "v1",
+                        "block": "SPI"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {
@@ -2465,6 +2470,11 @@
                 {
                     "name": "SPI2",
                     "address": 1073756160,
+                    "registers": {
+                        "kind": "spi",
+                        "version": "v1",
+                        "block": "SPI"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {
@@ -2540,6 +2550,11 @@
                 {
                     "name": "SPI3",
                     "address": 1073757184,
+                    "registers": {
+                        "kind": "spi",
+                        "version": "v1",
+                        "block": "SPI"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {

--- a/data/chips/STM32F207ZE.json
+++ b/data/chips/STM32F207ZE.json
@@ -2380,6 +2380,11 @@
                 {
                     "name": "SPI1",
                     "address": 1073819648,
+                    "registers": {
+                        "kind": "spi",
+                        "version": "v1",
+                        "block": "SPI"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {
@@ -2465,6 +2470,11 @@
                 {
                     "name": "SPI2",
                     "address": 1073756160,
+                    "registers": {
+                        "kind": "spi",
+                        "version": "v1",
+                        "block": "SPI"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {
@@ -2540,6 +2550,11 @@
                 {
                     "name": "SPI3",
                     "address": 1073757184,
+                    "registers": {
+                        "kind": "spi",
+                        "version": "v1",
+                        "block": "SPI"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {

--- a/data/chips/STM32F207ZF.json
+++ b/data/chips/STM32F207ZF.json
@@ -2380,6 +2380,11 @@
                 {
                     "name": "SPI1",
                     "address": 1073819648,
+                    "registers": {
+                        "kind": "spi",
+                        "version": "v1",
+                        "block": "SPI"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {
@@ -2465,6 +2470,11 @@
                 {
                     "name": "SPI2",
                     "address": 1073756160,
+                    "registers": {
+                        "kind": "spi",
+                        "version": "v1",
+                        "block": "SPI"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {
@@ -2540,6 +2550,11 @@
                 {
                     "name": "SPI3",
                     "address": 1073757184,
+                    "registers": {
+                        "kind": "spi",
+                        "version": "v1",
+                        "block": "SPI"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {

--- a/data/chips/STM32F207ZG.json
+++ b/data/chips/STM32F207ZG.json
@@ -2380,6 +2380,11 @@
                 {
                     "name": "SPI1",
                     "address": 1073819648,
+                    "registers": {
+                        "kind": "spi",
+                        "version": "v1",
+                        "block": "SPI"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {
@@ -2465,6 +2470,11 @@
                 {
                     "name": "SPI2",
                     "address": 1073756160,
+                    "registers": {
+                        "kind": "spi",
+                        "version": "v1",
+                        "block": "SPI"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {
@@ -2540,6 +2550,11 @@
                 {
                     "name": "SPI3",
                     "address": 1073757184,
+                    "registers": {
+                        "kind": "spi",
+                        "version": "v1",
+                        "block": "SPI"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {

--- a/data/chips/STM32F215RE.json
+++ b/data/chips/STM32F215RE.json
@@ -1637,6 +1637,11 @@
                 {
                     "name": "SPI1",
                     "address": 1073819648,
+                    "registers": {
+                        "kind": "spi",
+                        "version": "v1",
+                        "block": "SPI"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {
@@ -1722,6 +1727,11 @@
                 {
                     "name": "SPI2",
                     "address": 1073756160,
+                    "registers": {
+                        "kind": "spi",
+                        "version": "v1",
+                        "block": "SPI"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {
@@ -1797,6 +1807,11 @@
                 {
                     "name": "SPI3",
                     "address": 1073757184,
+                    "registers": {
+                        "kind": "spi",
+                        "version": "v1",
+                        "block": "SPI"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {

--- a/data/chips/STM32F215RG.json
+++ b/data/chips/STM32F215RG.json
@@ -1637,6 +1637,11 @@
                 {
                     "name": "SPI1",
                     "address": 1073819648,
+                    "registers": {
+                        "kind": "spi",
+                        "version": "v1",
+                        "block": "SPI"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {
@@ -1722,6 +1727,11 @@
                 {
                     "name": "SPI2",
                     "address": 1073756160,
+                    "registers": {
+                        "kind": "spi",
+                        "version": "v1",
+                        "block": "SPI"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {
@@ -1797,6 +1807,11 @@
                 {
                     "name": "SPI3",
                     "address": 1073757184,
+                    "registers": {
+                        "kind": "spi",
+                        "version": "v1",
+                        "block": "SPI"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {

--- a/data/chips/STM32F215VE.json
+++ b/data/chips/STM32F215VE.json
@@ -1930,6 +1930,11 @@
                 {
                     "name": "SPI1",
                     "address": 1073819648,
+                    "registers": {
+                        "kind": "spi",
+                        "version": "v1",
+                        "block": "SPI"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {
@@ -2015,6 +2020,11 @@
                 {
                     "name": "SPI2",
                     "address": 1073756160,
+                    "registers": {
+                        "kind": "spi",
+                        "version": "v1",
+                        "block": "SPI"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {
@@ -2090,6 +2100,11 @@
                 {
                     "name": "SPI3",
                     "address": 1073757184,
+                    "registers": {
+                        "kind": "spi",
+                        "version": "v1",
+                        "block": "SPI"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {

--- a/data/chips/STM32F215VG.json
+++ b/data/chips/STM32F215VG.json
@@ -1930,6 +1930,11 @@
                 {
                     "name": "SPI1",
                     "address": 1073819648,
+                    "registers": {
+                        "kind": "spi",
+                        "version": "v1",
+                        "block": "SPI"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {
@@ -2015,6 +2020,11 @@
                 {
                     "name": "SPI2",
                     "address": 1073756160,
+                    "registers": {
+                        "kind": "spi",
+                        "version": "v1",
+                        "block": "SPI"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {
@@ -2090,6 +2100,11 @@
                 {
                     "name": "SPI3",
                     "address": 1073757184,
+                    "registers": {
+                        "kind": "spi",
+                        "version": "v1",
+                        "block": "SPI"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {

--- a/data/chips/STM32F215ZE.json
+++ b/data/chips/STM32F215ZE.json
@@ -2132,6 +2132,11 @@
                 {
                     "name": "SPI1",
                     "address": 1073819648,
+                    "registers": {
+                        "kind": "spi",
+                        "version": "v1",
+                        "block": "SPI"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {
@@ -2217,6 +2222,11 @@
                 {
                     "name": "SPI2",
                     "address": 1073756160,
+                    "registers": {
+                        "kind": "spi",
+                        "version": "v1",
+                        "block": "SPI"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {
@@ -2292,6 +2302,11 @@
                 {
                     "name": "SPI3",
                     "address": 1073757184,
+                    "registers": {
+                        "kind": "spi",
+                        "version": "v1",
+                        "block": "SPI"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {

--- a/data/chips/STM32F215ZG.json
+++ b/data/chips/STM32F215ZG.json
@@ -2132,6 +2132,11 @@
                 {
                     "name": "SPI1",
                     "address": 1073819648,
+                    "registers": {
+                        "kind": "spi",
+                        "version": "v1",
+                        "block": "SPI"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {
@@ -2217,6 +2222,11 @@
                 {
                     "name": "SPI2",
                     "address": 1073756160,
+                    "registers": {
+                        "kind": "spi",
+                        "version": "v1",
+                        "block": "SPI"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {
@@ -2292,6 +2302,11 @@
                 {
                     "name": "SPI3",
                     "address": 1073757184,
+                    "registers": {
+                        "kind": "spi",
+                        "version": "v1",
+                        "block": "SPI"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {

--- a/data/chips/STM32F217IE.json
+++ b/data/chips/STM32F217IE.json
@@ -2591,6 +2591,11 @@
                 {
                     "name": "SPI1",
                     "address": 1073819648,
+                    "registers": {
+                        "kind": "spi",
+                        "version": "v1",
+                        "block": "SPI"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {
@@ -2676,6 +2681,11 @@
                 {
                     "name": "SPI2",
                     "address": 1073756160,
+                    "registers": {
+                        "kind": "spi",
+                        "version": "v1",
+                        "block": "SPI"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {
@@ -2771,6 +2781,11 @@
                 {
                     "name": "SPI3",
                     "address": 1073757184,
+                    "registers": {
+                        "kind": "spi",
+                        "version": "v1",
+                        "block": "SPI"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {

--- a/data/chips/STM32F217IG.json
+++ b/data/chips/STM32F217IG.json
@@ -2591,6 +2591,11 @@
                 {
                     "name": "SPI1",
                     "address": 1073819648,
+                    "registers": {
+                        "kind": "spi",
+                        "version": "v1",
+                        "block": "SPI"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {
@@ -2676,6 +2681,11 @@
                 {
                     "name": "SPI2",
                     "address": 1073756160,
+                    "registers": {
+                        "kind": "spi",
+                        "version": "v1",
+                        "block": "SPI"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {
@@ -2771,6 +2781,11 @@
                 {
                     "name": "SPI3",
                     "address": 1073757184,
+                    "registers": {
+                        "kind": "spi",
+                        "version": "v1",
+                        "block": "SPI"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {

--- a/data/chips/STM32F217VE.json
+++ b/data/chips/STM32F217VE.json
@@ -2210,6 +2210,11 @@
                 {
                     "name": "SPI1",
                     "address": 1073819648,
+                    "registers": {
+                        "kind": "spi",
+                        "version": "v1",
+                        "block": "SPI"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {
@@ -2295,6 +2300,11 @@
                 {
                     "name": "SPI2",
                     "address": 1073756160,
+                    "registers": {
+                        "kind": "spi",
+                        "version": "v1",
+                        "block": "SPI"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {
@@ -2370,6 +2380,11 @@
                 {
                     "name": "SPI3",
                     "address": 1073757184,
+                    "registers": {
+                        "kind": "spi",
+                        "version": "v1",
+                        "block": "SPI"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {

--- a/data/chips/STM32F217VG.json
+++ b/data/chips/STM32F217VG.json
@@ -2210,6 +2210,11 @@
                 {
                     "name": "SPI1",
                     "address": 1073819648,
+                    "registers": {
+                        "kind": "spi",
+                        "version": "v1",
+                        "block": "SPI"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {
@@ -2295,6 +2300,11 @@
                 {
                     "name": "SPI2",
                     "address": 1073756160,
+                    "registers": {
+                        "kind": "spi",
+                        "version": "v1",
+                        "block": "SPI"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {
@@ -2370,6 +2380,11 @@
                 {
                     "name": "SPI3",
                     "address": 1073757184,
+                    "registers": {
+                        "kind": "spi",
+                        "version": "v1",
+                        "block": "SPI"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {

--- a/data/chips/STM32F217ZE.json
+++ b/data/chips/STM32F217ZE.json
@@ -2442,6 +2442,11 @@
                 {
                     "name": "SPI1",
                     "address": 1073819648,
+                    "registers": {
+                        "kind": "spi",
+                        "version": "v1",
+                        "block": "SPI"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {
@@ -2527,6 +2532,11 @@
                 {
                     "name": "SPI2",
                     "address": 1073756160,
+                    "registers": {
+                        "kind": "spi",
+                        "version": "v1",
+                        "block": "SPI"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {
@@ -2602,6 +2612,11 @@
                 {
                     "name": "SPI3",
                     "address": 1073757184,
+                    "registers": {
+                        "kind": "spi",
+                        "version": "v1",
+                        "block": "SPI"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {

--- a/data/chips/STM32F217ZG.json
+++ b/data/chips/STM32F217ZG.json
@@ -2442,6 +2442,11 @@
                 {
                     "name": "SPI1",
                     "address": 1073819648,
+                    "registers": {
+                        "kind": "spi",
+                        "version": "v1",
+                        "block": "SPI"
+                    },
                     "rcc": {
                         "clock": "APB2",
                         "enable": {
@@ -2527,6 +2532,11 @@
                 {
                     "name": "SPI2",
                     "address": 1073756160,
+                    "registers": {
+                        "kind": "spi",
+                        "version": "v1",
+                        "block": "SPI"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {
@@ -2602,6 +2612,11 @@
                 {
                     "name": "SPI3",
                     "address": 1073757184,
+                    "registers": {
+                        "kind": "spi",
+                        "version": "v1",
+                        "block": "SPI"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {

--- a/stm32data/__main__.py
+++ b/stm32data/__main__.py
@@ -105,6 +105,7 @@ perimap = [
     ('.*:RNG:rng1_v2_1', ('rng', 'v1', 'RNG')),
     ('.*:RNG:rng1_v3_1', ('rng', 'v1', 'RNG')),
     ('.*:SPI:spi2_v1_4', ('spi', 'f1', 'SPI')),
+    ('.*:SPI:spi2s1_v2_1', ('spi', 'v1', 'SPI')),
     ('.*:SPI:spi2s1_v2_2', ('spi', 'v1', 'SPI')),
     ('.*:SPI:spi2s1_v3_2', ('spi', 'v2', 'SPI')),
     ('.*:SPI:spi2s1_v3_3', ('spi', 'v2', 'SPI')),


### PR DESCRIPTION
This seems identical to v2_2 (as used by F429) with one naming exception in status register SR bit 8 (TI frame format error):

v2_1 data names the bit "TIFRFE" and the enum TIFRERR
v2_2 data names the bit "FRE" and the enum FRER

The register bit layout is identical