### PR TITLE
Special case handling for STM32F0 ADC peripheral

### DIFF
--- a/data/chips/STM32F030C6.json
+++ b/data/chips/STM32F030C6.json
@@ -289,7 +289,7 @@
             "peripherals": [
                 {
                     "name": "ADC",
-                    "address": 1073817352,
+                    "address": 1073816576,
                     "registers": {
                         "kind": "adc",
                         "version": "v1",

--- a/data/chips/STM32F030C8.json
+++ b/data/chips/STM32F030C8.json
@@ -289,7 +289,7 @@
             "peripherals": [
                 {
                     "name": "ADC",
-                    "address": 1073817352,
+                    "address": 1073816576,
                     "registers": {
                         "kind": "adc",
                         "version": "v1",

--- a/data/chips/STM32F030CC.json
+++ b/data/chips/STM32F030CC.json
@@ -289,7 +289,7 @@
             "peripherals": [
                 {
                     "name": "ADC",
-                    "address": 1073817352,
+                    "address": 1073816576,
                     "registers": {
                         "kind": "adc",
                         "version": "v1",

--- a/data/chips/STM32F030F4.json
+++ b/data/chips/STM32F030F4.json
@@ -289,7 +289,7 @@
             "peripherals": [
                 {
                     "name": "ADC",
-                    "address": 1073817352,
+                    "address": 1073816576,
                     "registers": {
                         "kind": "adc",
                         "version": "v1",

--- a/data/chips/STM32F030K6.json
+++ b/data/chips/STM32F030K6.json
@@ -289,7 +289,7 @@
             "peripherals": [
                 {
                     "name": "ADC",
-                    "address": 1073817352,
+                    "address": 1073816576,
                     "registers": {
                         "kind": "adc",
                         "version": "v1",

--- a/data/chips/STM32F030R8.json
+++ b/data/chips/STM32F030R8.json
@@ -289,7 +289,7 @@
             "peripherals": [
                 {
                     "name": "ADC",
-                    "address": 1073817352,
+                    "address": 1073816576,
                     "registers": {
                         "kind": "adc",
                         "version": "v1",

--- a/data/chips/STM32F030RC.json
+++ b/data/chips/STM32F030RC.json
@@ -289,7 +289,7 @@
             "peripherals": [
                 {
                     "name": "ADC",
-                    "address": 1073817352,
+                    "address": 1073816576,
                     "registers": {
                         "kind": "adc",
                         "version": "v1",

--- a/data/chips/STM32F031C4.json
+++ b/data/chips/STM32F031C4.json
@@ -289,7 +289,7 @@
             "peripherals": [
                 {
                     "name": "ADC",
-                    "address": 1073817352,
+                    "address": 1073816576,
                     "registers": {
                         "kind": "adc",
                         "version": "v1",

--- a/data/chips/STM32F031C6.json
+++ b/data/chips/STM32F031C6.json
@@ -289,7 +289,7 @@
             "peripherals": [
                 {
                     "name": "ADC",
-                    "address": 1073817352,
+                    "address": 1073816576,
                     "registers": {
                         "kind": "adc",
                         "version": "v1",

--- a/data/chips/STM32F031E6.json
+++ b/data/chips/STM32F031E6.json
@@ -283,7 +283,7 @@
             "peripherals": [
                 {
                     "name": "ADC",
-                    "address": 1073817352,
+                    "address": 1073816576,
                     "registers": {
                         "kind": "adc",
                         "version": "v1",

--- a/data/chips/STM32F031F4.json
+++ b/data/chips/STM32F031F4.json
@@ -289,7 +289,7 @@
             "peripherals": [
                 {
                     "name": "ADC",
-                    "address": 1073817352,
+                    "address": 1073816576,
                     "registers": {
                         "kind": "adc",
                         "version": "v1",

--- a/data/chips/STM32F031F6.json
+++ b/data/chips/STM32F031F6.json
@@ -289,7 +289,7 @@
             "peripherals": [
                 {
                     "name": "ADC",
-                    "address": 1073817352,
+                    "address": 1073816576,
                     "registers": {
                         "kind": "adc",
                         "version": "v1",

--- a/data/chips/STM32F031G4.json
+++ b/data/chips/STM32F031G4.json
@@ -289,7 +289,7 @@
             "peripherals": [
                 {
                     "name": "ADC",
-                    "address": 1073817352,
+                    "address": 1073816576,
                     "registers": {
                         "kind": "adc",
                         "version": "v1",

--- a/data/chips/STM32F031G6.json
+++ b/data/chips/STM32F031G6.json
@@ -289,7 +289,7 @@
             "peripherals": [
                 {
                     "name": "ADC",
-                    "address": 1073817352,
+                    "address": 1073816576,
                     "registers": {
                         "kind": "adc",
                         "version": "v1",

--- a/data/chips/STM32F031K4.json
+++ b/data/chips/STM32F031K4.json
@@ -289,7 +289,7 @@
             "peripherals": [
                 {
                     "name": "ADC",
-                    "address": 1073817352,
+                    "address": 1073816576,
                     "registers": {
                         "kind": "adc",
                         "version": "v1",

--- a/data/chips/STM32F031K6.json
+++ b/data/chips/STM32F031K6.json
@@ -293,7 +293,7 @@
             "peripherals": [
                 {
                     "name": "ADC",
-                    "address": 1073817352,
+                    "address": 1073816576,
                     "registers": {
                         "kind": "adc",
                         "version": "v1",

--- a/data/chips/STM32F038C6.json
+++ b/data/chips/STM32F038C6.json
@@ -289,7 +289,7 @@
             "peripherals": [
                 {
                     "name": "ADC",
-                    "address": 1073817352,
+                    "address": 1073816576,
                     "registers": {
                         "kind": "adc",
                         "version": "v1",

--- a/data/chips/STM32F038E6.json
+++ b/data/chips/STM32F038E6.json
@@ -283,7 +283,7 @@
             "peripherals": [
                 {
                     "name": "ADC",
-                    "address": 1073817352,
+                    "address": 1073816576,
                     "registers": {
                         "kind": "adc",
                         "version": "v1",

--- a/data/chips/STM32F038F6.json
+++ b/data/chips/STM32F038F6.json
@@ -289,7 +289,7 @@
             "peripherals": [
                 {
                     "name": "ADC",
-                    "address": 1073817352,
+                    "address": 1073816576,
                     "registers": {
                         "kind": "adc",
                         "version": "v1",

--- a/data/chips/STM32F038G6.json
+++ b/data/chips/STM32F038G6.json
@@ -289,7 +289,7 @@
             "peripherals": [
                 {
                     "name": "ADC",
-                    "address": 1073817352,
+                    "address": 1073816576,
                     "registers": {
                         "kind": "adc",
                         "version": "v1",

--- a/data/chips/STM32F038K6.json
+++ b/data/chips/STM32F038K6.json
@@ -289,7 +289,7 @@
             "peripherals": [
                 {
                     "name": "ADC",
-                    "address": 1073817352,
+                    "address": 1073816576,
                     "registers": {
                         "kind": "adc",
                         "version": "v1",

--- a/data/chips/STM32F042C4.json
+++ b/data/chips/STM32F042C4.json
@@ -305,7 +305,7 @@
             "peripherals": [
                 {
                     "name": "ADC",
-                    "address": 1073817352,
+                    "address": 1073816576,
                     "registers": {
                         "kind": "adc",
                         "version": "v1",

--- a/data/chips/STM32F042C6.json
+++ b/data/chips/STM32F042C6.json
@@ -305,7 +305,7 @@
             "peripherals": [
                 {
                     "name": "ADC",
-                    "address": 1073817352,
+                    "address": 1073816576,
                     "registers": {
                         "kind": "adc",
                         "version": "v1",

--- a/data/chips/STM32F042F4.json
+++ b/data/chips/STM32F042F4.json
@@ -301,7 +301,7 @@
             "peripherals": [
                 {
                     "name": "ADC",
-                    "address": 1073817352,
+                    "address": 1073816576,
                     "registers": {
                         "kind": "adc",
                         "version": "v1",

--- a/data/chips/STM32F042F6.json
+++ b/data/chips/STM32F042F6.json
@@ -301,7 +301,7 @@
             "peripherals": [
                 {
                     "name": "ADC",
-                    "address": 1073817352,
+                    "address": 1073816576,
                     "registers": {
                         "kind": "adc",
                         "version": "v1",

--- a/data/chips/STM32F042G4.json
+++ b/data/chips/STM32F042G4.json
@@ -301,7 +301,7 @@
             "peripherals": [
                 {
                     "name": "ADC",
-                    "address": 1073817352,
+                    "address": 1073816576,
                     "registers": {
                         "kind": "adc",
                         "version": "v1",

--- a/data/chips/STM32F042G6.json
+++ b/data/chips/STM32F042G6.json
@@ -301,7 +301,7 @@
             "peripherals": [
                 {
                     "name": "ADC",
-                    "address": 1073817352,
+                    "address": 1073816576,
                     "registers": {
                         "kind": "adc",
                         "version": "v1",

--- a/data/chips/STM32F042K4.json
+++ b/data/chips/STM32F042K4.json
@@ -305,7 +305,7 @@
             "peripherals": [
                 {
                     "name": "ADC",
-                    "address": 1073817352,
+                    "address": 1073816576,
                     "registers": {
                         "kind": "adc",
                         "version": "v1",

--- a/data/chips/STM32F042K6.json
+++ b/data/chips/STM32F042K6.json
@@ -305,7 +305,7 @@
             "peripherals": [
                 {
                     "name": "ADC",
-                    "address": 1073817352,
+                    "address": 1073816576,
                     "registers": {
                         "kind": "adc",
                         "version": "v1",

--- a/data/chips/STM32F042T6.json
+++ b/data/chips/STM32F042T6.json
@@ -301,7 +301,7 @@
             "peripherals": [
                 {
                     "name": "ADC",
-                    "address": 1073817352,
+                    "address": 1073816576,
                     "registers": {
                         "kind": "adc",
                         "version": "v1",

--- a/data/chips/STM32F048C6.json
+++ b/data/chips/STM32F048C6.json
@@ -295,7 +295,7 @@
             "peripherals": [
                 {
                     "name": "ADC",
-                    "address": 1073817352,
+                    "address": 1073816576,
                     "registers": {
                         "kind": "adc",
                         "version": "v1",

--- a/data/chips/STM32F048G6.json
+++ b/data/chips/STM32F048G6.json
@@ -295,7 +295,7 @@
             "peripherals": [
                 {
                     "name": "ADC",
-                    "address": 1073817352,
+                    "address": 1073816576,
                     "registers": {
                         "kind": "adc",
                         "version": "v1",

--- a/data/chips/STM32F048T6.json
+++ b/data/chips/STM32F048T6.json
@@ -295,7 +295,7 @@
             "peripherals": [
                 {
                     "name": "ADC",
-                    "address": 1073817352,
+                    "address": 1073816576,
                     "registers": {
                         "kind": "adc",
                         "version": "v1",

--- a/data/chips/STM32F051C4.json
+++ b/data/chips/STM32F051C4.json
@@ -293,7 +293,7 @@
             "peripherals": [
                 {
                     "name": "ADC",
-                    "address": 1073817352,
+                    "address": 1073816576,
                     "registers": {
                         "kind": "adc",
                         "version": "v1",

--- a/data/chips/STM32F051C6.json
+++ b/data/chips/STM32F051C6.json
@@ -293,7 +293,7 @@
             "peripherals": [
                 {
                     "name": "ADC",
-                    "address": 1073817352,
+                    "address": 1073816576,
                     "registers": {
                         "kind": "adc",
                         "version": "v1",

--- a/data/chips/STM32F051C8.json
+++ b/data/chips/STM32F051C8.json
@@ -293,7 +293,7 @@
             "peripherals": [
                 {
                     "name": "ADC",
-                    "address": 1073817352,
+                    "address": 1073816576,
                     "registers": {
                         "kind": "adc",
                         "version": "v1",

--- a/data/chips/STM32F051K4.json
+++ b/data/chips/STM32F051K4.json
@@ -293,7 +293,7 @@
             "peripherals": [
                 {
                     "name": "ADC",
-                    "address": 1073817352,
+                    "address": 1073816576,
                     "registers": {
                         "kind": "adc",
                         "version": "v1",

--- a/data/chips/STM32F051K6.json
+++ b/data/chips/STM32F051K6.json
@@ -293,7 +293,7 @@
             "peripherals": [
                 {
                     "name": "ADC",
-                    "address": 1073817352,
+                    "address": 1073816576,
                     "registers": {
                         "kind": "adc",
                         "version": "v1",

--- a/data/chips/STM32F051K8.json
+++ b/data/chips/STM32F051K8.json
@@ -293,7 +293,7 @@
             "peripherals": [
                 {
                     "name": "ADC",
-                    "address": 1073817352,
+                    "address": 1073816576,
                     "registers": {
                         "kind": "adc",
                         "version": "v1",

--- a/data/chips/STM32F051R4.json
+++ b/data/chips/STM32F051R4.json
@@ -289,7 +289,7 @@
             "peripherals": [
                 {
                     "name": "ADC",
-                    "address": 1073817352,
+                    "address": 1073816576,
                     "registers": {
                         "kind": "adc",
                         "version": "v1",

--- a/data/chips/STM32F051R6.json
+++ b/data/chips/STM32F051R6.json
@@ -289,7 +289,7 @@
             "peripherals": [
                 {
                     "name": "ADC",
-                    "address": 1073817352,
+                    "address": 1073816576,
                     "registers": {
                         "kind": "adc",
                         "version": "v1",

--- a/data/chips/STM32F051R8.json
+++ b/data/chips/STM32F051R8.json
@@ -293,7 +293,7 @@
             "peripherals": [
                 {
                     "name": "ADC",
-                    "address": 1073817352,
+                    "address": 1073816576,
                     "registers": {
                         "kind": "adc",
                         "version": "v1",

--- a/data/chips/STM32F051T8.json
+++ b/data/chips/STM32F051T8.json
@@ -283,7 +283,7 @@
             "peripherals": [
                 {
                     "name": "ADC",
-                    "address": 1073817352,
+                    "address": 1073816576,
                     "registers": {
                         "kind": "adc",
                         "version": "v1",

--- a/data/chips/STM32F058C8.json
+++ b/data/chips/STM32F058C8.json
@@ -289,7 +289,7 @@
             "peripherals": [
                 {
                     "name": "ADC",
-                    "address": 1073817352,
+                    "address": 1073816576,
                     "registers": {
                         "kind": "adc",
                         "version": "v1",

--- a/data/chips/STM32F058R8.json
+++ b/data/chips/STM32F058R8.json
@@ -293,7 +293,7 @@
             "peripherals": [
                 {
                     "name": "ADC",
-                    "address": 1073817352,
+                    "address": 1073816576,
                     "registers": {
                         "kind": "adc",
                         "version": "v1",

--- a/data/chips/STM32F058T8.json
+++ b/data/chips/STM32F058T8.json
@@ -283,7 +283,7 @@
             "peripherals": [
                 {
                     "name": "ADC",
-                    "address": 1073817352,
+                    "address": 1073816576,
                     "registers": {
                         "kind": "adc",
                         "version": "v1",

--- a/data/chips/STM32F070C6.json
+++ b/data/chips/STM32F070C6.json
@@ -295,7 +295,7 @@
             "peripherals": [
                 {
                     "name": "ADC",
-                    "address": 1073817352,
+                    "address": 1073816576,
                     "registers": {
                         "kind": "adc",
                         "version": "v1",

--- a/data/chips/STM32F070CB.json
+++ b/data/chips/STM32F070CB.json
@@ -295,7 +295,7 @@
             "peripherals": [
                 {
                     "name": "ADC",
-                    "address": 1073817352,
+                    "address": 1073816576,
                     "registers": {
                         "kind": "adc",
                         "version": "v1",

--- a/data/chips/STM32F070F6.json
+++ b/data/chips/STM32F070F6.json
@@ -295,7 +295,7 @@
             "peripherals": [
                 {
                     "name": "ADC",
-                    "address": 1073817352,
+                    "address": 1073816576,
                     "registers": {
                         "kind": "adc",
                         "version": "v1",

--- a/data/chips/STM32F070RB.json
+++ b/data/chips/STM32F070RB.json
@@ -295,7 +295,7 @@
             "peripherals": [
                 {
                     "name": "ADC",
-                    "address": 1073817352,
+                    "address": 1073816576,
                     "registers": {
                         "kind": "adc",
                         "version": "v1",

--- a/data/chips/STM32F071C8.json
+++ b/data/chips/STM32F071C8.json
@@ -281,7 +281,7 @@
             "peripherals": [
                 {
                     "name": "ADC",
-                    "address": 1073817352,
+                    "address": 1073816576,
                     "registers": {
                         "kind": "adc",
                         "version": "v1",

--- a/data/chips/STM32F071CB.json
+++ b/data/chips/STM32F071CB.json
@@ -297,7 +297,7 @@
             "peripherals": [
                 {
                     "name": "ADC",
-                    "address": 1073817352,
+                    "address": 1073816576,
                     "registers": {
                         "kind": "adc",
                         "version": "v1",

--- a/data/chips/STM32F071RB.json
+++ b/data/chips/STM32F071RB.json
@@ -289,7 +289,7 @@
             "peripherals": [
                 {
                     "name": "ADC",
-                    "address": 1073817352,
+                    "address": 1073816576,
                     "registers": {
                         "kind": "adc",
                         "version": "v1",

--- a/data/chips/STM32F071V8.json
+++ b/data/chips/STM32F071V8.json
@@ -287,7 +287,7 @@
             "peripherals": [
                 {
                     "name": "ADC",
-                    "address": 1073817352,
+                    "address": 1073816576,
                     "registers": {
                         "kind": "adc",
                         "version": "v1",

--- a/data/chips/STM32F071VB.json
+++ b/data/chips/STM32F071VB.json
@@ -293,7 +293,7 @@
             "peripherals": [
                 {
                     "name": "ADC",
-                    "address": 1073817352,
+                    "address": 1073816576,
                     "registers": {
                         "kind": "adc",
                         "version": "v1",

--- a/data/chips/STM32F072C8.json
+++ b/data/chips/STM32F072C8.json
@@ -305,7 +305,7 @@
             "peripherals": [
                 {
                     "name": "ADC",
-                    "address": 1073817352,
+                    "address": 1073816576,
                     "registers": {
                         "kind": "adc",
                         "version": "v1",

--- a/data/chips/STM32F072CB.json
+++ b/data/chips/STM32F072CB.json
@@ -309,7 +309,7 @@
             "peripherals": [
                 {
                     "name": "ADC",
-                    "address": 1073817352,
+                    "address": 1073816576,
                     "registers": {
                         "kind": "adc",
                         "version": "v1",

--- a/data/chips/STM32F072R8.json
+++ b/data/chips/STM32F072R8.json
@@ -301,7 +301,7 @@
             "peripherals": [
                 {
                     "name": "ADC",
-                    "address": 1073817352,
+                    "address": 1073816576,
                     "registers": {
                         "kind": "adc",
                         "version": "v1",

--- a/data/chips/STM32F072RB.json
+++ b/data/chips/STM32F072RB.json
@@ -309,7 +309,7 @@
             "peripherals": [
                 {
                     "name": "ADC",
-                    "address": 1073817352,
+                    "address": 1073816576,
                     "registers": {
                         "kind": "adc",
                         "version": "v1",

--- a/data/chips/STM32F072V8.json
+++ b/data/chips/STM32F072V8.json
@@ -305,7 +305,7 @@
             "peripherals": [
                 {
                     "name": "ADC",
-                    "address": 1073817352,
+                    "address": 1073816576,
                     "registers": {
                         "kind": "adc",
                         "version": "v1",

--- a/data/chips/STM32F072VB.json
+++ b/data/chips/STM32F072VB.json
@@ -305,7 +305,7 @@
             "peripherals": [
                 {
                     "name": "ADC",
-                    "address": 1073817352,
+                    "address": 1073816576,
                     "registers": {
                         "kind": "adc",
                         "version": "v1",

--- a/data/chips/STM32F078CB.json
+++ b/data/chips/STM32F078CB.json
@@ -309,7 +309,7 @@
             "peripherals": [
                 {
                     "name": "ADC",
-                    "address": 1073817352,
+                    "address": 1073816576,
                     "registers": {
                         "kind": "adc",
                         "version": "v1",

--- a/data/chips/STM32F078RB.json
+++ b/data/chips/STM32F078RB.json
@@ -305,7 +305,7 @@
             "peripherals": [
                 {
                     "name": "ADC",
-                    "address": 1073817352,
+                    "address": 1073816576,
                     "registers": {
                         "kind": "adc",
                         "version": "v1",

--- a/data/chips/STM32F078VB.json
+++ b/data/chips/STM32F078VB.json
@@ -305,7 +305,7 @@
             "peripherals": [
                 {
                     "name": "ADC",
-                    "address": 1073817352,
+                    "address": 1073816576,
                     "registers": {
                         "kind": "adc",
                         "version": "v1",

--- a/data/chips/STM32F091CB.json
+++ b/data/chips/STM32F091CB.json
@@ -293,7 +293,7 @@
             "peripherals": [
                 {
                     "name": "ADC",
-                    "address": 1073817352,
+                    "address": 1073816576,
                     "registers": {
                         "kind": "adc",
                         "version": "v1",

--- a/data/chips/STM32F091CC.json
+++ b/data/chips/STM32F091CC.json
@@ -293,7 +293,7 @@
             "peripherals": [
                 {
                     "name": "ADC",
-                    "address": 1073817352,
+                    "address": 1073816576,
                     "registers": {
                         "kind": "adc",
                         "version": "v1",

--- a/data/chips/STM32F091RB.json
+++ b/data/chips/STM32F091RB.json
@@ -289,7 +289,7 @@
             "peripherals": [
                 {
                     "name": "ADC",
-                    "address": 1073817352,
+                    "address": 1073816576,
                     "registers": {
                         "kind": "adc",
                         "version": "v1",

--- a/data/chips/STM32F091RC.json
+++ b/data/chips/STM32F091RC.json
@@ -297,7 +297,7 @@
             "peripherals": [
                 {
                     "name": "ADC",
-                    "address": 1073817352,
+                    "address": 1073816576,
                     "registers": {
                         "kind": "adc",
                         "version": "v1",

--- a/data/chips/STM32F091VB.json
+++ b/data/chips/STM32F091VB.json
@@ -289,7 +289,7 @@
             "peripherals": [
                 {
                     "name": "ADC",
-                    "address": 1073817352,
+                    "address": 1073816576,
                     "registers": {
                         "kind": "adc",
                         "version": "v1",

--- a/data/chips/STM32F091VC.json
+++ b/data/chips/STM32F091VC.json
@@ -293,7 +293,7 @@
             "peripherals": [
                 {
                     "name": "ADC",
-                    "address": 1073817352,
+                    "address": 1073816576,
                     "registers": {
                         "kind": "adc",
                         "version": "v1",

--- a/data/chips/STM32F098CC.json
+++ b/data/chips/STM32F098CC.json
@@ -293,7 +293,7 @@
             "peripherals": [
                 {
                     "name": "ADC",
-                    "address": 1073817352,
+                    "address": 1073816576,
                     "registers": {
                         "kind": "adc",
                         "version": "v1",

--- a/data/chips/STM32F098RC.json
+++ b/data/chips/STM32F098RC.json
@@ -297,7 +297,7 @@
             "peripherals": [
                 {
                     "name": "ADC",
-                    "address": 1073817352,
+                    "address": 1073816576,
                     "registers": {
                         "kind": "adc",
                         "version": "v1",

--- a/data/chips/STM32F098VC.json
+++ b/data/chips/STM32F098VC.json
@@ -293,7 +293,7 @@
             "peripherals": [
                 {
                     "name": "ADC",
-                    "address": 1073817352,
+                    "address": 1073816576,
                     "registers": {
                         "kind": "adc",
                         "version": "v1",

--- a/stm32data/__main__.py
+++ b/stm32data/__main__.py
@@ -769,7 +769,10 @@ def parse_chips():
 
             peris = []
             for pname, pkind in peri_kinds.items():
-                addr = get_peri_addr(defines, pname)
+                if chip_name.startswith('STM32F0') and pname == 'ADC':
+                    addr = get_peri_addr(defines, 'ADC1')
+                else:
+                    addr = get_peri_addr(defines, pname)
                 if addr is None:
                     continue
 


### PR DESCRIPTION
Fixes #156

This adds special case handling to get the correct base address for the ADC peripheral for STM32F0 devices.

I'm not sure if this is the best way to fix the problem, but it does produce correct JSON, and the ADC peripheral works correctly.
