### PR TITLE
Add IWDG v1 definitions

### DIFF
--- a/data/chips/STM32F100C4.json
+++ b/data/chips/STM32F100C4.json
@@ -775,7 +775,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F100C6.json
+++ b/data/chips/STM32F100C6.json
@@ -775,7 +775,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F100C8.json
+++ b/data/chips/STM32F100C8.json
@@ -829,7 +829,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F100CB.json
+++ b/data/chips/STM32F100CB.json
@@ -829,7 +829,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F100R4.json
+++ b/data/chips/STM32F100R4.json
@@ -803,7 +803,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F100R6.json
+++ b/data/chips/STM32F100R6.json
@@ -803,7 +803,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F100R8.json
+++ b/data/chips/STM32F100R8.json
@@ -857,7 +857,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F100RB.json
+++ b/data/chips/STM32F100RB.json
@@ -857,7 +857,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F100RC.json
+++ b/data/chips/STM32F100RC.json
@@ -935,7 +935,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F100RD.json
+++ b/data/chips/STM32F100RD.json
@@ -935,7 +935,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F100RE.json
+++ b/data/chips/STM32F100RE.json
@@ -935,7 +935,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F100V8.json
+++ b/data/chips/STM32F100V8.json
@@ -853,7 +853,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F100VB.json
+++ b/data/chips/STM32F100VB.json
@@ -853,7 +853,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F100VC.json
+++ b/data/chips/STM32F100VC.json
@@ -1145,7 +1145,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F100VD.json
+++ b/data/chips/STM32F100VD.json
@@ -1145,7 +1145,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F100VE.json
+++ b/data/chips/STM32F100VE.json
@@ -1145,7 +1145,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F100ZC.json
+++ b/data/chips/STM32F100ZC.json
@@ -1229,7 +1229,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F100ZD.json
+++ b/data/chips/STM32F100ZD.json
@@ -1229,7 +1229,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F100ZE.json
+++ b/data/chips/STM32F100ZE.json
@@ -1229,7 +1229,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F101C4.json
+++ b/data/chips/STM32F101C4.json
@@ -705,7 +705,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F101C6.json
+++ b/data/chips/STM32F101C6.json
@@ -711,7 +711,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F101C8.json
+++ b/data/chips/STM32F101C8.json
@@ -789,7 +789,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F101CB.json
+++ b/data/chips/STM32F101CB.json
@@ -783,7 +783,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F101R4.json
+++ b/data/chips/STM32F101R4.json
@@ -735,7 +735,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F101R6.json
+++ b/data/chips/STM32F101R6.json
@@ -741,7 +741,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F101R8.json
+++ b/data/chips/STM32F101R8.json
@@ -815,7 +815,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F101RB.json
+++ b/data/chips/STM32F101RB.json
@@ -819,7 +819,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F101RC.json
+++ b/data/chips/STM32F101RC.json
@@ -934,7 +934,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F101RD.json
+++ b/data/chips/STM32F101RD.json
@@ -934,7 +934,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F101RE.json
+++ b/data/chips/STM32F101RE.json
@@ -934,7 +934,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F101RF.json
+++ b/data/chips/STM32F101RF.json
@@ -940,7 +940,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F101RG.json
+++ b/data/chips/STM32F101RG.json
@@ -922,7 +922,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F101T4.json
+++ b/data/chips/STM32F101T4.json
@@ -697,7 +697,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F101T6.json
+++ b/data/chips/STM32F101T6.json
@@ -697,7 +697,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F101T8.json
+++ b/data/chips/STM32F101T8.json
@@ -723,7 +723,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F101TB.json
+++ b/data/chips/STM32F101TB.json
@@ -711,7 +711,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F101V8.json
+++ b/data/chips/STM32F101V8.json
@@ -809,7 +809,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F101VB.json
+++ b/data/chips/STM32F101VB.json
@@ -809,7 +809,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F101VC.json
+++ b/data/chips/STM32F101VC.json
@@ -1156,7 +1156,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F101VD.json
+++ b/data/chips/STM32F101VD.json
@@ -1156,7 +1156,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F101VE.json
+++ b/data/chips/STM32F101VE.json
@@ -1150,7 +1150,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F101VF.json
+++ b/data/chips/STM32F101VF.json
@@ -1144,7 +1144,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F101VG.json
+++ b/data/chips/STM32F101VG.json
@@ -1144,7 +1144,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F101ZC.json
+++ b/data/chips/STM32F101ZC.json
@@ -1278,7 +1278,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F101ZD.json
+++ b/data/chips/STM32F101ZD.json
@@ -1278,7 +1278,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F101ZE.json
+++ b/data/chips/STM32F101ZE.json
@@ -1278,7 +1278,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F101ZF.json
+++ b/data/chips/STM32F101ZF.json
@@ -1248,7 +1248,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F101ZG.json
+++ b/data/chips/STM32F101ZG.json
@@ -1272,7 +1272,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F102C4.json
+++ b/data/chips/STM32F102C4.json
@@ -705,7 +705,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F102C6.json
+++ b/data/chips/STM32F102C6.json
@@ -705,7 +705,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F102C8.json
+++ b/data/chips/STM32F102C8.json
@@ -759,7 +759,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F102CB.json
+++ b/data/chips/STM32F102CB.json
@@ -759,7 +759,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F102R4.json
+++ b/data/chips/STM32F102R4.json
@@ -729,7 +729,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F102R6.json
+++ b/data/chips/STM32F102R6.json
@@ -729,7 +729,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F102R8.json
+++ b/data/chips/STM32F102R8.json
@@ -783,7 +783,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F102RB.json
+++ b/data/chips/STM32F102RB.json
@@ -783,7 +783,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F103C4.json
+++ b/data/chips/STM32F103C4.json
@@ -829,7 +829,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F103C6.json
+++ b/data/chips/STM32F103C6.json
@@ -839,7 +839,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F103C8.json
+++ b/data/chips/STM32F103C8.json
@@ -909,7 +909,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F103CB.json
+++ b/data/chips/STM32F103CB.json
@@ -907,7 +907,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F103R4.json
+++ b/data/chips/STM32F103R4.json
@@ -881,7 +881,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F103R6.json
+++ b/data/chips/STM32F103R6.json
@@ -887,7 +887,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F103R8.json
+++ b/data/chips/STM32F103R8.json
@@ -961,7 +961,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F103RB.json
+++ b/data/chips/STM32F103RB.json
@@ -961,7 +961,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F103RC.json
+++ b/data/chips/STM32F103RC.json
@@ -1140,7 +1140,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F103RD.json
+++ b/data/chips/STM32F103RD.json
@@ -1140,7 +1140,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F103RE.json
+++ b/data/chips/STM32F103RE.json
@@ -1140,7 +1140,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F103RF.json
+++ b/data/chips/STM32F103RF.json
@@ -1130,7 +1130,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F103RG.json
+++ b/data/chips/STM32F103RG.json
@@ -1130,7 +1130,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F103T4.json
+++ b/data/chips/STM32F103T4.json
@@ -813,7 +813,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F103T6.json
+++ b/data/chips/STM32F103T6.json
@@ -813,7 +813,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F103T8.json
+++ b/data/chips/STM32F103T8.json
@@ -833,7 +833,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F103TB.json
+++ b/data/chips/STM32F103TB.json
@@ -827,7 +827,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F103V8.json
+++ b/data/chips/STM32F103V8.json
@@ -969,7 +969,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F103VB.json
+++ b/data/chips/STM32F103VB.json
@@ -973,7 +973,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F103VC.json
+++ b/data/chips/STM32F103VC.json
@@ -1376,7 +1376,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F103VD.json
+++ b/data/chips/STM32F103VD.json
@@ -1376,7 +1376,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F103VE.json
+++ b/data/chips/STM32F103VE.json
@@ -1376,7 +1376,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F103VF.json
+++ b/data/chips/STM32F103VF.json
@@ -1366,7 +1366,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F103VG.json
+++ b/data/chips/STM32F103VG.json
@@ -1366,7 +1366,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F103ZC.json
+++ b/data/chips/STM32F103ZC.json
@@ -1524,7 +1524,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F103ZD.json
+++ b/data/chips/STM32F103ZD.json
@@ -1524,7 +1524,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F103ZE.json
+++ b/data/chips/STM32F103ZE.json
@@ -1524,7 +1524,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F103ZF.json
+++ b/data/chips/STM32F103ZF.json
@@ -1518,7 +1518,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F103ZG.json
+++ b/data/chips/STM32F103ZG.json
@@ -1518,7 +1518,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F105R8.json
+++ b/data/chips/STM32F105R8.json
@@ -1072,7 +1072,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F105RB.json
+++ b/data/chips/STM32F105RB.json
@@ -1072,7 +1072,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F105RC.json
+++ b/data/chips/STM32F105RC.json
@@ -1072,7 +1072,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F105V8.json
+++ b/data/chips/STM32F105V8.json
@@ -1084,7 +1084,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F105VB.json
+++ b/data/chips/STM32F105VB.json
@@ -1084,7 +1084,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F105VC.json
+++ b/data/chips/STM32F105VC.json
@@ -1080,7 +1080,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F107RB.json
+++ b/data/chips/STM32F107RB.json
@@ -1134,7 +1134,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F107RC.json
+++ b/data/chips/STM32F107RC.json
@@ -1134,7 +1134,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F107VB.json
+++ b/data/chips/STM32F107VB.json
@@ -1166,7 +1166,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F107VC.json
+++ b/data/chips/STM32F107VC.json
@@ -1170,7 +1170,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F205RB.json
+++ b/data/chips/STM32F205RB.json
@@ -1343,7 +1343,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F205RC.json
+++ b/data/chips/STM32F205RC.json
@@ -1343,7 +1343,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F205RE.json
+++ b/data/chips/STM32F205RE.json
@@ -1347,7 +1347,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F205RF.json
+++ b/data/chips/STM32F205RF.json
@@ -1343,7 +1343,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F205RG.json
+++ b/data/chips/STM32F205RG.json
@@ -1351,7 +1351,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F205VB.json
+++ b/data/chips/STM32F205VB.json
@@ -1636,7 +1636,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F205VC.json
+++ b/data/chips/STM32F205VC.json
@@ -1636,7 +1636,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F205VE.json
+++ b/data/chips/STM32F205VE.json
@@ -1636,7 +1636,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F205VF.json
+++ b/data/chips/STM32F205VF.json
@@ -1636,7 +1636,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F205VG.json
+++ b/data/chips/STM32F205VG.json
@@ -1636,7 +1636,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F205ZC.json
+++ b/data/chips/STM32F205ZC.json
@@ -1838,7 +1838,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F205ZE.json
+++ b/data/chips/STM32F205ZE.json
@@ -1838,7 +1838,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F205ZF.json
+++ b/data/chips/STM32F205ZF.json
@@ -1838,7 +1838,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F205ZG.json
+++ b/data/chips/STM32F205ZG.json
@@ -1838,7 +1838,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F207IC.json
+++ b/data/chips/STM32F207IC.json
@@ -2303,7 +2303,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F207IE.json
+++ b/data/chips/STM32F207IE.json
@@ -2303,7 +2303,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F207IF.json
+++ b/data/chips/STM32F207IF.json
@@ -2303,7 +2303,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F207IG.json
+++ b/data/chips/STM32F207IG.json
@@ -2303,7 +2303,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F207VC.json
+++ b/data/chips/STM32F207VC.json
@@ -1927,7 +1927,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F207VE.json
+++ b/data/chips/STM32F207VE.json
@@ -1927,7 +1927,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F207VF.json
+++ b/data/chips/STM32F207VF.json
@@ -1927,7 +1927,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F207VG.json
+++ b/data/chips/STM32F207VG.json
@@ -1927,7 +1927,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F207ZC.json
+++ b/data/chips/STM32F207ZC.json
@@ -2159,7 +2159,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F207ZE.json
+++ b/data/chips/STM32F207ZE.json
@@ -2159,7 +2159,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F207ZF.json
+++ b/data/chips/STM32F207ZF.json
@@ -2159,7 +2159,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F207ZG.json
+++ b/data/chips/STM32F207ZG.json
@@ -2159,7 +2159,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F215RE.json
+++ b/data/chips/STM32F215RE.json
@@ -1400,7 +1400,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F215RG.json
+++ b/data/chips/STM32F215RG.json
@@ -1400,7 +1400,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F215VE.json
+++ b/data/chips/STM32F215VE.json
@@ -1693,7 +1693,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F215VG.json
+++ b/data/chips/STM32F215VG.json
@@ -1693,7 +1693,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F215ZE.json
+++ b/data/chips/STM32F215ZE.json
@@ -1895,7 +1895,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F215ZG.json
+++ b/data/chips/STM32F215ZG.json
@@ -1895,7 +1895,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F217IE.json
+++ b/data/chips/STM32F217IE.json
@@ -2360,7 +2360,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F217IG.json
+++ b/data/chips/STM32F217IG.json
@@ -2360,7 +2360,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F217VE.json
+++ b/data/chips/STM32F217VE.json
@@ -1984,7 +1984,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F217VG.json
+++ b/data/chips/STM32F217VG.json
@@ -1984,7 +1984,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F217ZE.json
+++ b/data/chips/STM32F217ZE.json
@@ -2216,7 +2216,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F217ZG.json
+++ b/data/chips/STM32F217ZG.json
@@ -2216,7 +2216,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F401CB.json
+++ b/data/chips/STM32F401CB.json
@@ -949,7 +949,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F401CC.json
+++ b/data/chips/STM32F401CC.json
@@ -953,7 +953,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F401CD.json
+++ b/data/chips/STM32F401CD.json
@@ -949,7 +949,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F401CE.json
+++ b/data/chips/STM32F401CE.json
@@ -949,7 +949,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F401RB.json
+++ b/data/chips/STM32F401RB.json
@@ -974,7 +974,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F401RC.json
+++ b/data/chips/STM32F401RC.json
@@ -974,7 +974,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F401RD.json
+++ b/data/chips/STM32F401RD.json
@@ -974,7 +974,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F401RE.json
+++ b/data/chips/STM32F401RE.json
@@ -974,7 +974,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F401VB.json
+++ b/data/chips/STM32F401VB.json
@@ -983,7 +983,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F401VC.json
+++ b/data/chips/STM32F401VC.json
@@ -983,7 +983,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F401VD.json
+++ b/data/chips/STM32F401VD.json
@@ -983,7 +983,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F401VE.json
+++ b/data/chips/STM32F401VE.json
@@ -983,7 +983,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F405OE.json
+++ b/data/chips/STM32F405OE.json
@@ -1575,7 +1575,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F405OG.json
+++ b/data/chips/STM32F405OG.json
@@ -1575,7 +1575,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F405RG.json
+++ b/data/chips/STM32F405RG.json
@@ -1355,7 +1355,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F405VG.json
+++ b/data/chips/STM32F405VG.json
@@ -1648,7 +1648,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F405ZG.json
+++ b/data/chips/STM32F405ZG.json
@@ -1850,7 +1850,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F407IE.json
+++ b/data/chips/STM32F407IE.json
@@ -2327,7 +2327,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F407IG.json
+++ b/data/chips/STM32F407IG.json
@@ -2327,7 +2327,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F407VE.json
+++ b/data/chips/STM32F407VE.json
@@ -1951,7 +1951,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F407VG.json
+++ b/data/chips/STM32F407VG.json
@@ -1951,7 +1951,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F407ZE.json
+++ b/data/chips/STM32F407ZE.json
@@ -2183,7 +2183,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F407ZG.json
+++ b/data/chips/STM32F407ZG.json
@@ -2183,7 +2183,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F410C8.json
+++ b/data/chips/STM32F410C8.json
@@ -943,7 +943,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "LPTIM1",

