### PR TITLE
gpio_v2: remove another case where indexing was potentially misleading

### DIFF
--- a/data/registers/gpio_v2.yaml
+++ b/data/registers/gpio_v2.yaml
@@ -44,10 +44,10 @@ block/GPIO:
       byte_offset: 32
       fieldset: AFR
 fieldset/AFR:
-  description: GPIO alternate function register
+  description: GPIO alternate function register. This contains an array of 8 fields, which correspond to pins 0-7 of the port (for AFRL) or pins 8-15 of the port (for AFRH).
   fields:
     - name: AFR
-      description: Alternate function selection for port x bit y (y = 0..15)
+      description: Alternate function selection for one of the pins controlled by this register (0-7).
       bit_offset: 0
       bit_size: 4
       array:


### PR DESCRIPTION
The field docs suggested that the index was in the range 0..15, which is not true in this case.