### PR TITLE
DAC update and cleanup

### DIFF
--- a/data/chips/STM32F100C4.json
+++ b/data/chips/STM32F100C4.json
@@ -421,6 +421,11 @@
                 {
                     "name": "DAC",
                     "address": 1073771520,
+                    "registers": {
+                        "kind": "dac",
+                        "version": "v1",
+                        "block": "DAC"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {

--- a/data/chips/STM32F100C6.json
+++ b/data/chips/STM32F100C6.json
@@ -421,6 +421,11 @@
                 {
                     "name": "DAC",
                     "address": 1073771520,
+                    "registers": {
+                        "kind": "dac",
+                        "version": "v1",
+                        "block": "DAC"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {

--- a/data/chips/STM32F100C8.json
+++ b/data/chips/STM32F100C8.json
@@ -421,6 +421,11 @@
                 {
                     "name": "DAC",
                     "address": 1073771520,
+                    "registers": {
+                        "kind": "dac",
+                        "version": "v1",
+                        "block": "DAC"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {

--- a/data/chips/STM32F100CB.json
+++ b/data/chips/STM32F100CB.json
@@ -421,6 +421,11 @@
                 {
                     "name": "DAC",
                     "address": 1073771520,
+                    "registers": {
+                        "kind": "dac",
+                        "version": "v1",
+                        "block": "DAC"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {

--- a/data/chips/STM32F100R4.json
+++ b/data/chips/STM32F100R4.json
@@ -449,6 +449,11 @@
                 {
                     "name": "DAC",
                     "address": 1073771520,
+                    "registers": {
+                        "kind": "dac",
+                        "version": "v1",
+                        "block": "DAC"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {

--- a/data/chips/STM32F100R6.json
+++ b/data/chips/STM32F100R6.json
@@ -449,6 +449,11 @@
                 {
                     "name": "DAC",
                     "address": 1073771520,
+                    "registers": {
+                        "kind": "dac",
+                        "version": "v1",
+                        "block": "DAC"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {

--- a/data/chips/STM32F100R8.json
+++ b/data/chips/STM32F100R8.json
@@ -449,6 +449,11 @@
                 {
                     "name": "DAC",
                     "address": 1073771520,
+                    "registers": {
+                        "kind": "dac",
+                        "version": "v1",
+                        "block": "DAC"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {

--- a/data/chips/STM32F100RB.json
+++ b/data/chips/STM32F100RB.json
@@ -449,6 +449,11 @@
                 {
                     "name": "DAC",
                     "address": 1073771520,
+                    "registers": {
+                        "kind": "dac",
+                        "version": "v1",
+                        "block": "DAC"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {

--- a/data/chips/STM32F100RC.json
+++ b/data/chips/STM32F100RC.json
@@ -445,6 +445,11 @@
                 {
                     "name": "DAC",
                     "address": 1073771520,
+                    "registers": {
+                        "kind": "dac",
+                        "version": "v1",
+                        "block": "DAC"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {

--- a/data/chips/STM32F100RD.json
+++ b/data/chips/STM32F100RD.json
@@ -445,6 +445,11 @@
                 {
                     "name": "DAC",
                     "address": 1073771520,
+                    "registers": {
+                        "kind": "dac",
+                        "version": "v1",
+                        "block": "DAC"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {

--- a/data/chips/STM32F100RE.json
+++ b/data/chips/STM32F100RE.json
@@ -445,6 +445,11 @@
                 {
                     "name": "DAC",
                     "address": 1073771520,
+                    "registers": {
+                        "kind": "dac",
+                        "version": "v1",
+                        "block": "DAC"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {

--- a/data/chips/STM32F100V8.json
+++ b/data/chips/STM32F100V8.json
@@ -445,6 +445,11 @@
                 {
                     "name": "DAC",
                     "address": 1073771520,
+                    "registers": {
+                        "kind": "dac",
+                        "version": "v1",
+                        "block": "DAC"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {

--- a/data/chips/STM32F100VB.json
+++ b/data/chips/STM32F100VB.json
@@ -445,6 +445,11 @@
                 {
                     "name": "DAC",
                     "address": 1073771520,
+                    "registers": {
+                        "kind": "dac",
+                        "version": "v1",
+                        "block": "DAC"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {

--- a/data/chips/STM32F100VC.json
+++ b/data/chips/STM32F100VC.json
@@ -445,6 +445,11 @@
                 {
                     "name": "DAC",
                     "address": 1073771520,
+                    "registers": {
+                        "kind": "dac",
+                        "version": "v1",
+                        "block": "DAC"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {

--- a/data/chips/STM32F100VD.json
+++ b/data/chips/STM32F100VD.json
@@ -445,6 +445,11 @@
                 {
                     "name": "DAC",
                     "address": 1073771520,
+                    "registers": {
+                        "kind": "dac",
+                        "version": "v1",
+                        "block": "DAC"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {

--- a/data/chips/STM32F100VE.json
+++ b/data/chips/STM32F100VE.json
@@ -445,6 +445,11 @@
                 {
                     "name": "DAC",
                     "address": 1073771520,
+                    "registers": {
+                        "kind": "dac",
+                        "version": "v1",
+                        "block": "DAC"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {

--- a/data/chips/STM32F100ZC.json
+++ b/data/chips/STM32F100ZC.json
@@ -445,6 +445,11 @@
                 {
                     "name": "DAC",
                     "address": 1073771520,
+                    "registers": {
+                        "kind": "dac",
+                        "version": "v1",
+                        "block": "DAC"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {

--- a/data/chips/STM32F100ZD.json
+++ b/data/chips/STM32F100ZD.json
@@ -445,6 +445,11 @@
                 {
                     "name": "DAC",
                     "address": 1073771520,
+                    "registers": {
+                        "kind": "dac",
+                        "version": "v1",
+                        "block": "DAC"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {

--- a/data/chips/STM32F100ZE.json
+++ b/data/chips/STM32F100ZE.json
@@ -445,6 +445,11 @@
                 {
                     "name": "DAC",
                     "address": 1073771520,
+                    "registers": {
+                        "kind": "dac",
+                        "version": "v1",
+                        "block": "DAC"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {

--- a/data/chips/STM32F101RC.json
+++ b/data/chips/STM32F101RC.json
@@ -454,6 +454,11 @@
                 {
                     "name": "DAC",
                     "address": 1073771520,
+                    "registers": {
+                        "kind": "dac",
+                        "version": "v1",
+                        "block": "DAC"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {

--- a/data/chips/STM32F101RD.json
+++ b/data/chips/STM32F101RD.json
@@ -454,6 +454,11 @@
                 {
                     "name": "DAC",
                     "address": 1073771520,
+                    "registers": {
+                        "kind": "dac",
+                        "version": "v1",
+                        "block": "DAC"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {

--- a/data/chips/STM32F101RE.json
+++ b/data/chips/STM32F101RE.json
@@ -454,6 +454,11 @@
                 {
                     "name": "DAC",
                     "address": 1073771520,
+                    "registers": {
+                        "kind": "dac",
+                        "version": "v1",
+                        "block": "DAC"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {

--- a/data/chips/STM32F101RF.json
+++ b/data/chips/STM32F101RF.json
@@ -460,6 +460,11 @@
                 {
                     "name": "DAC",
                     "address": 1073771520,
+                    "registers": {
+                        "kind": "dac",
+                        "version": "v1",
+                        "block": "DAC"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {

--- a/data/chips/STM32F101RG.json
+++ b/data/chips/STM32F101RG.json
@@ -442,6 +442,11 @@
                 {
                     "name": "DAC",
                     "address": 1073771520,
+                    "registers": {
+                        "kind": "dac",
+                        "version": "v1",
+                        "block": "DAC"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {

--- a/data/chips/STM32F101VC.json
+++ b/data/chips/STM32F101VC.json
@@ -448,6 +448,11 @@
                 {
                     "name": "DAC",
                     "address": 1073771520,
+                    "registers": {
+                        "kind": "dac",
+                        "version": "v1",
+                        "block": "DAC"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {

--- a/data/chips/STM32F101VD.json
+++ b/data/chips/STM32F101VD.json
@@ -448,6 +448,11 @@
                 {
                     "name": "DAC",
                     "address": 1073771520,
+                    "registers": {
+                        "kind": "dac",
+                        "version": "v1",
+                        "block": "DAC"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {

--- a/data/chips/STM32F101VE.json
+++ b/data/chips/STM32F101VE.json
@@ -442,6 +442,11 @@
                 {
                     "name": "DAC",
                     "address": 1073771520,
+                    "registers": {
+                        "kind": "dac",
+                        "version": "v1",
+                        "block": "DAC"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {

--- a/data/chips/STM32F101VF.json
+++ b/data/chips/STM32F101VF.json
@@ -436,6 +436,11 @@
                 {
                     "name": "DAC",
                     "address": 1073771520,
+                    "registers": {
+                        "kind": "dac",
+                        "version": "v1",
+                        "block": "DAC"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {

--- a/data/chips/STM32F101VG.json
+++ b/data/chips/STM32F101VG.json
@@ -436,6 +436,11 @@
                 {
                     "name": "DAC",
                     "address": 1073771520,
+                    "registers": {
+                        "kind": "dac",
+                        "version": "v1",
+                        "block": "DAC"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {

--- a/data/chips/STM32F101ZC.json
+++ b/data/chips/STM32F101ZC.json
@@ -442,6 +442,11 @@
                 {
                     "name": "DAC",
                     "address": 1073771520,
+                    "registers": {
+                        "kind": "dac",
+                        "version": "v1",
+                        "block": "DAC"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {

--- a/data/chips/STM32F101ZD.json
+++ b/data/chips/STM32F101ZD.json
@@ -442,6 +442,11 @@
                 {
                     "name": "DAC",
                     "address": 1073771520,
+                    "registers": {
+                        "kind": "dac",
+                        "version": "v1",
+                        "block": "DAC"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {

--- a/data/chips/STM32F101ZE.json
+++ b/data/chips/STM32F101ZE.json
@@ -442,6 +442,11 @@
                 {
                     "name": "DAC",
                     "address": 1073771520,
+                    "registers": {
+                        "kind": "dac",
+                        "version": "v1",
+                        "block": "DAC"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {

--- a/data/chips/STM32F101ZF.json
+++ b/data/chips/STM32F101ZF.json
@@ -412,6 +412,11 @@
                 {
                     "name": "DAC",
                     "address": 1073771520,
+                    "registers": {
+                        "kind": "dac",
+                        "version": "v1",
+                        "block": "DAC"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {

--- a/data/chips/STM32F101ZG.json
+++ b/data/chips/STM32F101ZG.json
@@ -436,6 +436,11 @@
                 {
                     "name": "DAC",
                     "address": 1073771520,
+                    "registers": {
+                        "kind": "dac",
+                        "version": "v1",
+                        "block": "DAC"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {

--- a/data/chips/STM32F103RC.json
+++ b/data/chips/STM32F103RC.json
@@ -660,6 +660,11 @@
                 {
                     "name": "DAC",
                     "address": 1073771520,
+                    "registers": {
+                        "kind": "dac",
+                        "version": "v1",
+                        "block": "DAC"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {

--- a/data/chips/STM32F103RD.json
+++ b/data/chips/STM32F103RD.json
@@ -660,6 +660,11 @@
                 {
                     "name": "DAC",
                     "address": 1073771520,
+                    "registers": {
+                        "kind": "dac",
+                        "version": "v1",
+                        "block": "DAC"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {

--- a/data/chips/STM32F103RE.json
+++ b/data/chips/STM32F103RE.json
@@ -660,6 +660,11 @@
                 {
                     "name": "DAC",
                     "address": 1073771520,
+                    "registers": {
+                        "kind": "dac",
+                        "version": "v1",
+                        "block": "DAC"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {

--- a/data/chips/STM32F103RF.json
+++ b/data/chips/STM32F103RF.json
@@ -650,6 +650,11 @@
                 {
                     "name": "DAC",
                     "address": 1073771520,
+                    "registers": {
+                        "kind": "dac",
+                        "version": "v1",
+                        "block": "DAC"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {

--- a/data/chips/STM32F103RG.json
+++ b/data/chips/STM32F103RG.json
@@ -650,6 +650,11 @@
                 {
                     "name": "DAC",
                     "address": 1073771520,
+                    "registers": {
+                        "kind": "dac",
+                        "version": "v1",
+                        "block": "DAC"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {

--- a/data/chips/STM32F103VC.json
+++ b/data/chips/STM32F103VC.json
@@ -668,6 +668,11 @@
                 {
                     "name": "DAC",
                     "address": 1073771520,
+                    "registers": {
+                        "kind": "dac",
+                        "version": "v1",
+                        "block": "DAC"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {

--- a/data/chips/STM32F103VD.json
+++ b/data/chips/STM32F103VD.json
@@ -668,6 +668,11 @@
                 {
                     "name": "DAC",
                     "address": 1073771520,
+                    "registers": {
+                        "kind": "dac",
+                        "version": "v1",
+                        "block": "DAC"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {

--- a/data/chips/STM32F103VE.json
+++ b/data/chips/STM32F103VE.json
@@ -668,6 +668,11 @@
                 {
                     "name": "DAC",
                     "address": 1073771520,
+                    "registers": {
+                        "kind": "dac",
+                        "version": "v1",
+                        "block": "DAC"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {

--- a/data/chips/STM32F103VF.json
+++ b/data/chips/STM32F103VF.json
@@ -658,6 +658,11 @@
                 {
                     "name": "DAC",
                     "address": 1073771520,
+                    "registers": {
+                        "kind": "dac",
+                        "version": "v1",
+                        "block": "DAC"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {

--- a/data/chips/STM32F103VG.json
+++ b/data/chips/STM32F103VG.json
@@ -658,6 +658,11 @@
                 {
                     "name": "DAC",
                     "address": 1073771520,
+                    "registers": {
+                        "kind": "dac",
+                        "version": "v1",
+                        "block": "DAC"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {

--- a/data/chips/STM32F103ZC.json
+++ b/data/chips/STM32F103ZC.json
@@ -688,6 +688,11 @@
                 {
                     "name": "DAC",
                     "address": 1073771520,
+                    "registers": {
+                        "kind": "dac",
+                        "version": "v1",
+                        "block": "DAC"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {

--- a/data/chips/STM32F103ZD.json
+++ b/data/chips/STM32F103ZD.json
@@ -688,6 +688,11 @@
                 {
                     "name": "DAC",
                     "address": 1073771520,
+                    "registers": {
+                        "kind": "dac",
+                        "version": "v1",
+                        "block": "DAC"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {

--- a/data/chips/STM32F103ZE.json
+++ b/data/chips/STM32F103ZE.json
@@ -688,6 +688,11 @@
                 {
                     "name": "DAC",
                     "address": 1073771520,
+                    "registers": {
+                        "kind": "dac",
+                        "version": "v1",
+                        "block": "DAC"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {

--- a/data/chips/STM32F103ZF.json
+++ b/data/chips/STM32F103ZF.json
@@ -682,6 +682,11 @@
                 {
                     "name": "DAC",
                     "address": 1073771520,
+                    "registers": {
+                        "kind": "dac",
+                        "version": "v1",
+                        "block": "DAC"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {

--- a/data/chips/STM32F103ZG.json
+++ b/data/chips/STM32F103ZG.json
@@ -682,6 +682,11 @@
                 {
                     "name": "DAC",
                     "address": 1073771520,
+                    "registers": {
+                        "kind": "dac",
+                        "version": "v1",
+                        "block": "DAC"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {

--- a/data/chips/STM32F105R8.json
+++ b/data/chips/STM32F105R8.json
@@ -632,6 +632,11 @@
                 {
                     "name": "DAC",
                     "address": 1073771520,
+                    "registers": {
+                        "kind": "dac",
+                        "version": "v1",
+                        "block": "DAC"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {

--- a/data/chips/STM32F105RB.json
+++ b/data/chips/STM32F105RB.json
@@ -632,6 +632,11 @@
                 {
                     "name": "DAC",
                     "address": 1073771520,
+                    "registers": {
+                        "kind": "dac",
+                        "version": "v1",
+                        "block": "DAC"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {

--- a/data/chips/STM32F105RC.json
+++ b/data/chips/STM32F105RC.json
@@ -632,6 +632,11 @@
                 {
                     "name": "DAC",
                     "address": 1073771520,
+                    "registers": {
+                        "kind": "dac",
+                        "version": "v1",
+                        "block": "DAC"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {

--- a/data/chips/STM32F105V8.json
+++ b/data/chips/STM32F105V8.json
@@ -644,6 +644,11 @@
                 {
                     "name": "DAC",
                     "address": 1073771520,
+                    "registers": {
+                        "kind": "dac",
+                        "version": "v1",
+                        "block": "DAC"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {

--- a/data/chips/STM32F105VB.json
+++ b/data/chips/STM32F105VB.json
@@ -644,6 +644,11 @@
                 {
                     "name": "DAC",
                     "address": 1073771520,
+                    "registers": {
+                        "kind": "dac",
+                        "version": "v1",
+                        "block": "DAC"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {

--- a/data/chips/STM32F105VC.json
+++ b/data/chips/STM32F105VC.json
@@ -640,6 +640,11 @@
                 {
                     "name": "DAC",
                     "address": 1073771520,
+                    "registers": {
+                        "kind": "dac",
+                        "version": "v1",
+                        "block": "DAC"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {

--- a/data/chips/STM32F107RB.json
+++ b/data/chips/STM32F107RB.json
@@ -632,6 +632,11 @@
                 {
                     "name": "DAC",
                     "address": 1073771520,
+                    "registers": {
+                        "kind": "dac",
+                        "version": "v1",
+                        "block": "DAC"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {

--- a/data/chips/STM32F107RC.json
+++ b/data/chips/STM32F107RC.json
@@ -632,6 +632,11 @@
                 {
                     "name": "DAC",
                     "address": 1073771520,
+                    "registers": {
+                        "kind": "dac",
+                        "version": "v1",
+                        "block": "DAC"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {

--- a/data/chips/STM32F107VB.json
+++ b/data/chips/STM32F107VB.json
@@ -640,6 +640,11 @@
                 {
                     "name": "DAC",
                     "address": 1073771520,
+                    "registers": {
+                        "kind": "dac",
+                        "version": "v1",
+                        "block": "DAC"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {

--- a/data/chips/STM32F107VC.json
+++ b/data/chips/STM32F107VC.json
@@ -644,6 +644,11 @@
                 {
                     "name": "DAC",
                     "address": 1073771520,
+                    "registers": {
+                        "kind": "dac",
+                        "version": "v1",
+                        "block": "DAC"
+                    },
                     "rcc": {
                         "clock": "APB1",
                         "enable": {

--- a/data/registers/dac_v1.yaml
+++ b/data/registers/dac_v1.yaml
@@ -80,14 +80,6 @@ fieldset/CR:
       array:
         len: 2
         stride: 16
-    - name: TSEL
-      description: DAC channel trigger selection
-      bit_offset: 3
-      bit_size: 3
-      array:
-        len: 2
-        stride: 16
-      enum: TSEL1
     - name: WAVE
       description: DAC channel noise/triangle wave generation enable
       bit_offset: 6
@@ -117,6 +109,16 @@ fieldset/CR:
       array:
         len: 2
         stride: 16
+    - name: TSEL1
+      description: DAC channel 1 trigger selection
+      bit_offset: 3
+      bit_size: 3
+      enum: TSEL1
+    - name: TSEL2
+      description: DAC channel 2 trigger selection
+      bit_offset: 19
+      bit_size: 3
+      enum: TSEL2
 fieldset/DHR12L:
   description: channel 12-bit left-aligned data holding register
   fields:

--- a/data/registers/dac_v1.yaml
+++ b/data/registers/dac_v1.yaml
@@ -11,30 +11,27 @@ block/DAC:
       byte_offset: 4
       access: Write
       fieldset: SWTRIGR
-    - name: DHR12R1
-      description: channel1 12-bit right-aligned data holding register
+    - name: DHR12R
+      description: channel 12-bit right-aligned data holding register
       byte_offset: 8
-      fieldset: DHR12R1
-    - name: DHR12L1
-      description: channel1 12-bit left aligned data holding register
+      fieldset: DHR12R
+      array:
+        len: 2
+        stride: 12
+    - name: DHR12L
+      description: channel 12-bit left-aligned data holding register
       byte_offset: 12
-      fieldset: DHR12L1
-    - name: DHR8R1
-      description: channel1 8-bit right aligned data holding register
+      fieldset: DHR12L
+      array:
+        len: 2
+        stride: 12
+    - name: DHR8R
+      description: channel 8-bit right-aligned data holding register
       byte_offset: 16
-      fieldset: DHR8R1
-    - name: DHR12R2
-      description: channel2 12-bit right aligned data holding register
-      byte_offset: 20
-      fieldset: DHR12R2
-    - name: DHR12L2
-      description: channel2 12-bit left aligned data holding register
-      byte_offset: 24
-      fieldset: DHR12L2
-    - name: DHR8R2
-      description: channel2 8-bit right-aligned data holding register
-      byte_offset: 28
-      fieldset: DHR8R2
+      fieldset: DHR8R
+      array:
+        len: 2
+        stride: 12
     - name: DHR12RD
       description: Dual DAC 12-bit right-aligned data holding register
       byte_offset: 32
@@ -47,16 +44,14 @@ block/DAC:
       description: DUAL DAC 8-bit right aligned data holding register
       byte_offset: 40
       fieldset: DHR8RD
-    - name: DOR1
-      description: channel1 data output register
+    - name: DOR
+      description: channel data output register
       byte_offset: 44
       access: Read
-      fieldset: DOR1
-    - name: DOR2
-      description: channel2 data output register
-      byte_offset: 48
-      access: Read
-      fieldset: DOR2
+      fieldset: DOR
+      array:
+        len: 2
+        stride: 4
     - name: SR
       description: status register
       byte_offset: 52
@@ -65,31 +60,28 @@ fieldset/CR:
   description: control register
   fields:
     - name: EN
-      description: DAC channel1 enable
+      description: DAC channel enable
       bit_offset: 0
       bit_size: 1
       array:
         len: 2
         stride: 16
-      enum: EN
     - name: BOFF
-      description: DAC channel1 output buffer disable
+      description: DAC channel output buffer disable
       bit_offset: 1
       bit_size: 1
       array:
         len: 2
         stride: 16
-      enum: BOFF
     - name: TEN
-      description: DAC channel1 trigger enable
+      description: DAC channel trigger enable
       bit_offset: 2
       bit_size: 1
       array:
         len: 2
         stride: 16
-      enum: TEN
     - name: TSEL
-      description: DAC channel1 trigger selection
+      description: DAC channel trigger selection
       bit_offset: 3
       bit_size: 3
       array:
@@ -97,7 +89,7 @@ fieldset/CR:
         stride: 16
       enum: TSEL1
     - name: WAVE
-      description: DAC channel1 noise/triangle wave generation enable
+      description: DAC channel noise/triangle wave generation enable
       bit_offset: 6
       bit_size: 2
       array:
@@ -105,202 +97,104 @@ fieldset/CR:
         stride: 16
       enum: WAVE
     - name: MAMP
-      description: DAC channel1 mask/amplitude selector
+      description: DAC channel mask/amplitude selector
       bit_offset: 8
       bit_size: 4
       array:
         len: 2
         stride: 16
     - name: DMAEN
-      description: DAC channel1 DMA enable
+      description: DAC channel DMA enable
       bit_offset: 12
       bit_size: 1
       array:
         len: 2
         stride: 16
-      enum: DMAEN
     - name: DMAUDRIE
-      description: DAC channel1 DMA Underrun Interrupt enable
+      description: DAC channel DMA Underrun Interrupt enable
       bit_offset: 13
       bit_size: 1
       array:
         len: 2
         stride: 16
-      enum: DMAUDRIE
-fieldset/DHR12L1:
-  description: channel1 12-bit left aligned data holding register
+fieldset/DHR12L:
+  description: channel 12-bit left-aligned data holding register
   fields:
-    - name: DACC1DHR
-      description: DAC channel1 12-bit left-aligned data
-      bit_offset: 4
-      bit_size: 12
-fieldset/DHR12L2:
-  description: channel2 12-bit left aligned data holding register
-  fields:
-    - name: DACC2DHR
-      description: DAC channel2 12-bit left-aligned data
+    - name: DHR
+      description: DAC channel 12-bit left-aligned data
       bit_offset: 4
       bit_size: 12
 fieldset/DHR12LD:
   description: DUAL DAC 12-bit left aligned data holding register
   fields:
-    - name: DACC1DHR
-      description: DAC channel1 12-bit left-aligned data
+    - name: DHR
+      description: DAC channel 12-bit left-aligned data
       bit_offset: 4
       bit_size: 12
-    - name: DACC2DHR
-      description: DAC channel2 12-bit left-aligned data
-      bit_offset: 20
-      bit_size: 12
-fieldset/DHR12R1:
-  description: channel1 12-bit right-aligned data holding register
+      array:
+        len: 2
+        stride: 16
+fieldset/DHR12R:
+  description: channel 12-bit right-aligned data holding register
   fields:
-    - name: DACC1DHR
-      description: DAC channel1 12-bit right-aligned data
-      bit_offset: 0
-      bit_size: 12
-fieldset/DHR12R2:
-  description: channel2 12-bit right aligned data holding register
-  fields:
-    - name: DACC2DHR
-      description: DAC channel2 12-bit right-aligned data
+    - name: DHR
+      description: DAC channel 12-bit right-aligned data
       bit_offset: 0
       bit_size: 12
 fieldset/DHR12RD:
   description: Dual DAC 12-bit right-aligned data holding register
   fields:
-    - name: DACC1DHR
-      description: DAC channel1 12-bit right-aligned data
+    - name: DHR
+      description: DAC channel 12-bit right-aligned data
       bit_offset: 0
       bit_size: 12
-    - name: DACC2DHR
-      description: DAC channel2 12-bit right-aligned data
-      bit_offset: 16
-      bit_size: 12
-fieldset/DHR8R1:
-  description: channel1 8-bit right aligned data holding register
+      array:
+        len: 2
+        stride: 16
+fieldset/DHR8R:
+  description: channel 8-bit right-aligned data holding register
   fields:
-    - name: DACC1DHR
-      description: DAC channel1 8-bit right-aligned data
-      bit_offset: 0
-      bit_size: 8
-fieldset/DHR8R2:
-  description: channel2 8-bit right-aligned data holding register
-  fields:
-    - name: DACC2DHR
-      description: DAC channel2 8-bit right-aligned data
+    - name: DHR
+      description: DAC channel 8-bit right-aligned data
       bit_offset: 0
       bit_size: 8
 fieldset/DHR8RD:
   description: DUAL DAC 8-bit right aligned data holding register
   fields:
-    - name: DACC1DHR
-      description: DAC channel1 8-bit right-aligned data
+    - name: DHR
+      description: DAC channel 8-bit right-aligned data
       bit_offset: 0
       bit_size: 8
-    - name: DACC2DHR
-      description: DAC channel2 8-bit right-aligned data
-      bit_offset: 8
-      bit_size: 8
-fieldset/DOR1:
-  description: channel1 data output register
+      array:
+        len: 2
+        stride: 8
+fieldset/DOR:
+  description: channel data output register
   fields:
-    - name: DACC1DOR
-      description: DAC channel1 data output
-      bit_offset: 0
-      bit_size: 12
-fieldset/DOR2:
-  description: channel2 data output register
-  fields:
-    - name: DACC2DOR
-      description: DAC channel2 data output
+    - name: DOR
+      description: DAC channel data output
       bit_offset: 0
       bit_size: 12
 fieldset/SR:
   description: status register
   fields:
     - name: DMAUDR
-      description: DAC channel1 DMA underrun flag
+      description: DAC channel DMA underrun flag
       bit_offset: 13
       bit_size: 1
       array:
         len: 2
         stride: 16
-      enum: DMAUDR
 fieldset/SWTRIGR:
   description: software trigger register
   fields:
     - name: SWTRIG
-      description: DAC channel1 software trigger
+      description: DAC channel software trigger
       bit_offset: 0
       bit_size: 1
       array:
         len: 2
         stride: 1
-      enum: SWTRIG
-enum/BOFF:
-  bit_size: 1
-  variants:
-    - name: Enabled
-      description: DAC channel X output buffer enabled
-      value: 0
-    - name: Disabled
-      description: DAC channel X output buffer disabled
-      value: 1
-enum/DMAEN:
-  bit_size: 1
-  variants:
-    - name: Disabled
-      description: DAC channel X DMA mode disabled
-      value: 0
-    - name: Enabled
-      description: DAC channel X DMA mode enabled
-      value: 1
-enum/DMAUDR:
-  bit_size: 1
-  variants:
-    - name: NoUnderrun
-      description: No DMA underrun error condition occurred for DAC channel X
-      value: 0
-    - name: Underrun
-      description: DMA underrun error condition occurred for DAC channel X
-      value: 1
-enum/DMAUDRIE:
-  bit_size: 1
-  variants:
-    - name: Disabled
-      description: DAC channel X DMA Underrun Interrupt disabled
-      value: 0
-    - name: Enabled
-      description: DAC channel X DMA Underrun Interrupt enabled
-      value: 1
-enum/EN:
-  bit_size: 1
-  variants:
-    - name: Disabled
-      description: DAC channel X disabled
-      value: 0
-    - name: Enabled
-      description: DAC channel X enabled
-      value: 1
-enum/SWTRIG:
-  bit_size: 1
-  variants:
-    - name: Disabled
-      description: DAC channel X software trigger disabled
-      value: 0
-    - name: Enabled
-      description: DAC channel X software trigger enabled
-      value: 1
-enum/TEN:
-  bit_size: 1
-  variants:
-    - name: Disabled
-      description: DAC channel X trigger disabled
-      value: 0
-    - name: Enabled
-      description: DAC channel X trigger enabled
-      value: 1
 enum/TSEL1:
   bit_size: 3
   variants:

--- a/data/registers/dac_v2.yaml
+++ b/data/registers/dac_v2.yaml
@@ -107,14 +107,6 @@ fieldset/CR:
       array:
         len: 2
         stride: 16
-    - name: TSEL
-      description: DAC channel trigger selection
-      bit_offset: 3
-      bit_size: 3
-      array:
-        len: 2
-        stride: 16
-      enum: TSEL1
     - name: WAVE
       description: DAC channel noise/triangle wave generation enable
       bit_offset: 6
@@ -151,6 +143,16 @@ fieldset/CR:
       array:
         len: 2
         stride: 16
+    - name: TSEL1
+      description: DAC channel 1 trigger selection
+      bit_offset: 3
+      bit_size: 3
+      enum: TSEL1
+    - name: TSEL2
+      description: DAC channel 2 trigger selection
+      bit_offset: 19
+      bit_size: 3
+      enum: TSEL2
 fieldset/DHR12L:
   description: channel 12-bit left-aligned data holding register
   fields:

--- a/data/registers/dac_v2.yaml
+++ b/data/registers/dac_v2.yaml
@@ -11,30 +11,27 @@ block/DAC:
       byte_offset: 4
       access: Write
       fieldset: SWTRIGR
-    - name: DHR12R1
-      description: channel1 12-bit right-aligned data holding register
+    - name: DHR12R
+      description: channel 12-bit right-aligned data holding register
       byte_offset: 8
-      fieldset: DHR12R1
-    - name: DHR12L1
-      description: channel1 12-bit left-aligned data holding register
+      fieldset: DHR12R
+      array:
+        len: 2
+        stride: 12
+    - name: DHR12L
+      description: channel 12-bit left-aligned data holding register
       byte_offset: 12
-      fieldset: DHR12L1
-    - name: DHR8R1
-      description: channel1 8-bit right-aligned data holding register
+      fieldset: DHR12L
+      array:
+        len: 2
+        stride: 12
+    - name: DHR8R
+      description: channel 8-bit right-aligned data holding register
       byte_offset: 16
-      fieldset: DHR8R1
-    - name: DHR12R2
-      description: channel2 12-bit right aligned data holding register
-      byte_offset: 20
-      fieldset: DHR12R2
-    - name: DHR12L2
-      description: channel2 12-bit left aligned data holding register
-      byte_offset: 24
-      fieldset: DHR12L2
-    - name: DHR8R2
-      description: channel2 8-bit right-aligned data holding register
-      byte_offset: 28
-      fieldset: DHR8R2
+      fieldset: DHR8R
+      array:
+        len: 2
+        stride: 12
     - name: DHR12RD
       description: Dual DAC 12-bit right-aligned data holding register
       byte_offset: 32
@@ -47,16 +44,14 @@ block/DAC:
       description: DUAL DAC 8-bit right aligned data holding register
       byte_offset: 40
       fieldset: DHR8RD
-    - name: DOR1
-      description: channel1 data output register
+    - name: DOR
+      description: channel data output register
       byte_offset: 44
       access: Read
-      fieldset: DOR1
-    - name: DOR2
-      description: channel2 data output register
-      byte_offset: 48
-      access: Read
-      fieldset: DOR2
+      fieldset: DOR
+      array:
+        len: 2
+        stride: 4
     - name: SR
       description: status register
       byte_offset: 52
@@ -70,13 +65,12 @@ block/DAC:
       byte_offset: 60
       fieldset: MCR
     - name: SHSR1
-      description: Sample and Hold sample time register 1
+      description: Sample and Hold sample time register
       byte_offset: 64
-      fieldset: SHSR1
-    - name: SHSR2
-      description: Sample and Hold sample time register 2
-      byte_offset: 68
-      fieldset: SHSR2
+      fieldset: SHSR
+      array:
+        len: 2
+        stride: 4
     - name: SHHR
       description: Sample and Hold hold time register
       byte_offset: 72
@@ -99,248 +93,193 @@ fieldset/CCR:
 fieldset/CR:
   description: control register
   fields:
-    - name: EN1
-      description: DAC channel1 enable
+    - name: EN
+      description: DAC channel enable
       bit_offset: 0
       bit_size: 1
-    - name: TEN1
-      description: DAC channel1 trigger enable
+      array:
+        len: 2
+        stride: 16
+    - name: TEN
+      description: DAC channel trigger enable
       bit_offset: 2
       bit_size: 1
-    - name: TSEL1
-      description: DAC channel1 trigger selection
+      array:
+        len: 2
+        stride: 16
+    - name: TSEL
+      description: DAC channel trigger selection
       bit_offset: 3
       bit_size: 3
+      array:
+        len: 2
+        stride: 16
       enum: TSEL1
-    - name: WAVE1
-      description: DAC channel1 noise/triangle wave generation enable
+    - name: WAVE
+      description: DAC channel noise/triangle wave generation enable
       bit_offset: 6
       bit_size: 2
+      array:
+        len: 2
+        stride: 16
       enum: WAVE
-    - name: MAMP1
-      description: DAC channel1 mask/amplitude selector
+    - name: MAMP
+      description: DAC channel mask/amplitude selector
       bit_offset: 8
       bit_size: 4
-    - name: DMAEN1
-      description: DAC channel1 DMA enable
+      array:
+        len: 2
+        stride: 16
+    - name: DMAEN
+      description: DAC channel DMA enable
       bit_offset: 12
       bit_size: 1
-    - name: DMAUDRIE1
-      description: DAC channel1 DMA Underrun Interrupt enable
+      array:
+        len: 2
+        stride: 16
+    - name: DMAUDRIE
+      description: DAC channel DMA Underrun Interrupt enable
       bit_offset: 13
       bit_size: 1
-    - name: CEN1
-      description: DAC Channel 1 calibration enable
+      array:
+        len: 2
+        stride: 16
+    - name: CEN
+      description: DAC channel calibration enable
       bit_offset: 14
       bit_size: 1
-    - name: EN2
-      description: DAC channel2 enable
-      bit_offset: 16
-      bit_size: 1
-    - name: TEN2
-      description: DAC channel2 trigger enable
-      bit_offset: 18
-      bit_size: 1
-    - name: TSEL2
-      description: DAC channel2 trigger selection
-      bit_offset: 19
-      bit_size: 3
-      enum: TSEL2
-    - name: WAVE2
-      description: DAC channel2 noise/triangle wave generation enable
-      bit_offset: 22
-      bit_size: 2
-      enum: WAVE
-    - name: MAMP2
-      description: DAC channel2 mask/amplitude selector
-      bit_offset: 24
-      bit_size: 4
-    - name: DMAEN2
-      description: DAC channel2 DMA enable
-      bit_offset: 28
-      bit_size: 1
-    - name: DMAUDRIE2
-      description: DAC channel2 DMA underrun interrupt enable
-      bit_offset: 29
-      bit_size: 1
-    - name: CEN2
-      description: DAC Channel 2 calibration enable
-      bit_offset: 30
-      bit_size: 1
-fieldset/DHR12L1:
-  description: channel1 12-bit left-aligned data holding register
+      array:
+        len: 2
+        stride: 16
+fieldset/DHR12L:
+  description: channel 12-bit left-aligned data holding register
   fields:
-    - name: DACC1DHR
-      description: DAC channel1 12-bit left-aligned data
-      bit_offset: 4
-      bit_size: 12
-fieldset/DHR12L2:
-  description: channel2 12-bit left aligned data holding register
-  fields:
-    - name: DACC2DHR
-      description: DAC channel2 12-bit left-aligned data
+    - name: DHR
+      description: DAC channel 12-bit left-aligned data
       bit_offset: 4
       bit_size: 12
 fieldset/DHR12LD:
   description: DUAL DAC 12-bit left aligned data holding register
   fields:
-    - name: DACC1DHR
-      description: DAC channel1 12-bit left-aligned data
+    - name: DHR
+      description: DAC channel 12-bit left-aligned data
       bit_offset: 4
       bit_size: 12
-    - name: DACC2DHR
-      description: DAC channel2 12-bit left-aligned data
-      bit_offset: 20
-      bit_size: 12
-fieldset/DHR12R1:
-  description: channel1 12-bit right-aligned data holding register
+      array:
+        len: 2
+        stride: 16
+fieldset/DHR12R:
+  description: channel 12-bit right-aligned data holding register
   fields:
-    - name: DACC1DHR
-      description: DAC channel1 12-bit right-aligned data
-      bit_offset: 0
-      bit_size: 12
-fieldset/DHR12R2:
-  description: channel2 12-bit right aligned data holding register
-  fields:
-    - name: DACC2DHR
-      description: DAC channel2 12-bit right-aligned data
+    - name: DHR
+      description: DAC channel 12-bit right-aligned data
       bit_offset: 0
       bit_size: 12
 fieldset/DHR12RD:
   description: Dual DAC 12-bit right-aligned data holding register
   fields:
-    - name: DACC1DHR
-      description: DAC channel1 12-bit right-aligned data
+    - name: DHR
+      description: DAC channel 12-bit right-aligned data
       bit_offset: 0
       bit_size: 12
-    - name: DACC2DHR
-      description: DAC channel2 12-bit right-aligned data
-      bit_offset: 16
-      bit_size: 12
-fieldset/DHR8R1:
-  description: channel1 8-bit right-aligned data holding register
+      array:
+        len: 2
+        stride: 16
+fieldset/DHR8R:
+  description: channel 8-bit right-aligned data holding register
   fields:
-    - name: DACC1DHR
-      description: DAC channel1 8-bit right-aligned data
-      bit_offset: 0
-      bit_size: 8
-fieldset/DHR8R2:
-  description: channel2 8-bit right-aligned data holding register
-  fields:
-    - name: DACC2DHR
-      description: DAC channel2 8-bit right-aligned data
+    - name: DHR
+      description: DAC channel 8-bit right-aligned data
       bit_offset: 0
       bit_size: 8
 fieldset/DHR8RD:
   description: DUAL DAC 8-bit right aligned data holding register
   fields:
-    - name: DACC1DHR
-      description: DAC channel1 8-bit right-aligned data
+    - name: DHR
+      description: DAC channel 8-bit right-aligned data
       bit_offset: 0
       bit_size: 8
-    - name: DACC2DHR
-      description: DAC channel2 8-bit right-aligned data
-      bit_offset: 8
-      bit_size: 8
-fieldset/DOR1:
-  description: channel1 data output register
+      array:
+        len: 2
+        stride: 8
+fieldset/DOR:
+  description: channel data output register
   fields:
-    - name: DACC1DOR
-      description: DAC channel1 data output
-      bit_offset: 0
-      bit_size: 12
-fieldset/DOR2:
-  description: channel2 data output register
-  fields:
-    - name: DACC2DOR
-      description: DAC channel2 data output
+    - name: DOR
+      description: DAC channel data output
       bit_offset: 0
       bit_size: 12
 fieldset/MCR:
   description: mode control register
   fields:
-    - name: MODE1
-      description: DAC Channel 1 mode
+    - name: MODE
+      description: DAC channel mode
       bit_offset: 0
       bit_size: 3
-    - name: MODE2
-      description: DAC Channel 2 mode
-      bit_offset: 16
-      bit_size: 3
+      array:
+        len: 2
+        stride: 16
 fieldset/SHHR:
   description: Sample and Hold hold time register
   fields:
-    - name: THOLD1
-      description: DAC Channel 1 hold Time
+    - name: THOLD
+      description: DAC channel hold Time
       bit_offset: 0
       bit_size: 10
-    - name: THOLD2
-      description: DAC Channel 2 hold time
-      bit_offset: 16
-      bit_size: 10
+      array:
+        len: 2
+        stride: 16
 fieldset/SHRR:
   description: Sample and Hold refresh time register
   fields:
-    - name: TREFRESH1
-      description: DAC Channel 1 refresh Time
+    - name: TREFRESH
+      description: DAC channel refresh Time
       bit_offset: 0
       bit_size: 8
-    - name: TREFRESH2
-      description: DAC Channel 2 refresh Time
-      bit_offset: 16
-      bit_size: 8
-fieldset/SHSR1:
-  description: Sample and Hold sample time register 1
+      array:
+        len: 2
+        stride: 16
+fieldset/SHSR:
+  description: Sample and Hold sample time register
   fields:
-    - name: TSAMPLE1
-      description: DAC Channel 1 sample Time
-      bit_offset: 0
-      bit_size: 10
-fieldset/SHSR2:
-  description: Sample and Hold sample time register 2
-  fields:
-    - name: TSAMPLE2
-      description: DAC Channel 2 sample Time
+    - name: TSAMPLE
+      description: DAC channel sample Time
       bit_offset: 0
       bit_size: 10
 fieldset/SR:
   description: status register
   fields:
-    - name: DMAUDR1
-      description: DAC channel1 DMA underrun flag
+    - name: DMAUDR
+      description: DAC channel DMA underrun flag
       bit_offset: 13
       bit_size: 1
-    - name: CAL_FLAG1
-      description: DAC Channel 1 calibration offset status
+      array:
+        len: 2
+        stride: 16
+    - name: CAL_FLAG
+      description: DAC channel calibration offset status
       bit_offset: 14
       bit_size: 1
-    - name: BWST1
-      description: DAC Channel 1 busy writing sample time flag
+      array:
+        len: 2
+        stride: 16
+    - name: BWST
+      description: DAC channel busy writing sample time flag
       bit_offset: 15
       bit_size: 1
-    - name: DMAUDR2
-      description: DAC channel2 DMA underrun flag
-      bit_offset: 29
-      bit_size: 1
-    - name: CAL_FLAG2
-      description: DAC Channel 2 calibration offset status
-      bit_offset: 30
-      bit_size: 1
-    - name: BWST2
-      description: DAC Channel 2 busy writing sample time flag
-      bit_offset: 31
-      bit_size: 1
+      array:
+        len: 2
+        stride: 16
 fieldset/SWTRIGR:
   description: software trigger register
   fields:
-    - name: SWTRIG1
-      description: DAC channel1 software trigger
+    - name: SWTRIG
+      description: DAC channel software trigger
       bit_offset: 0
       bit_size: 1
-    - name: SWTRIG2
-      description: DAC channel2 software trigger
-      bit_offset: 1
-      bit_size: 1
+      array:
+        len: 2
+        stride: 1
 enum/TSEL1:
   bit_size: 3
   variants:

--- a/stm32data/__main__.py
+++ b/stm32data/__main__.py
@@ -121,6 +121,7 @@ perimap = [
     ('.*:I2C:i2c2_v1_1U5', ('i2c', 'v2', 'I2C')),
 
     ('.*:DAC:dacif_v1_1', ('dac', 'v1', 'DAC')),
+    ('.*:DAC:dacif_v1_1F1', ('dac', 'v1', 'DAC')),
     ('.*:DAC:dacif_v2_0', ('dac', 'v2', 'DAC')),
     ('.*:DAC:dacif_v3_0', ('dac', 'v2', 'DAC')),
 


### PR DESCRIPTION
- Fixed DAC register mapping for F1
- Arrayified DAC registers where possible (channels 1/2)
- Removed "enable" enums
- Removed all non-functional differences between v1 and v2 (check diff between them)

Technically v2 DAC is just an extension of v1, so I'm not sure if it's worth keeping 2 separate definitions? For other peripherals that is handled in the HAL. The differences are:
- v1 has output buffer disable bit, where v2 doesn't
- v2 has additional calibration, mode, sample hold registers