--- a/data/chips/STM32F410CB.json
+++ b/data/chips/STM32F410CB.json
@@ -943,7 +943,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "LPTIM1",

--- a/data/chips/STM32F410R8.json
+++ b/data/chips/STM32F410R8.json
@@ -992,7 +992,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "LPTIM1",

--- a/data/chips/STM32F410RB.json
+++ b/data/chips/STM32F410RB.json
@@ -992,7 +992,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "LPTIM1",

--- a/data/chips/STM32F410T8.json
+++ b/data/chips/STM32F410T8.json
@@ -890,7 +890,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "LPTIM1",

--- a/data/chips/STM32F410TB.json
+++ b/data/chips/STM32F410TB.json
@@ -890,7 +890,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "LPTIM1",

--- a/data/chips/STM32F411CC.json
+++ b/data/chips/STM32F411CC.json
@@ -958,7 +958,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F411CE.json
+++ b/data/chips/STM32F411CE.json
@@ -964,7 +964,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F411RC.json
+++ b/data/chips/STM32F411RC.json
@@ -983,7 +983,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F411RE.json
+++ b/data/chips/STM32F411RE.json
@@ -989,7 +989,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F411VC.json
+++ b/data/chips/STM32F411VC.json
@@ -992,7 +992,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F411VE.json
+++ b/data/chips/STM32F411VE.json
@@ -998,7 +998,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F412CE.json
+++ b/data/chips/STM32F412CE.json
@@ -1203,7 +1203,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F412CG.json
+++ b/data/chips/STM32F412CG.json
@@ -1203,7 +1203,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F412RE.json
+++ b/data/chips/STM32F412RE.json
@@ -1423,7 +1423,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F412RG.json
+++ b/data/chips/STM32F412RG.json
@@ -1423,7 +1423,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F412VE.json
+++ b/data/chips/STM32F412VE.json
@@ -1769,7 +1769,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F412VG.json
+++ b/data/chips/STM32F412VG.json
@@ -1769,7 +1769,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F412ZE.json
+++ b/data/chips/STM32F412ZE.json
@@ -1964,7 +1964,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F412ZG.json
+++ b/data/chips/STM32F412ZG.json
@@ -1964,7 +1964,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F413CG.json
+++ b/data/chips/STM32F413CG.json
@@ -1534,7 +1534,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "LPTIM1",

