### PR TITLE
gpio_v2: expand docs on AFRx register pair to describe indexing.

### DIFF
--- a/data/registers/gpio_v2.yaml
+++ b/data/registers/gpio_v2.yaml
@@ -37,7 +37,7 @@ block/GPIO:
       byte_offset: 28
       fieldset: LCKR
     - name: AFR
-      description: "GPIO alternate function register (low, high)"
+      description: "GPIO alternate function registers. The register described in the datasheet as AFRL is index 0 in this array, and AFRH is index 1. Note that when operating on AFRH, you need to subtract 8 from any operations on the field array it contains -- the alternate function for pin 9 is at index 1, for instance."
       array:
         len: 2
         stride: 4


### PR DESCRIPTION
In an attempt to keep other people from making the mistake I described in #206, I've expanded the docs to explain how indexing of the fields works (because I don't expect users to read and understand the YAML).

These docs don't meet my normal standards for Rustdoc: they don't include a code example, they don't link the types involved using Markdown references, etc. However, it appears that the description field in the YAML is intended to be language-neutral; I don't think good API documentation can be language neutral, so you may want a way of adding language-specific documentation in the future.

For now, I have described it in very generic terms that apply to any language using 0-based array indexing, which does not cover all languages used in embedded (e.g. Lua, or in some cases Ada), but does cover C and Rust and Python.