### PR TITLE
Fix DMA channels for single DAC chips

### DIFF
--- a/data/chips/STM32F205RB.json
+++ b/data/chips/STM32F205RB.json
@@ -750,6 +750,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F205RC.json
+++ b/data/chips/STM32F205RC.json
@@ -750,6 +750,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F205RE.json
+++ b/data/chips/STM32F205RE.json
@@ -754,6 +754,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F205RF.json
+++ b/data/chips/STM32F205RF.json
@@ -750,6 +750,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F205RG.json
+++ b/data/chips/STM32F205RG.json
@@ -758,6 +758,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F205VB.json
+++ b/data/chips/STM32F205VB.json
@@ -760,6 +760,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F205VC.json
+++ b/data/chips/STM32F205VC.json
@@ -760,6 +760,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F205VE.json
+++ b/data/chips/STM32F205VE.json
@@ -760,6 +760,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F205VF.json
+++ b/data/chips/STM32F205VF.json
@@ -760,6 +760,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F205VG.json
+++ b/data/chips/STM32F205VG.json
@@ -760,6 +760,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F205ZC.json
+++ b/data/chips/STM32F205ZC.json
@@ -792,6 +792,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F205ZE.json
+++ b/data/chips/STM32F205ZE.json
@@ -792,6 +792,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F205ZF.json
+++ b/data/chips/STM32F205ZF.json
@@ -792,6 +792,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F205ZG.json
+++ b/data/chips/STM32F205ZG.json
@@ -792,6 +792,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F207IC.json
+++ b/data/chips/STM32F207IC.json
@@ -806,6 +806,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F207IE.json
+++ b/data/chips/STM32F207IE.json
@@ -806,6 +806,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F207IF.json
+++ b/data/chips/STM32F207IF.json
@@ -806,6 +806,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F207IG.json
+++ b/data/chips/STM32F207IG.json
@@ -806,6 +806,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F207VC.json
+++ b/data/chips/STM32F207VC.json
@@ -760,6 +760,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F207VE.json
+++ b/data/chips/STM32F207VE.json
@@ -760,6 +760,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F207VF.json
+++ b/data/chips/STM32F207VF.json
@@ -760,6 +760,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F207VG.json
+++ b/data/chips/STM32F207VG.json
@@ -760,6 +760,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F207ZC.json
+++ b/data/chips/STM32F207ZC.json
@@ -792,6 +792,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F207ZE.json
+++ b/data/chips/STM32F207ZE.json
@@ -792,6 +792,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F207ZF.json
+++ b/data/chips/STM32F207ZF.json
@@ -792,6 +792,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F207ZG.json
+++ b/data/chips/STM32F207ZG.json
@@ -792,6 +792,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F215RE.json
+++ b/data/chips/STM32F215RE.json
@@ -783,6 +783,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F215RG.json
+++ b/data/chips/STM32F215RG.json
@@ -783,6 +783,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F215VE.json
+++ b/data/chips/STM32F215VE.json
@@ -793,6 +793,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F215VG.json
+++ b/data/chips/STM32F215VG.json
@@ -793,6 +793,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F215ZE.json
+++ b/data/chips/STM32F215ZE.json
@@ -825,6 +825,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F215ZG.json
+++ b/data/chips/STM32F215ZG.json
@@ -825,6 +825,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F217IE.json
+++ b/data/chips/STM32F217IE.json
@@ -839,6 +839,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F217IG.json
+++ b/data/chips/STM32F217IG.json
@@ -839,6 +839,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F217VE.json
+++ b/data/chips/STM32F217VE.json
@@ -793,6 +793,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F217VG.json
+++ b/data/chips/STM32F217VG.json
@@ -793,6 +793,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F217ZE.json
+++ b/data/chips/STM32F217ZE.json
@@ -825,6 +825,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F217ZG.json
+++ b/data/chips/STM32F217ZG.json
@@ -825,6 +825,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F405OE.json
+++ b/data/chips/STM32F405OE.json
@@ -744,6 +744,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F405OG.json
+++ b/data/chips/STM32F405OG.json
@@ -744,6 +744,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F405RG.json
+++ b/data/chips/STM32F405RG.json
@@ -762,6 +762,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F405VG.json
+++ b/data/chips/STM32F405VG.json
@@ -772,6 +772,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F405ZG.json
+++ b/data/chips/STM32F405ZG.json
@@ -804,6 +804,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F407IE.json
+++ b/data/chips/STM32F407IE.json
@@ -830,6 +830,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F407IG.json
+++ b/data/chips/STM32F407IG.json
@@ -830,6 +830,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F407VE.json
+++ b/data/chips/STM32F407VE.json
@@ -784,6 +784,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F407VG.json
+++ b/data/chips/STM32F407VG.json
@@ -784,6 +784,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F407ZE.json
+++ b/data/chips/STM32F407ZE.json
@@ -816,6 +816,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F407ZG.json
+++ b/data/chips/STM32F407ZG.json
@@ -816,6 +816,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F410C8.json
+++ b/data/chips/STM32F410C8.json
@@ -420,6 +420,13 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F410CB.json
+++ b/data/chips/STM32F410CB.json
@@ -420,6 +420,13 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F410R8.json
+++ b/data/chips/STM32F410R8.json
@@ -444,6 +444,13 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F410RB.json
+++ b/data/chips/STM32F410RB.json
@@ -444,6 +444,13 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F410T8.json
+++ b/data/chips/STM32F410T8.json
@@ -392,6 +392,13 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F410TB.json
+++ b/data/chips/STM32F410TB.json
@@ -392,6 +392,13 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F413CG.json
+++ b/data/chips/STM32F413CG.json
@@ -636,6 +636,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F413CH.json
+++ b/data/chips/STM32F413CH.json
@@ -636,6 +636,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F413MG.json
+++ b/data/chips/STM32F413MG.json
@@ -665,6 +665,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F413MH.json
+++ b/data/chips/STM32F413MH.json
@@ -665,6 +665,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F413RG.json
+++ b/data/chips/STM32F413RG.json
@@ -660,6 +660,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F413RH.json
+++ b/data/chips/STM32F413RH.json
@@ -660,6 +660,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F413VG.json
+++ b/data/chips/STM32F413VG.json
@@ -674,6 +674,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F413VH.json
+++ b/data/chips/STM32F413VH.json
@@ -674,6 +674,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F413ZG.json
+++ b/data/chips/STM32F413ZG.json
@@ -694,6 +694,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F413ZH.json
+++ b/data/chips/STM32F413ZH.json
@@ -694,6 +694,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F415OG.json
+++ b/data/chips/STM32F415OG.json
@@ -777,6 +777,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F415RG.json
+++ b/data/chips/STM32F415RG.json
@@ -795,6 +795,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F415VG.json
+++ b/data/chips/STM32F415VG.json
@@ -805,6 +805,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F415ZG.json
+++ b/data/chips/STM32F415ZG.json
@@ -837,6 +837,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F417IE.json
+++ b/data/chips/STM32F417IE.json
@@ -863,6 +863,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F417IG.json
+++ b/data/chips/STM32F417IG.json
@@ -863,6 +863,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F417VE.json
+++ b/data/chips/STM32F417VE.json
@@ -817,6 +817,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F417VG.json
+++ b/data/chips/STM32F417VG.json
@@ -817,6 +817,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F417ZE.json
+++ b/data/chips/STM32F417ZE.json
@@ -849,6 +849,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F417ZG.json
+++ b/data/chips/STM32F417ZG.json
@@ -849,6 +849,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F423CH.json
+++ b/data/chips/STM32F423CH.json
@@ -658,6 +658,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F423MH.json
+++ b/data/chips/STM32F423MH.json
@@ -687,6 +687,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F423RH.json
+++ b/data/chips/STM32F423RH.json
@@ -682,6 +682,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F423VH.json
+++ b/data/chips/STM32F423VH.json
@@ -696,6 +696,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F423ZH.json
+++ b/data/chips/STM32F423ZH.json
@@ -716,6 +716,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F427AG.json
+++ b/data/chips/STM32F427AG.json
@@ -804,6 +804,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F427AI.json
+++ b/data/chips/STM32F427AI.json
@@ -804,6 +804,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F427IG.json
+++ b/data/chips/STM32F427IG.json
@@ -836,6 +836,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F427II.json
+++ b/data/chips/STM32F427II.json
@@ -836,6 +836,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F427VG.json
+++ b/data/chips/STM32F427VG.json
@@ -790,6 +790,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F427VI.json
+++ b/data/chips/STM32F427VI.json
@@ -790,6 +790,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F427ZG.json
+++ b/data/chips/STM32F427ZG.json
@@ -822,6 +822,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F427ZI.json
+++ b/data/chips/STM32F427ZI.json
@@ -822,6 +822,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F429AG.json
+++ b/data/chips/STM32F429AG.json
@@ -816,6 +816,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F429AI.json
+++ b/data/chips/STM32F429AI.json
@@ -816,6 +816,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F429BE.json
+++ b/data/chips/STM32F429BE.json
@@ -832,6 +832,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F429BG.json
+++ b/data/chips/STM32F429BG.json
@@ -838,6 +838,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F429BI.json
+++ b/data/chips/STM32F429BI.json
@@ -838,6 +838,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F429IE.json
+++ b/data/chips/STM32F429IE.json
@@ -836,6 +836,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F429IG.json
+++ b/data/chips/STM32F429IG.json
@@ -848,6 +848,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F429II.json
+++ b/data/chips/STM32F429II.json
@@ -848,6 +848,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F429NE.json
+++ b/data/chips/STM32F429NE.json
@@ -832,6 +832,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F429NG.json
+++ b/data/chips/STM32F429NG.json
@@ -838,6 +838,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F429NI.json
+++ b/data/chips/STM32F429NI.json
@@ -838,6 +838,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F429VE.json
+++ b/data/chips/STM32F429VE.json
@@ -790,6 +790,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F429VG.json
+++ b/data/chips/STM32F429VG.json
@@ -796,6 +796,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F429VI.json
+++ b/data/chips/STM32F429VI.json
@@ -796,6 +796,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F429ZE.json
+++ b/data/chips/STM32F429ZE.json
@@ -822,6 +822,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F429ZG.json
+++ b/data/chips/STM32F429ZG.json
@@ -832,6 +832,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F429ZI.json
+++ b/data/chips/STM32F429ZI.json
@@ -832,6 +832,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F437AI.json
+++ b/data/chips/STM32F437AI.json
@@ -837,6 +837,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F437IG.json
+++ b/data/chips/STM32F437IG.json
@@ -869,6 +869,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F437II.json
+++ b/data/chips/STM32F437II.json
@@ -869,6 +869,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F437VG.json
+++ b/data/chips/STM32F437VG.json
@@ -823,6 +823,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F437VI.json
+++ b/data/chips/STM32F437VI.json
@@ -823,6 +823,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F437ZG.json
+++ b/data/chips/STM32F437ZG.json
@@ -855,6 +855,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F437ZI.json
+++ b/data/chips/STM32F437ZI.json
@@ -855,6 +855,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F439AI.json
+++ b/data/chips/STM32F439AI.json
@@ -849,6 +849,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F439BG.json
+++ b/data/chips/STM32F439BG.json
@@ -871,6 +871,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F439BI.json
+++ b/data/chips/STM32F439BI.json
@@ -871,6 +871,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F439IG.json
+++ b/data/chips/STM32F439IG.json
@@ -881,6 +881,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F439II.json
+++ b/data/chips/STM32F439II.json
@@ -881,6 +881,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F439NG.json
+++ b/data/chips/STM32F439NG.json
@@ -871,6 +871,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F439NI.json
+++ b/data/chips/STM32F439NI.json
@@ -871,6 +871,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F439VG.json
+++ b/data/chips/STM32F439VG.json
@@ -829,6 +829,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F439VI.json
+++ b/data/chips/STM32F439VI.json
@@ -829,6 +829,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F439ZG.json
+++ b/data/chips/STM32F439ZG.json
@@ -865,6 +865,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F439ZI.json
+++ b/data/chips/STM32F439ZI.json
@@ -865,6 +865,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F446MC.json
+++ b/data/chips/STM32F446MC.json
@@ -763,6 +763,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F446ME.json
+++ b/data/chips/STM32F446ME.json
@@ -763,6 +763,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F446RC.json
+++ b/data/chips/STM32F446RC.json
@@ -773,6 +773,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F446RE.json
+++ b/data/chips/STM32F446RE.json
@@ -773,6 +773,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F446VC.json
+++ b/data/chips/STM32F446VC.json
@@ -783,6 +783,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F446VE.json
+++ b/data/chips/STM32F446VE.json
@@ -783,6 +783,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F446ZC.json
+++ b/data/chips/STM32F446ZC.json
@@ -823,6 +823,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F446ZE.json
+++ b/data/chips/STM32F446ZE.json
@@ -823,6 +823,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F469AE.json
+++ b/data/chips/STM32F469AE.json
@@ -780,6 +780,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F469AG.json
+++ b/data/chips/STM32F469AG.json
@@ -780,6 +780,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F469AI.json
+++ b/data/chips/STM32F469AI.json
@@ -780,6 +780,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F469BE.json
+++ b/data/chips/STM32F469BE.json
@@ -832,6 +832,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F469BG.json
+++ b/data/chips/STM32F469BG.json
@@ -832,6 +832,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F469BI.json
+++ b/data/chips/STM32F469BI.json
@@ -832,6 +832,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F469IE.json
+++ b/data/chips/STM32F469IE.json
@@ -831,6 +831,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F469IG.json
+++ b/data/chips/STM32F469IG.json
@@ -831,6 +831,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F469II.json
+++ b/data/chips/STM32F469II.json
@@ -831,6 +831,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F469NE.json
+++ b/data/chips/STM32F469NE.json
@@ -832,6 +832,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F469NG.json
+++ b/data/chips/STM32F469NG.json
@@ -832,6 +832,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F469NI.json
+++ b/data/chips/STM32F469NI.json
@@ -832,6 +832,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F469VE.json
+++ b/data/chips/STM32F469VE.json
@@ -768,6 +768,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F469VG.json
+++ b/data/chips/STM32F469VG.json
@@ -768,6 +768,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F469VI.json
+++ b/data/chips/STM32F469VI.json
@@ -768,6 +768,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F469ZE.json
+++ b/data/chips/STM32F469ZE.json
@@ -800,6 +800,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F469ZG.json
+++ b/data/chips/STM32F469ZG.json
@@ -800,6 +800,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F469ZI.json
+++ b/data/chips/STM32F469ZI.json
@@ -800,6 +800,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F479AG.json
+++ b/data/chips/STM32F479AG.json
@@ -813,6 +813,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F479AI.json
+++ b/data/chips/STM32F479AI.json
@@ -813,6 +813,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F479BG.json
+++ b/data/chips/STM32F479BG.json
@@ -865,6 +865,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F479BI.json
+++ b/data/chips/STM32F479BI.json
@@ -865,6 +865,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F479IG.json
+++ b/data/chips/STM32F479IG.json
@@ -864,6 +864,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F479II.json
+++ b/data/chips/STM32F479II.json
@@ -864,6 +864,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F479NG.json
+++ b/data/chips/STM32F479NG.json
@@ -865,6 +865,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F479NI.json
+++ b/data/chips/STM32F479NI.json
@@ -865,6 +865,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F479VG.json
+++ b/data/chips/STM32F479VG.json
@@ -801,6 +801,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F479VI.json
+++ b/data/chips/STM32F479VI.json
@@ -801,6 +801,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F479ZG.json
+++ b/data/chips/STM32F479ZG.json
@@ -833,6 +833,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F479ZI.json
+++ b/data/chips/STM32F479ZI.json
@@ -833,6 +833,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F722IC.json
+++ b/data/chips/STM32F722IC.json
@@ -757,6 +757,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F722IE.json
+++ b/data/chips/STM32F722IE.json
@@ -757,6 +757,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F722RC.json
+++ b/data/chips/STM32F722RC.json
@@ -688,6 +688,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F722RE.json
+++ b/data/chips/STM32F722RE.json
@@ -688,6 +688,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F722VC.json
+++ b/data/chips/STM32F722VC.json
@@ -706,6 +706,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F722VE.json
+++ b/data/chips/STM32F722VE.json
@@ -706,6 +706,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F722ZC.json
+++ b/data/chips/STM32F722ZC.json
@@ -738,6 +738,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F722ZE.json
+++ b/data/chips/STM32F722ZE.json
@@ -738,6 +738,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F723IC.json
+++ b/data/chips/STM32F723IC.json
@@ -757,6 +757,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F723IE.json
+++ b/data/chips/STM32F723IE.json
@@ -757,6 +757,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F723VC.json
+++ b/data/chips/STM32F723VC.json
@@ -710,6 +710,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F723VE.json
+++ b/data/chips/STM32F723VE.json
@@ -710,6 +710,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F723ZC.json
+++ b/data/chips/STM32F723ZC.json
@@ -742,6 +742,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F723ZE.json
+++ b/data/chips/STM32F723ZE.json
@@ -742,6 +742,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F730I8.json
+++ b/data/chips/STM32F730I8.json
@@ -774,6 +774,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F730R8.json
+++ b/data/chips/STM32F730R8.json
@@ -709,6 +709,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F730V8.json
+++ b/data/chips/STM32F730V8.json
@@ -727,6 +727,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F730Z8.json
+++ b/data/chips/STM32F730Z8.json
@@ -759,6 +759,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F732IE.json
+++ b/data/chips/STM32F732IE.json
@@ -790,6 +790,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F732RE.json
+++ b/data/chips/STM32F732RE.json
@@ -721,6 +721,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F732VE.json
+++ b/data/chips/STM32F732VE.json
@@ -739,6 +739,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F732ZE.json
+++ b/data/chips/STM32F732ZE.json
@@ -771,6 +771,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F733IE.json
+++ b/data/chips/STM32F733IE.json
@@ -790,6 +790,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F733VE.json
+++ b/data/chips/STM32F733VE.json
@@ -743,6 +743,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F733ZE.json
+++ b/data/chips/STM32F733ZE.json
@@ -775,6 +775,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F745IE.json
+++ b/data/chips/STM32F745IE.json
@@ -833,6 +833,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F745IG.json
+++ b/data/chips/STM32F745IG.json
@@ -833,6 +833,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F745VE.json
+++ b/data/chips/STM32F745VE.json
@@ -791,6 +791,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F745VG.json
+++ b/data/chips/STM32F745VG.json
@@ -791,6 +791,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F745ZE.json
+++ b/data/chips/STM32F745ZE.json
@@ -819,6 +819,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F745ZG.json
+++ b/data/chips/STM32F745ZG.json
@@ -819,6 +819,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F746BE.json
+++ b/data/chips/STM32F746BE.json
@@ -835,6 +835,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F746BG.json
+++ b/data/chips/STM32F746BG.json
@@ -835,6 +835,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F746IE.json
+++ b/data/chips/STM32F746IE.json
@@ -839,6 +839,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F746IG.json
+++ b/data/chips/STM32F746IG.json
@@ -839,6 +839,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F746NE.json
+++ b/data/chips/STM32F746NE.json
@@ -835,6 +835,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F746NG.json
+++ b/data/chips/STM32F746NG.json
@@ -835,6 +835,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F746VE.json
+++ b/data/chips/STM32F746VE.json
@@ -797,6 +797,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F746VG.json
+++ b/data/chips/STM32F746VG.json
@@ -797,6 +797,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F746ZE.json
+++ b/data/chips/STM32F746ZE.json
@@ -829,6 +829,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F746ZG.json
+++ b/data/chips/STM32F746ZG.json
@@ -829,6 +829,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F750N8.json
+++ b/data/chips/STM32F750N8.json
@@ -844,6 +844,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F750V8.json
+++ b/data/chips/STM32F750V8.json
@@ -802,6 +802,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F750Z8.json
+++ b/data/chips/STM32F750Z8.json
@@ -834,6 +834,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F756BG.json
+++ b/data/chips/STM32F756BG.json
@@ -868,6 +868,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F756IG.json
+++ b/data/chips/STM32F756IG.json
@@ -872,6 +872,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F756NG.json
+++ b/data/chips/STM32F756NG.json
@@ -868,6 +868,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F756VG.json
+++ b/data/chips/STM32F756VG.json
@@ -830,6 +830,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F756ZG.json
+++ b/data/chips/STM32F756ZG.json
@@ -862,6 +862,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F765BG.json
+++ b/data/chips/STM32F765BG.json
@@ -888,6 +888,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F765BI.json
+++ b/data/chips/STM32F765BI.json
@@ -894,6 +894,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F765IG.json
+++ b/data/chips/STM32F765IG.json
@@ -898,6 +898,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F765II.json
+++ b/data/chips/STM32F765II.json
@@ -898,6 +898,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F765NG.json
+++ b/data/chips/STM32F765NG.json
@@ -894,6 +894,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F765NI.json
+++ b/data/chips/STM32F765NI.json
@@ -894,6 +894,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F765VG.json
+++ b/data/chips/STM32F765VG.json
@@ -851,6 +851,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F765VI.json
+++ b/data/chips/STM32F765VI.json
@@ -851,6 +851,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F765ZG.json
+++ b/data/chips/STM32F765ZG.json
@@ -879,6 +879,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F765ZI.json
+++ b/data/chips/STM32F765ZI.json
@@ -879,6 +879,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F767BG.json
+++ b/data/chips/STM32F767BG.json
@@ -900,6 +900,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F767BI.json
+++ b/data/chips/STM32F767BI.json
@@ -900,6 +900,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F767IG.json
+++ b/data/chips/STM32F767IG.json
@@ -904,6 +904,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F767II.json
+++ b/data/chips/STM32F767II.json
@@ -904,6 +904,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F767NG.json
+++ b/data/chips/STM32F767NG.json
@@ -900,6 +900,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F767NI.json
+++ b/data/chips/STM32F767NI.json
@@ -900,6 +900,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F767VG.json
+++ b/data/chips/STM32F767VG.json
@@ -857,6 +857,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F767VI.json
+++ b/data/chips/STM32F767VI.json
@@ -857,6 +857,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F767ZG.json
+++ b/data/chips/STM32F767ZG.json
@@ -885,6 +885,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F767ZI.json
+++ b/data/chips/STM32F767ZI.json
@@ -885,6 +885,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F768AI.json
+++ b/data/chips/STM32F768AI.json
@@ -567,6 +567,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F769AG.json
+++ b/data/chips/STM32F769AG.json
@@ -567,6 +567,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F769AI.json
+++ b/data/chips/STM32F769AI.json
@@ -856,6 +856,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F769BG.json
+++ b/data/chips/STM32F769BG.json
@@ -912,6 +912,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F769BI.json
+++ b/data/chips/STM32F769BI.json
@@ -912,6 +912,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F769IG.json
+++ b/data/chips/STM32F769IG.json
@@ -902,6 +902,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F769II.json
+++ b/data/chips/STM32F769II.json
@@ -902,6 +902,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F769NG.json
+++ b/data/chips/STM32F769NG.json
@@ -912,6 +912,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F769NI.json
+++ b/data/chips/STM32F769NI.json
@@ -912,6 +912,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F777BI.json
+++ b/data/chips/STM32F777BI.json
@@ -939,6 +939,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F777II.json
+++ b/data/chips/STM32F777II.json
@@ -943,6 +943,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F777NI.json
+++ b/data/chips/STM32F777NI.json
@@ -939,6 +939,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F777VI.json
+++ b/data/chips/STM32F777VI.json
@@ -896,6 +896,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F777ZI.json
+++ b/data/chips/STM32F777ZI.json
@@ -924,6 +924,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F778AI.json
+++ b/data/chips/STM32F778AI.json
@@ -883,6 +883,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F779AI.json
+++ b/data/chips/STM32F779AI.json
@@ -889,6 +889,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F779BI.json
+++ b/data/chips/STM32F779BI.json
@@ -945,6 +945,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F779II.json
+++ b/data/chips/STM32F779II.json
@@ -935,6 +935,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32F779NI.json
+++ b/data/chips/STM32F779NI.json
@@ -945,6 +945,18 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH5",
+                            "request": 7
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH6",
+                            "request": 7
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32L431CB.json
+++ b/data/chips/STM32L431CB.json
@@ -738,6 +738,28 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH3",
+                            "request": 6
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH4",
+                            "request": 5
+                        },
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA2_CH4",
+                            "request": 3
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA2_CH5",
+                            "request": 3
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32L431CC.json
+++ b/data/chips/STM32L431CC.json
@@ -738,6 +738,28 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH3",
+                            "request": 6
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH4",
+                            "request": 5
+                        },
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA2_CH4",
+                            "request": 3
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA2_CH5",
+                            "request": 3
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32L431KB.json
+++ b/data/chips/STM32L431KB.json
@@ -702,6 +702,28 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH3",
+                            "request": 6
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH4",
+                            "request": 5
+                        },
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA2_CH4",
+                            "request": 3
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA2_CH5",
+                            "request": 3
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32L431KC.json
+++ b/data/chips/STM32L431KC.json
@@ -702,6 +702,28 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH3",
+                            "request": 6
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH4",
+                            "request": 5
+                        },
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA2_CH4",
+                            "request": 3
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA2_CH5",
+                            "request": 3
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32L431RB.json
+++ b/data/chips/STM32L431RB.json
@@ -766,6 +766,28 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH3",
+                            "request": 6
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH4",
+                            "request": 5
+                        },
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA2_CH4",
+                            "request": 3
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA2_CH5",
+                            "request": 3
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32L431RC.json
+++ b/data/chips/STM32L431RC.json
@@ -766,6 +766,28 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH3",
+                            "request": 6
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH4",
+                            "request": 5
+                        },
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA2_CH4",
+                            "request": 3
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA2_CH5",
+                            "request": 3
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32L431VC.json
+++ b/data/chips/STM32L431VC.json
@@ -772,6 +772,28 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH3",
+                            "request": 6
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH4",
+                            "request": 5
+                        },
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA2_CH4",
+                            "request": 3
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA2_CH5",
+                            "request": 3
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32L432KB.json
+++ b/data/chips/STM32L432KB.json
@@ -715,6 +715,28 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH3",
+                            "request": 6
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH4",
+                            "request": 5
+                        },
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA2_CH4",
+                            "request": 3
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA2_CH5",
+                            "request": 3
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32L432KC.json
+++ b/data/chips/STM32L432KC.json
@@ -715,6 +715,28 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH3",
+                            "request": 6
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH4",
+                            "request": 5
+                        },
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA2_CH4",
+                            "request": 3
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA2_CH5",
+                            "request": 3
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32L433CB.json
+++ b/data/chips/STM32L433CB.json
@@ -757,6 +757,28 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH3",
+                            "request": 6
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH4",
+                            "request": 5
+                        },
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA2_CH4",
+                            "request": 3
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA2_CH5",
+                            "request": 3
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32L433CC.json
+++ b/data/chips/STM32L433CC.json
@@ -757,6 +757,28 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH3",
+                            "request": 6
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH4",
+                            "request": 5
+                        },
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA2_CH4",
+                            "request": 3
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA2_CH5",
+                            "request": 3
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32L433RB.json
+++ b/data/chips/STM32L433RB.json
@@ -785,6 +785,28 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH3",
+                            "request": 6
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH4",
+                            "request": 5
+                        },
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA2_CH4",
+                            "request": 3
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA2_CH5",
+                            "request": 3
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32L433RC.json
+++ b/data/chips/STM32L433RC.json
@@ -795,6 +795,28 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH3",
+                            "request": 6
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH4",
+                            "request": 5
+                        },
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA2_CH4",
+                            "request": 3
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA2_CH5",
+                            "request": 3
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32L433VC.json
+++ b/data/chips/STM32L433VC.json
@@ -791,6 +791,28 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH3",
+                            "request": 6
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH4",
+                            "request": 5
+                        },
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA2_CH4",
+                            "request": 3
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA2_CH5",
+                            "request": 3
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32L442KC.json
+++ b/data/chips/STM32L442KC.json
@@ -758,6 +758,28 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH3",
+                            "request": 6
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH4",
+                            "request": 5
+                        },
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA2_CH4",
+                            "request": 3
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA2_CH5",
+                            "request": 3
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32L443CC.json
+++ b/data/chips/STM32L443CC.json
@@ -800,6 +800,28 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH3",
+                            "request": 6
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH4",
+                            "request": 5
+                        },
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA2_CH4",
+                            "request": 3
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA2_CH5",
+                            "request": 3
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32L443RC.json
+++ b/data/chips/STM32L443RC.json
@@ -828,6 +828,28 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH3",
+                            "request": 6
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH4",
+                            "request": 5
+                        },
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA2_CH4",
+                            "request": 3
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA2_CH5",
+                            "request": 3
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32L443VC.json
+++ b/data/chips/STM32L443VC.json
@@ -834,6 +834,28 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH3",
+                            "request": 6
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH4",
+                            "request": 5
+                        },
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA2_CH4",
+                            "request": 3
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA2_CH5",
+                            "request": 3
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32L451CC.json
+++ b/data/chips/STM32L451CC.json
@@ -742,6 +742,28 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH3",
+                            "request": 6
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH4",
+                            "request": 5
+                        },
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA2_CH4",
+                            "request": 3
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA2_CH5",
+                            "request": 3
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32L451CE.json
+++ b/data/chips/STM32L451CE.json
@@ -746,6 +746,28 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH3",
+                            "request": 6
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH4",
+                            "request": 5
+                        },
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA2_CH4",
+                            "request": 3
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA2_CH5",
+                            "request": 3
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32L451RC.json
+++ b/data/chips/STM32L451RC.json
@@ -782,6 +782,28 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH3",
+                            "request": 6
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH4",
+                            "request": 5
+                        },
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA2_CH4",
+                            "request": 3
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA2_CH5",
+                            "request": 3
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32L451RE.json
+++ b/data/chips/STM32L451RE.json
@@ -782,6 +782,28 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH3",
+                            "request": 6
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH4",
+                            "request": 5
+                        },
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA2_CH4",
+                            "request": 3
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA2_CH5",
+                            "request": 3
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32L451VC.json
+++ b/data/chips/STM32L451VC.json
@@ -788,6 +788,28 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH3",
+                            "request": 6
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH4",
+                            "request": 5
+                        },
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA2_CH4",
+                            "request": 3
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA2_CH5",
+                            "request": 3
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32L451VE.json
+++ b/data/chips/STM32L451VE.json
@@ -788,6 +788,28 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH3",
+                            "request": 6
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH4",
+                            "request": 5
+                        },
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA2_CH4",
+                            "request": 3
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA2_CH5",
+                            "request": 3
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32L452CC.json
+++ b/data/chips/STM32L452CC.json
@@ -755,6 +755,28 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH3",
+                            "request": 6
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH4",
+                            "request": 5
+                        },
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA2_CH4",
+                            "request": 3
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA2_CH5",
+                            "request": 3
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32L452CE.json
+++ b/data/chips/STM32L452CE.json
@@ -759,6 +759,28 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH3",
+                            "request": 6
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH4",
+                            "request": 5
+                        },
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA2_CH4",
+                            "request": 3
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA2_CH5",
+                            "request": 3
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32L452RC.json
+++ b/data/chips/STM32L452RC.json
@@ -795,6 +795,28 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH3",
+                            "request": 6
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH4",
+                            "request": 5
+                        },
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA2_CH4",
+                            "request": 3
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA2_CH5",
+                            "request": 3
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32L452RE.json
+++ b/data/chips/STM32L452RE.json
@@ -805,6 +805,28 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH3",
+                            "request": 6
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH4",
+                            "request": 5
+                        },
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA2_CH4",
+                            "request": 3
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA2_CH5",
+                            "request": 3
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32L452VC.json
+++ b/data/chips/STM32L452VC.json
@@ -801,6 +801,28 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH3",
+                            "request": 6
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH4",
+                            "request": 5
+                        },
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA2_CH4",
+                            "request": 3
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA2_CH5",
+                            "request": 3
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32L452VE.json
+++ b/data/chips/STM32L452VE.json
@@ -801,6 +801,28 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH3",
+                            "request": 6
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH4",
+                            "request": 5
+                        },
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA2_CH4",
+                            "request": 3
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA2_CH5",
+                            "request": 3
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32L462CE.json
+++ b/data/chips/STM32L462CE.json
@@ -808,6 +808,28 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH3",
+                            "request": 6
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH4",
+                            "request": 5
+                        },
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA2_CH4",
+                            "request": 3
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA2_CH5",
+                            "request": 3
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32L462RE.json
+++ b/data/chips/STM32L462RE.json
@@ -838,6 +838,28 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH3",
+                            "request": 6
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH4",
+                            "request": 5
+                        },
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA2_CH4",
+                            "request": 3
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA2_CH5",
+                            "request": 3
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32L462VE.json
+++ b/data/chips/STM32L462VE.json
@@ -844,6 +844,28 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH3",
+                            "request": 6
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH4",
+                            "request": 5
+                        },
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA2_CH4",
+                            "request": 3
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA2_CH5",
+                            "request": 3
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32L471QE.json
+++ b/data/chips/STM32L471QE.json
@@ -846,6 +846,28 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH3",
+                            "request": 6
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH4",
+                            "request": 5
+                        },
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA2_CH4",
+                            "request": 3
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA2_CH5",
+                            "request": 3
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32L471QG.json
+++ b/data/chips/STM32L471QG.json
@@ -846,6 +846,28 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH3",
+                            "request": 6
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH4",
+                            "request": 5
+                        },
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA2_CH4",
+                            "request": 3
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA2_CH5",
+                            "request": 3
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32L471RE.json
+++ b/data/chips/STM32L471RE.json
@@ -824,6 +824,28 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH3",
+                            "request": 6
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH4",
+                            "request": 5
+                        },
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA2_CH4",
+                            "request": 3
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA2_CH5",
+                            "request": 3
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32L471RG.json
+++ b/data/chips/STM32L471RG.json
@@ -824,6 +824,28 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH3",
+                            "request": 6
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH4",
+                            "request": 5
+                        },
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA2_CH4",
+                            "request": 3
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA2_CH5",
+                            "request": 3
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32L471VE.json
+++ b/data/chips/STM32L471VE.json
@@ -834,6 +834,28 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH3",
+                            "request": 6
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH4",
+                            "request": 5
+                        },
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA2_CH4",
+                            "request": 3
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA2_CH5",
+                            "request": 3
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32L471VG.json
+++ b/data/chips/STM32L471VG.json
@@ -834,6 +834,28 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH3",
+                            "request": 6
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH4",
+                            "request": 5
+                        },
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA2_CH4",
+                            "request": 3
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA2_CH5",
+                            "request": 3
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32L471ZE.json
+++ b/data/chips/STM32L471ZE.json
@@ -870,6 +870,28 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH3",
+                            "request": 6
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH4",
+                            "request": 5
+                        },
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA2_CH4",
+                            "request": 3
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA2_CH5",
+                            "request": 3
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32L471ZG.json
+++ b/data/chips/STM32L471ZG.json
@@ -870,6 +870,28 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH3",
+                            "request": 6
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH4",
+                            "request": 5
+                        },
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA2_CH4",
+                            "request": 3
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA2_CH5",
+                            "request": 3
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32L475RC.json
+++ b/data/chips/STM32L475RC.json
@@ -830,6 +830,28 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH3",
+                            "request": 6
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH4",
+                            "request": 5
+                        },
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA2_CH4",
+                            "request": 3
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA2_CH5",
+                            "request": 3
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32L475RE.json
+++ b/data/chips/STM32L475RE.json
@@ -830,6 +830,28 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH3",
+                            "request": 6
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH4",
+                            "request": 5
+                        },
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA2_CH4",
+                            "request": 3
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA2_CH5",
+                            "request": 3
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32L475RG.json
+++ b/data/chips/STM32L475RG.json
@@ -830,6 +830,28 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH3",
+                            "request": 6
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH4",
+                            "request": 5
+                        },
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA2_CH4",
+                            "request": 3
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA2_CH5",
+                            "request": 3
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32L475VC.json
+++ b/data/chips/STM32L475VC.json
@@ -840,6 +840,28 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH3",
+                            "request": 6
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH4",
+                            "request": 5
+                        },
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA2_CH4",
+                            "request": 3
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA2_CH5",
+                            "request": 3
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32L475VE.json
+++ b/data/chips/STM32L475VE.json
@@ -840,6 +840,28 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH3",
+                            "request": 6
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH4",
+                            "request": 5
+                        },
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA2_CH4",
+                            "request": 3
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA2_CH5",
+                            "request": 3
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32L475VG.json
+++ b/data/chips/STM32L475VG.json
@@ -840,6 +840,28 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH3",
+                            "request": 6
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH4",
+                            "request": 5
+                        },
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA2_CH4",
+                            "request": 3
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA2_CH5",
+                            "request": 3
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32L476JE.json
+++ b/data/chips/STM32L476JE.json
@@ -854,6 +854,28 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH3",
+                            "request": 6
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH4",
+                            "request": 5
+                        },
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA2_CH4",
+                            "request": 3
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA2_CH5",
+                            "request": 3
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32L476JG.json
+++ b/data/chips/STM32L476JG.json
@@ -864,6 +864,28 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH3",
+                            "request": 6
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH4",
+                            "request": 5
+                        },
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA2_CH4",
+                            "request": 3
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA2_CH5",
+                            "request": 3
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32L476ME.json
+++ b/data/chips/STM32L476ME.json
@@ -854,6 +854,28 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH3",
+                            "request": 6
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH4",
+                            "request": 5
+                        },
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA2_CH4",
+                            "request": 3
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA2_CH5",
+                            "request": 3
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32L476MG.json
+++ b/data/chips/STM32L476MG.json
@@ -854,6 +854,28 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH3",
+                            "request": 6
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH4",
+                            "request": 5
+                        },
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA2_CH4",
+                            "request": 3
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA2_CH5",
+                            "request": 3
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32L476QE.json
+++ b/data/chips/STM32L476QE.json
@@ -882,6 +882,28 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH3",
+                            "request": 6
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH4",
+                            "request": 5
+                        },
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA2_CH4",
+                            "request": 3
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA2_CH5",
+                            "request": 3
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32L476QG.json
+++ b/data/chips/STM32L476QG.json
@@ -882,6 +882,28 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH3",
+                            "request": 6
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH4",
+                            "request": 5
+                        },
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA2_CH4",
+                            "request": 3
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA2_CH5",
+                            "request": 3
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32L476RC.json
+++ b/data/chips/STM32L476RC.json
@@ -854,6 +854,28 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH3",
+                            "request": 6
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH4",
+                            "request": 5
+                        },
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA2_CH4",
+                            "request": 3
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA2_CH5",
+                            "request": 3
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32L476RE.json
+++ b/data/chips/STM32L476RE.json
@@ -854,6 +854,28 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH3",
+                            "request": 6
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH4",
+                            "request": 5
+                        },
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA2_CH4",
+                            "request": 3
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA2_CH5",
+                            "request": 3
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32L476RG.json
+++ b/data/chips/STM32L476RG.json
@@ -854,6 +854,28 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH3",
+                            "request": 6
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH4",
+                            "request": 5
+                        },
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA2_CH4",
+                            "request": 3
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA2_CH5",
+                            "request": 3
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32L476VC.json
+++ b/data/chips/STM32L476VC.json
@@ -870,6 +870,28 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH3",
+                            "request": 6
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH4",
+                            "request": 5
+                        },
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA2_CH4",
+                            "request": 3
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA2_CH5",
+                            "request": 3
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32L476VE.json
+++ b/data/chips/STM32L476VE.json
@@ -870,6 +870,28 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH3",
+                            "request": 6
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH4",
+                            "request": 5
+                        },
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA2_CH4",
+                            "request": 3
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA2_CH5",
+                            "request": 3
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32L476VG.json
+++ b/data/chips/STM32L476VG.json
@@ -870,6 +870,28 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH3",
+                            "request": 6
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH4",
+                            "request": 5
+                        },
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA2_CH4",
+                            "request": 3
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA2_CH5",
+                            "request": 3
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32L476ZE.json
+++ b/data/chips/STM32L476ZE.json
@@ -902,6 +902,28 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH3",
+                            "request": 6
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH4",
+                            "request": 5
+                        },
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA2_CH4",
+                            "request": 3
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA2_CH5",
+                            "request": 3
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32L476ZG.json
+++ b/data/chips/STM32L476ZG.json
@@ -916,6 +916,28 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH3",
+                            "request": 6
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH4",
+                            "request": 5
+                        },
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA2_CH4",
+                            "request": 3
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA2_CH5",
+                            "request": 3
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32L486JG.json
+++ b/data/chips/STM32L486JG.json
@@ -897,6 +897,28 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH3",
+                            "request": 6
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH4",
+                            "request": 5
+                        },
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA2_CH4",
+                            "request": 3
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA2_CH5",
+                            "request": 3
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32L486QG.json
+++ b/data/chips/STM32L486QG.json
@@ -925,6 +925,28 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH3",
+                            "request": 6
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH4",
+                            "request": 5
+                        },
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA2_CH4",
+                            "request": 3
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA2_CH5",
+                            "request": 3
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32L486RG.json
+++ b/data/chips/STM32L486RG.json
@@ -897,6 +897,28 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH3",
+                            "request": 6
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH4",
+                            "request": 5
+                        },
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA2_CH4",
+                            "request": 3
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA2_CH5",
+                            "request": 3
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32L486VG.json
+++ b/data/chips/STM32L486VG.json
@@ -913,6 +913,28 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH3",
+                            "request": 6
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH4",
+                            "request": 5
+                        },
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA2_CH4",
+                            "request": 3
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA2_CH5",
+                            "request": 3
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32L486ZG.json
+++ b/data/chips/STM32L486ZG.json
@@ -945,6 +945,28 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH3",
+                            "request": 6
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH4",
+                            "request": 5
+                        },
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA2_CH4",
+                            "request": 3
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA2_CH5",
+                            "request": 3
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32L496AE.json
+++ b/data/chips/STM32L496AE.json
@@ -966,6 +966,28 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH3",
+                            "request": 6
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH4",
+                            "request": 5
+                        },
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA2_CH4",
+                            "request": 3
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA2_CH5",
+                            "request": 3
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32L496AG.json
+++ b/data/chips/STM32L496AG.json
@@ -976,6 +976,28 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH3",
+                            "request": 6
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH4",
+                            "request": 5
+                        },
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA2_CH4",
+                            "request": 3
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA2_CH5",
+                            "request": 3
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32L496QE.json
+++ b/data/chips/STM32L496QE.json
@@ -952,6 +952,28 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH3",
+                            "request": 6
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH4",
+                            "request": 5
+                        },
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA2_CH4",
+                            "request": 3
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA2_CH5",
+                            "request": 3
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32L496QG.json
+++ b/data/chips/STM32L496QG.json
@@ -956,6 +956,28 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH3",
+                            "request": 6
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH4",
+                            "request": 5
+                        },
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA2_CH4",
+                            "request": 3
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA2_CH5",
+                            "request": 3
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32L496RE.json
+++ b/data/chips/STM32L496RE.json
@@ -930,6 +930,28 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH3",
+                            "request": 6
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH4",
+                            "request": 5
+                        },
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA2_CH4",
+                            "request": 3
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA2_CH5",
+                            "request": 3
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32L496RG.json
+++ b/data/chips/STM32L496RG.json
@@ -934,6 +934,28 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH3",
+                            "request": 6
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH4",
+                            "request": 5
+                        },
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA2_CH4",
+                            "request": 3
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA2_CH5",
+                            "request": 3
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32L496VE.json
+++ b/data/chips/STM32L496VE.json
@@ -940,6 +940,28 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH3",
+                            "request": 6
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH4",
+                            "request": 5
+                        },
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA2_CH4",
+                            "request": 3
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA2_CH5",
+                            "request": 3
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32L496VG.json
+++ b/data/chips/STM32L496VG.json
@@ -958,6 +958,28 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH3",
+                            "request": 6
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH4",
+                            "request": 5
+                        },
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA2_CH4",
+                            "request": 3
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA2_CH5",
+                            "request": 3
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32L496WG.json
+++ b/data/chips/STM32L496WG.json
@@ -1187,6 +1187,28 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH3",
+                            "request": 6
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH4",
+                            "request": 5
+                        },
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA2_CH4",
+                            "request": 3
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA2_CH5",
+                            "request": 3
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32L496ZE.json
+++ b/data/chips/STM32L496ZE.json
@@ -972,6 +972,28 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH3",
+                            "request": 6
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH4",
+                            "request": 5
+                        },
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA2_CH4",
+                            "request": 3
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA2_CH5",
+                            "request": 3
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32L496ZG.json
+++ b/data/chips/STM32L496ZG.json
@@ -982,6 +982,28 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH3",
+                            "request": 6
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH4",
+                            "request": 5
+                        },
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA2_CH4",
+                            "request": 3
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA2_CH5",
+                            "request": 3
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32L4A6AG.json
+++ b/data/chips/STM32L4A6AG.json
@@ -1013,6 +1013,28 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH3",
+                            "request": 6
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH4",
+                            "request": 5
+                        },
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA2_CH4",
+                            "request": 3
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA2_CH5",
+                            "request": 3
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32L4A6QG.json
+++ b/data/chips/STM32L4A6QG.json
@@ -999,6 +999,28 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH3",
+                            "request": 6
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH4",
+                            "request": 5
+                        },
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA2_CH4",
+                            "request": 3
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA2_CH5",
+                            "request": 3
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32L4A6RG.json
+++ b/data/chips/STM32L4A6RG.json
@@ -977,6 +977,28 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH3",
+                            "request": 6
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH4",
+                            "request": 5
+                        },
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA2_CH4",
+                            "request": 3
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA2_CH5",
+                            "request": 3
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32L4A6VG.json
+++ b/data/chips/STM32L4A6VG.json
@@ -995,6 +995,28 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH3",
+                            "request": 6
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH4",
+                            "request": 5
+                        },
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA2_CH4",
+                            "request": 3
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA2_CH5",
+                            "request": 3
+                        }
                     ]
                 },
                 {

--- a/data/chips/STM32L4A6ZG.json
+++ b/data/chips/STM32L4A6ZG.json
@@ -1019,6 +1019,28 @@
                             "signal": "GLOBAL",
                             "interrupt": "TIM6_DAC"
                         }