--- a/data/chips/STM32F413CH.json
+++ b/data/chips/STM32F413CH.json
@@ -1534,7 +1534,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "LPTIM1",

--- a/data/chips/STM32F413MG.json
+++ b/data/chips/STM32F413MG.json
@@ -1945,7 +1945,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "LPTIM1",

--- a/data/chips/STM32F413MH.json
+++ b/data/chips/STM32F413MH.json
@@ -1945,7 +1945,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "LPTIM1",

--- a/data/chips/STM32F413RG.json
+++ b/data/chips/STM32F413RG.json
@@ -1790,7 +1790,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "LPTIM1",

--- a/data/chips/STM32F413RH.json
+++ b/data/chips/STM32F413RH.json
@@ -1790,7 +1790,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "LPTIM1",

--- a/data/chips/STM32F413VG.json
+++ b/data/chips/STM32F413VG.json
@@ -2199,7 +2199,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "LPTIM1",

--- a/data/chips/STM32F413VH.json
+++ b/data/chips/STM32F413VH.json
@@ -2199,7 +2199,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "LPTIM1",

--- a/data/chips/STM32F413ZG.json
+++ b/data/chips/STM32F413ZG.json
@@ -2354,7 +2354,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "LPTIM1",

--- a/data/chips/STM32F413ZH.json
+++ b/data/chips/STM32F413ZH.json
@@ -2354,7 +2354,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "LPTIM1",

