### PR TITLE
Unify and cleanup USB OTG registers

### DIFF
--- a/data/registers/otgfs_v1.yaml
+++ b/data/registers/otgfs_v1.yaml
@@ -30,43 +30,33 @@ block/OTG_FS:
       description: Interrupt mask register
       byte_offset: 24
       fieldset: GINTMSK
-    - name: GRXSTSR_Device
-      description: Receive status debug read (Device mode)
+    - name: GRXSTSR
+      description: Receive status debug read register
       byte_offset: 28
       access: Read
-      fieldset: GRXSTS_Device
-    - name: GRXSTSR_Host
-      description: Receive status debug read (Host mode)
-      byte_offset: 28
-      access: Read
-      fieldset: GRXSTS_Host
-    - name: GRXSTSP_Device
-      description: Status read and pop (Device mode)
+      fieldset: GRXSTS
+    - name: GRXSTSP
+      description: Status read and pop register
       byte_offset: 32
       access: Read
-      fieldset: GRXSTS_Device
-    - name: GRXSTSP_Host
-      description: Status read and pop (Host mode)
-      byte_offset: 32
-      access: Read
-      fieldset: GRXSTS_Host
+      fieldset: GRXSTS
     - name: GRXFSIZ
       description: Receive FIFO size register
       byte_offset: 36
       fieldset: GRXFSIZ
     - name: DIEPTXF0
-      description: Non-periodic transmit FIFO size register (Device mode)
+      description: Endpoint 0 transmit FIFO size register (device mode)
       byte_offset: 40
       fieldset: FSIZ
     - name: HNPTXFSIZ
-      description: Non-periodic transmit FIFO size register (Host mode)
+      description: Non-periodic transmit FIFO size register (host mode)
       byte_offset: 40
       fieldset: FSIZ
-    - name: GNPTXSTS
-      description: Non-periodic transmit FIFO/queue status register
+    - name: HNPTXSTS
+      description: Non-periodic transmit FIFO/queue status register (host mode)
       byte_offset: 44
       access: Read
-      fieldset: GNPTXSTS
+      fieldset: HNPTXSTS
     - name: GCCFG
       description: General core configuration register
       byte_offset: 56
@@ -186,91 +176,62 @@ block/OTG_FS:
       description: Device IN endpoint FIFO empty interrupt mask register
       byte_offset: 2100
       fieldset: DIEPEMPMSK
-    - name: DIEPCTL0
-      description: Device IN endpoint 0 control register
-      byte_offset: 2304
-      fieldset: DIEPCTL0
-    - name: DIEPINT0
-      description: Device IN endpoint 0 interrupt register
-      byte_offset: 2312
-      fieldset: DIEPINT0
-    - name: DIEPTSIZ0
-      description: Device IN endpoint 0 transfer size register
-      byte_offset: 2320
-      fieldset: DIEPTSIZ0
-    - name: DTXFSTS0
-      description: Device IN endpoint 0 transmit FIFO status register
-      byte_offset: 2328
-      access: Read
-      fieldset: DTXFSTS0
     - name: DIEPCTL
-      description: Device IN endpoint 1-3 control register
+      description: Device IN endpoint control register
       array:
-        len: 7
+        len: 8
         stride: 32
-      byte_offset: 2336
+      byte_offset: 2304
       fieldset: DIEPCTL
     - name: DIEPINT
-      description: Device IN endpoint 1-3 interrupt register
+      description: Device IN endpoint interrupt register
       array:
-        len: 7
+        len: 8
         stride: 32
-      byte_offset: 2344
+      byte_offset: 2312
       fieldset: DIEPINT
     - name: DIEPTSIZ
-      description: Device IN endpoint 1-3 transfer size register
+      description: Device IN endpoint transfer size register
       array:
-        len: 7
+        len: 8
         stride: 32
-      byte_offset: 2352
+      byte_offset: 2320
       fieldset: DIEPTSIZ
     - name: DTXFSTS
-      description: Device IN endpoint 1-3 transmit FIFO status register
+      description: Device IN endpoint transmit FIFO status register
       array:
-        len: 7
+        len: 8
         stride: 32
-      byte_offset: 2360
+      byte_offset: 2328
       access: Read
       fieldset: DTXFSTS
-    - name: DOEPCTL0
-      description: Device OUT endpoint 0 control register
-      byte_offset: 2816
-      fieldset: DOEPCTL0
-    - name: DOEPINT0
-      description: Device OUT endpoint 0 interrupt register
-      byte_offset: 2824
-      fieldset: DOEPINT0
-    - name: DOEPTSIZ0
-      description: Device OUT endpoint 0 transfer size register
-      byte_offset: 2832
-      fieldset: DOEPTSIZ0
     - name: DOEPCTL
-      description: Device OUT endpoint 1-3 control register
+      description: Device OUT endpoint control register
       array:
-        len: 7
+        len: 8
         stride: 32
-      byte_offset: 2848
+      byte_offset: 2816
       fieldset: DOEPCTL
     - name: DOEPINT
-      description: Device OUT endpoint 1-3 interrupt register
+      description: Device OUT endpoint interrupt register
       array:
-        len: 7
+        len: 8
         stride: 32
-      byte_offset: 2856
+      byte_offset: 2824
       fieldset: DOEPINT
     - name: DOEPTSIZ
-      description: Device OUT endpoint 1-3 transfer size register
+      description: Device OUT endpoint transfer size register
       array:
-        len: 7
+        len: 8
         stride: 32
-      byte_offset: 2864
+      byte_offset: 2832
       fieldset: DOEPTSIZ
     - name: PCGCCTL
       description: Power and clock gating control register
       byte_offset: 3584
       fieldset: PCGCCTL
     - name: FIFO
-      description: Device endpoint 0-3 Fifo / Host channel 0-7 Fifo register
+      description: Device endpoint / host channel FIFO register
       array:
         len: 8
         stride: 4096
@@ -312,6 +273,7 @@ fieldset/DCFG:
       description: Device speed
       bit_offset: 0
       bit_size: 2
+      enum: DSPD
     - name: NZLSOHSK
       description: Non-zero-length status OUT handshake
       bit_offset: 2
@@ -324,6 +286,7 @@ fieldset/DCFG:
       description: Periodic frame interval
       bit_offset: 11
       bit_size: 2
+      enum: PFIVL
 fieldset/DCTL:
   description: Device control register
   fields:
@@ -390,6 +353,11 @@ fieldset/DIEPCTL:
       description: EPTYP
       bit_offset: 18
       bit_size: 2
+      enum: EPTYP
+    - name: SNPM
+      description: SNPM
+      bit_offset: 20
+      bit_size: 1
     - name: STALL
       description: STALL
       bit_offset: 21
@@ -422,49 +390,6 @@ fieldset/DIEPCTL:
       description: EPENA
       bit_offset: 31
       bit_size: 1
-fieldset/DIEPCTL0:
-  description: Device control IN endpoint 0 control register
-  fields:
-    - name: MPSIZ
-      description: Maximum packet size
-      bit_offset: 0
-      bit_size: 2
-    - name: USBAEP
-      description: USB active endpoint
-      bit_offset: 15
-      bit_size: 1
-    - name: NAKSTS
-      description: NAK status
-      bit_offset: 17
-      bit_size: 1
-    - name: EPTYP
-      description: Endpoint type
-      bit_offset: 18
-      bit_size: 2
-    - name: STALL
-      description: STALL handshake
-      bit_offset: 21
-      bit_size: 1
-    - name: TXFNUM
-      description: TxFIFO number
-      bit_offset: 22
-      bit_size: 4
-    - name: CNAK
-      description: Clear NAK
-      bit_offset: 26
-      bit_size: 1
-    - name: SNAK
-      description: Set NAK
-      bit_offset: 27
-      bit_size: 1
-    - name: EPDIS
-      description: Endpoint disable
-      bit_offset: 30
-      bit_size: 1
-    - name: EPENA
-      description: Endpoint enable
-      bit_offset: 31
-      bit_size: 1
 fieldset/DIEPEMPMSK:
   description: Device IN endpoint FIFO empty interrupt mask register
   fields:
@@ -474,33 +399,6 @@ fieldset/DIEPEMPMSK:
       bit_size: 16
 fieldset/DIEPINT:
   description: Device endpoint interrupt register
-  fields:
-    - name: XFRC
-      description: XFRC
-      bit_offset: 0
-      bit_size: 1
-    - name: EPDISD
-      description: EPDISD
-      bit_offset: 1
-      bit_size: 1
-    - name: TOC
-      description: TOC
-      bit_offset: 3
-      bit_size: 1
-    - name: ITTXFE
-      description: ITTXFE
-      bit_offset: 4
-      bit_size: 1
-    - name: INEPNE
-      description: INEPNE
-      bit_offset: 6
-      bit_size: 1
-    - name: TXFE
-      description: TXFE
-      bit_offset: 7
-      bit_size: 1
-fieldset/DIEPINT0:
-  description: Device endpoint 0 interrupt register
   fields:
     - name: XFRC
       description: XFRC
