### PR TITLE
USB OTG: Add XCVRDLY bit

### DIFF
--- a/data/registers/otg_v1.yaml
+++ b/data/registers/otg_v1.yaml
@@ -305,6 +305,10 @@ fieldset/DCFG:
       bit_offset: 11
       bit_size: 2
       enum: PFIVL
+    - name: XCVRDLY
+      description: Transceiver delay
+      bit_offset: 14
+      bit_size: 1
 fieldset/DCTL:
   description: Device control register
   fields:


### PR DESCRIPTION
The XCVRDLY bit is a poorly-documented feature of the Synopsis ULPI link IP which helps work around timing constraints in some ULPI PHYs. [More information here](https://github.com/stm32-rs/synopsys-usb-otg/pull/17#issue-841324871).