--- a/data/chips/STM32F415OG.json
+++ b/data/chips/STM32F415OG.json
@@ -1632,7 +1632,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F415RG.json
+++ b/data/chips/STM32F415RG.json
@@ -1412,7 +1412,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F415VG.json
+++ b/data/chips/STM32F415VG.json
@@ -1705,7 +1705,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F415ZG.json
+++ b/data/chips/STM32F415ZG.json
@@ -1907,7 +1907,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F417IE.json
+++ b/data/chips/STM32F417IE.json
@@ -2384,7 +2384,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F417IG.json
+++ b/data/chips/STM32F417IG.json
@@ -2384,7 +2384,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F417VE.json
+++ b/data/chips/STM32F417VE.json
@@ -2008,7 +2008,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F417VG.json
+++ b/data/chips/STM32F417VG.json
@@ -2008,7 +2008,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F417ZE.json
+++ b/data/chips/STM32F417ZE.json
@@ -2240,7 +2240,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F417ZG.json
+++ b/data/chips/STM32F417ZG.json
@@ -2240,7 +2240,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F423CH.json
+++ b/data/chips/STM32F423CH.json
@@ -1556,7 +1556,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "LPTIM1",

--- a/data/chips/STM32F423MH.json
+++ b/data/chips/STM32F423MH.json
@@ -1967,7 +1967,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "LPTIM1",

--- a/data/chips/STM32F423RH.json
+++ b/data/chips/STM32F423RH.json
@@ -1812,7 +1812,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "LPTIM1",

--- a/data/chips/STM32F423VH.json
+++ b/data/chips/STM32F423VH.json
@@ -2221,7 +2221,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "LPTIM1",

--- a/data/chips/STM32F423ZH.json
+++ b/data/chips/STM32F423ZH.json
@@ -2376,7 +2376,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "LPTIM1",

--- a/data/chips/STM32F427AG.json
+++ b/data/chips/STM32F427AG.json
@@ -2497,7 +2497,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F427AI.json
+++ b/data/chips/STM32F427AI.json
@@ -2497,7 +2497,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F427IG.json
+++ b/data/chips/STM32F427IG.json
@@ -2609,7 +2609,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F427II.json
+++ b/data/chips/STM32F427II.json
@@ -2609,7 +2609,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F427VG.json
+++ b/data/chips/STM32F427VG.json
@@ -2053,7 +2053,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F427VI.json
+++ b/data/chips/STM32F427VI.json
@@ -2053,7 +2053,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F427ZG.json
+++ b/data/chips/STM32F427ZG.json
@@ -2340,7 +2340,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F427ZI.json
+++ b/data/chips/STM32F427ZI.json
@@ -2340,7 +2340,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F429AG.json
+++ b/data/chips/STM32F429AG.json
@@ -2509,7 +2509,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "LTDC",

--- a/data/chips/STM32F429AI.json
+++ b/data/chips/STM32F429AI.json
@@ -2509,7 +2509,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "LTDC",

--- a/data/chips/STM32F429BE.json
+++ b/data/chips/STM32F429BE.json
@@ -2605,7 +2605,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "LTDC",

--- a/data/chips/STM32F429BG.json
+++ b/data/chips/STM32F429BG.json
@@ -2611,7 +2611,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "LTDC",

--- a/data/chips/STM32F429BI.json
+++ b/data/chips/STM32F429BI.json
@@ -2611,7 +2611,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "LTDC",

--- a/data/chips/STM32F429IE.json
+++ b/data/chips/STM32F429IE.json
@@ -2609,7 +2609,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "LTDC",

--- a/data/chips/STM32F429IG.json
+++ b/data/chips/STM32F429IG.json
@@ -2621,7 +2621,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "LTDC",

--- a/data/chips/STM32F429II.json
+++ b/data/chips/STM32F429II.json
@@ -2621,7 +2621,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "LTDC",

--- a/data/chips/STM32F429NE.json
+++ b/data/chips/STM32F429NE.json
@@ -2605,7 +2605,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "LTDC",

--- a/data/chips/STM32F429NG.json
+++ b/data/chips/STM32F429NG.json
@@ -2611,7 +2611,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "LTDC",

--- a/data/chips/STM32F429NI.json
+++ b/data/chips/STM32F429NI.json
@@ -2611,7 +2611,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "LTDC",

--- a/data/chips/STM32F429VE.json
+++ b/data/chips/STM32F429VE.json
@@ -2028,7 +2028,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "LTDC",

--- a/data/chips/STM32F429VG.json
+++ b/data/chips/STM32F429VG.json
@@ -2034,7 +2034,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "LTDC",

--- a/data/chips/STM32F429VI.json
+++ b/data/chips/STM32F429VI.json
@@ -2034,7 +2034,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "LTDC",

--- a/data/chips/STM32F429ZE.json
+++ b/data/chips/STM32F429ZE.json
@@ -2340,7 +2340,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "LTDC",

