### PR TITLE
add enums to STM32G4 Flash/RCC register YAMLs

### DIFF
--- a/data/registers/flash_g4.yaml
+++ b/data/registers/flash_g4.yaml
@@ -64,6 +64,7 @@ fieldset/ACR:
       description: Latency
       bit_offset: 0
       bit_size: 4
+      enum: LATENCY
     - name: PRFTEN
       description: Prefetch enable
       bit_offset: 8
@@ -211,6 +212,7 @@ fieldset/OPTR:
       description: Read protection level
       bit_offset: 0
       bit_size: 8
+      enum: RDP
     - name: BOR_LEV
       description: BOR reset Level
       bit_offset: 8
@@ -267,6 +269,7 @@ fieldset/OPTR:
       description: NRST_MODE
       bit_offset: 28
       bit_size: 2
+      enum: NRST_MODE
     - name: IRHEN
       description: Internal reset holder enable bit
       bit_offset: 30
@@ -380,3 +383,45 @@ fieldset/WRP1BR:
       description: Bank 1 WRP second area B start offset
       bit_offset: 16
       bit_size: 7
+enum/LATENCY:
+  bit_size: 3
+  variants:
+    - name: WS0
+      description: Zero wait states
+      value: 0
+    - name: WS1
+      description: One wait state
+      value: 1
+    - name: WS2
+      description: Two wait states
+      value: 2
+    - name: WS3
+      description: Three wait states
+      value: 3
+    - name: WS4
+      description: Four wait states
+      value: 4
+enum/NRST_MODE:
+  bit_size: 2
+  variants:
+    - name: INPUT_ONLY
+      description: Reset pin is in reset input mode only
+      value: 1
+    - name: GPIO
+      description: Reset pin is in GPIO mode only
+      value: 2
+    - name: INPUT_OUTPUT
+      description: Reset pin is in reset input and output mode
+      value: 3
+enum/RDP:
+  bit_size: 8
+  variants:
+    - name: LEVEL_0
+      description: Read protection not active
+      value: 170
+    - name: LEVEL_1
+      description: Memories read protection active
+      value: 187
+    - name: LEVEL_2
+      description: Chip read protection active
+      value: 204

--- a/data/registers/rcc_g4.yaml
+++ b/data/registers/rcc_g4.yaml
@@ -933,6 +933,7 @@ fieldset/BDCR:
       description: SE oscillator drive capability
       bit_offset: 3
       bit_size: 2
+      enum: LSEDRV
     - name: LSECSSON
       description: LSECSSON
       bit_offset: 5
@@ -945,6 +946,7 @@ fieldset/BDCR:
       description: RTC clock source selection
       bit_offset: 8
       bit_size: 2
+      enum: RTCSEL
     - name: RTCEN
       description: RTC clock enable
       bit_offset: 15
@@ -1046,18 +1048,22 @@ fieldset/CFGR:
       description: System clock switch
       bit_offset: 0
       bit_size: 2
+      enum: SW
     - name: SWS
       description: System clock switch status
       bit_offset: 2
       bit_size: 2
+      enum: SW
     - name: HPRE
       description: AHB prescaler
       bit_offset: 4
       bit_size: 4
+      enum: HPRE
     - name: PPRE1
       description: PB low-speed prescaler (APB1)
       bit_offset: 8
       bit_size: 3
+      enum: PPRE
     - name: PPRE2
       description: APB high-speed prescaler (APB2)
       bit_offset: 11
@@ -1066,10 +1072,12 @@ fieldset/CFGR:
       description: Microcontroller clock output
       bit_offset: 24
       bit_size: 4
+      enum: MCOSEL
     - name: MCOPRE
       description: Microcontroller clock output prescaler
       bit_offset: 28
       bit_size: 3
+      enum: MCOPRE
 fieldset/CICR:
   description: Clock interrupt clear register
   fields:
@@ -1286,6 +1294,7 @@ fieldset/PLLCFGR:
       description: "Main PLL, PLLSAI1 and PLLSAI2 entry clock source"
       bit_offset: 0
       bit_size: 2
+      enum: PLLSRC
     - name: PLLM
       description: Division factor for the main PLL and audio PLL (PLLSAI1 and PLLSAI2) input clock
       bit_offset: 4
