### PR TITLE
G0 SYSCFG: fix PA11/PA12 RMP definitions

### DIFF
--- a/data/registers/syscfg_g0.yaml
+++ b/data/registers/syscfg_g0.yaml
@@ -186,8 +186,12 @@ fieldset/CFGR1:
       bit_offset: 0
       bit_size: 2
       enum: MEM_MODE
-    - name: PA11_PA12_RMP
-      description: PA11 and PA12 remapping bit.
+    - name: PA11_RMP
+      description: "PA11 pin remapping\r This bit is set and cleared by software. When set, it remaps the PA11 pin to operate as PA9 GPIO port, instead as PA11 GPIO port."
+      bit_offset: 3
+      bit_size: 1
+    - name: PA12_RMP
+      description: "PA12 pin remapping\r This bit is set and cleared by software. When set, it remaps the PA12 pin to operate as PA10 GPIO port, instead as PA12 GPIO port."
       bit_offset: 4
       bit_size: 1
     - name: IR_POL


### PR DESCRIPTION
It looks like the G0 file here picked up the F0-style "one remapping bit for both pins" field definition. The G0 series actually has C0-style dual remapping bits.