--- a/data/chips/STM32F429ZG.json
+++ b/data/chips/STM32F429ZG.json
@@ -2350,7 +2350,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "LTDC",

--- a/data/chips/STM32F429ZI.json
+++ b/data/chips/STM32F429ZI.json
@@ -2350,7 +2350,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "LTDC",

--- a/data/chips/STM32F437AI.json
+++ b/data/chips/STM32F437AI.json
@@ -2554,7 +2554,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F437IG.json
+++ b/data/chips/STM32F437IG.json
@@ -2666,7 +2666,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F437II.json
+++ b/data/chips/STM32F437II.json
@@ -2666,7 +2666,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F437VG.json
+++ b/data/chips/STM32F437VG.json
@@ -2110,7 +2110,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F437VI.json
+++ b/data/chips/STM32F437VI.json
@@ -2110,7 +2110,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F437ZG.json
+++ b/data/chips/STM32F437ZG.json
@@ -2397,7 +2397,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F437ZI.json
+++ b/data/chips/STM32F437ZI.json
@@ -2397,7 +2397,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F439AI.json
+++ b/data/chips/STM32F439AI.json
@@ -2566,7 +2566,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "LTDC",

--- a/data/chips/STM32F439BG.json
+++ b/data/chips/STM32F439BG.json
@@ -2668,7 +2668,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "LTDC",

--- a/data/chips/STM32F439BI.json
+++ b/data/chips/STM32F439BI.json
@@ -2668,7 +2668,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "LTDC",

--- a/data/chips/STM32F439IG.json
+++ b/data/chips/STM32F439IG.json
@@ -2678,7 +2678,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "LTDC",

--- a/data/chips/STM32F439II.json
+++ b/data/chips/STM32F439II.json
@@ -2678,7 +2678,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "LTDC",

--- a/data/chips/STM32F439NG.json
+++ b/data/chips/STM32F439NG.json
@@ -2668,7 +2668,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "LTDC",

--- a/data/chips/STM32F439NI.json
+++ b/data/chips/STM32F439NI.json
@@ -2668,7 +2668,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "LTDC",

--- a/data/chips/STM32F439VG.json
+++ b/data/chips/STM32F439VG.json
@@ -2091,7 +2091,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "LTDC",

--- a/data/chips/STM32F439VI.json
+++ b/data/chips/STM32F439VI.json
@@ -2091,7 +2091,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "LTDC",

--- a/data/chips/STM32F439ZG.json
+++ b/data/chips/STM32F439ZG.json
@@ -2407,7 +2407,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "LTDC",

--- a/data/chips/STM32F439ZI.json
+++ b/data/chips/STM32F439ZI.json
@@ -2407,7 +2407,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "LTDC",

--- a/data/chips/STM32F446MC.json
+++ b/data/chips/STM32F446MC.json
@@ -1550,7 +1550,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F446ME.json
+++ b/data/chips/STM32F446ME.json
@@ -1550,7 +1550,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F446RC.json
+++ b/data/chips/STM32F446RC.json
@@ -1535,7 +1535,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F446RE.json
+++ b/data/chips/STM32F446RE.json
@@ -1535,7 +1535,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F446VC.json
+++ b/data/chips/STM32F446VC.json
@@ -1908,7 +1908,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F446VE.json
+++ b/data/chips/STM32F446VE.json
@@ -1908,7 +1908,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F446ZC.json
+++ b/data/chips/STM32F446ZC.json
@@ -2171,7 +2171,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F446ZE.json
+++ b/data/chips/STM32F446ZE.json
@@ -2171,7 +2171,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32F469AE.json
+++ b/data/chips/STM32F469AE.json
@@ -2277,7 +2277,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "LTDC",

--- a/data/chips/STM32F469AG.json
+++ b/data/chips/STM32F469AG.json
@@ -2277,7 +2277,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "LTDC",

--- a/data/chips/STM32F469AI.json
+++ b/data/chips/STM32F469AI.json
@@ -2277,7 +2277,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "LTDC",

--- a/data/chips/STM32F469BE.json
+++ b/data/chips/STM32F469BE.json
@@ -2570,7 +2570,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "LTDC",

--- a/data/chips/STM32F469BG.json
+++ b/data/chips/STM32F469BG.json
@@ -2570,7 +2570,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "LTDC",

--- a/data/chips/STM32F469BI.json
+++ b/data/chips/STM32F469BI.json
@@ -2570,7 +2570,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "LTDC",

--- a/data/chips/STM32F469IE.json
+++ b/data/chips/STM32F469IE.json
@@ -2474,7 +2474,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "LTDC",

--- a/data/chips/STM32F469IG.json
+++ b/data/chips/STM32F469IG.json
@@ -2474,7 +2474,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "LTDC",

--- a/data/chips/STM32F469II.json
+++ b/data/chips/STM32F469II.json
@@ -2474,7 +2474,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "LTDC",

--- a/data/chips/STM32F469NE.json
+++ b/data/chips/STM32F469NE.json
@@ -2570,7 +2570,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "LTDC",

--- a/data/chips/STM32F469NG.json
+++ b/data/chips/STM32F469NG.json
@@ -2570,7 +2570,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "LTDC",

--- a/data/chips/STM32F469NI.json
+++ b/data/chips/STM32F469NI.json
@@ -2570,7 +2570,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "LTDC",

--- a/data/chips/STM32F469VE.json
+++ b/data/chips/STM32F469VE.json
@@ -1805,7 +1805,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "LTDC",

--- a/data/chips/STM32F469VG.json
+++ b/data/chips/STM32F469VG.json
@@ -1805,7 +1805,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "LTDC",

--- a/data/chips/STM32F469VI.json
+++ b/data/chips/STM32F469VI.json
@@ -1805,7 +1805,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "LTDC",

--- a/data/chips/STM32F469ZE.json
+++ b/data/chips/STM32F469ZE.json
@@ -2102,7 +2102,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "LTDC",

--- a/data/chips/STM32F469ZG.json
+++ b/data/chips/STM32F469ZG.json
@@ -2102,7 +2102,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "LTDC",

--- a/data/chips/STM32F469ZI.json
+++ b/data/chips/STM32F469ZI.json
@@ -2102,7 +2102,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "LTDC",