+                    ],
+                    "dma_channels": [
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA1_CH3",
+                            "request": 6
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA1_CH4",
+                            "request": 5
+                        },
+                        {
+                            "signal": "CH1",
+                            "channel": "DMA2_CH4",
+                            "request": 3
+                        },
+                        {
+                            "signal": "CH2",
+                            "channel": "DMA2_CH5",
+                            "request": 3
+                        }
                     ]
                 },
                 {

--- a/stm32data/__main__.py
+++ b/stm32data/__main__.py
@@ -1194,6 +1194,13 @@ def parse_dma():
                         original_target_name = target_name
                         parts = target_name.split(':')
                         target_name = parts[0]
+
+                        # Chips with single DAC refer to channels by DAC1/DAC2
+                        if target_name == "DAC1":
+                            target_name = "DAC_CH1"
+                        if target_name == "DAC2":
+                            target_name = "DAC_CH2"
+
                         parts = target_name.split('_')
                         target_peri_name = parts[0]
                         if len(parts) < 2:

--- a/stm32data/__main__.py
+++ b/stm32data/__main__.py
@@ -839,7 +839,13 @@ def parse_chips():
             for p in peris:
                 chs = []
                 for dma in chip_dmas:
-                    if peri_chs := dma_channels[dma]['peripherals'].get(p['name']):
+                    peri_chs = dma_channels[dma]['peripherals'].get(p['name'])
+
+                    # DAC1 is sometimes interchanged with DAC
+                    if not peri_chs and p['name'] == "DAC1":
+                        peri_chs = dma_channels[dma]['peripherals'].get("DAC")
+
+                    if peri_chs:
                         chs.extend([
                             ch
                             for ch in peri_chs


### PR DESCRIPTION
Chips with multiple DACs name signals by `DACx_CHy` as by the "standard", however chips that have only a single DAC name signals by `DACy`. This PR fixes it.