### PR TITLE
README: add link to lovely generated docs site

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,11 @@ families, including:
 
 :heavy_check_mark: = done, :construction: = work in progress, :x: = to do
 
+## Docs
+
+If you're looking for the API docs for `stm32-metapac` customized to a
+particular chip, they are available here: https://docs.embassy.dev/stm32-metapac
+
 ## Data sources
 
 These are the data sources currently used.


### PR DESCRIPTION
In #199, @Dirbaio pointed me at the _fantastic_ index of generated docs for each chip variant supported by `stm32-metapac`. As a newcomer, it would have answered a lot of questions to find that link near the top of the README (which is where I went looking for it).

So, here's a PR. :-)