--- a/data/chips/STM32F479AG.json
+++ b/data/chips/STM32F479AG.json
@@ -2334,7 +2334,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "LTDC",

--- a/data/chips/STM32F479AI.json
+++ b/data/chips/STM32F479AI.json
@@ -2334,7 +2334,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "LTDC",

--- a/data/chips/STM32F479BG.json
+++ b/data/chips/STM32F479BG.json
@@ -2627,7 +2627,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "LTDC",

--- a/data/chips/STM32F479BI.json
+++ b/data/chips/STM32F479BI.json
@@ -2627,7 +2627,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "LTDC",

--- a/data/chips/STM32F479IG.json
+++ b/data/chips/STM32F479IG.json
@@ -2531,7 +2531,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "LTDC",

--- a/data/chips/STM32F479II.json
+++ b/data/chips/STM32F479II.json
@@ -2531,7 +2531,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "LTDC",

--- a/data/chips/STM32F479NG.json
+++ b/data/chips/STM32F479NG.json
@@ -2627,7 +2627,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "LTDC",

--- a/data/chips/STM32F479NI.json
+++ b/data/chips/STM32F479NI.json
@@ -2627,7 +2627,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "LTDC",

--- a/data/chips/STM32F479VG.json
+++ b/data/chips/STM32F479VG.json
@@ -1862,7 +1862,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "LTDC",

--- a/data/chips/STM32F479VI.json
+++ b/data/chips/STM32F479VI.json
@@ -1862,7 +1862,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "LTDC",

--- a/data/chips/STM32F479ZG.json
+++ b/data/chips/STM32F479ZG.json
@@ -2159,7 +2159,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "LTDC",

--- a/data/chips/STM32F479ZI.json
+++ b/data/chips/STM32F479ZI.json
@@ -2159,7 +2159,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "LTDC",

--- a/data/chips/STM32L100C6-A.json
+++ b/data/chips/STM32L100C6-A.json
@@ -926,7 +926,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "LCD",

--- a/data/chips/STM32L100C6.json
+++ b/data/chips/STM32L100C6.json
@@ -926,7 +926,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "LCD",

--- a/data/chips/STM32L100R8-A.json
+++ b/data/chips/STM32L100R8-A.json
@@ -974,7 +974,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "LCD",

--- a/data/chips/STM32L100R8.json
+++ b/data/chips/STM32L100R8.json
@@ -974,7 +974,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "LCD",

--- a/data/chips/STM32L100RB-A.json
+++ b/data/chips/STM32L100RB-A.json
@@ -974,7 +974,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "LCD",

--- a/data/chips/STM32L100RB.json
+++ b/data/chips/STM32L100RB.json
@@ -974,7 +974,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "LCD",

--- a/data/chips/STM32L100RC.json
+++ b/data/chips/STM32L100RC.json
@@ -1042,7 +1042,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "LCD",

--- a/data/chips/STM32L151C6-A.json
+++ b/data/chips/STM32L151C6-A.json
@@ -950,7 +950,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32L151C6.json
+++ b/data/chips/STM32L151C6.json
@@ -956,7 +956,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32L151C8-A.json
+++ b/data/chips/STM32L151C8-A.json
@@ -950,7 +950,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32L151C8.json
+++ b/data/chips/STM32L151C8.json
@@ -956,7 +956,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32L151CB-A.json
+++ b/data/chips/STM32L151CB-A.json
@@ -950,7 +950,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32L151CB.json
+++ b/data/chips/STM32L151CB.json
@@ -956,7 +956,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32L151CC.json
+++ b/data/chips/STM32L151CC.json
@@ -1014,7 +1014,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "OPAMP1",

--- a/data/chips/STM32L151QC.json
+++ b/data/chips/STM32L151QC.json
@@ -1208,7 +1208,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "OPAMP1",

--- a/data/chips/STM32L151QD.json
+++ b/data/chips/STM32L151QD.json
@@ -1580,7 +1580,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "OPAMP1",

--- a/data/chips/STM32L151QE.json
+++ b/data/chips/STM32L151QE.json
@@ -1239,7 +1239,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "OPAMP1",

--- a/data/chips/STM32L151R6-A.json
+++ b/data/chips/STM32L151R6-A.json
@@ -998,7 +998,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32L151R6.json
+++ b/data/chips/STM32L151R6.json
@@ -1004,7 +1004,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32L151R8-A.json
+++ b/data/chips/STM32L151R8-A.json
@@ -998,7 +998,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32L151R8.json
+++ b/data/chips/STM32L151R8.json
@@ -1004,7 +1004,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32L151RB-A.json
+++ b/data/chips/STM32L151RB-A.json
@@ -998,7 +998,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32L151RB.json
+++ b/data/chips/STM32L151RB.json
@@ -1004,7 +1004,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32L151RC-A.json
+++ b/data/chips/STM32L151RC-A.json
@@ -1092,7 +1092,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "OPAMP1",

--- a/data/chips/STM32L151RC.json
+++ b/data/chips/STM32L151RC.json
@@ -1068,7 +1068,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "OPAMP1",

--- a/data/chips/STM32L151RD.json
+++ b/data/chips/STM32L151RD.json
@@ -1113,7 +1113,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "OPAMP1",

--- a/data/chips/STM32L151RE.json
+++ b/data/chips/STM32L151RE.json
@@ -1132,7 +1132,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "OPAMP1",

--- a/data/chips/STM32L151UC.json
+++ b/data/chips/STM32L151UC.json
@@ -1058,7 +1058,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "OPAMP1",

--- a/data/chips/STM32L151V8-A.json
+++ b/data/chips/STM32L151V8-A.json
@@ -1030,7 +1030,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32L151V8.json
+++ b/data/chips/STM32L151V8.json
@@ -1036,7 +1036,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32L151VB-A.json
+++ b/data/chips/STM32L151VB-A.json
@@ -1030,7 +1030,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32L151VB.json
+++ b/data/chips/STM32L151VB.json
@@ -1036,7 +1036,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "PWR",

--- a/data/chips/STM32L151VC-A.json
+++ b/data/chips/STM32L151VC-A.json
@@ -1124,7 +1124,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "OPAMP1",