@@ -568,17 +466,6 @@ fieldset/DIEPTSIZ:
       description: Multi count
       bit_offset: 29
       bit_size: 2
-fieldset/DIEPTSIZ0:
-  description: Device endpoint 0 transfer size register
-  fields:
-    - name: XFRSIZ
-      description: Transfer size
-      bit_offset: 0
-      bit_size: 7
-    - name: PKTCNT
-      description: Packet count
-      bit_offset: 19
-      bit_size: 2
 fieldset/DOEPCTL:
   description: Device endpoint control register
   fields:
@@ -602,6 +489,7 @@ fieldset/DOEPCTL:
       description: EPTYP
       bit_offset: 18
       bit_size: 2
+      enum: EPTYP
     - name: SNPM
       description: SNPM
       bit_offset: 20
@@ -634,74 +522,8 @@ fieldset/DOEPCTL:
       description: EPENA
       bit_offset: 31
       bit_size: 1
-fieldset/DOEPCTL0:
-  description: Device endpoint 0 control register
-  fields:
-    - name: MPSIZ
-      description: MPSIZ
-      bit_offset: 0
-      bit_size: 2
-    - name: USBAEP
-      description: USBAEP
-      bit_offset: 15
-      bit_size: 1
-    - name: NAKSTS
-      description: NAKSTS
-      bit_offset: 17
-      bit_size: 1
-    - name: EPTYP
-      description: EPTYP
-      bit_offset: 18
-      bit_size: 2
-    - name: SNPM
-      description: SNPM
-      bit_offset: 20
-      bit_size: 1
-    - name: STALL
-      description: STALL
-      bit_offset: 21
-      bit_size: 1
-    - name: CNAK
-      description: CNAK
-      bit_offset: 26
-      bit_size: 1
-    - name: SNAK
-      description: SNAK
-      bit_offset: 27
-      bit_size: 1
-    - name: EPDIS
-      description: EPDIS
-      bit_offset: 30
-      bit_size: 1
-    - name: EPENA
-      description: EPENA
-      bit_offset: 31
-      bit_size: 1
 fieldset/DOEPINT:
   description: Device endpoint interrupt register
-  fields:
-    - name: XFRC
-      description: XFRC
-      bit_offset: 0
-      bit_size: 1
-    - name: EPDISD
-      description: EPDISD
-      bit_offset: 1
-      bit_size: 1
-    - name: STUP
-      description: STUP
-      bit_offset: 3
-      bit_size: 1
-    - name: OTEPDIS
-      description: OTEPDIS
-      bit_offset: 4
-      bit_size: 1
-    - name: B2BSTUP
-      description: B2BSTUP
-      bit_offset: 6
-      bit_size: 1
-fieldset/DOEPINT0:
-  description: Device endpoint 0 interrupt register
   fields:
     - name: XFRC
       description: XFRC
@@ -757,21 +579,6 @@ fieldset/DOEPTSIZ:
       description: Received data PID/SETUP packet count
       bit_offset: 29
       bit_size: 2
-fieldset/DOEPTSIZ0:
-  description: Device OUT endpoint 0 transfer size register
-  fields:
-    - name: XFRSIZ
-      description: Transfer size
-      bit_offset: 0
-      bit_size: 7
-    - name: PKTCNT
-      description: Packet count
-      bit_offset: 19
-      bit_size: 1
-    - name: STUPCNT
-      description: SETUP packet count
-      bit_offset: 29
-      bit_size: 2
 fieldset/DSTS:
   description: Device status register
   fields:
@@ -783,6 +590,7 @@ fieldset/DSTS:
       description: Enumerated speed
       bit_offset: 1
       bit_size: 2
+      enum: DSPD
     - name: EERR
       description: Erratic error
       bit_offset: 3
@@ -792,13 +600,6 @@ fieldset/DSTS:
       bit_offset: 8
       bit_size: 14
 fieldset/DTXFSTS:
-  description: Device IN endpoint transmit FIFO status register
-  fields:
-    - name: INEPTFSAV
-      description: IN endpoint TxFIFO space available
-      bit_offset: 0
-      bit_size: 16
-fieldset/DTXFSTS0:
   description: Device IN endpoint transmit FIFO status register
   fields:
     - name: INEPTFSAV
@@ -820,7 +621,7 @@ fieldset/DVBUSPULSE:
       bit_offset: 0
       bit_size: 12
 fieldset/FIFO:
-  description: Fifo register
+  description: FIFO register
   fields:
     - name: DATA
       description: Data
@@ -849,16 +650,24 @@ fieldset/GCCFG:
       bit_offset: 16
       bit_size: 1
     - name: VBUSASEN
-      description: Enable the VBUS sensing device
+      description: Enable the VBUS "A" sensing device
       bit_offset: 18
       bit_size: 1
     - name: VBUSBSEN
-      description: Enable the VBUS sensing device
+      description: Enable the VBUS "B" sensing device
       bit_offset: 19
       bit_size: 1
     - name: SOFOUTEN
       description: SOF output enable
       bit_offset: 20
+      bit_size: 1
+    - name: NOVBUSSENS
+      description: VBUS sensing disable
+      bit_offset: 21
+      bit_size: 1
+    - name: VBDEN
+      description: USB VBUS detection enable
+      bit_offset: 21
       bit_size: 1
 fieldset/GINTMSK:
   description: Interrupt mask register
@@ -932,7 +741,7 @@ fieldset/GINTMSK:
       bit_offset: 20
       bit_size: 1
     - name: IPXFRM_IISOOXFRM
-      description: Incomplete periodic transfer mask(Host mode)/Incomplete isochronous OUT transfer mask(Device mode)
+      description: Incomplete periodic transfer mask (host mode) / Incomplete isochronous OUT transfer mask (device mode)
       bit_offset: 21
       bit_size: 1
     - name: PRTIM
@@ -1035,7 +844,7 @@ fieldset/GINTSTS:
       bit_offset: 20
       bit_size: 1
     - name: IPXFR_INCOMPISOOUT
-      description: Incomplete periodic transfer(Host mode)/Incomplete isochronous OUT transfer(Device mode)
+      description: Incomplete periodic transfer (host mode) / Incomplete isochronous OUT transfer (device mode)
       bit_offset: 21
       bit_size: 1
     - name: HPRTINT
@@ -1091,6 +900,30 @@ fieldset/GOTGCTL:
     - name: SRQ
       description: Session request
       bit_offset: 1
+      bit_size: 1
+    - name: VBVALOEN
+      description: VBUS valid override enable
+      bit_offset: 2
+      bit_size: 1
+    - name: VBVALOVAL
+      description: VBUS valid override value
+      bit_offset: 3
+      bit_size: 1
+    - name: AVALOEN
+      description: A-peripheral session valid override enable
+      bit_offset: 4
+      bit_size: 1
+    - name: AVALOVAL
+      description: A-peripheral session valid override value
+      bit_offset: 5
+      bit_size: 1
+    - name: BVALOEN
+      description: B-peripheral session valid override enable
+      bit_offset: 6
+      bit_size: 1
+    - name: BVALOVAL
+      description: B-peripheral session valid override value
+      bit_offset: 7
       bit_size: 1
     - name: HNGSCS
       description: Host negotiation success
@@ -1178,7 +1011,6 @@ fieldset/GRSTCTL:
       description: TxFIFO number
       bit_offset: 6
       bit_size: 5
-      enum: TXFNUM
     - name: AHBIDL
       description: AHB master idle
       bit_offset: 31
@@ -1190,35 +1022,11 @@ fieldset/GRXFSIZ:
       description: RxFIFO depth
       bit_offset: 0
       bit_size: 16
-fieldset/GRXSTS_Device:
-  description: Receive status (Device mode)
+fieldset/GRXSTS:
+  description: Status read and pop register
   fields:
     - name: EPNUM
-      description: Endpoint number
-      bit_offset: 0
-      bit_size: 4
-    - name: BCNT
-      description: Byte count
-      bit_offset: 4
-      bit_size: 11
-    - name: DPID
-      description: Data PID
-      bit_offset: 15
-      bit_size: 2
-    - name: PKTSTS
-      description: Packet status
-      bit_offset: 17
-      bit_size: 4
-      enum: PKTSTSD
-    - name: FRMNUM
-      description: Frame number
-      bit_offset: 21
-      bit_size: 4
-fieldset/GRXSTS_Host:
-  description: Receive status (Host mode)
-  fields:
-    - name: CHNUM
-      description: Channel number
+      description: Endpoint number (device mode) / Channel number (host mode)
       bit_offset: 0
       bit_size: 4
     - name: BCNT
@@ -1230,11 +1038,20 @@ fieldset/GRXSTS_Host:
       bit_offset: 15
       bit_size: 2
       enum: DPID
-    - name: PKTSTS
-      description: Packet status
+    - name: PKTSTSD
+      description: Packet status (device mode)
+      bit_offset: 17
+      bit_size: 4
+      enum: PKTSTSD
+    - name: PKTSTSH
+      description: Packet status (host mode)
       bit_offset: 17
       bit_size: 4
       enum: PKTSTSH
