### PR TITLE
Feat/add uid regs

### DIFF
--- a/data/registers/uid_v1.yaml
+++ b/data/registers/uid_v1.yaml
@@ -1,0 +1,45 @@
+---
+block/UID:
+  description: Device Factory programmed 96-bit unique device identifier
+  items:
+    - name: UID0
+      description: Factory programmed 96-bit unique device identifier word 0
+      byte_offset: 0
+      access: Read
+      fieldset: UID0
+    - name: UID1
+      description: Factory programmed 96-bit unique device identifier word 1
+      byte_offset: 0x04
+      access: Read
+      fieldset: UID1
+    - name: UID2
+      description: Factory programmed 96-bit unique device identifier word 2
+      byte_offset: 0x08
+      access: Read
+      fieldset: UID2
+fieldset/UID0:
+  description: UID0
+  fields:
+    - name: XYCOORD
+      description: X and Y coordinates on the wafer
+      bit_offset: 0
+      bit_size: 32
+fieldset/UID1:
+  description: UID1
+  fields:
+    - name: WAF_NUM
+      description: Wafer number (8-bit unsigned number)
+      bit_offset: 0
+      bit_size: 8
+    - name: LOT_NUM
+      description: Lot number[23:0] (ASCII encoded)
+      bit_offset: 8
+      bit_size: 24
+fieldset/UID2:
+  description: UID2
+  fields:
+    - name: LOT_NUM
+      description: Lot number[55:24] (ASCII encoded)
+      bit_offset: 0
+      bit_size: 32
+    

--- a/data/registers/uid_v1.yaml
+++ b/data/registers/uid_v1.yaml
@@ -6,40 +6,13 @@ block/UID:
       description: Factory programmed 96-bit unique device identifier word 0
       byte_offset: 0
       access: Read
-      fieldset: UID0
     - name: UID1
       description: Factory programmed 96-bit unique device identifier word 1
       byte_offset: 0x04
       access: Read
-      fieldset: UID1
     - name: UID2
       description: Factory programmed 96-bit unique device identifier word 2
       byte_offset: 0x08
       access: Read
-      fieldset: UID2
-fieldset/UID0:
-  description: UID0
-  fields:
-    - name: XYCOORD
-      description: X and Y coordinates on the wafer
-      bit_offset: 0
-      bit_size: 32
-fieldset/UID1:
-  description: UID1
-  fields:
-    - name: WAF_NUM
-      description: Wafer number (8-bit unsigned number)
-      bit_offset: 0
-      bit_size: 8
-    - name: LOT_NUM
-      description: Lot number[23:0] (ASCII encoded)
-      bit_offset: 8
-      bit_size: 24
-fieldset/UID2:
-  description: UID2
-  fields:
-    - name: LOT_NUM
-      description: Lot number[55:24] (ASCII encoded)
-      bit_offset: 0
-      bit_size: 32
+
     

--- a/data/registers/uid_v1.yaml
+++ b/data/registers/uid_v1.yaml
@@ -2,17 +2,12 @@
 block/UID:
   description: Device Factory programmed 96-bit unique device identifier
   items:
-    - name: UID0
+    - name: UID
       description: Factory programmed 96-bit unique device identifier word 0
+      array:
+        len: 3
+        stride: 4
       byte_offset: 0
-      access: Read
-    - name: UID1
-      description: Factory programmed 96-bit unique device identifier word 1
-      byte_offset: 0x04
-      access: Read
-    - name: UID2
-      description: Factory programmed 96-bit unique device identifier word 2
-      byte_offset: 0x08
       access: Read
 
     

--- a/stm32-data-gen/src/chips.rs
+++ b/stm32-data-gen/src/chips.rs
@@ -380,6 +380,7 @@ impl PeriMatcher {
             (".*:LCD:lcdc1_v1.0.*", ("lcd", "v1", "LCD")),
             (".*:LCD:lcdc1_v1.2.*", ("lcd", "v2", "LCD")),
             (".*:LCD:lcdc1_v1.3.*", ("lcd", "v2", "LCD")),
+            (".*:UID:.*", ("uid", "v1", "UID")),
         ];
 
         Self {
@@ -742,6 +743,7 @@ fn process_core(
         .collect();
     interrupts.sort_unstable_by_key(|x| x.number);
     let mut peri_kinds = HashMap::new();
+    peri_kinds.insert("UID".to_string(), "UID".to_string());
     for ip in group.ips.values() {
         let pname = ip.instance_name.clone();
         let pkind = format!("{}:{}", ip.name, ip.version);


### PR DESCRIPTION
This PR adds support for the Unique ID regs on all chips.

Based on the zephyrproject-rtos/zephyr#14208 PR, this is supported on all STM32 families/parts, and this seems to be confirmed by the presence of the UID_BASE definition in all part header files.

I originally implemented ([in this commit](https://github.com/embassy-rs/stm32-data/pull/181/commits/910246a88c159539fee377d98cf43d6ceb2e8f66)) the register mapping based on the "breakdown" specified in the L4x1 ref manual, which identifies the wafer x/y coordinates, wafer and lot numbers, however, this isn't defined for all families. Based on a preliminary investigation it was defined starting on the F0 line, and likely all newer parts, but I don't have cycles to verify that as this point. I also question the usefulness of having the lot/wafer/coord breakdown.