### PR TITLE
G0/C0: fix SYSCFG.CFGR1.MEM_MODE definition

### DIFF
--- a/data/registers/syscfg_c0.yaml
+++ b/data/registers/syscfg_c0.yaml
@@ -123,7 +123,7 @@ fieldset/CFGR1:
   description: configuration register 1
   fields:
     - name: MEM_MODE
-      description: "Memory mapping selection bits\r This bitfield controlled by software selects the memory internally mapped at the address 0x0000 0000. Its reset value is determined by the boot mode configuration. Refer to for more details.\r x0: Main Flash memory"
+      description: "Memory mapping selection bits. This bitfield controlled by software selects the memory internally mapped at the address 0x0000_0000. Its reset value is determined by the boot mode configuration. Refer to Reference Manual section 2.5 for more details."
       bit_offset: 0
       bit_size: 2
       enum: MEM_MODE
@@ -403,11 +403,17 @@ enum/IR_MOD:
 enum/MEM_MODE:
   bit_size: 2
   variants:
-    - name: FLASH
-      description: System Flash memory
+    - name: MAIN_FLASH
+      description: Main Flash memory mapped at address 0
+      value: 0
+    - name: MAIN_FLASH_ALT
+      description: Main Flash memory mapped at address 0 (alternate encoding)
+      value: 2
+    - name: SYSTEM_FLASH
+      description: System Flash memory mapped at address 0
       value: 1
     - name: SRAM
-      description: Embedded SRAM
+      description: Embedded SRAM mapped at address 0
       value: 3
 enum/PINMUX0:
   bit_size: 2

--- a/data/registers/syscfg_g0.yaml
+++ b/data/registers/syscfg_g0.yaml
@@ -182,7 +182,7 @@ fieldset/CFGR1:
   description: configuration register 1
   fields:
     - name: MEM_MODE
-      description: Memory mapping selection bits
+      description: "Memory mapping selection bits. This bitfield controlled by software selects the memory internally mapped at the address 0x0000_0000. Its reset value is determined by the boot mode configuration. Refer to Reference Manual section 2.5 for more details."
       bit_offset: 0
       bit_size: 2
       enum: MEM_MODE
@@ -661,9 +661,15 @@ fieldset/VREFBUF_CSR:
 enum/MEM_MODE:
   bit_size: 2
   variants:
-    - name: FLASH
-      description: System Flash memory
+    - name: MAIN_FLASH
+      description: Main Flash memory mapped at address 0
+      value: 0
+    - name: MAIN_FLASH_ALT
+      description: Main Flash memory mapped at address 0 (alternate encoding)
+      value: 2
+    - name: SYSTEM_FLASH
+      description: System Flash memory mapped at address 0
       value: 1
     - name: SRAM
-      description: Embedded SRAM
+      description: Embedded SRAM mapped at address 0
       value: 3


### PR DESCRIPTION
- Added docs from reference manual / fixed existing partial copy of reference manual docs
- Renamed System Flash case to SYSTEM_FLASH because FLASH was ambiguous (you really don't want to activate the System Flash when you wanted Main Flash, where your program lives!)
- Added Main Flash case.

Stylistically: note that main flash is actually `x0`. So the value I've given is valid for writes, but on read `== MAIN_FLASH` here could be misleading. Not sure how you prefer to handle cases like that.