+    - name: FRMNUM
+      description: Frame number (device mode)
+      bit_offset: 21
+      bit_size: 4
 fieldset/GUSBCFG:
   description: USB configuration register
   fields:
@@ -1243,7 +1060,7 @@ fieldset/GUSBCFG:
       bit_offset: 0
       bit_size: 3
     - name: PHYSEL
-      description: Full Speed serial transceiver select
+      description: Full-speed internal serial transceiver enable
       bit_offset: 6
       bit_size: 1
     - name: SRPCAP
@@ -1307,6 +1124,7 @@ fieldset/HCCHAR:
       description: Endpoint type
       bit_offset: 18
       bit_size: 2
+      enum: EPTYP
     - name: MCNT
       description: Multicount
       bit_offset: 20
@@ -1334,7 +1152,6 @@ fieldset/HCFG:
       description: FS/LS PHY clock select
       bit_offset: 0
       bit_size: 2
-      enum: SPEED
     - name: FSLSS
       description: FS- and LS-only support
       bit_offset: 2
@@ -1454,6 +1271,21 @@ fieldset/HFNUM:
       description: Frame time remaining
       bit_offset: 16
       bit_size: 16
+fieldset/HNPTXSTS:
+  description: Non-periodic transmit FIFO/queue status register
+  fields:
+    - name: NPTXFSAV
+      description: Non-periodic TxFIFO space available
+      bit_offset: 0
+      bit_size: 16
+    - name: NPTQXSAV
+      description: Non-periodic transmit request queue space available
+      bit_offset: 16
+      bit_size: 8
+    - name: NPTXQTOP
+      description: Top of the non-periodic transmit request queue
+      bit_offset: 24
+      bit_size: 7
 fieldset/FSIZ:
   description: FIFO size register
   fields:
@@ -1520,7 +1352,6 @@ fieldset/HPRT:
       description: Port speed
       bit_offset: 17
       bit_size: 2
-      enum: SPEED
 fieldset/HPTXSTS:
   description: Periodic transmit FIFO/queue status register
   fields:
@@ -1562,6 +1393,44 @@ enum/DPID:
       value: 2
     - name: MDATA
       value: 3
+enum/DSPD:
+  bit_size: 2
+  variants:
+    - name: HIGH_SPEED
+      description: High speed
+      value: 0
+    - name: FULL_SPEED_EXTERNAL
+      description: Full speed using external ULPI PHY
+      value: 1
+    - name: FULL_SPEED_INTERNAL
+      description: Full speed using internal embedded PHY
+      value: 3
+enum/EPTYP:
+  bit_size: 2
+  variants:
+    - name: CONTROL
+      value: 0
+    - name: ISOCHRONOUS
+      value: 1
+    - name: BULK
+      value: 2
+    - name: INTERRUPT
+      value: 3
+enum/PFIVL:
+  bit_size: 2
+  variants:
+    - name: FRAME_INTERVAL_80
+      description: 80% of the frame interval
+      value: 0
+    - name: FRAME_INTERVAL_85
+      description: 85% of the frame interval
+      value: 1
+    - name: FRAME_INTERVAL_90
+      description: 90% of the frame interval
+      value: 2
+    - name: FRAME_INTERVAL_95
+      description: 95% of the frame interval
+      value: 3
 enum/PKTSTSD:
   bit_size: 4
   variants:
@@ -1595,15 +1464,3 @@ enum/PKTSTSH:
     - name: CHANNEL_HALTED
       description: Channel halted (triggers an interrupt)
       value: 7
-enum/SPEED:
-  bit_size: 2
-  variants:
-    - name: FULL_SPEED
-      value: 1
-    - name: LOW_SPEED
-      value: 2
-enum/TXFNUM:
-  bit_size: 5
-  variants:
-    - name: ALL
-      value: 16

--- a/data/registers/otgfs_v1.yaml
+++ b/data/registers/otgfs_v1.yaml
@@ -669,6 +669,10 @@ fieldset/GCCFG:
       description: USB VBUS detection enable
       bit_offset: 21
       bit_size: 1
+    - name: PHYHSEN
+      description: Internal high-speed PHY enable.
+      bit_offset: 23
+      bit_size: 1
 fieldset/GINTMSK:
   description: Interrupt mask register
   fields:

--- a/data/registers/otghs_v1.yaml
+++ b/data/registers/otghs_v1.yaml
@@ -711,6 +711,10 @@ fieldset/GCCFG:
       description: USB VBUS detection enable
       bit_offset: 21
       bit_size: 1
+    - name: PHYHSEN
+      description: Internal high-speed PHY enable.
+      bit_offset: 23
+      bit_size: 1
 fieldset/GI2CCTL:
   description: I2C access register
   fields:

--- a/data/registers/otghs_v1.yaml
+++ b/data/registers/otghs_v1.yaml
@@ -2,221 +2,647 @@
 block/OTG_HS:
   description: USB on the go high speed
   items:
-    - name: OTG_HS_GOTGCTL
-      description: OTG_HS control and status register
+    - name: GOTGCTL
+      description: Control and status register
       byte_offset: 0
-      fieldset: OTG_HS_GOTGCTL
-    - name: OTG_HS_GOTGINT
-      description: OTG_HS interrupt register
+      fieldset: GOTGCTL
+    - name: GOTGINT
+      description: Interrupt register
       byte_offset: 4
-      fieldset: OTG_HS_GOTGINT
-    - name: OTG_HS_GAHBCFG
-      description: OTG_HS AHB configuration register
+      fieldset: GOTGINT
+    - name: GAHBCFG
+      description: AHB configuration register
       byte_offset: 8
-      fieldset: OTG_HS_GAHBCFG
-    - name: OTG_HS_GUSBCFG
-      description: OTG_HS USB configuration register
+      fieldset: GAHBCFG
+    - name: GUSBCFG
+      description: USB configuration register
       byte_offset: 12
-      fieldset: OTG_HS_GUSBCFG
-    - name: OTG_HS_GRSTCTL
-      description: OTG_HS reset register
+      fieldset: GUSBCFG
+    - name: GRSTCTL
+      description: Reset register
       byte_offset: 16
-      fieldset: OTG_HS_GRSTCTL
-    - name: OTG_HS_GINTSTS
-      description: OTG_HS core interrupt register
+      fieldset: GRSTCTL
+    - name: GINTSTS
+      description: Core interrupt register
       byte_offset: 20
-      fieldset: OTG_HS_GINTSTS
-    - name: OTG_HS_GINTMSK
-      description: OTG_HS interrupt mask register
+      fieldset: GINTSTS
+    - name: GINTMSK
+      description: Interrupt mask register
       byte_offset: 24
-      fieldset: OTG_HS_GINTMSK
-    - name: OTG_HS_GRXSTSR_Device
-      description: OTG_HS Receive status debug read register (peripheral mode mode)
+      fieldset: GINTMSK
+    - name: GRXSTSR
+      description: Receive status debug read register
       byte_offset: 28
       access: Read
-      fieldset: OTG_HS_GRXSTSR_Device
-    - name: OTG_HS_GRXSTSR_Host
-      description: OTG_HS Receive status debug read register (host mode)
-      byte_offset: 28
-      access: Read
-      fieldset: OTG_HS_GRXSTSR_Host
-    - name: OTG_HS_GRXSTSP_Device
-      description: OTG_HS status read and pop register (peripheral mode)
+      fieldset: GRXSTS
+    - name: GRXSTSP
+      description: Status read and pop register
       byte_offset: 32
       access: Read
-      fieldset: OTG_HS_GRXSTSP_Device
-    - name: OTG_HS_GRXSTSP_Host
-      description: OTG_HS status read and pop register (host mode)
-      byte_offset: 32
-      access: Read
-      fieldset: OTG_HS_GRXSTSP_Host
-    - name: OTG_HS_GRXFSIZ
-      description: OTG_HS Receive FIFO size register
+      fieldset: GRXSTS
+    - name: GRXFSIZ
+      description: Receive FIFO size register
       byte_offset: 36
-      fieldset: OTG_HS_GRXFSIZ
-    - name: OTG_HS_DIEPTXF0_Device
-      description: Endpoint 0 transmit FIFO size (peripheral mode)
+      fieldset: GRXFSIZ
+    - name: DIEPTXF0
+      description: Endpoint 0 transmit FIFO size register (device mode)
       byte_offset: 40
-      fieldset: OTG_HS_DIEPTXF0_Device
-    - name: OTG_HS_HNPTXFSIZ_Host
-      description: OTG_HS nonperiodic transmit FIFO size register (host mode)
+      fieldset: FSIZ
+    - name: HNPTXFSIZ
+      description: Non-periodic transmit FIFO size register (host mode)
       byte_offset: 40
-      fieldset: OTG_HS_HNPTXFSIZ_Host
-    - name: OTG_HS_GNPTXSTS
-      description: OTG_HS nonperiodic transmit FIFO/queue status register
+      fieldset: FSIZ
+    - name: HNPTXSTS
+      description: Non-periodic transmit FIFO/queue status register (host mode)
       byte_offset: 44
       access: Read
