### PR TITLE
Fix LPUART interrupts for the L0 family

### DIFF
--- a/data/chips/STM32L021D4.json
+++ b/data/chips/STM32L021D4.json
@@ -380,7 +380,12 @@
                 {
                     "name": "AES",
                     "address": 1073897472,
-                    "interrupts": [],
+                    "interrupts": [
+                        {
+                            "signal": "GLOBAL",
+                            "interrupt": "AES_LPUART1"
+                        }
+                    ],
                     "dma_channels": [
                         {
                             "signal": "IN",
@@ -901,7 +906,12 @@
                             "af": 6
                         }
                     ],
-                    "interrupts": [],
+                    "interrupts": [
+                        {
+                            "signal": "GLOBAL",
+                            "interrupt": "AES_LPUART1"
+                        }
+                    ],
                     "dma_channels": [
                         {
                             "signal": "TX",

--- a/data/chips/STM32L021F4.json
+++ b/data/chips/STM32L021F4.json
@@ -404,7 +404,12 @@
                 {
                     "name": "AES",
                     "address": 1073897472,
-                    "interrupts": [],
+                    "interrupts": [
+                        {
+                            "signal": "GLOBAL",
+                            "interrupt": "AES_LPUART1"
+                        }
+                    ],
                     "dma_channels": [
                         {
                             "signal": "IN",
@@ -1029,7 +1034,12 @@
                             "af": 6
                         }
                     ],
-                    "interrupts": [],
+                    "interrupts": [
+                        {
+                            "signal": "GLOBAL",
+                            "interrupt": "AES_LPUART1"
+                        }
+                    ],
                     "dma_channels": [
                         {
                             "signal": "TX",

--- a/data/chips/STM32L021G4.json
+++ b/data/chips/STM32L021G4.json
@@ -404,7 +404,12 @@
                 {
                     "name": "AES",
                     "address": 1073897472,
-                    "interrupts": [],
+                    "interrupts": [
+                        {
+                            "signal": "GLOBAL",
+                            "interrupt": "AES_LPUART1"
+                        }
+                    ],
                     "dma_channels": [
                         {
                             "signal": "IN",
@@ -1056,7 +1061,12 @@
                             "af": 6
                         }
                     ],
-                    "interrupts": [],
+                    "interrupts": [
+                        {
+                            "signal": "GLOBAL",
+                            "interrupt": "AES_LPUART1"
+                        }
+                    ],
                     "dma_channels": [
                         {
                             "signal": "TX",

--- a/data/chips/STM32L021K4.json
+++ b/data/chips/STM32L021K4.json
@@ -408,7 +408,12 @@
                 {
                     "name": "AES",
                     "address": 1073897472,
-                    "interrupts": [],
+                    "interrupts": [
+                        {
+                            "signal": "GLOBAL",
+                            "interrupt": "AES_LPUART1"
+                        }
+                    ],
                     "dma_channels": [
                         {
                             "signal": "IN",
@@ -1085,7 +1090,12 @@
                             "af": 6
                         }
                     ],
-                    "interrupts": [],
+                    "interrupts": [
+                        {
+                            "signal": "GLOBAL",
+                            "interrupt": "AES_LPUART1"
+                        }
+                    ],
                     "dma_channels": [
                         {
                             "signal": "TX",

--- a/data/chips/STM32L041C4.json
+++ b/data/chips/STM32L041C4.json
@@ -116,7 +116,12 @@
                 {
                     "name": "AES",
                     "address": 1073897472,
-                    "interrupts": [],
+                    "interrupts": [
+                        {
+                            "signal": "GLOBAL",
+                            "interrupt": "AES_LPUART1"
+                        }
+                    ],
                     "dma_channels": [
                         {
                             "signal": "IN",
@@ -777,7 +782,12 @@
                             "af": 6
                         }
                     ],
-                    "interrupts": [],
+                    "interrupts": [
+                        {
+                            "signal": "GLOBAL",
+                            "interrupt": "AES_LPUART1"
+                        }
+                    ],
                     "dma_channels": [
                         {
                             "signal": "TX",

--- a/data/chips/STM32L041C6.json
+++ b/data/chips/STM32L041C6.json
@@ -403,7 +403,12 @@
                 {
                     "name": "AES",
                     "address": 1073897472,
-                    "interrupts": [],
+                    "interrupts": [
+                        {
+                            "signal": "GLOBAL",
+                            "interrupt": "AES_LPUART1"
+                        }
+                    ],
                     "dma_channels": [
                         {
                             "signal": "IN",
@@ -1064,7 +1069,12 @@
                             "af": 6
                         }
                     ],
-                    "interrupts": [],
+                    "interrupts": [
+                        {
+                            "signal": "GLOBAL",
+                            "interrupt": "AES_LPUART1"
+                        }
+                    ],
                     "dma_channels": [
                         {
                             "signal": "TX",

--- a/data/chips/STM32L041E6.json
+++ b/data/chips/STM32L041E6.json
@@ -393,7 +393,12 @@
                 {
                     "name": "AES",
                     "address": 1073897472,
-                    "interrupts": [],
+                    "interrupts": [
+                        {
+                            "signal": "GLOBAL",
+                            "interrupt": "AES_LPUART1"
+                        }
+                    ],
                     "dma_channels": [
                         {
                             "signal": "IN",
@@ -976,7 +981,12 @@
                             "af": 4
                         }
                     ],
-                    "interrupts": [],
+                    "interrupts": [
+                        {
+                            "signal": "GLOBAL",
+                            "interrupt": "AES_LPUART1"
+                        }
+                    ],
                     "dma_channels": [
                         {
                             "signal": "TX",

--- a/data/chips/STM32L041F6.json
+++ b/data/chips/STM32L041F6.json
@@ -395,7 +395,12 @@
                 {
                     "name": "AES",
                     "address": 1073897472,
-                    "interrupts": [],
+                    "interrupts": [
+                        {
+                            "signal": "GLOBAL",
+                            "interrupt": "AES_LPUART1"
+                        }
+                    ],
                     "dma_channels": [
                         {
                             "signal": "IN",
@@ -941,7 +946,12 @@
                             "af": 4
                         }
                     ],
-                    "interrupts": [],
+                    "interrupts": [
+                        {
+                            "signal": "GLOBAL",
+                            "interrupt": "AES_LPUART1"
+                        }
+                    ],
                     "dma_channels": [
                         {
                             "signal": "TX",

--- a/data/chips/STM32L041G6.json
+++ b/data/chips/STM32L041G6.json
@@ -403,7 +403,12 @@
                 {
                     "name": "AES",
                     "address": 1073897472,
-                    "interrupts": [],
+                    "interrupts": [
+                        {
+                            "signal": "GLOBAL",
+                            "interrupt": "AES_LPUART1"
+                        }
+                    ],
                     "dma_channels": [
                         {
                             "signal": "IN",
@@ -1004,7 +1009,12 @@
                             "af": 4
                         }
                     ],
-                    "interrupts": [],
+                    "interrupts": [
+                        {
+                            "signal": "GLOBAL",
+                            "interrupt": "AES_LPUART1"
+                        }
+                    ],
                     "dma_channels": [
                         {
                             "signal": "TX",

--- a/data/chips/STM32L041K6.json
+++ b/data/chips/STM32L041K6.json
@@ -403,7 +403,12 @@
                 {
                     "name": "AES",
                     "address": 1073897472,
-                    "interrupts": [],
+                    "interrupts": [
+                        {
+                            "signal": "GLOBAL",
+                            "interrupt": "AES_LPUART1"
+                        }
+                    ],
                     "dma_channels": [
                         {
                             "signal": "IN",
@@ -1024,7 +1029,12 @@
                             "af": 4
                         }
                     ],
-                    "interrupts": [],
+                    "interrupts": [
+                        {
+                            "signal": "GLOBAL",
+                            "interrupt": "AES_LPUART1"
+                        }
+                    ],
                     "dma_channels": [
                         {
                             "signal": "TX",

--- a/data/chips/STM32L081CB.json
+++ b/data/chips/STM32L081CB.json
@@ -393,7 +393,12 @@
                 {
                     "name": "AES",
                     "address": 1073897472,
-                    "interrupts": [],
+                    "interrupts": [
+                        {
+                            "signal": "GLOBAL",
+                            "interrupt": "AES_LPUART1"
+                        }
+                    ],
                     "dma_channels": [
                         {
                             "signal": "IN",
@@ -1187,7 +1192,12 @@
                             "af": 4
                         }
                     ],
-                    "interrupts": [],
+                    "interrupts": [
+                        {
+                            "signal": "GLOBAL",
+                            "interrupt": "AES_LPUART1"
+                        }
+                    ],
                     "dma_channels": [
                         {
                             "signal": "TX",

--- a/data/chips/STM32L081CZ.json
+++ b/data/chips/STM32L081CZ.json
@@ -403,7 +403,12 @@
                 {
                     "name": "AES",
                     "address": 1073897472,
-                    "interrupts": [],
+                    "interrupts": [
+                        {
+                            "signal": "GLOBAL",
+                            "interrupt": "AES_LPUART1"
+                        }
+                    ],
                     "dma_channels": [
                         {
                             "signal": "IN",
@@ -1197,7 +1202,12 @@
                             "af": 4
                         }
                     ],
-                    "interrupts": [],
+                    "interrupts": [
+                        {
+                            "signal": "GLOBAL",
+                            "interrupt": "AES_LPUART1"
+                        }
+                    ],
                     "dma_channels": [
                         {
                             "signal": "TX",

--- a/data/chips/STM32L081KZ.json
+++ b/data/chips/STM32L081KZ.json
@@ -403,7 +403,12 @@
                 {
                     "name": "AES",
                     "address": 1073897472,
-                    "interrupts": [],
+                    "interrupts": [
+                        {
+                            "signal": "GLOBAL",
+                            "interrupt": "AES_LPUART1"
+                        }
+                    ],
                     "dma_channels": [
                         {
                             "signal": "IN",
@@ -1068,7 +1073,12 @@
                             "af": 4
                         }
                     ],
-                    "interrupts": [],
+                    "interrupts": [
+                        {
+                            "signal": "GLOBAL",
+                            "interrupt": "AES_LPUART1"
+                        }
+                    ],
                     "dma_channels": [
                         {
                             "signal": "TX",

--- a/stm32data/interrupts.py
+++ b/stm32data/interrupts.py
@@ -33,6 +33,11 @@ def parse():
 
             # Interrupt name
             name = removesuffix(parts[0], "_IRQn")
+
+            # Fix typo in STM32Lxx and L083 devices
+            if name == "AES_RNG_LPUART1" and "RNG" not in str(parts[1:]):
+                name = "AES_LPUART1"
+
             if name in irqs:
                 continue
 


### PR DESCRIPTION
Slight typo in the source files which caused the interrupts to not be matched correctly.