### PR TITLE
USARTv2 split ixr into icr and isr

### DIFF
--- a/data/registers/usart_v2.yaml
+++ b/data/registers/usart_v2.yaml
@@ -35,12 +35,12 @@ block/USART:
       description: Interrupt & status register
       byte_offset: 28
       access: Read
-      fieldset: IXR
+      fieldset: ISR
     - name: ICR
       description: Interrupt flag clear register
       byte_offset: 32
       access: Write
-      fieldset: IXR
+      fieldset: ICR
     - name: RDR
       description: Receive data register
       byte_offset: 36
@@ -339,7 +339,7 @@ fieldset/GTPR:
       description: Guard time value
       bit_offset: 8
       bit_size: 8
-fieldset/IXR:
+fieldset/ISR:
   description: Interrupt & status register
   fields:
     - name: PE
@@ -430,6 +430,57 @@ fieldset/IXR:
     - name: REACK
       description: Receive enable acknowledge flag
       bit_offset: 22
+      bit_size: 1
+fieldset/ICR:
+  description: Interrupt flag clear register
+  fields:
+    - name: PE
+      description: Parity error clear flag
+      bit_offset: 0
+      bit_size: 1
+    - name: FE
+      description: Framing error clear flag
+      bit_offset: 1
+      bit_size: 1
+    - name: NE
+      description: Noise error clear flag
+      bit_offset: 2
+      bit_size: 1
+    - name: ORE
+      description: Overrun error clear flag
+      bit_offset: 3
+      bit_size: 1
+    - name: IDLE
+      description: Idle line detected clear flag
+      bit_offset: 4
+      bit_size: 1
+    - name: TC
+      description: Transmission complete clear flag
+      bit_offset: 6
+      bit_size: 1
+    - name: LBD
+      description: LIN break detection clear flag
+      bit_offset: 8
+      bit_size: 1
+    - name: CTS
+      description: CTS clear flag
+      bit_offset: 9
+      bit_size: 1
+    - name: RTOF
+      description: Receiver timeout clear flag
+      bit_offset: 11
+      bit_size: 1
+    - name: EOBF
+      description: End of block clear flag
+      bit_offset: 12
+      bit_size: 1
+    - name: CMF
+      description: Character match clear flag
+      bit_offset: 17
+      bit_size: 1
+    - name: WUF
+      description: Wakeup from Stop mode clear flag
+      bit_offset: 20
       bit_size: 1
 fieldset/RQR:
   description: Request register


### PR DESCRIPTION
IXR was incorrect due to a few bits not being writable (or readable, even) in ICR