-      fieldset: OTG_HS_GNPTXSTS
-    - name: OTG_HS_HNPTXSTS
-      description: OTG_HS nonperiodic transmit FIFO/queue status register
-      byte_offset: 44
-      access: Read
-      fieldset: OTG_HS_HNPTXSTS
-    - name: OTG_HS_GI2CCTL
+      fieldset: HNPTXSTS
+    - name: GI2CCTL
       description: OTG I2C access register
       byte_offset: 48
-      fieldset: OTG_HS_GI2CCTL
-    - name: OTG_HS_GCCFG
-      description: OTG_HS general core configuration register
+      fieldset: GI2CCTL
+    - name: GCCFG
+      description: General core configuration register
       byte_offset: 56
-      fieldset: OTG_HS_GCCFG
-    - name: OTG_HS_CID
-      description: OTG_HS core ID register
+      fieldset: GCCFG
+    - name: CID
+      description: Core ID register
       byte_offset: 60
-      fieldset: OTG_HS_CID
-    - name: OTG_HS_GLPMCFG
+      fieldset: CID
+    - name: GLPMCFG
       description: OTG core LPM configuration register
       byte_offset: 84
-      fieldset: OTG_HS_GLPMCFG
-    - name: OTG_HS_HPTXFSIZ
-      description: OTG_HS Host periodic transmit FIFO size register
+      fieldset: GLPMCFG
+    - name: HPTXFSIZ
+      description: Host periodic transmit FIFO size register
       byte_offset: 256
-      fieldset: OTG_HS_HPTXFSIZ
-    - name: OTG_HS_DIEPTXF1
-      description: OTG_HS device IN endpoint transmit FIFO size register
+      fieldset: FSIZ
+    - name: DIEPTXF
+      description: Device IN endpoint transmit FIFO size register
+      array:
+        len: 7
+        stride: 4
       byte_offset: 260
-      fieldset: OTG_HS_DIEPTXF1
-    - name: OTG_HS_DIEPTXF2
-      description: OTG_HS device IN endpoint transmit FIFO size register
-      byte_offset: 264
-      fieldset: OTG_HS_DIEPTXF2
-    - name: OTG_HS_DIEPTXF3
-      description: OTG_HS device IN endpoint transmit FIFO size register
-      byte_offset: 268
-      fieldset: OTG_HS_DIEPTXF3
-    - name: OTG_HS_DIEPTXF4
-      description: OTG_HS device IN endpoint transmit FIFO size register
-      byte_offset: 272
-      fieldset: OTG_HS_DIEPTXF4
-    - name: OTG_HS_DIEPTXF5
-      description: OTG_HS device IN endpoint transmit FIFO size register
-      byte_offset: 276
-      fieldset: OTG_HS_DIEPTXF5
-    - name: OTG_HS_DIEPTXF6
-      description: OTG_HS device IN endpoint transmit FIFO size register
-      byte_offset: 280
-      fieldset: OTG_HS_DIEPTXF6
-    - name: OTG_HS_DIEPTXF7
-      description: OTG_HS device IN endpoint transmit FIFO size register
-      byte_offset: 284
-      fieldset: OTG_HS_DIEPTXF7
-fieldset/OTG_HS_CID:
-  description: OTG_HS core ID register
+      fieldset: FSIZ
+    - name: HCFG
+      description: Host configuration register
+      byte_offset: 1024
+      fieldset: HCFG
+    - name: HFIR
+      description: Host frame interval register
+      byte_offset: 1028
+      fieldset: HFIR
+    - name: HFNUM
+      description: Host frame number/frame time remaining register
+      byte_offset: 1032
+      access: Read
+      fieldset: HFNUM
+    - name: HPTXSTS
+      description: Periodic transmit FIFO/queue status register
+      byte_offset: 1040
+      fieldset: HPTXSTS
+    - name: HAINT
+      description: Host all channels interrupt register
+      byte_offset: 1044
+      access: Read
+      fieldset: HAINT
+    - name: HAINTMSK
+      description: Host all channels interrupt mask register
+      byte_offset: 1048
+      fieldset: HAINTMSK
+    - name: HPRT
+      description: Host port control and status register
+      byte_offset: 1088
+      fieldset: HPRT
+    - name: HCCHAR
+      description: Host channel characteristics register
+      array:
+        len: 12
+        stride: 32
+      byte_offset: 1280
+      fieldset: HCCHAR
+    - name: HCSPLT
+      description: Host channel split control register
+      array:
+        len: 12
+        stride: 32
+      byte_offset: 1284
+    - name: HCINT
+      description: Host channel interrupt register
+      array:
+        len: 12
+        stride: 32
+      byte_offset: 1288
+      fieldset: HCINT
+    - name: HCINTMSK
+      description: Host channel mask register
+      array:
+        len: 12
+        stride: 32
+      byte_offset: 1292
+      fieldset: HCINTMSK
+    - name: HCTSIZ
+      description: Host channel transfer size register
+      array:
+        len: 12
+        stride: 32
+      byte_offset: 1296
+      fieldset: HCTSIZ
+    - name: DCFG
+      description: Device configuration register
+      byte_offset: 2048
+      fieldset: DCFG
+    - name: DCTL
+      description: Device control register
+      byte_offset: 2052
+      fieldset: DCTL
+    - name: DSTS
+      description: Device status register
+      byte_offset: 2056
+      access: Read
+      fieldset: DSTS
+    - name: DIEPMSK
+      description: Device IN endpoint common interrupt mask register
+      byte_offset: 2064
+      fieldset: DIEPMSK
+    - name: DOEPMSK
+      description: Device OUT endpoint common interrupt mask register
+      byte_offset: 2068
+      fieldset: DOEPMSK
+    - name: DAINT
+      description: Device all endpoints interrupt register
+      byte_offset: 2072
+      access: Read
+      fieldset: DAINT
+    - name: DAINTMSK
+      description: All endpoints interrupt mask register
+      byte_offset: 2076
+      fieldset: DAINTMSK
+    - name: DVBUSDIS
+      description: Device VBUS discharge time register
+      byte_offset: 2088
+      fieldset: DVBUSDIS
+    - name: DVBUSPULSE
+      description: Device VBUS pulsing time register
+      byte_offset: 2092
+      fieldset: DVBUSPULSE
+    - name: DIEPEMPMSK
+      description: Device IN endpoint FIFO empty interrupt mask register
+      byte_offset: 2100
+      fieldset: DIEPEMPMSK
+    - name: DIEPCTL
+      description: Device IN endpoint control register
+      array:
+        len: 8
+        stride: 32
+      byte_offset: 2304
+      fieldset: DIEPCTL
+    - name: DIEPINT
+      description: Device IN endpoint interrupt register
+      array:
+        len: 8
+        stride: 32
+      byte_offset: 2312
+      fieldset: DIEPINT
+    - name: DIEPTSIZ
+      description: Device IN endpoint transfer size register
+      array:
+        len: 8
+        stride: 32
+      byte_offset: 2320
+      fieldset: DIEPTSIZ
+    - name: DTXFSTS
+      description: Device IN endpoint transmit FIFO status register
+      array:
+        len: 8
+        stride: 32
+      byte_offset: 2328
+      access: Read
+      fieldset: DTXFSTS
+    - name: DOEPCTL
+      description: Device OUT endpoint control register
+      array:
+        len: 8
+        stride: 32
+      byte_offset: 2816
+      fieldset: DOEPCTL
+    - name: DOEPINT
+      description: Device OUT endpoint interrupt register
+      array:
+        len: 8
+        stride: 32
+      byte_offset: 2824
+      fieldset: DOEPINT
+    - name: DOEPTSIZ
+      description: Device OUT endpoint transfer size register
+      array:
+        len: 8
+        stride: 32
+      byte_offset: 2832
+      fieldset: DOEPTSIZ
+    - name: PCGCCTL
+      description: Power and clock gating control register
+      byte_offset: 3584
+      fieldset: PCGCCTL
+    - name: FIFO
+      description: Device endpoint / host channel FIFO register
+      array:
+        len: 8
+        stride: 4096
+      byte_offset: 4096
+      fieldset: FIFO
+fieldset/CID:
+  description: Core ID register
   fields:
     - name: PRODUCT_ID
       description: Product ID field
       bit_offset: 0
       bit_size: 32
-fieldset/OTG_HS_DIEPTXF0_Device:
-  description: Endpoint 0 transmit FIFO size (peripheral mode)
+fieldset/DAINT:
+  description: Device all endpoints interrupt register
   fields:
-    - name: TX0FSA
-      description: Endpoint 0 transmit RAM start address
+    - name: IEPINT
+      description: IN endpoint interrupt bits
       bit_offset: 0
       bit_size: 16
-    - name: TX0FD
-      description: Endpoint 0 TxFIFO depth
+    - name: OEPINT
+      description: OUT endpoint interrupt bits
       bit_offset: 16
       bit_size: 16
-fieldset/OTG_HS_DIEPTXF1:
-  description: OTG_HS device IN endpoint transmit FIFO size register
+fieldset/DAINTMSK:
+  description: All endpoints interrupt mask register
   fields:
-    - name: INEPTXSA
-      description: IN endpoint FIFOx transmit RAM start address
+    - name: IEPM
+      description: IN EP interrupt mask bits
       bit_offset: 0
       bit_size: 16
