### PR TITLE
can: skip duplicate interrupt in f107

### DIFF
--- a/.vscode/.gitignore
+++ b/.vscode/.gitignore
@@ -1,0 +1,2 @@
+launch.json
+tasks.json

--- a/stm32-data-gen/src/chips.rs
+++ b/stm32-data-gen/src/chips.rs
@@ -935,13 +935,40 @@ fn process_core(
         }
 
         if let Some(peri_irqs) = chip_irqs.get(&pname) {
+            use stm32_data_serde::chip::core::peripheral::Interrupt;
+
             //filter by available, because some are conditioned on <Die>
-            let mut irqs: Vec<_> = peri_irqs
-                .iter()
-                .filter(|i| header_irqs.contains_key(&i.interrupt))
-                .cloned()
-                .collect();
+
+            let mut irqs: Vec<_> =
+                if pname == "CAN" && (chip_name.starts_with("STM32F358") || chip_name.starts_with("STM32F398")) {
+                    /*
+                        This section is needed because the interrupt definition file does not apply uniformly to
+                        all chips that it covers in this specific case. This cannot be done in interrupt.rs
+                        because there, it's only possible to modify the interrupt definition file in a uniform manner.
+                    */
+
+                    peri_irqs
+                        .iter()
+                        .map(|i| Interrupt {
+                            interrupt: i
+                                .interrupt
+                                .trim_start_matches("USB_LP_")
+                                .trim_start_matches("USB_HP_")
+                                .to_owned(),
+                            signal: i.signal.clone(),
+                        })
+                        .filter(|i| header_irqs.contains_key(&i.interrupt))
+                        .collect()
+                } else {
+                    peri_irqs
+                        .iter()
+                        .filter(|i| header_irqs.contains_key(&i.interrupt))
+                        .cloned()
+                        .collect()
+                };
             irqs.sort_by_key(|x| (x.signal.clone(), x.interrupt.clone()));
+            irqs.dedup_by_key(|x| (x.signal.clone(), x.interrupt.clone()));
+
             p.interrupts = Some(irqs);
         }
         peripherals.push(p);


### PR DESCRIPTION
This skips interrupts with a peripheral named can. This peripheral does not exist, but causes later duplicate interrupts with the correct peripheral to be skipped. If an IP file contains only interrupts with an incorrect CAN peripheral, this could cause those interrupts to be removed. However, I am not aware of such a file and am not sure how I would identify it.