### PR TITLE
Added missing I2C IP version to `perimap`

### DIFF
--- a/stm32-data-gen/src/chips.rs
+++ b/stm32-data-gen/src/chips.rs
@@ -149,6 +149,7 @@ impl PeriMatcher {
             (".*:SPI:spi2s3_v1_1", ("spi", "v5", "SPI")),
             (".*:I2C:i2c1_v1_5", ("i2c", "v1", "I2C")),
             (".*:I2C:i2c2_v1_1", ("i2c", "v2", "I2C")),
+            (".*:I2C:F0-i2c2_v1_1", ("i2c", "v2", "I2C")),
             (".*:I2C:i2c2_v1_1F7", ("i2c", "v2", "I2C")),
             (".*:I2C:i2c2_v1_1U5", ("i2c", "v2", "I2C")),
             (".*:DAC:dacif_v1_1", ("dac", "v1", "DAC")),


### PR DESCRIPTION
Fixes I2C2 peripheral for the following chips:

- STM32F072C(8-B)Tx
- STM32F098CCUx
- STM32F098CCTx
- STM32F091C(B-C)Ux
- STM32F091C(B-C)Tx
- STM32F078VBTx
- STM32F078VBHx
- STM32F091V(B-C)Tx
- STM32F098VCTx
- STM32F078CBYx
- STM32F098VCHx
- STM32F091RCYx
- STM32F098RCYx
- STM32F072V(8-B)Hx
- STM32F098RCTx
- STM32F072RBHx
- STM32F078RBTx
- STM32F072R(8-B)Tx
- STM32F091R(B-C)Tx
- STM32F091RCHx
- STM32F071V(8-B)Hx
- STM32F078CBTx
- STM32F071CBYx
- STM32F072V(8-B)Tx
- STM32F098RCHx
- STM32F072RBIx
- STM32F091VCHx
- STM32F072CBYx
- STM32F078RBHx
- STM32F072C(8-B)Ux
- STM32F071V(8-B)Tx
- STM32F078CBUx
- STM32F071RBTx
- STM32F071C(8-B)Ux
- STM32F030RCTx
- STM32F070RBTx
- STM32F071C(8-B)Tx
- STM32F030CCTx
- STM32F070CBTx