-    - name: INEPTXFD
-      description: IN endpoint TxFIFO depth
+    - name: OEPM
+      description: OUT EP interrupt mask bits
       bit_offset: 16
       bit_size: 16
-fieldset/OTG_HS_DIEPTXF2:
-  description: OTG_HS device IN endpoint transmit FIFO size register
+fieldset/DCFG:
+  description: Device configuration register
   fields:
-    - name: INEPTXSA
-      description: IN endpoint FIFOx transmit RAM start address
+    - name: DSPD
+      description: Device speed
+      bit_offset: 0
+      bit_size: 2
+      enum: DSPD
+    - name: NZLSOHSK
+      description: Non-zero-length status OUT handshake
+      bit_offset: 2
+      bit_size: 1
+    - name: DAD
+      description: Device address
+      bit_offset: 4
+      bit_size: 7
+    - name: PFIVL
+      description: Periodic frame interval
+      bit_offset: 11
+      bit_size: 2
+      enum: PFIVL
+fieldset/DCTL:
+  description: Device control register
+  fields:
+    - name: RWUSIG
+      description: Remote wakeup signaling
+      bit_offset: 0
+      bit_size: 1
+    - name: SDIS
+      description: Soft disconnect
+      bit_offset: 1
+      bit_size: 1
+    - name: GINSTS
+      description: Global IN NAK status
+      bit_offset: 2
+      bit_size: 1
+    - name: GONSTS
+      description: Global OUT NAK status
+      bit_offset: 3
+      bit_size: 1
+    - name: TCTL
+      description: Test control
+      bit_offset: 4
+      bit_size: 3
+    - name: SGINAK
+      description: Set global IN NAK
+      bit_offset: 7
+      bit_size: 1
+    - name: CGINAK
+      description: Clear global IN NAK
+      bit_offset: 8
+      bit_size: 1
+    - name: SGONAK
+      description: Set global OUT NAK
+      bit_offset: 9
+      bit_size: 1
+    - name: CGONAK
+      description: Clear global OUT NAK
+      bit_offset: 10
+      bit_size: 1
+    - name: POPRGDNE
+      description: Power-on programming done
+      bit_offset: 11
+      bit_size: 1
+fieldset/DIEPCTL:
+  description: Device endpoint control register
+  fields:
+    - name: MPSIZ
+      description: MPSIZ
+      bit_offset: 0
+      bit_size: 11
+    - name: USBAEP
+      description: USBAEP
+      bit_offset: 15
+      bit_size: 1
+    - name: EONUM_DPID
+      description: EONUM/DPID
+      bit_offset: 16
+      bit_size: 1
+    - name: NAKSTS
+      description: NAKSTS
+      bit_offset: 17
+      bit_size: 1
+    - name: EPTYP
+      description: EPTYP
+      bit_offset: 18
+      bit_size: 2
+      enum: EPTYP
+    - name: SNPM
+      description: SNPM
+      bit_offset: 20
+      bit_size: 1
+    - name: STALL
+      description: STALL
+      bit_offset: 21
+      bit_size: 1
+    - name: TXFNUM
+      description: TXFNUM
+      bit_offset: 22
+      bit_size: 4
+    - name: CNAK
+      description: CNAK
+      bit_offset: 26
+      bit_size: 1
+    - name: SNAK
+      description: SNAK
+      bit_offset: 27
+      bit_size: 1
+    - name: SD0PID_SEVNFRM
+      description: SD0PID/SEVNFRM
+      bit_offset: 28
+      bit_size: 1
+    - name: SODDFRM_SD1PID
+      description: SODDFRM/SD1PID
+      bit_offset: 29
+      bit_size: 1
+    - name: EPDIS
+      description: EPDIS
+      bit_offset: 30
+      bit_size: 1
+    - name: EPENA
+      description: EPENA
+      bit_offset: 31
+      bit_size: 1
+fieldset/DIEPEMPMSK:
+  description: Device IN endpoint FIFO empty interrupt mask register
+  fields:
+    - name: INEPTXFEM
+      description: IN EP Tx FIFO empty interrupt mask bits
       bit_offset: 0
       bit_size: 16
-    - name: INEPTXFD
-      description: IN endpoint TxFIFO depth
-      bit_offset: 16
-      bit_size: 16
-fieldset/OTG_HS_DIEPTXF3:
-  description: OTG_HS device IN endpoint transmit FIFO size register
+fieldset/DIEPINT:
+  description: Device endpoint interrupt register
   fields:
-    - name: INEPTXSA
-      description: IN endpoint FIFOx transmit RAM start address
+    - name: XFRC
+      description: XFRC
+      bit_offset: 0
+      bit_size: 1
+    - name: EPDISD
+      description: EPDISD
+      bit_offset: 1
+      bit_size: 1
+    - name: TOC
+      description: TOC
+      bit_offset: 3
+      bit_size: 1
+    - name: ITTXFE
+      description: ITTXFE
+      bit_offset: 4
+      bit_size: 1
+    - name: INEPNE
+      description: INEPNE
+      bit_offset: 6
+      bit_size: 1
+    - name: TXFE
+      description: TXFE
+      bit_offset: 7
+      bit_size: 1
+fieldset/DIEPMSK:
+  description: Device IN endpoint common interrupt mask register
+  fields:
+    - name: XFRCM
+      description: Transfer completed interrupt mask
+      bit_offset: 0
+      bit_size: 1
+    - name: EPDM
+      description: Endpoint disabled interrupt mask
+      bit_offset: 1
+      bit_size: 1
+    - name: TOM
+      description: Timeout condition mask (Non-isochronous endpoints)
+      bit_offset: 3
+      bit_size: 1
+    - name: ITTXFEMSK
+      description: IN token received when TxFIFO empty mask
+      bit_offset: 4
+      bit_size: 1
+    - name: INEPNMM
+      description: IN token received with EP mismatch mask
+      bit_offset: 5
+      bit_size: 1
+    - name: INEPNEM
+      description: IN endpoint NAK effective mask
+      bit_offset: 6
+      bit_size: 1
+fieldset/DIEPTSIZ:
+  description: Device endpoint transfer size register
+  fields:
+    - name: XFRSIZ
+      description: Transfer size
+      bit_offset: 0
+      bit_size: 19
+    - name: PKTCNT
+      description: Packet count
+      bit_offset: 19
+      bit_size: 10
+    - name: MCNT
+      description: Multi count
+      bit_offset: 29
+      bit_size: 2
+fieldset/DOEPCTL:
+  description: Device endpoint control register
+  fields:
+    - name: MPSIZ
+      description: MPSIZ
+      bit_offset: 0
+      bit_size: 11
+    - name: USBAEP
+      description: USBAEP
+      bit_offset: 15
+      bit_size: 1
+    - name: EONUM_DPID
+      description: EONUM/DPID
+      bit_offset: 16
+      bit_size: 1
+    - name: NAKSTS
+      description: NAKSTS
+      bit_offset: 17
+      bit_size: 1
+    - name: EPTYP
+      description: EPTYP
+      bit_offset: 18
+      bit_size: 2
+      enum: EPTYP
+    - name: SNPM
+      description: SNPM
+      bit_offset: 20
+      bit_size: 1
+    - name: STALL
+      description: STALL
+      bit_offset: 21
+      bit_size: 1
+    - name: CNAK
+      description: CNAK
+      bit_offset: 26
+      bit_size: 1
+    - name: SNAK
+      description: SNAK
+      bit_offset: 27
+      bit_size: 1
+    - name: SD0PID_SEVNFRM
+      description: SD0PID/SEVNFRM
+      bit_offset: 28
+      bit_size: 1
+    - name: SODDFRM
+      description: SODDFRM
+      bit_offset: 29
+      bit_size: 1
+    - name: EPDIS
+      description: EPDIS
+      bit_offset: 30
+      bit_size: 1
+    - name: EPENA
+      description: EPENA
+      bit_offset: 31
+      bit_size: 1
+fieldset/DOEPINT:
+  description: Device endpoint interrupt register
+  fields:
+    - name: XFRC
+      description: XFRC
+      bit_offset: 0
+      bit_size: 1
+    - name: EPDISD
+      description: EPDISD
+      bit_offset: 1
+      bit_size: 1
+    - name: STUP
+      description: STUP
+      bit_offset: 3
+      bit_size: 1
+    - name: OTEPDIS
+      description: OTEPDIS
+      bit_offset: 4
+      bit_size: 1
+    - name: B2BSTUP
+      description: B2BSTUP
+      bit_offset: 6
+      bit_size: 1
+fieldset/DOEPMSK:
+  description: Device OUT endpoint common interrupt mask register
+  fields:
+    - name: XFRCM
+      description: Transfer completed interrupt mask
+      bit_offset: 0
+      bit_size: 1
+    - name: EPDM
+      description: Endpoint disabled interrupt mask
+      bit_offset: 1
+      bit_size: 1
+    - name: STUPM
+      description: SETUP phase done mask
+      bit_offset: 3
+      bit_size: 1
+    - name: OTEPDM
+      description: OUT token received when endpoint disabled mask
+      bit_offset: 4
+      bit_size: 1
+fieldset/DOEPTSIZ:
+  description: Device OUT endpoint transfer size register
+  fields:
+    - name: XFRSIZ
+      description: Transfer size
+      bit_offset: 0
+      bit_size: 19
+    - name: PKTCNT
+      description: Packet count
+      bit_offset: 19
+      bit_size: 10
+    - name: RXDPID_STUPCNT
+      description: Received data PID/SETUP packet count
+      bit_offset: 29
+      bit_size: 2
+fieldset/DSTS:
+  description: Device status register
+  fields:
+    - name: SUSPSTS
+      description: Suspend status
+      bit_offset: 0
+      bit_size: 1
+    - name: ENUMSPD
+      description: Enumerated speed
+      bit_offset: 1
+      bit_size: 2
+      enum: DSPD
+    - name: EERR
+      description: Erratic error
+      bit_offset: 3
+      bit_size: 1
+    - name: FNSOF
+      description: Frame number of the received SOF
+      bit_offset: 8
+      bit_size: 14
+fieldset/DTXFSTS:
+  description: Device IN endpoint transmit FIFO status register
+  fields:
+    - name: INEPTFSAV
+      description: IN endpoint TxFIFO space available
       bit_offset: 0
       bit_size: 16