--- a/data/chips/STM32L151VC.json
+++ b/data/chips/STM32L151VC.json
@@ -1094,7 +1094,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "OPAMP1",

--- a/data/chips/STM32L151VD-X.json
+++ b/data/chips/STM32L151VD-X.json
@@ -1172,7 +1172,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "OPAMP1",

--- a/data/chips/STM32L151VD.json
+++ b/data/chips/STM32L151VD.json
@@ -1403,7 +1403,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "OPAMP1",

--- a/data/chips/STM32L151VE.json
+++ b/data/chips/STM32L151VE.json
@@ -1172,7 +1172,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "OPAMP1",

--- a/data/chips/STM32L151ZC.json
+++ b/data/chips/STM32L151ZC.json
@@ -1216,7 +1216,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "OPAMP1",

--- a/data/chips/STM32L151ZD.json
+++ b/data/chips/STM32L151ZD.json
@@ -1588,7 +1588,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "OPAMP1",

--- a/data/chips/STM32L151ZE.json
+++ b/data/chips/STM32L151ZE.json
@@ -1248,7 +1248,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "OPAMP1",

--- a/data/chips/STM32L152C6-A.json
+++ b/data/chips/STM32L152C6-A.json
@@ -950,7 +950,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "LCD",

--- a/data/chips/STM32L152C6.json
+++ b/data/chips/STM32L152C6.json
@@ -956,7 +956,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "LCD",

--- a/data/chips/STM32L152C8-A.json
+++ b/data/chips/STM32L152C8-A.json
@@ -950,7 +950,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "LCD",

--- a/data/chips/STM32L152C8.json
+++ b/data/chips/STM32L152C8.json
@@ -956,7 +956,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "LCD",

--- a/data/chips/STM32L152CB-A.json
+++ b/data/chips/STM32L152CB-A.json
@@ -950,7 +950,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "LCD",

--- a/data/chips/STM32L152CB.json
+++ b/data/chips/STM32L152CB.json
@@ -956,7 +956,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "LCD",

--- a/data/chips/STM32L152CC.json
+++ b/data/chips/STM32L152CC.json
@@ -1014,7 +1014,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "LCD",

--- a/data/chips/STM32L152QC.json
+++ b/data/chips/STM32L152QC.json
@@ -1208,7 +1208,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "LCD",

--- a/data/chips/STM32L152QD.json
+++ b/data/chips/STM32L152QD.json
@@ -1580,7 +1580,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "LCD",

--- a/data/chips/STM32L152QE.json
+++ b/data/chips/STM32L152QE.json
@@ -1239,7 +1239,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "LCD",

--- a/data/chips/STM32L152R6-A.json
+++ b/data/chips/STM32L152R6-A.json
@@ -998,7 +998,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "LCD",

--- a/data/chips/STM32L152R6.json
+++ b/data/chips/STM32L152R6.json
@@ -1004,7 +1004,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "LCD",

--- a/data/chips/STM32L152R8-A.json
+++ b/data/chips/STM32L152R8-A.json
@@ -998,7 +998,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "LCD",

--- a/data/chips/STM32L152R8.json
+++ b/data/chips/STM32L152R8.json
@@ -1004,7 +1004,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "LCD",

--- a/data/chips/STM32L152RB-A.json
+++ b/data/chips/STM32L152RB-A.json
@@ -998,7 +998,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "LCD",

--- a/data/chips/STM32L152RB.json
+++ b/data/chips/STM32L152RB.json
@@ -1004,7 +1004,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "LCD",

--- a/data/chips/STM32L152RC-A.json
+++ b/data/chips/STM32L152RC-A.json
@@ -1092,7 +1092,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "LCD",

--- a/data/chips/STM32L152RC.json
+++ b/data/chips/STM32L152RC.json
@@ -1064,7 +1064,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "LCD",

--- a/data/chips/STM32L152RD.json
+++ b/data/chips/STM32L152RD.json
@@ -1113,7 +1113,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "LCD",

--- a/data/chips/STM32L152RE.json
+++ b/data/chips/STM32L152RE.json
@@ -1132,7 +1132,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "LCD",

--- a/data/chips/STM32L152UC.json
+++ b/data/chips/STM32L152UC.json
@@ -1058,7 +1058,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "LCD",

--- a/data/chips/STM32L152V8-A.json
+++ b/data/chips/STM32L152V8-A.json
@@ -1030,7 +1030,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "LCD",

--- a/data/chips/STM32L152V8.json
+++ b/data/chips/STM32L152V8.json
@@ -1036,7 +1036,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "LCD",

--- a/data/chips/STM32L152VB-A.json
+++ b/data/chips/STM32L152VB-A.json
@@ -1030,7 +1030,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "LCD",

--- a/data/chips/STM32L152VB.json
+++ b/data/chips/STM32L152VB.json
@@ -1036,7 +1036,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "LCD",

--- a/data/chips/STM32L152VC-A.json
+++ b/data/chips/STM32L152VC-A.json
@@ -1124,7 +1124,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "LCD",

--- a/data/chips/STM32L152VC.json
+++ b/data/chips/STM32L152VC.json
@@ -1100,7 +1100,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "LCD",

--- a/data/chips/STM32L152VD-X.json
+++ b/data/chips/STM32L152VD-X.json
@@ -1168,7 +1168,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "LCD",

--- a/data/chips/STM32L152VD.json
+++ b/data/chips/STM32L152VD.json
@@ -1403,7 +1403,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "LCD",

--- a/data/chips/STM32L152VE.json
+++ b/data/chips/STM32L152VE.json
@@ -1172,7 +1172,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "LCD",

--- a/data/chips/STM32L152ZC.json
+++ b/data/chips/STM32L152ZC.json
@@ -1216,7 +1216,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "LCD",

--- a/data/chips/STM32L152ZD.json
+++ b/data/chips/STM32L152ZD.json
@@ -1588,7 +1588,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "LCD",

--- a/data/chips/STM32L152ZE.json
+++ b/data/chips/STM32L152ZE.json
@@ -1248,7 +1248,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "LCD",

