### PR TITLE
Update chips.rs to include perimap for SPI in STM32F410 MCUs

### DIFF
--- a/stm32-data-gen/src/chips.rs
+++ b/stm32-data-gen/src/chips.rs
@@ -139,6 +139,7 @@ impl PeriMatcher {
             (".*:SPI:spi2_v1_4", ("spi", "f1", "SPI")),
             (".*:SPI:spi2s1_v2_1", ("spi", "v1", "SPI")),
             (".*:SPI:spi2s1_v2_2", ("spi", "v1", "SPI")),
+            (".*:SPI:spi2s1_v2_4", ("spi", "v1", "SPI")),
             (".*:SPI:spi2s1_v3_0", ("spi", "v2", "SPI")),
             (".*:SPI:spi2s1_v3_2", ("spi", "v2", "SPI")),
             (".*:SPI:spi2s1_v3_3", ("spi", "v2", "SPI")),


### PR DESCRIPTION
+ SPI perimap for spi2s1_v2_4_Cube