-    - name: INEPTXFD
-      description: IN endpoint TxFIFO depth
-      bit_offset: 16
-      bit_size: 16
-fieldset/OTG_HS_DIEPTXF4:
-  description: OTG_HS device IN endpoint transmit FIFO size register
+fieldset/DVBUSDIS:
+  description: Device VBUS discharge time register
   fields:
-    - name: INEPTXSA
-      description: IN endpoint FIFOx transmit RAM start address
+    - name: VBUSDT
+      description: Device VBUS discharge time
       bit_offset: 0
       bit_size: 16
-    - name: INEPTXFD
-      description: IN endpoint TxFIFO depth
-      bit_offset: 16
-      bit_size: 16
-fieldset/OTG_HS_DIEPTXF5:
-  description: OTG_HS device IN endpoint transmit FIFO size register
+fieldset/DVBUSPULSE:
+  description: Device VBUS pulsing time register
   fields:
-    - name: INEPTXSA
-      description: IN endpoint FIFOx transmit RAM start address
+    - name: DVBUSP
+      description: Device VBUS pulsing time
       bit_offset: 0
-      bit_size: 16
-    - name: INEPTXFD
-      description: IN endpoint TxFIFO depth
-      bit_offset: 16
-      bit_size: 16
-fieldset/OTG_HS_DIEPTXF6:
-  description: OTG_HS device IN endpoint transmit FIFO size register
+      bit_size: 12
+fieldset/FIFO:
+  description: FIFO register
   fields:
-    - name: INEPTXSA
-      description: IN endpoint FIFOx transmit RAM start address
+    - name: DATA
+      description: Data
       bit_offset: 0
-      bit_size: 16
-    - name: INEPTXFD
-      description: IN endpoint TxFIFO depth
-      bit_offset: 16
-      bit_size: 16
-fieldset/OTG_HS_DIEPTXF7:
-  description: OTG_HS device IN endpoint transmit FIFO size register
-  fields:
-    - name: INEPTXSA
-      description: IN endpoint FIFOx transmit RAM start address
-      bit_offset: 0
-      bit_size: 16
-    - name: INEPTXFD
-      description: IN endpoint TxFIFO depth
-      bit_offset: 16
-      bit_size: 16
-fieldset/OTG_HS_GAHBCFG:
-  description: OTG_HS AHB configuration register
+      bit_size: 32
+fieldset/GAHBCFG:
+  description: AHB configuration register
   fields:
     - name: GINT
       description: Global interrupt mask
@@ -238,8 +664,8 @@ fieldset/OTG_HS_GAHBCFG:
       description: Periodic TxFIFO empty level
       bit_offset: 8
       bit_size: 1
-fieldset/OTG_HS_GCCFG:
-  description: OTG_HS general core configuration register
+fieldset/GCCFG:
+  description: General core configuration register
   fields:
     - name: DCDET
       description: Data contact detection (DCD) status
@@ -277,12 +703,16 @@ fieldset/OTG_HS_GCCFG:
       description: Secondary detection (SD) mode enable
       bit_offset: 20
       bit_size: 1
+    - name: NOVBUSSENS
+      description: VBUS sensing disable
+      bit_offset: 21
+      bit_size: 1
     - name: VBDEN
       description: USB VBUS detection enable
       bit_offset: 21
       bit_size: 1
-fieldset/OTG_HS_GI2CCTL:
-  description: OTG I2C access register
+fieldset/GI2CCTL:
+  description: I2C access register
   fields:
     - name: RWDATA
       description: I2C Read/Write Data
@@ -320,8 +750,8 @@ fieldset/OTG_HS_GI2CCTL:
       description: I2C Busy/Done
       bit_offset: 31
       bit_size: 1
-fieldset/OTG_HS_GINTMSK:
-  description: OTG_HS interrupt mask register
+fieldset/GINTMSK:
+  description: Interrupt mask register
   fields:
     - name: MMISM
       description: Mode mismatch interrupt mask
@@ -336,15 +766,15 @@ fieldset/OTG_HS_GINTMSK:
       bit_offset: 3
       bit_size: 1
     - name: RXFLVLM
-      description: Receive FIFO nonempty mask
+      description: Receive FIFO non-empty mask
       bit_offset: 4
       bit_size: 1
     - name: NPTXFEM
-      description: Nonperiodic TxFIFO empty mask
+      description: Non-periodic TxFIFO empty mask
       bit_offset: 5
       bit_size: 1
     - name: GINAKEFFM
-      description: Global nonperiodic IN NAK effective mask
+      description: Global non-periodic IN NAK effective mask
       bit_offset: 6
       bit_size: 1
     - name: GONAKEFFM
@@ -387,8 +817,8 @@ fieldset/OTG_HS_GINTMSK:
       description: Incomplete isochronous IN transfer mask
       bit_offset: 20
       bit_size: 1
-    - name: PXFRM_IISOOXFRM
-      description: Incomplete periodic transfer mask
+    - name: IPXFRM_IISOOXFRM
+      description: Incomplete periodic transfer mask (host mode) / Incomplete isochronous OUT transfer mask (device mode)
       bit_offset: 21
       bit_size: 1
     - name: FSUSPM
@@ -431,8 +861,8 @@ fieldset/OTG_HS_GINTMSK:
       description: Resume/remote wakeup detected interrupt mask
       bit_offset: 31
       bit_size: 1
-fieldset/OTG_HS_GINTSTS:
-  description: OTG_HS core interrupt register
+fieldset/GINTSTS:
+  description: Core interrupt register
   fields:
     - name: CMOD
       description: Current mode of operation
@@ -451,18 +881,18 @@ fieldset/OTG_HS_GINTSTS:
       bit_offset: 3
       bit_size: 1
     - name: RXFLVL
-      description: RxFIFO nonempty
+      description: RxFIFO non-empty
       bit_offset: 4
       bit_size: 1
     - name: NPTXFE
-      description: Nonperiodic TxFIFO empty
+      description: Non-periodic TxFIFO empty
       bit_offset: 5
       bit_size: 1
     - name: GINAKEFF
-      description: Global IN nonperiodic NAK effective
+      description: Global IN non-periodic NAK effective
       bit_offset: 6
       bit_size: 1
-    - name: BOUTNAKEFF
+    - name: GOUTNAKEFF
       description: Global OUT NAK effective
       bit_offset: 7
       bit_size: 1
@@ -502,8 +932,8 @@ fieldset/OTG_HS_GINTSTS:
       description: Incomplete isochronous IN transfer
       bit_offset: 20
       bit_size: 1
-    - name: PXFR_INCOMPISOOUT
-      description: Incomplete periodic transfer
+    - name: IPXFR_INCOMPISOOUT
+      description: Incomplete periodic transfer (host mode) / Incomplete isochronous OUT transfer (device mode)
       bit_offset: 21
       bit_size: 1
     - name: DATAFSUSP
@@ -534,12 +964,12 @@ fieldset/OTG_HS_GINTSTS:
       description: Session request/new session detected interrupt
       bit_offset: 30
       bit_size: 1
-    - name: WKUINT
+    - name: WKUPINT
       description: Resume/remote wakeup detected interrupt
       bit_offset: 31
       bit_size: 1
-fieldset/OTG_HS_GLPMCFG:
-  description: OTG core LPM configuration register
+fieldset/GLPMCFG:
+  description: Core LPM configuration register
   fields:
     - name: LPMEN
       description: LPM support enable
@@ -601,23 +1031,23 @@ fieldset/OTG_HS_GLPMCFG:
       description: Enable best effort service latency
       bit_offset: 28
       bit_size: 1
-fieldset/OTG_HS_GNPTXSTS:
-  description: OTG_HS nonperiodic transmit FIFO/queue status register
+fieldset/GNPTXSTS:
+  description: Non-periodic transmit FIFO/queue status register
   fields:
     - name: NPTXFSAV