--- a/data/chips/STM32L162QC.json
+++ b/data/chips/STM32L162QC.json
@@ -1222,7 +1222,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "LCD",

--- a/data/chips/STM32L162QD.json
+++ b/data/chips/STM32L162QD.json
@@ -1600,7 +1600,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "LCD",

--- a/data/chips/STM32L162RC-A.json
+++ b/data/chips/STM32L162RC-A.json
@@ -1112,7 +1112,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "LCD",

--- a/data/chips/STM32L162RC.json
+++ b/data/chips/STM32L162RC.json
@@ -1078,7 +1078,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "LCD",

--- a/data/chips/STM32L162RD.json
+++ b/data/chips/STM32L162RD.json
@@ -1127,7 +1127,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "LCD",

--- a/data/chips/STM32L162RE.json
+++ b/data/chips/STM32L162RE.json
@@ -1152,7 +1152,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "LCD",

--- a/data/chips/STM32L162VC-A.json
+++ b/data/chips/STM32L162VC-A.json
@@ -1144,7 +1144,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "LCD",

--- a/data/chips/STM32L162VC.json
+++ b/data/chips/STM32L162VC.json
@@ -1114,7 +1114,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "LCD",

--- a/data/chips/STM32L162VD-X.json
+++ b/data/chips/STM32L162VD-X.json
@@ -1188,7 +1188,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "LCD",

--- a/data/chips/STM32L162VD.json
+++ b/data/chips/STM32L162VD.json
@@ -1423,7 +1423,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "LCD",

--- a/data/chips/STM32L162VE.json
+++ b/data/chips/STM32L162VE.json
@@ -1192,7 +1192,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "LCD",

--- a/data/chips/STM32L162ZC.json
+++ b/data/chips/STM32L162ZC.json
@@ -1230,7 +1230,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "LCD",

--- a/data/chips/STM32L162ZD.json
+++ b/data/chips/STM32L162ZD.json
@@ -1608,7 +1608,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "LCD",

--- a/data/chips/STM32L162ZE.json
+++ b/data/chips/STM32L162ZE.json
@@ -1268,7 +1268,12 @@
                 },
                 {
                     "name": "IWDG",
-                    "address": 1073754112
+                    "address": 1073754112,
+                    "registers": {
+                        "kind": "iwdg",
+                        "version": "v1",
+                        "block": "IWDG"
+                    }
                 },
                 {
                     "name": "LCD",

--- a/data/registers/iwdg_v1.yaml
+++ b/data/registers/iwdg_v1.yaml
@@ -1,0 +1,95 @@
+---
+block/IWDG:
+  description: Independent watchdog
+  items:
+    - name: KR
+      description: Key register
+      byte_offset: 0
+      access: Write
+      fieldset: KR
+    - name: PR
+      description: Prescaler register
+      byte_offset: 4
+      fieldset: PR
+    - name: RLR
+      description: Reload register
+      byte_offset: 8
+      fieldset: RLR
+    - name: SR
+      description: Status register
+      byte_offset: 12
+      access: Read
+      fieldset: SR
+fieldset/KR:
+  description: Key register
+  fields:
+    - name: KEY
+      description: "Key value (write only, read 0000h)"
+      bit_offset: 0
+      bit_size: 16
+      enum: KEY
+fieldset/PR:
+  description: Prescaler register
+  fields:
+    - name: PR
+      description: Prescaler divider
+      bit_offset: 0
+      bit_size: 3
+      enum: PR
+fieldset/RLR:
+  description: Reload register
+  fields:
+    - name: RL
+      description: Watchdog counter reload value
+      bit_offset: 0
+      bit_size: 12
+fieldset/SR:
+  description: Status register
+  fields:
+    - name: PVU
+      description: Watchdog prescaler value update
+      bit_offset: 0
+      bit_size: 1
+    - name: RVU
+      description: Watchdog counter reload value update
+      bit_offset: 1
+      bit_size: 1
+enum/KEY:
+  bit_size: 16
+  variants:
+    - name: Enable
+      description: "Enable access to PR, RLR and WINR registers (0x5555)"
+      value: 21845
+    - name: Reset
+      description: Reset the watchdog value (0xAAAA)
+      value: 43690
+    - name: Start
+      description: Start the watchdog (0xCCCC)
+      value: 52428
+enum/PR:
+  bit_size: 3
+  variants:
+    - name: DivideBy4
+      description: Divider /4
+      value: 0
+    - name: DivideBy8
+      description: Divider /8
+      value: 1
+    - name: DivideBy16
+      description: Divider /16
+      value: 2
+    - name: DivideBy32
+      description: Divider /32
+      value: 3
+    - name: DivideBy64
+      description: Divider /64
+      value: 4
+    - name: DivideBy128
+      description: Divider /128
+      value: 5
+    - name: DivideBy256
+      description: Divider /256
+      value: 6
+    - name: DivideBy256bis
+      description: Divider /256
+      value: 7

--- a/stm32data/__main__.py
+++ b/stm32data/__main__.py
@@ -155,6 +155,7 @@ perimap = [
     ('STM32WL5.*:SYSCFG:.*', ('syscfg', 'wl5', 'SYSCFG')),
     ('STM32WLE.*:SYSCFG:.*', ('syscfg', 'wle', 'SYSCFG')),
 
+    ('.*:IWDG:iwdg1_v1_1', ('iwdg', 'v1', 'IWDG')),
     ('.*:IWDG:iwdg1_v2_0', ('iwdg', 'v2', 'IWDG')),
     ('.*:WWDG:wwdg1_v1_0', ('wwdg', 'v1', 'WWDG')),
     ('.*:JPEG:jpeg1_v1_0', ('jpeg', 'v1', 'JPEG')),


### PR DESCRIPTION
IWDG v1 and v2 only differ by window register:

```diff
22a23,26
>     - name: WINR
>       description: Window register
>       byte_offset: 16
>       fieldset: WINR
56a61,71
>     - name: WVU
>       description: Watchdog counter window value update
>       bit_offset: 2
>       bit_size: 1
> fieldset/WINR:
>   description: Window register
>   fields:
>     - name: WIN
>       description: Watchdog counter window value
>       bit_offset: 0
>       bit_size: 12
```