@@ -1322,3 +1331,150 @@ fieldset/PLLCFGR:
       description: Main PLL division factor for PLLSAI2CLK
       bit_offset: 27
       bit_size: 5
+enum/HPRE:
+  bit_size: 4
+  variants:
+    - name: Div1
+      description: SYSCLK not divided
+      value: 0
+    - name: Div2
+      description: SYSCLK is divided by 2
+      value: 8
+    - name: Div4
+      description: SYSCLK is divided by 4
+      value: 9
+    - name: Div8
+      description: SYSCLK is divided by 8
+      value: 10
+    - name: Div16
+      description: SYSCLK is divided by 16
+      value: 11
+    - name: Div64
+      description: SYSCLK is divided by 64
+      value: 12
+    - name: Div128
+      description: SYSCLK is divided by 128
+      value: 13
+    - name: Div256
+      description: SYSCLK is divided by 256
+      value: 14
+    - name: Div512
+      description: SYSCLK is divided by 512
+      value: 15
+enum/LSEDRV:
+  bit_size: 2
+  variants:
+    - name: Low
+      description: Low driving capability
+      value: 0
+    - name: MediumLow
+      description: Medium low driving capability
+      value: 1
+    - name: MediumHigh
+      description: Medium high driving capability
+      value: 2
+    - name: High
+      description: High driving capability
+      value: 3
+enum/MCOPRE:
+  bit_size: 3
+  variants:
+    - name: Div1
+      description: MCO1 not divided
+      value: 0
+    - name: Div2
+      description: MCO clock is divided by 2
+      value: 1
+    - name: Div4
+      description: MCO clock is divided by 4
+      value: 2
+    - name: Div8
+      description: MCO clock is divided by 8
+      value: 3
+    - name: Div16
+      description: MCO clock is divided divided by 16
+      value: 4
+enum/MCOSEL:
+  bit_size: 4
+  variants:
+    - name: NoClock
+      description: "No clock, MCO output disabled"
+      value: 0
+    - name: SYSCLK
+      description: SYSCLK selected as MCO source
+      value: 1
+    - name: HSI16
+      description: HSI16 selected as MCO source
+      value: 3
+    - name: HSE
+      description: HSE selected as MCO source
+      value: 4
+    - name: PLLCLK
+      description: Main PLLCLK selected as MCO source
+      value: 5
+    - name: LSI
+      description: LSI selected as MCO source
+      value: 6
+    - name: LSE
+      description: LSE selected as MCO source
+      value: 7
+    - name: HSI48
+      description: HSI48 selected as MCO source
+      value: 8
+enum/PLLSRC:
+  bit_size: 2
+  variants:
+    - name: NoClock
+      description: No clock selected as PLL entry clock source
+      value: 0
+    - name: HSI16
+      description: HSI16 selected as PLL entry clock source
+      value: 2
+    - name: HSE
+      description: HSE selected as PLL entry clock source
+      value: 3
+enum/PPRE:
+  bit_size: 4
+  variants:
+    - name: Div1
+      description: HCLK not divided
+      value: 0
+    - name: Div2
+      description: HCLK is divided by 2
+      value: 4
+    - name: Div4
+      description: HCLK is divided by 4
+      value: 5
+    - name: Div8
+      description: HCLK is divided by 8
+      value: 6
+    - name: Div16
+      description: HCLK is divided by 16
+      value: 7
+enum/RTCSEL:
+  bit_size: 2
+  variants:
+    - name: NoClock
+      description: No clock used as RTC clock
+      value: 0
+    - name: LSE
+      description: LSE used as RTC clock
+      value: 1
+    - name: LSI
+      description: LSI used as RTC clock
+      value: 2
+    - name: HSE_Div32
+      description: HSE divided by 32 used as RTC clock
+      value: 3
+enum/SW:
+  bit_size: 2
+  variants:
+    - name: HSI16
+      description: HSI16 selected as system clock
+      value: 1
+    - name: HSE
+      description: HSE selected as system clock
+      value: 2
+    - name: PLLRCLK
+      description: PLLRCLK selected as system clock
+      value: 3


### PR DESCRIPTION
Modeled enums on STM32G0 definitions for RCC/FLASH peripherals of STM32G4. Checked enums against RM0440 Rev 7.