-      description: Nonperiodic TxFIFO space available
+      description: Non-periodic TxFIFO space available
       bit_offset: 0
       bit_size: 16
     - name: NPTQXSAV
-      description: Nonperiodic transmit request queue space available
+      description: Non-periodic transmit request queue space available
       bit_offset: 16
       bit_size: 8
     - name: NPTXQTOP
-      description: Top of the nonperiodic transmit request queue
+      description: Top of the non-periodic transmit request queue
       bit_offset: 24
       bit_size: 7
-fieldset/OTG_HS_GOTGCTL:
-  description: OTG_HS control and status register
+fieldset/GOTGCTL:
+  description: Control and status register
   fields:
     - name: SRQSCS
       description: Session request success
@@ -626,6 +1056,30 @@ fieldset/OTG_HS_GOTGCTL:
     - name: SRQ
       description: Session request
       bit_offset: 1
+      bit_size: 1
+    - name: VBVALOEN
+      description: VBUS valid override enable
+      bit_offset: 2
+      bit_size: 1
+    - name: VBVALOVAL
+      description: VBUS valid override value
+      bit_offset: 3
+      bit_size: 1
+    - name: AVALOEN
+      description: A-peripheral session valid override enable
+      bit_offset: 4
+      bit_size: 1
+    - name: AVALOVAL
+      description: A-peripheral session valid override value
+      bit_offset: 5
+      bit_size: 1
+    - name: BVALOEN
+      description: B-peripheral session valid override enable
+      bit_offset: 6
+      bit_size: 1
+    - name: BVALOVAL
+      description: B-peripheral session valid override value
+      bit_offset: 7
       bit_size: 1
     - name: HNGSCS
       description: Host negotiation success
@@ -663,8 +1117,8 @@ fieldset/OTG_HS_GOTGCTL:
       description: B-session valid
       bit_offset: 19
       bit_size: 1
-fieldset/OTG_HS_GOTGINT:
-  description: OTG_HS interrupt register
+fieldset/GOTGINT:
+  description: Interrupt register
   fields:
     - name: SEDET
       description: Session end detected
@@ -694,8 +1148,8 @@ fieldset/OTG_HS_GOTGINT:
       description: ID input pin changed
       bit_offset: 20
       bit_size: 1
-fieldset/OTG_HS_GRSTCTL:
-  description: OTG_HS reset register
+fieldset/GRSTCTL:
+  description: Reset register
   fields:
     - name: CSRST
       description: Core soft reset
@@ -729,18 +1183,18 @@ fieldset/OTG_HS_GRSTCTL:
       description: AHB master idle
       bit_offset: 31
       bit_size: 1
-fieldset/OTG_HS_GRXFSIZ:
-  description: OTG_HS Receive FIFO size register
+fieldset/GRXFSIZ:
+  description: Receive FIFO size register
   fields:
     - name: RXFD
       description: RxFIFO depth
       bit_offset: 0
       bit_size: 16
-fieldset/OTG_HS_GRXSTSP_Device:
-  description: OTG_HS status read and pop register (peripheral mode)
+fieldset/GRXSTS:
+  description: Status read and pop register
   fields:
     - name: EPNUM
-      description: Endpoint number
+      description: Endpoint number (device mode) / Channel number (host mode)
       bit_offset: 0
       bit_size: 4
     - name: BCNT
@@ -751,84 +1205,30 @@ fieldset/OTG_HS_GRXSTSP_Device:
       description: Data PID
       bit_offset: 15
       bit_size: 2
-    - name: PKTSTS
-      description: Packet status
+      enum: DPID
+    - name: PKTSTSD
+      description: Packet status (device mode)
       bit_offset: 17
       bit_size: 4
+      enum: PKTSTSD
+    - name: PKTSTSH
+      description: Packet status (host mode)
+      bit_offset: 17
+      bit_size: 4
+      enum: PKTSTSH
     - name: FRMNUM
-      description: Frame number
+      description: Frame number (device mode)
       bit_offset: 21
       bit_size: 4
-fieldset/OTG_HS_GRXSTSP_Host:
-  description: OTG_HS status read and pop register (host mode)
-  fields:
-    - name: CHNUM
-      description: Channel number
-      bit_offset: 0
-      bit_size: 4
-    - name: BCNT
-      description: Byte count
-      bit_offset: 4
-      bit_size: 11
-    - name: DPID
-      description: Data PID
-      bit_offset: 15
-      bit_size: 2
-    - name: PKTSTS
-      description: Packet status
-      bit_offset: 17
-      bit_size: 4
-fieldset/OTG_HS_GRXSTSR_Device:
-  description: OTG_HS Receive status debug read register (peripheral mode mode)
-  fields:
-    - name: EPNUM
-      description: Endpoint number
-      bit_offset: 0
-      bit_size: 4
-    - name: BCNT
-      description: Byte count
-      bit_offset: 4
-      bit_size: 11
-    - name: DPID
-      description: Data PID
-      bit_offset: 15
-      bit_size: 2
-    - name: PKTSTS
-      description: Packet status
-      bit_offset: 17
-      bit_size: 4
-    - name: FRMNUM
-      description: Frame number
-      bit_offset: 21
-      bit_size: 4
-fieldset/OTG_HS_GRXSTSR_Host:
-  description: OTG_HS Receive status debug read register (host mode)
-  fields:
-    - name: CHNUM
-      description: Channel number
-      bit_offset: 0
-      bit_size: 4
-    - name: BCNT
-      description: Byte count
-      bit_offset: 4
-      bit_size: 11
-    - name: DPID
-      description: Data PID
-      bit_offset: 15
-      bit_size: 2
-    - name: PKTSTS
-      description: Packet status
-      bit_offset: 17
-      bit_size: 4
-fieldset/OTG_HS_GUSBCFG:
-  description: OTG_HS USB configuration register
+fieldset/GUSBCFG:
+  description: USB configuration register
   fields:
     - name: TOCAL
       description: FS timeout calibration
       bit_offset: 0
       bit_size: 3
     - name: PHYSEL
-      description: USB 2.0 high-speed ULPI PHY or USB 1.1 full-speed serial transceiver select
+      description: Full-speed internal serial transceiver enable
       bit_offset: 6
       bit_size: 1
     - name: SRPCAP
@@ -884,47 +1284,387 @@ fieldset/OTG_HS_GUSBCFG:
       bit_offset: 25
       bit_size: 1
     - name: FHMOD
-      description: Forced host mode
+      description: Force host mode
       bit_offset: 29
       bit_size: 1
     - name: FDMOD
-      description: Forced peripheral mode
+      description: Force device mode
       bit_offset: 30
       bit_size: 1
-fieldset/OTG_HS_HNPTXFSIZ_Host:
-  description: OTG_HS nonperiodic transmit FIFO size register (host mode)
+fieldset/HAINT:
+  description: Host all channels interrupt register
   fields:
-    - name: NPTXFSA
-      description: Nonperiodic transmit RAM start address
+    - name: HAINT
+      description: Channel interrupts
       bit_offset: 0
       bit_size: 16
-    - name: NPTXFD
-      description: Nonperiodic TxFIFO depth
+fieldset/HAINTMSK:
+  description: Host all channels interrupt mask register
+  fields:
+    - name: HAINTM
+      description: Channel interrupt mask
+      bit_offset: 0
+      bit_size: 16
+fieldset/HCCHAR:
+  description: Host channel characteristics register
+  fields:
+    - name: MPSIZ
+      description: Maximum packet size
+      bit_offset: 0
+      bit_size: 11
+    - name: EPNUM
+      description: Endpoint number
+      bit_offset: 11
+      bit_size: 4
+    - name: EPDIR
+      description: Endpoint direction
+      bit_offset: 15
+      bit_size: 1
+    - name: LSDEV
+      description: Low-speed device
+      bit_offset: 17
+      bit_size: 1
+    - name: EPTYP
+      description: Endpoint type
+      bit_offset: 18
+      bit_size: 2
+      enum: EPTYP
+    - name: MCNT
+      description: Multicount
+      bit_offset: 20
+      bit_size: 2
+    - name: DAD
+      description: Device address
+      bit_offset: 22
+      bit_size: 7
+    - name: ODDFRM
+      description: Odd frame
+      bit_offset: 29
+      bit_size: 1
+    - name: CHDIS
+      description: Channel disable
+      bit_offset: 30
+      bit_size: 1
+    - name: CHENA
+      description: Channel enable
+      bit_offset: 31
+      bit_size: 1
+fieldset/HCFG:
+  description: Host configuration register
+  fields:
+    - name: FSLSPCS
+      description: FS/LS PHY clock select
+      bit_offset: 0
+      bit_size: 2
+    - name: FSLSS
+      description: FS- and LS-only support
+      bit_offset: 2
+      bit_size: 1
+fieldset/HCINT:
+  description: Host channel interrupt register
+  fields:
+    - name: XFRC
+      description: Transfer completed
+      bit_offset: 0
+      bit_size: 1
+    - name: CHH
+      description: Channel halted
+      bit_offset: 1
+      bit_size: 1
+    - name: STALL
+      description: STALL response received interrupt
+      bit_offset: 3
+      bit_size: 1
+    - name: NAK
+      description: NAK response received interrupt
+      bit_offset: 4
+      bit_size: 1
+    - name: ACK
+      description: ACK response received/transmitted interrupt
+      bit_offset: 5
+      bit_size: 1
+    - name: TXERR
+      description: Transaction error
+      bit_offset: 7
+      bit_size: 1
+    - name: BBERR
+      description: Babble error
+      bit_offset: 8
+      bit_size: 1
+    - name: FRMOR
+      description: Frame overrun
+      bit_offset: 9
+      bit_size: 1
+    - name: DTERR
+      description: Data toggle error
+      bit_offset: 10
+      bit_size: 1
+fieldset/HCINTMSK:
+  description: Host channel mask register
+  fields:
+    - name: XFRCM
+      description: Transfer completed mask
+      bit_offset: 0
+      bit_size: 1
+    - name: CHHM
+      description: Channel halted mask
+      bit_offset: 1
+      bit_size: 1
+    - name: STALLM
+      description: STALL response received interrupt mask
+      bit_offset: 3
+      bit_size: 1
+    - name: NAKM
+      description: NAK response received interrupt mask
+      bit_offset: 4
+      bit_size: 1
+    - name: ACKM
+      description: ACK response received/transmitted interrupt mask
+      bit_offset: 5
+      bit_size: 1
+    - name: NYET
+      description: Response received interrupt mask
+      bit_offset: 6
+      bit_size: 1
+    - name: TXERRM
+      description: Transaction error mask
+      bit_offset: 7
+      bit_size: 1
+    - name: BBERRM
+      description: Babble error mask
+      bit_offset: 8
+      bit_size: 1
+    - name: FRMORM
+      description: Frame overrun mask
+      bit_offset: 9
+      bit_size: 1
+    - name: DTERRM
+      description: Data toggle error mask
+      bit_offset: 10
+      bit_size: 1
+fieldset/HCTSIZ:
+  description: Host channel transfer size register
+  fields:
+    - name: XFRSIZ
+      description: Transfer size
+      bit_offset: 0
+      bit_size: 19
+    - name: PKTCNT
+      description: Packet count
+      bit_offset: 19
+      bit_size: 10
+    - name: DPID
+      description: Data PID
+      bit_offset: 29
+      bit_size: 2
+fieldset/HFIR:
+  description: Host frame interval register
+  fields:
+    - name: FRIVL
+      description: Frame interval
+      bit_offset: 0
+      bit_size: 16
+fieldset/HFNUM:
+  description: Host frame number/frame time remaining register
+  fields:
+    - name: FRNUM
+      description: Frame number
+      bit_offset: 0
+      bit_size: 16
+    - name: FTREM
+      description: Frame time remaining
       bit_offset: 16
       bit_size: 16
-fieldset/OTG_HS_HNPTXSTS:
-  description: OTG_HS nonperiodic transmit FIFO/queue status register
+fieldset/HNPTXSTS:
+  description: Non-periodic transmit FIFO/queue status register
   fields:
     - name: NPTXFSAV
-      description: Nonperiodic TxFIFO space available
+      description: Non-periodic TxFIFO space available
       bit_offset: 0
       bit_size: 16
     - name: NPTQXSAV
-      description: Nonperiodic transmit request queue space available
+      description: Non-periodic transmit request queue space available
       bit_offset: 16
       bit_size: 8
     - name: NPTXQTOP
-      description: Top of the nonperiodic transmit request queue
+      description: Top of the non-periodic transmit request queue
       bit_offset: 24
       bit_size: 7
-fieldset/OTG_HS_HPTXFSIZ:
-  description: OTG_HS Host periodic transmit FIFO size register
+fieldset/FSIZ:
+  description: FIFO size register
   fields:
-    - name: PTXSA
-      description: Host periodic TxFIFO start address
+    - name: SA
+      description: RAM start address
       bit_offset: 0
       bit_size: 16
-    - name: PTXFD
-      description: Host periodic TxFIFO depth
+    - name: FD
+      description: FIFO depth
       bit_offset: 16
       bit_size: 16
+fieldset/HPRT:
+  description: Host port control and status register
+  fields:
+    - name: PCSTS
+      description: Port connect status
+      bit_offset: 0
+      bit_size: 1
+    - name: PCDET
+      description: Port connect detected
+      bit_offset: 1
+      bit_size: 1
+    - name: PENA
+      description: Port enable
+      bit_offset: 2
+      bit_size: 1
+    - name: PENCHNG
+      description: Port enable/disable change
+      bit_offset: 3
+      bit_size: 1
+    - name: POCA
+      description: Port overcurrent active
+      bit_offset: 4
+      bit_size: 1
+    - name: POCCHNG
+      description: Port overcurrent change
+      bit_offset: 5
+      bit_size: 1
+    - name: PRES
+      description: Port resume
+      bit_offset: 6
+      bit_size: 1
+    - name: PSUSP
+      description: Port suspend
+      bit_offset: 7
+      bit_size: 1
+    - name: PRST
+      description: Port reset
+      bit_offset: 8
+      bit_size: 1
+    - name: PLSTS
+      description: Port line status
+      bit_offset: 10
+      bit_size: 2
+    - name: PPWR
+      description: Port power
+      bit_offset: 12
+      bit_size: 1
+    - name: PTCTL
+      description: Port test control
+      bit_offset: 13
+      bit_size: 4
+    - name: PSPD
+      description: Port speed
+      bit_offset: 17
+      bit_size: 2
+fieldset/HPTXSTS:
+  description: Periodic transmit FIFO/queue status register
+  fields:
+    - name: PTXFSAVL
+      description: Periodic transmit data FIFO space available
+      bit_offset: 0
+      bit_size: 16
+    - name: PTXQSAV
+      description: Periodic transmit request queue space available
+      bit_offset: 16
+      bit_size: 8
+    - name: PTXQTOP
+      description: Top of the periodic transmit request queue
+      bit_offset: 24
+      bit_size: 8
+fieldset/PCGCCTL:
+  description: Power and clock gating control register
+  fields:
+    - name: STPPCLK
+      description: Stop PHY clock
+      bit_offset: 0
+      bit_size: 1
+    - name: GATEHCLK
+      description: Gate HCLK
+      bit_offset: 1
+      bit_size: 1
+    - name: PHYSUSP
+      description: PHY Suspended
+      bit_offset: 4
+      bit_size: 1
+enum/DPID:
+  bit_size: 2
+  variants:
+    - name: DATA0
+      value: 0
+    - name: DATA2
+      value: 1
+    - name: DATA1
+      value: 2
+    - name: MDATA
+      value: 3
+enum/DSPD:
+  bit_size: 2
+  variants:
+    - name: HIGH_SPEED
+      description: High speed
+      value: 0
+    - name: FULL_SPEED_EXTERNAL
+      description: Full speed using external ULPI PHY
+      value: 1
+    - name: FULL_SPEED_INTERNAL
+      description: Full speed using internal embedded PHY
+      value: 3
+enum/EPTYP:
+  bit_size: 2
+  variants:
+    - name: CONTROL
+      value: 0
+    - name: ISOCHRONOUS
+      value: 1
+    - name: BULK
+      value: 2
+    - name: INTERRUPT
+      value: 3
+enum/PFIVL:
+  bit_size: 2
+  variants:
+    - name: FRAME_INTERVAL_80
+      description: 80% of the frame interval
+      value: 0
+    - name: FRAME_INTERVAL_85
+      description: 85% of the frame interval
+      value: 1
+    - name: FRAME_INTERVAL_90
+      description: 90% of the frame interval
+      value: 2
+    - name: FRAME_INTERVAL_95
+      description: 95% of the frame interval
+      value: 3
+enum/PKTSTSD:
+  bit_size: 4
+  variants:
+    - name: OUT_NAK
+      description: Global OUT NAK (triggers an interrupt)
+      value: 1
+    - name: OUT_DATA_RX
+      description: OUT data packet received
+      value: 2
+    - name: OUT_DATA_DONE
+      description: OUT transfer completed (triggers an interrupt)
+      value: 3
+    - name: SETUP_DATA_DONE
+      description: SETUP transaction completed (triggers an interrupt)
+      value: 4
+    - name: SETUP_DATA_RX
+      description: SETUP data packet received
+      value: 6
+enum/PKTSTSH:
+  bit_size: 4
+  variants:
+    - name: IN_DATA_RX
+      description: IN data packet received
+      value: 2
+    - name: IN_DATA_DONE
+      description: IN transfer completed (triggers an interrupt)
+      value: 3
+    - name: DATA_TOGGLE_ERR
+      description: Data toggle error (triggers an interrupt)
+      value: 5
+    - name: CHANNEL_HALTED
+      description: Channel halted (triggers an interrupt)
+      value: 7


### PR DESCRIPTION
This removes as many differences between FS and HS versions as possible.

The `GCCFG` register has a lot of variations between chips, because it deals with vbus, charging, etc detections. I think it can be fixed when the need arises, so I just left it as is for now