### PR TITLE
hrtim: add common registers and v2

### DIFF
--- a/data/registers/hrtim_v1.yaml
+++ b/data/registers/hrtim_v1.yaml
@@ -111,10 +111,50 @@ block/HRTIM:
       description: "High Resolution Timer: External Event Control Register 3"
       byte_offset: 0x3b8
       fieldset: HRTIM_EECR3
+    - name: ADC1R
+      description: "High Resolution Timer: ADC Trigger [1, 3] Register"
+      byte_offset: 0x3bc
+      fieldset: HRTIM_ADC1R
+      array:
+        offsets:
+          - 0
+          - 8
+    - name: ADC2R
+      description: "High Resolution Timer: ADC Trigger [2, 4] Register"
+      byte_offset: 0x3c0
+      fieldset: HRTIM_ADC2R
+      array:
+        offsets:
+          - 0
+          - 8
     - name: DLLCR
       description: "High Resolution Timer: DLL Control Register"
       byte_offset: 0x3cc
-      fieldset: HRTIM_DLLCR      
+      fieldset: HRTIM_DLLCR
+    - name: FLTINR1
+      description: "High Resolution Timer: Fault Input Register 1"
+      byte_offset: 0x3d0
+      fieldset: HRTIM_FLTINR1
+    - name: FLTINR2
+      description: "High Resolution Timer: Fault Input Register 2"
+      byte_offset: 0x3d0
+      fieldset: HRTIM_FLTINR2
+    - name: BDMUPR
+      description: "High Resolution Timer: Burst DMA Master timer update Register"
+      byte_offset: 0x3d8
+      fieldset: HRTIM_BDMUPR
+    - name: BDTUPR
+      description: "High Resolution Timer: Burst DMA Timer X update Register"
+      byte_offset: 0x3dc
+      fieldset: HRTIM_BDTUPR
+      array:
+        len: 5
+        stride: 4
+    - name: BDMADR
+      description: "High Resolution Timer: Burst DMA Data Register"
+      byte_offset: 0x3f0
+      access: Write
+      fieldset: HRTIM_BDMADR
 block/HRTIM_TIMX:
   description: "High Resolution Timer: Timing Unit"
   items:
@@ -632,6 +672,152 @@ fieldset/HRTIM_EECR3:
       description: External Event Sampling Clock Division
       bit_offset: 30
       bit_size: 2
+fieldset/HRTIM_ADC1R:
+  description: "High Resolution Timer: ADC Trigger 1 Register"
+  fields:
+    - name: ADCMC
+      description: ADC trigger X on Master Compare Y
+      bit_offset: 0
+      bit_size: 1
+      array:
+        len: 4
+        stride: 1
+    - name: ADCMPER
+      description: ADC trigger X on Master Period
+      bit_offset: 4
+      bit_size: 1
+    - name: ADCEEV
+      description: ADC trigger X on External Event Y
+      bit_offset: 5
+      bit_size: 1
+      array:
+        len: 5
+        stride: 1
+    - name: ADCTC2
+      description: ADC trigger X on Timer Y Compare 2
+      bit_offset: 10
+      bit_size: 1
+      array:
+        offsets:
+          - 0
+          - 5
+          - 10
+          - 14
+          - 18
+    - name: ADCTC3
+      description: ADC trigger X on Timer Y Compare 3
+      bit_offset: 11
+      bit_size: 1
+      array:
+        offsets:
+          - 0 
+          - 5
+          - 10
+          - 14
+          - 18
+    - name: ADCTC4
+      description: ADC trigger X on Timer Y Compare 3
+      bit_offset: 12
+      bit_size: 1
+      array:
+        offsets:
+          - 0 
+          - 5
+          - 10
+          - 14
+          - 18
+    - name: ADCTPER
+      description: ADC trigger X on Timer Y Period
+      bit_offset: 13
+      bit_size: 1
+      array:
+        offsets:
+          - 0 
+          - 5
+          - 10
+          - 14
+          - 18
+    - name: ADCTRST
+      description: ADC trigger X on Timer Y Reset
+      bit_offset: 14
+      bit_size: 1
+      array:
+        offsets:
+          - 0 
+          - 5
+fieldset/HRTIM_ADC2R:
+  description: "High Resolution Timer: ADC Trigger 2 Register"
+  fields:
+    - name: ADCMC
+      description: ADC trigger X on Master Compare Y
+      bit_offset: 0
+      bit_size: 1
+      array:
+        len: 4
+        stride: 1
+    - name: ADCMPER
+      description: ADC trigger X on Master Period
+      bit_offset: 4
+      bit_size: 1
+    - name: ADCEEV
+      description: ADC trigger X on External Event Y
+      bit_offset: 5
+      bit_size: 1
+      array:
+        len: 5
+        stride: 1
+    - name: ADCTC2
+      description: ADC trigger X on Timer Y Compare 2
+      bit_offset: 10
+      bit_size: 1
+      array:
+        offsets:
+          - 0
+          - 4
+          - 8
+          - 13
+          - 18
+    - name: ADCTC3
+      description: ADC trigger X on Timer Y Compare 3
+      bit_offset: 11
+      bit_size: 1
+      array:
+        offsets:
+          - 0 
+          - 4
+          - 8
+          - 13
+          - 18
+    - name: ADCTC4
+      description: ADC trigger X on Timer Y Compare 3
+      bit_offset: 12
+      bit_size: 1
+      array:
+        offsets:
+          - 0
+          - 4
+          - 8
+          - 13
+          - 18
+    - name: ADCTPER
+      description: ADC trigger X on Timer Y Period
+      bit_offset: 13
+      bit_size: 1
+      array:
+        offsets:
+          - 0 
+          - 4
+          - 8
+          - 13
+    - name: ADCTRST
+      description: ADC trigger X on Timer Y Reset
+      bit_offset: 22
+      bit_size: 1
+      array:
+        offsets:
+          - 0 
+          - 5
+          - 9
 fieldset/HRTIM_DLLCR:
   description: "High Resolution Timer: DLL Control Register"
   fields:
@@ -647,6 +833,176 @@ fieldset/HRTIM_DLLCR:
       description: DLL Calibration Rate
       bit_offset: 2
       bit_size: 2
+fieldset/HRTIM_FLTINR1:
+  description: "High Resolution Timer: Fault Input Register 1"
+  fields:
+    - name: FLTE
+      description: Fault X enable
+      bit_offset: 0
+      bit_size: 1
+      array:
+        offsets:
+          - 0
+          - 8
+          - 16
+          - 24
+    - name: FLTP
+      description: Fault X polarity
+      bit_offset: 1
+      bit_size: 1
+      array:
+        offsets:
+          - 0
+          - 8
+          - 16
+          - 24
+    - name: FLTSRC
+      description: Fault X source
+      bit_offset: 2
+      bit_size: 1
+      array:
+        offsets:
+          - 0
+          - 8
+          - 16
+          - 24
+    - name: FLTF
+      description: Fault X filter
+      bit_offset: 3
+      bit_size: 4
+      array:
+        offsets:
+          - 0
+          - 8
+          - 16
+          - 24
+    - name: FLTLCK
+      description: Fault X Lock
+      bit_offset: 7
+      bit_size: 1
+      array:
+        offsets:
+          - 0
+          - 8
+          - 16
+          - 24
+fieldset/HRTIM_FLTINR2:
+  description: "High Resolution Timer: Fault Input Register 2"
+  fields:
+    - name: FLTE
+      description: Fault X enable
+      bit_offset: 0
+      bit_size: 1
+      array:
+        offsets:
+          - 0
+    - name: FLTP
+      description: Fault X polarity
+      bit_offset: 1
+      bit_size: 1
+      array:
+        offsets:
+          - 0
+    - name: FLTSRC
+      description: Fault X source
+      bit_offset: 2
+      bit_size: 1
+      array:
+        offsets:
+          - 0
+    - name: FLTF
+      description: Fault X filter
+      bit_offset: 3
+      bit_size: 4
+      array:
+        offsets:
+          - 0
+    - name: FLTLCK
+      description: Fault X Lock
+      bit_offset: 7
+      bit_size: 1
+      array:
+        offsets:
+          - 0
+    - name: FLTSD
+      description: Fault Sampling clock division
+      bit_offset: 24
+      bit_size: 2
+fieldset/HRTIM_BDMUPR:
+  description: "High Resolution Timer: Burst DMA Master timer update Register"
+  fields:
+    - name: MCR
+      description: MCR register update enable
+      bit_offset: 0
+      bit_size: 1
+    - name: MICR
+      description: MICR register update enable
+      bit_offset: 1
+      bit_size: 1
+    - name: MDIER
+      description: MDIER register update enable
+      bit_offset: 2
+      bit_size: 1
+    - name: MCNT
+      description: MCNT register update enable
+      bit_offset: 3
+      bit_size: 1
+    - name: MPER
+      description: MPER register update enable
+      bit_offset: 4
+      bit_size: 1
+    - name: MREP
+      description: MREP register update enable
+      bit_offset: 5
+      bit_size: 1
+    - name: MCMP
+      description: MCMP register X update enable
+      bit_offset: 6
+      bit_size: 1
+      array:
+        len: 4
+        stride: 1
+fieldset/HRTIM_BDTUPR:
+  description: "High Resolution Timer: Burst DMA Master timer update Register"
+  fields:
+    - name: CR
+      description: CR register update enable
+      bit_offset: 0
+      bit_size: 1
+    - name: ICR
+      description: ICR register update enable
+      bit_offset: 1
+      bit_size: 1
+    - name: DIER
+      description: DIER register update enable
+      bit_offset: 2
+      bit_size: 1
+    - name: CNT
+      description: CNT register update enable
+      bit_offset: 3
+      bit_size: 1
+    - name: PER
+      description: PER register update enable
+      bit_offset: 4
+      bit_size: 1
+    - name: REP
+      description: REP register update enable
+      bit_offset: 5
+      bit_size: 1
+    - name: CMP
+      description: CMP register X update enable
+      bit_offset: 6
+      bit_size: 1
+      array:
+        len: 4
+        stride: 1
+fieldset/HRTIM_BDMADR:
+  description: "High Resolution Timer:  Burst DMA Data Register"
+  fields:
+    - name: BDMADR
+      description: Burst DMA Data register
+      bit_offset: 0
+      bit_size: 31
 fieldset/MCMPX:
   description: Master Timer Compare X Register
   fields:

--- a/data/registers/hrtim_v1.yaml
+++ b/data/registers/hrtim_v1.yaml
@@ -1,6 +1,6 @@
 ---
 block/HRTIM:
-  description: "High Resolution Timer: Master Timer"
+  description: "High Resolution Timer"
   items:
     - name: MCR
       description: Master Timer Control Register
@@ -49,6 +49,494 @@ block/HRTIM:
         stride: 128
       byte_offset: 128
       block: HRTIM_TIMX
+    - name: CR1
+      description: "High Resolution Timer: Control Register 1"
+      byte_offset: 0x380
+      fieldset: HRTIM_CR1
+    - name: CR2
+      description: "High Resolution Timer: Control Register 2"
+      byte_offset: 0x384
+      fieldset: HRTIM_CR2
+    - name: ISR
+      description: "High Resolution Timer: Interrupt Status Register"
+      byte_offset: 0x388
+      access: Read
+      fieldset: HRTIM_ISR
+    - name: ICR
+      description: "High Resolution Timer: Interrupt Clear Register"
+      byte_offset: 0x38c
+      access: Write
+      fieldset: HRTIM_ICR
+    - name: IER
+      description: "High Resolution Timer: Interrupt Enable Register"
+      byte_offset: 0x390
+      fieldset: HRTIM_IER
+    - name: OENR
+      description: "High Resolution Timer: Output Enable Register"
+      byte_offset: 0x394
+      fieldset: HRTIM_OENR
+    - name: ODISR
+      description: "High Resolution Timer: Output Disable Register"
+      byte_offset: 0x398
+      fieldset: HRTIM_ODISR
+    - name: ODSR
+      description: "High Resolution Timer: Output Disable Status Register"
+      byte_offset: 0x39c
+      fieldset: HRTIM_ODSR
+    - name: BMCR
+      description: "High Resolution Timer: Burst Mode Control Register"
+      byte_offset: 0x3a0
+      fieldset: HRTIM_BMCR
+    - name: BMTRGR
+      description: "High Resolution Timer: Burst Mode Trigger Register"
+      byte_offset: 0x3a4
+      fieldset: HRTIM_BMTRGR
+    - name: BMCMPR
+      description: "High Resolution Timer: Burst Mode Compare Register"
+      byte_offset: 0x3a8
+      fieldset: HRTIM_BMCMPR
+    - name: BMPER
+      description: "High Resolution Timer: Burst Mode Period Register"
+      byte_offset: 0x3ac
+      fieldset: HRTIM_BMPER
+    - name: EECR1
+      description: "High Resolution Timer: External Event Control Register 1"
+      byte_offset: 0x3b0
+      fieldset: HRTIM_EECR1
+    - name: EECR2
+      description: "High Resolution Timer: External Event Control Register 2"
+      byte_offset: 0x3b4
+      fieldset: HRTIM_EECR2
+    - name: EECR3
+      description: "High Resolution Timer: External Event Control Register 3"
+      byte_offset: 0x3b8
+      fieldset: HRTIM_EECR3
+    - name: DLLCR
+      description: "High Resolution Timer: DLL Control Register"
+      byte_offset: 0x3cc
+      fieldset: HRTIM_DLLCR      
+fieldset/HRTIM_CR1:
+  description: "High Resolution Timer: Control Register 1"
+  items:
+    - name: MUDIS
+      description: Master Update Disable
+      bit_offset: 0
+      bit_size: 1
+    - name: TUDIS
+      description: Timer X Update Disable
+      bit_offset: 1
+      bit_size: 1
+      array:
+        len: 5
+        stride: 1
+    - name: ADUSRC
+      description: ADC Trigger X Update Source
+      bit_offset: 16
+      bit_size: 3
+      array:
+        len: 4
+        stride: 2
+      enum: UPDATESOURCE
+fieldset/HRTIM_CR2:
+  description: "High Resolution Timer: Control Register 2"
+  items:
+    - name: MSWU
+      description: Master Timer Software Update
+      bit_offset: 0
+      bit_size: 1
+    - name: TSWU
+      description: Timer X Software Update
+      bit_offset: 1
+      bit_size: 1
+      array:
+        len: 5
+        stride: 1
+    - name: MRST
+      description: Master Counter Software Reset
+      bit_offset: 8
+      bit_size: 1
+    - name: TRST
+      description: Timer X Counter Software Reset
+      bit_offset: 9
+      bit_size: 1
+      array:
+        len: 5
+        stride: 1
+fieldset/HRTIM_ISR:
+  description: "High Resolution Timer: Interrupt Status Register"
+  items:
+    - name: FLT
+      description: Fault X Interrupt Flag
+      bit_offset: 0
+      bit_size: 1
+      array:
+        len: 5
+        stride: 1
+    - name: SYSFLT
+      description: System Fault Interrupt Flag
+      bit_offset: 5
+      bit_size: 1
+    - name: DLLRDY
+      description: DLL Ready Interrupt Flag
+      bit_offset: 16
+      bit_size: 1
+    - name: BMPER
+      description: Burst Mode Period Interrupt Flag
+      bit_offset: 17
+      bit_size: 1
+fieldset/HRTIM_ICR:
+  description: "High Resolution Timer: Interrupt Clear Register"
+  items:
+    - name: FLT
+      description: Fault X Interrupt Flag Clear
+      bit_offset: 0
+      bit_size: 1
+      array:
+        len: 5
+        stride: 1
+    - name: SYSFLT
+      description: System Fault Interrupt Flag Clear
+      bit_offset: 5
+      bit_size: 1
+    - name: DLLRDY
+      description: DLL Ready Interrupt Flag Clear
+      bit_offset: 16
+      bit_size: 1
+    - name: BMPER
+      description: Burst Mode Period Interrupt Flag Clear
+      bit_offset: 17
+      bit_size: 1
+fieldset/HRTIM_IER:
+  description: "High Resolution Timer: Interrupt Enable Register"
+  items:
+    - name: FLT
+      description: Fault X Interrupt Flag Enable
+      bit_offset: 0
+      bit_size: 1
+      array:
+        len: 5
+        stride: 1
+    - name: SYSFLT
+      description: System Fault Interrupt Flag Enable
+      bit_offset: 5
+      bit_size: 1
+    - name: DLLRDY
+      description: DLL Ready Interrupt Flag Enable
+      bit_offset: 16
+      bit_size: 1
+    - name: BMPER
+      description: Burst Mode Period Interrupt Flag Enable
+      bit_offset: 17
+      bit_size: 1
+fieldset/HRTIM_OENR:
+  description: "High Resolution Timer: Output Enable Register"
+  items:
+    - name: T1OEN
+      description: "Timer X Output Enable"
+      bit_offset: 0
+      bit_size: 1
+      array:
+        offsets:
+          - 0
+          - 2
+          - 4
+          - 6
+          - 8
+    - name: T2OEN
+      description: "Timer X Complementary Output Enable"
+      bit_offset: 1
+      bit_size: 1
+      array:
+        offsets:
+          - 0
+          - 2
+          - 4
+          - 6
+          - 8
+fieldset/HRTIM_ODISR:
+  description: "High Resolution Timer: Output Disable Register"
+  items:
+    - name: T1ODIS
+      description: "Timer X Output Disable"
+      bit_offset: 0
+      bit_size: 1
+      array:
+        offsets:
+          - 0
+          - 2
+          - 4
+          - 6
+          - 8
+    - name: T2ODIS
+      description: "Timer X Complementary Output Disable"
+      bit_offset: 1
+      bit_size: 1
+      array:
+        offsets:
+          - 0
+          - 2
+          - 4
+          - 6
+          - 8
+fieldset/HRTIM_ODSR:
+  description: "High Resolution Timer: Output Disable Status Register"
+  items:
+    - name: T1ODIS
+      description: "Timer X Output Disable Status"
+      bit_offset: 0
+      bit_size: 1
+      array:
+        offsets:
+          - 0
+          - 2
+          - 4
+          - 6
+          - 8
+    - name: T2ODIS
+      description: "Timer X Complementary Output Disable Status"
+      bit_offset: 1
+      bit_size: 1
+      array:
+        offsets:
+          - 0
+          - 2
+          - 4
+          - 6
+          - 8
+fieldset/HRTIM_BMCR:
+  description: "High Resolution Timer: Burst Mode Control Register"
+  items:
+    - name: BME
+      description: Burst Mode Enable
+      bit_offset: 0
+      bit_size: 1
+    - name: BMOM
+      description: Burst Mode Operating Mode
+      bit_offset: 1
+      bit_size: 1
+    - name: BMCLK
+      description: Burst Mode Clock source
+      bit_offset: 2
+      bit_size: 3
+    - name: BMPRSC
+      description: Burst Mode Prescaler
+      bit_offset: 6
+      bit_size: 3
+    - name: BMPREN
+      description: Burst Mode Preload Enable
+      bit_offset: 10
+      bit_size: 1
+    - name: MTBM
+      description: Master Timer Burst Mode
+      bit_offset: 16
+      bit_size: 1
+    - name: TBM
+      description: Timer X Burst Mode
+      bit_offset: 17
+      bit_size: 1
+      array:
+        len: 5
+        stride: 1
+    - name: BMSTAT
+      decription: Burst Mode Status
+      bit_offset: 31
+      bit_size: 1
+fieldset/HRTIM_BMTRGR:
+  description: "High Resolution Timer: Burst Mode Trigger Register"
+  items:
+    - name: SW
+      description: Software start
+      bit_offset: 0
+      bit_size: 1
+    - name: MSTRST
+      description: Master reset or roll-over
+      bit_offset: 1
+      bit_size: 1
+    - name: MSTREP
+      description: Master repetition
+      bit_offset: 2
+      bit_size: 1
+    - name: MSTCMP
+      description: Master Compare X
+      bit_offset: 3
+      bit_size: 1
+      array:
+        len: 4
+        stride: 1
+    - name: TRST
+      description: Timer X reset or roll-over
+      bit_offset: 7
+      bit_size: 1
+      array:
+        offsets:
+          - 0
+          - 4
+          - 8
+          - 12
+          - 16
+    - name: TREP
+      description: Timer X repetition
+      bit_offset: 8
+      bit_size: 1
+      array:
+        offsets:
+          - 0
+          - 4
+          - 8
+          - 12
+          - 16
+    - name: TCMP1
+      description: Timer X compare 1 event
+      bit_offset: 9
+      bit_size: 1
+      array:
+        offsets:
+          - 0
+          - 4
+          - 8
+          - 12
+          - 16
+    - name: TCMP2
+      description: Timer X compare 2 event
+      bit_offset: 10
+      bit_size: 1
+      array:
+        offsets:
+          - 0
+          - 4
+          - 8
+          - 12
+          - 16
+fieldset/HRTIM_BMCMPR:
+  description: "High Resolution Timer: Burst Mode Compare Register"
+  items:
+    - name: BMCMP
+      description: Burst mode compare value
+      bit_offset: 0 
+      bit_size: 16
+fieldset/HRTIM_BMPERs:
+  description: "High Resolution Timer: Burst Mode Period Register"
+  items:
+    - name: BMPER
+      description: Burst mode period value
+      bit_offset: 0 
+      bit_size: 16
+fieldset/HRTIM_EECR1:
+  description: "High Resolution Timer: External Events Control Register 1"
+  items:
+    - name: EESRC
+      description: External Event X Source
+      bit_offset: 0
+      bit_size: 2
+      array:
+        offsets:
+          - 0
+          - 6
+          - 12
+          - 18
+          - 24
+    - name: EEPOL
+      description: External Event X Polarity
+      bit_offset: 2
+      bit_size: 1
+      array:
+        offsets:
+          - 0
+          - 6
+          - 12
+          - 18
+          - 24
+    - name: EESNS
+      description: External Event X Sensitivity
+      bit_offset: 3
+      bit_size: 2
+      array:
+        offsets:
+          - 0
+          - 6
+          - 12
+          - 18
+          - 24
+    - name: EEFAST
+      description: External Event X Fast Mode
+      bit_offset: 5
+      bit_size: 2
+      array:
+        offsets:
+          - 0
+          - 6
+          - 12
+          - 18
+          - 24
+fieldset/HRTIM_EECR2:
+  description: "High Resolution Timer: External Events Control Register 2"
+  items:
+    - name: EESRC
+      description: External Event X Source
+      bit_offset: 0
+      bit_size: 2
+      array:
+        offsets:
+          - 0
+          - 6
+          - 12
+          - 18
+          - 24
+    - name: EEPOL
+      description: External Event X Polarity
+      bit_offset: 2
+      bit_size: 1
+      array:
+        offsets:
+          - 0
+          - 6
+          - 12
+          - 18
+          - 24
+    - name: EESNS
+      description: External Event X Sensitivity
+      bit_offset: 3
+      bit_size: 2
+      array:
+        offsets:
+          - 0
+          - 6
+          - 12
+          - 18
+          - 24
+fieldset/HRTIM_EECR3:
+  description: "High Resolution Timer: External Events Control Register 2"
+  items:
+    - name: EEF
+      description: External Event X filter
+      bit_offset: 0
+      bit_size: 3
+      array:
+        offsets:
+          - 0
+          - 6 
+          - 12
+          - 18
+          - 24
+    - name: EEVSD
+      description: External Event Sampling Clock Division
+      bit_offset: 30
+      bit_size: 2
+fieldset/HRTIM_DLLCR:
+  description: "High Resolution Timer: DLL Control Register"
+  items:
+    - name: CAL
+      description: DLL Calibration Start
+      bit_offset: 0
+      bit_size: 1
+    - name: CALEN
+      description: DLL Calibration Enable
+      bit_offset: 1
+      bit_size: 1
+    - name: CALRTE
+      description: DLL Calibration Rate
+      bit_offset: 2
+      bit_size: 2
 block/HRTIM_TIMX:
   description: "High Resolution Timer: Timing Unit"
   items:
@@ -1530,3 +2018,19 @@ enum/UPDGAT:
     - name: Input3_Update
       description: Update occurs on the update event following a rising edge of HRTIM update enable input 3
       value: 8
+enum/UPDATESOURCE:
+  bit_size: 3
+  variants:
+    - name: MasterTimer
+      value: 0
+    - name: TimerA
+      value: 1
+    - name: TimerB
+      value: 2
+    - name: TimerC
+      value: 3
+    - name: TimerD
+      value: 4
+    - name: TimerE
+      value: 5
+

--- a/data/registers/hrtim_v1.yaml
+++ b/data/registers/hrtim_v1.yaml
@@ -115,428 +115,6 @@ block/HRTIM:
       description: "High Resolution Timer: DLL Control Register"
       byte_offset: 0x3cc
       fieldset: HRTIM_DLLCR      
-fieldset/HRTIM_CR1:
-  description: "High Resolution Timer: Control Register 1"
-  items:
-    - name: MUDIS
-      description: Master Update Disable
-      bit_offset: 0
-      bit_size: 1
-    - name: TUDIS
-      description: Timer X Update Disable
-      bit_offset: 1
-      bit_size: 1
-      array:
-        len: 5
-        stride: 1
-    - name: ADUSRC
-      description: ADC Trigger X Update Source
-      bit_offset: 16
-      bit_size: 3
-      array:
-        len: 4
-        stride: 2
-      enum: UPDATESOURCE
-fieldset/HRTIM_CR2:
-  description: "High Resolution Timer: Control Register 2"
-  items:
-    - name: MSWU
-      description: Master Timer Software Update
-      bit_offset: 0
-      bit_size: 1
-    - name: TSWU
-      description: Timer X Software Update
-      bit_offset: 1
-      bit_size: 1
-      array:
-        len: 5
-        stride: 1
-    - name: MRST
-      description: Master Counter Software Reset
-      bit_offset: 8
-      bit_size: 1
-    - name: TRST
-      description: Timer X Counter Software Reset
-      bit_offset: 9
-      bit_size: 1
-      array:
-        len: 5
-        stride: 1
-fieldset/HRTIM_ISR:
-  description: "High Resolution Timer: Interrupt Status Register"
-  items:
-    - name: FLT
-      description: Fault X Interrupt Flag
-      bit_offset: 0
-      bit_size: 1
-      array:
-        len: 5
-        stride: 1
-    - name: SYSFLT
-      description: System Fault Interrupt Flag
-      bit_offset: 5
-      bit_size: 1
-    - name: DLLRDY
-      description: DLL Ready Interrupt Flag
-      bit_offset: 16
-      bit_size: 1
-    - name: BMPER
-      description: Burst Mode Period Interrupt Flag
-      bit_offset: 17
-      bit_size: 1
-fieldset/HRTIM_ICR:
-  description: "High Resolution Timer: Interrupt Clear Register"
-  items:
-    - name: FLT
-      description: Fault X Interrupt Flag Clear
-      bit_offset: 0
-      bit_size: 1
-      array:
-        len: 5
-        stride: 1
-    - name: SYSFLT
-      description: System Fault Interrupt Flag Clear
-      bit_offset: 5
-      bit_size: 1
-    - name: DLLRDY
-      description: DLL Ready Interrupt Flag Clear
-      bit_offset: 16
-      bit_size: 1
-    - name: BMPER
-      description: Burst Mode Period Interrupt Flag Clear
-      bit_offset: 17
-      bit_size: 1
-fieldset/HRTIM_IER:
-  description: "High Resolution Timer: Interrupt Enable Register"
-  items:
-    - name: FLT
-      description: Fault X Interrupt Flag Enable
-      bit_offset: 0
-      bit_size: 1
-      array:
-        len: 5
-        stride: 1
-    - name: SYSFLT
-      description: System Fault Interrupt Flag Enable
-      bit_offset: 5
-      bit_size: 1
-    - name: DLLRDY
-      description: DLL Ready Interrupt Flag Enable
-      bit_offset: 16
-      bit_size: 1
-    - name: BMPER
-      description: Burst Mode Period Interrupt Flag Enable
-      bit_offset: 17
-      bit_size: 1
-fieldset/HRTIM_OENR:
-  description: "High Resolution Timer: Output Enable Register"
-  items:
-    - name: T1OEN
-      description: "Timer X Output Enable"
-      bit_offset: 0
-      bit_size: 1
-      array:
-        offsets:
-          - 0
-          - 2
-          - 4
-          - 6
-          - 8
-    - name: T2OEN
-      description: "Timer X Complementary Output Enable"
-      bit_offset: 1
-      bit_size: 1
-      array:
-        offsets:
-          - 0
-          - 2
-          - 4
-          - 6
-          - 8
-fieldset/HRTIM_ODISR:
-  description: "High Resolution Timer: Output Disable Register"
-  items:
-    - name: T1ODIS
-      description: "Timer X Output Disable"
-      bit_offset: 0
-      bit_size: 1
-      array:
-        offsets:
-          - 0
-          - 2
-          - 4
-          - 6
-          - 8
-    - name: T2ODIS
-      description: "Timer X Complementary Output Disable"
-      bit_offset: 1
-      bit_size: 1
-      array:
-        offsets:
-          - 0
-          - 2
-          - 4
-          - 6
-          - 8
-fieldset/HRTIM_ODSR:
-  description: "High Resolution Timer: Output Disable Status Register"
-  items:
-    - name: T1ODIS
-      description: "Timer X Output Disable Status"
-      bit_offset: 0
-      bit_size: 1
-      array:
-        offsets:
-          - 0
-          - 2
-          - 4
-          - 6
-          - 8
-    - name: T2ODIS
-      description: "Timer X Complementary Output Disable Status"
-      bit_offset: 1
-      bit_size: 1
-      array:
-        offsets:
-          - 0
-          - 2
-          - 4
-          - 6
-          - 8
-fieldset/HRTIM_BMCR:
-  description: "High Resolution Timer: Burst Mode Control Register"
-  items:
-    - name: BME
-      description: Burst Mode Enable
-      bit_offset: 0
-      bit_size: 1
-    - name: BMOM
-      description: Burst Mode Operating Mode
-      bit_offset: 1
-      bit_size: 1
-    - name: BMCLK
-      description: Burst Mode Clock source
-      bit_offset: 2
-      bit_size: 3
-    - name: BMPRSC
-      description: Burst Mode Prescaler
-      bit_offset: 6
-      bit_size: 3
-    - name: BMPREN
-      description: Burst Mode Preload Enable
-      bit_offset: 10
-      bit_size: 1
-    - name: MTBM
-      description: Master Timer Burst Mode
-      bit_offset: 16
-      bit_size: 1
-    - name: TBM
-      description: Timer X Burst Mode
-      bit_offset: 17
-      bit_size: 1
-      array:
-        len: 5
-        stride: 1
-    - name: BMSTAT
-      decription: Burst Mode Status
-      bit_offset: 31
-      bit_size: 1
-fieldset/HRTIM_BMTRGR:
-  description: "High Resolution Timer: Burst Mode Trigger Register"
-  items:
-    - name: SW
-      description: Software start
-      bit_offset: 0
-      bit_size: 1
-    - name: MSTRST
-      description: Master reset or roll-over
-      bit_offset: 1
-      bit_size: 1
-    - name: MSTREP
-      description: Master repetition
-      bit_offset: 2
-      bit_size: 1
-    - name: MSTCMP
-      description: Master Compare X
-      bit_offset: 3
-      bit_size: 1
-      array:
-        len: 4
-        stride: 1
-    - name: TRST
-      description: Timer X reset or roll-over
-      bit_offset: 7
-      bit_size: 1
-      array:
-        offsets:
-          - 0
-          - 4
-          - 8
-          - 12
-          - 16
-    - name: TREP
-      description: Timer X repetition
-      bit_offset: 8
-      bit_size: 1
-      array:
-        offsets:
-          - 0
-          - 4
-          - 8
-          - 12
-          - 16
-    - name: TCMP1
-      description: Timer X compare 1 event
-      bit_offset: 9
-      bit_size: 1
-      array:
-        offsets:
-          - 0
-          - 4
-          - 8
-          - 12
-          - 16
-    - name: TCMP2
-      description: Timer X compare 2 event
-      bit_offset: 10
-      bit_size: 1
-      array:
-        offsets:
-          - 0
-          - 4
-          - 8
-          - 12
-          - 16
-fieldset/HRTIM_BMCMPR:
-  description: "High Resolution Timer: Burst Mode Compare Register"
-  items:
-    - name: BMCMP
-      description: Burst mode compare value
-      bit_offset: 0 
-      bit_size: 16
-fieldset/HRTIM_BMPERs:
-  description: "High Resolution Timer: Burst Mode Period Register"
-  items:
-    - name: BMPER
-      description: Burst mode period value
-      bit_offset: 0 
-      bit_size: 16
-fieldset/HRTIM_EECR1:
-  description: "High Resolution Timer: External Events Control Register 1"
-  items:
-    - name: EESRC
-      description: External Event X Source
-      bit_offset: 0
-      bit_size: 2
-      array:
-        offsets:
-          - 0
-          - 6
-          - 12
-          - 18
-          - 24
-    - name: EEPOL
-      description: External Event X Polarity
-      bit_offset: 2
-      bit_size: 1
-      array:
-        offsets:
-          - 0
-          - 6
-          - 12
-          - 18
-          - 24
-    - name: EESNS
-      description: External Event X Sensitivity
-      bit_offset: 3
-      bit_size: 2
-      array:
-        offsets:
-          - 0
-          - 6
-          - 12
-          - 18
-          - 24
-    - name: EEFAST
-      description: External Event X Fast Mode
-      bit_offset: 5
-      bit_size: 2
-      array:
-        offsets:
-          - 0
-          - 6
-          - 12
-          - 18
-          - 24
-fieldset/HRTIM_EECR2:
-  description: "High Resolution Timer: External Events Control Register 2"
-  items:
-    - name: EESRC
-      description: External Event X Source
-      bit_offset: 0
-      bit_size: 2
-      array:
-        offsets:
-          - 0
-          - 6
-          - 12
-          - 18
-          - 24
-    - name: EEPOL
-      description: External Event X Polarity
-      bit_offset: 2
-      bit_size: 1
-      array:
-        offsets:
-          - 0
-          - 6
-          - 12
-          - 18
-          - 24
-    - name: EESNS
-      description: External Event X Sensitivity
-      bit_offset: 3
-      bit_size: 2
-      array:
-        offsets:
-          - 0
-          - 6
-          - 12
-          - 18
-          - 24
-fieldset/HRTIM_EECR3:
-  description: "High Resolution Timer: External Events Control Register 2"
-  items:
-    - name: EEF
-      description: External Event X filter
-      bit_offset: 0
-      bit_size: 3
-      array:
-        offsets:
-          - 0
-          - 6 
-          - 12
-          - 18
-          - 24
-    - name: EEVSD
-      description: External Event Sampling Clock Division
-      bit_offset: 30
-      bit_size: 2
-fieldset/HRTIM_DLLCR:
-  description: "High Resolution Timer: DLL Control Register"
-  items:
-    - name: CAL
-      description: DLL Calibration Start
-      bit_offset: 0
-      bit_size: 1
-    - name: CALEN
-      description: DLL Calibration Enable
-      bit_offset: 1
-      bit_size: 1
-    - name: CALRTE
-      description: DLL Calibration Rate
-      bit_offset: 2
-      bit_size: 2
 block/HRTIM_TIMX:
   description: "High Resolution Timer: Timing Unit"
   items:
@@ -647,6 +225,428 @@ block/HRTIM_TIMX:
       description: Timer X Fault Register
       byte_offset: 104
       fieldset: TIMXFLT
+fieldset/HRTIM_CR1:
+  description: "High Resolution Timer: Control Register 1"
+  fields:
+    - name: MUDIS
+      description: Master Update Disable
+      bit_offset: 0
+      bit_size: 1
+    - name: TUDIS
+      description: Timer X Update Disable
+      bit_offset: 1
+      bit_size: 1
+      array:
+        len: 5
+        stride: 1
+    - name: ADUSRC
+      description: ADC Trigger X Update Source
+      bit_offset: 16
+      bit_size: 3
+      array:
+        len: 4
+        stride: 2
+      enum: UPDATESOURCE
+fieldset/HRTIM_CR2:
+  description: "High Resolution Timer: Control Register 2"
+  fields:
+    - name: MSWU
+      description: Master Timer Software Update
+      bit_offset: 0
+      bit_size: 1
+    - name: TSWU
+      description: Timer X Software Update
+      bit_offset: 1
+      bit_size: 1
+      array:
+        len: 5
+        stride: 1
+    - name: MRST
+      description: Master Counter Software Reset
+      bit_offset: 8
+      bit_size: 1
+    - name: TRST
+      description: Timer X Counter Software Reset
+      bit_offset: 9
+      bit_size: 1
+      array:
+        len: 5
+        stride: 1
+fieldset/HRTIM_ISR:
+  description: "High Resolution Timer: Interrupt Status Register"
+  fields:
+    - name: FLT
+      description: Fault X Interrupt Flag
+      bit_offset: 0
+      bit_size: 1
+      array:
+        len: 5
+        stride: 1
+    - name: SYSFLT
+      description: System Fault Interrupt Flag
+      bit_offset: 5
+      bit_size: 1
+    - name: DLLRDY
+      description: DLL Ready Interrupt Flag
+      bit_offset: 16
+      bit_size: 1
+    - name: BMPER
+      description: Burst Mode Period Interrupt Flag
+      bit_offset: 17
+      bit_size: 1
+fieldset/HRTIM_ICR:
+  description: "High Resolution Timer: Interrupt Clear Register"
+  fields:
+    - name: FLT
+      description: Fault X Interrupt Flag Clear
+      bit_offset: 0
+      bit_size: 1
+      array:
+        len: 5
+        stride: 1
+    - name: SYSFLT
+      description: System Fault Interrupt Flag Clear
+      bit_offset: 5
+      bit_size: 1
+    - name: DLLRDY
+      description: DLL Ready Interrupt Flag Clear
+      bit_offset: 16
+      bit_size: 1
+    - name: BMPER
+      description: Burst Mode Period Interrupt Flag Clear
+      bit_offset: 17
+      bit_size: 1
+fieldset/HRTIM_IER:
+  description: "High Resolution Timer: Interrupt Enable Register"
+  fields:
+    - name: FLT
+      description: Fault X Interrupt Flag Enable
+      bit_offset: 0
+      bit_size: 1
+      array:
+        len: 5
+        stride: 1
+    - name: SYSFLT
+      description: System Fault Interrupt Flag Enable
+      bit_offset: 5
+      bit_size: 1
+    - name: DLLRDY
+      description: DLL Ready Interrupt Flag Enable
+      bit_offset: 16
+      bit_size: 1
+    - name: BMPER
+      description: Burst Mode Period Interrupt Flag Enable
+      bit_offset: 17
+      bit_size: 1
+fieldset/HRTIM_OENR:
+  description: "High Resolution Timer: Output Enable Register"
+  fields:
+    - name: T1OEN
+      description: "Timer X Output Enable"
+      bit_offset: 0
+      bit_size: 1
+      array:
+        offsets:
+          - 0
+          - 2
+          - 4
+          - 6
+          - 8
+    - name: T2OEN
+      description: "Timer X Complementary Output Enable"
+      bit_offset: 1
+      bit_size: 1
+      array:
+        offsets:
+          - 0
+          - 2
+          - 4
+          - 6
+          - 8
+fieldset/HRTIM_ODISR:
+  description: "High Resolution Timer: Output Disable Register"
+  fields:
+    - name: T1ODIS
+      description: "Timer X Output Disable"
+      bit_offset: 0
+      bit_size: 1
+      array:
+        offsets:
+          - 0
+          - 2
+          - 4
+          - 6
+          - 8
+    - name: T2ODIS
+      description: "Timer X Complementary Output Disable"
+      bit_offset: 1
+      bit_size: 1
+      array:
+        offsets:
+          - 0
+          - 2
+          - 4
+          - 6
+          - 8
+fieldset/HRTIM_ODSR:
+  description: "High Resolution Timer: Output Disable Status Register"
+  fields:
+    - name: T1ODIS
+      description: "Timer X Output Disable Status"
+      bit_offset: 0
+      bit_size: 1
+      array:
+        offsets:
+          - 0
+          - 2
+          - 4
+          - 6
+          - 8
+    - name: T2ODIS
+      description: "Timer X Complementary Output Disable Status"
+      bit_offset: 1
+      bit_size: 1
+      array:
+        offsets:
+          - 0
+          - 2
+          - 4
+          - 6
+          - 8
+fieldset/HRTIM_BMCR:
+  description: "High Resolution Timer: Burst Mode Control Register"
+  fields:
+    - name: BME
+      description: Burst Mode Enable
+      bit_offset: 0
+      bit_size: 1
+    - name: BMOM
+      description: Burst Mode Operating Mode
+      bit_offset: 1
+      bit_size: 1
+    - name: BMCLK
+      description: Burst Mode Clock source
+      bit_offset: 2
+      bit_size: 3
+    - name: BMPRSC
+      description: Burst Mode Prescaler
+      bit_offset: 6
+      bit_size: 3
+    - name: BMPREN
+      description: Burst Mode Preload Enable
+      bit_offset: 10
+      bit_size: 1
+    - name: MTBM
+      description: Master Timer Burst Mode
+      bit_offset: 16
+      bit_size: 1
+    - name: TBM
+      description: Timer X Burst Mode
+      bit_offset: 17
+      bit_size: 1
+      array:
+        len: 5
+        stride: 1
+    - name: BMSTAT
+      decription: Burst Mode Status
+      bit_offset: 31
+      bit_size: 1
+fieldset/HRTIM_BMTRGR:
+  description: "High Resolution Timer: Burst Mode Trigger Register"
+  fields:
+    - name: SW
+      description: Software start
+      bit_offset: 0
+      bit_size: 1
+    - name: MSTRST
+      description: Master reset or roll-over
+      bit_offset: 1
+      bit_size: 1
+    - name: MSTREP
+      description: Master repetition
+      bit_offset: 2
+      bit_size: 1
+    - name: MSTCMP
+      description: Master Compare X
+      bit_offset: 3
+      bit_size: 1
+      array:
+        len: 4
+        stride: 1
+    - name: TRST
+      description: Timer X reset or roll-over
+      bit_offset: 7
+      bit_size: 1
+      array:
+        offsets:
+          - 0
+          - 4
+          - 8
+          - 12
+          - 16
+    - name: TREP
+      description: Timer X repetition
+      bit_offset: 8
+      bit_size: 1
+      array:
+        offsets:
+          - 0
+          - 4
+          - 8
+          - 12
+          - 16
+    - name: TCMP1
+      description: Timer X compare 1 event
+      bit_offset: 9
+      bit_size: 1
+      array:
+        offsets:
+          - 0
+          - 4
+          - 8
+          - 12
+          - 16
+    - name: TCMP2
+      description: Timer X compare 2 event
+      bit_offset: 10
+      bit_size: 1
+      array:
+        offsets:
+          - 0
+          - 4
+          - 8
+          - 12
+          - 16
+fieldset/HRTIM_BMCMPR:
+  description: "High Resolution Timer: Burst Mode Compare Register"
+  fields:
+    - name: BMCMP
+      description: Burst mode compare value
+      bit_offset: 0 
+      bit_size: 16
+fieldset/HRTIM_BMPER:
+  description: "High Resolution Timer: Burst Mode Period Register"
+  fields:
+    - name: BMPER
+      description: Burst mode period value
+      bit_offset: 0 
+      bit_size: 16
+fieldset/HRTIM_EECR1:
+  description: "High Resolution Timer: External Events Control Register 1"
+  fields:
+    - name: EESRC
+      description: External Event X Source
+      bit_offset: 0
+      bit_size: 2
+      array:
+        offsets:
+          - 0
+          - 6
+          - 12
+          - 18
+          - 24
+    - name: EEPOL
+      description: External Event X Polarity
+      bit_offset: 2
+      bit_size: 1
+      array:
+        offsets:
+          - 0
+          - 6
+          - 12
+          - 18
+          - 24
+    - name: EESNS
+      description: External Event X Sensitivity
+      bit_offset: 3
+      bit_size: 2
+      array:
+        offsets:
+          - 0
+          - 6
+          - 12
+          - 18
+          - 24
+    - name: EEFAST
+      description: External Event X Fast Mode
+      bit_offset: 5
+      bit_size: 2
+      array:
+        offsets:
+          - 0
+          - 6
+          - 12
+          - 18
+          - 24
+fieldset/HRTIM_EECR2:
+  description: "High Resolution Timer: External Events Control Register 2"
+  fields:
+    - name: EESRC
+      description: External Event X Source
+      bit_offset: 0
+      bit_size: 2
+      array:
+        offsets:
+          - 0
+          - 6
+          - 12
+          - 18
+          - 24
+    - name: EEPOL
+      description: External Event X Polarity
+      bit_offset: 2
+      bit_size: 1
+      array:
+        offsets:
+          - 0
+          - 6
+          - 12
+          - 18
+          - 24
+    - name: EESNS
+      description: External Event X Sensitivity
+      bit_offset: 3
+      bit_size: 2
+      array:
+        offsets:
+          - 0
+          - 6
+          - 12
+          - 18
+          - 24
+fieldset/HRTIM_EECR3:
+  description: "High Resolution Timer: External Events Control Register 2"
+  fields:
+    - name: EEF
+      description: External Event X filter
+      bit_offset: 0
+      bit_size: 3
+      array:
+        offsets:
+          - 0
+          - 6 
+          - 12
+          - 18
+          - 24
+    - name: EEVSD
+      description: External Event Sampling Clock Division
+      bit_offset: 30
+      bit_size: 2
+fieldset/HRTIM_DLLCR:
+  description: "High Resolution Timer: DLL Control Register"
+  fields:
+    - name: CAL
+      description: DLL Calibration Start
+      bit_offset: 0
+      bit_size: 1
+    - name: CALEN
+      description: DLL Calibration Enable
+      bit_offset: 1
+      bit_size: 1
+    - name: CALRTE
+      description: DLL Calibration Rate
+      bit_offset: 2
+      bit_size: 2
 fieldset/MCMPX:
   description: Master Timer Compare X Register
   fields:

--- a/data/registers/hrtim_v1.yaml
+++ b/data/registers/hrtim_v1.yaml
@@ -1842,37 +1842,38 @@ fieldset/TIMXRST:
         len: 10
         stride: 1
       enum: RESETEFFECT
-    - name: TIMXCMP
-      description: "Timer X Compare [1, 2, 4]"
+    - name: TCMP1
+      description: Timer X compare 1 event
       bit_offset: 19
       bit_size: 1
       array:
-        len: 3
-        stride: 1
+        offsets:
+          - 0
+          - 3
+          - 6
+          - 9
       enum: RESETEFFECT
-    - name: TIMYCMP
-      description: "Timer Y Compare [1, 2, 4]"
-      bit_offset: 22
+    - name: TCMP2
+      description: Timer X compare 2 event
+      bit_offset: 20
       bit_size: 1
       array:
-        len: 3
-        stride: 1
+        offsets:
+          - 0
+          - 3
+          - 6
+          - 9
       enum: RESETEFFECT
-    - name: TIMZCMP
-      description: "Timer Compare [1, 2, 4]"
-      bit_offset: 25
+    - name: TCMP4
+      description: Timer X compare 4 event
+      bit_offset: 21
       bit_size: 1
       array:
-        len: 3
-        stride: 1
-      enum: RESETEFFECT
-    - name: TIMTCMP
-      description: "Timer Compare [1, 2, 4]"
-      bit_offset: 28
-      bit_size: 1
-      array:
-        len: 3
-        stride: 1
+        offsets:
+          - 0
+          - 3
+          - 6
+          - 9
       enum: RESETEFFECT
 fieldset/TIMXRSTR:
   description: Timerx OutputX Reset Register

--- a/data/registers/hrtim_v1.yaml
+++ b/data/registers/hrtim_v1.yaml
@@ -286,7 +286,6 @@ fieldset/HRTIM_CR1:
       array:
         len: 4
         stride: 2
-      enum: UPDATESOURCE
 fieldset/HRTIM_CR2:
   description: "High Resolution Timer: Control Register 2"
   fields:
@@ -1028,7 +1027,6 @@ fieldset/MCR:
       description: Master Continuous mode
       bit_offset: 3
       bit_size: 1
-      enum: CONT
     - name: RETRIG
       description: Master Re-triggerable mode
       bit_offset: 4
@@ -1343,7 +1341,6 @@ fieldset/TIMXCR:
       description: Continuous mode
       bit_offset: 3
       bit_size: 1
-      enum: CONT
     - name: RETRIG
       description: Re-triggerable mode
       bit_offset: 4
@@ -1748,16 +1745,14 @@ fieldset/TIMXOUTR:
         offsets:
           - 0
           - 16
-      enum: IDLEM
     - name: IDLES
-      description: Output 1 Idle State
+      description: Output X Idle State
       bit_offset: 3
       bit_size: 1
       array:
         offsets:
           - 0
           - 16
-      enum: IDLES
     - name: FAULTX
       description: Output X Fault state
       bit_offset: 4
@@ -2029,15 +2024,6 @@ enum/CAPTUREEFFECT:
     - name: TriggerCapture
       description: Timer event triggers capture
       value: 1
-enum/CONT:
-  bit_size: 1
-  variants:
-    - name: SingleShot
-      description: The timer operates in single-shot mode and stops when it reaches the MPER value
-      value: 0
-    - name: Continuous
-      description: The timer operates in continuous (free-running) mode and rolls over to zero when it reaches the MPER value
-      value: 1
 enum/CPPSTAT:
   bit_size: 1
   variants:
@@ -2187,24 +2173,6 @@ enum/FLTEN:
       value: 0
     - name: Active
       description: Fault input is active and can disable HRTIM outputs
-      value: 1
-enum/IDLEM:
-  bit_size: 1
-  variants:
-    - name: NoEffect
-      description: "No action: the output is not affected by the burst mode operation"
-      value: 0
-    - name: SetIdle
-      description: The output is in idle state when requested by the burst mode controller
-      value: 1
-enum/IDLES:
-  bit_size: 1
-  variants:
-    - name: Inactive
-      description: Output idle state is inactive
-      value: 0
-    - name: Active
-      description: Output idle state is active
       value: 1
 enum/INACTIVEEFFECT:
   bit_size: 1
@@ -2374,19 +2342,3 @@ enum/UPDGAT:
     - name: Input3_Update
       description: Update occurs on the update event following a rising edge of HRTIM update enable input 3
       value: 8
-enum/UPDATESOURCE:
-  bit_size: 3
-  variants:
-    - name: MasterTimer
-      value: 0
-    - name: TimerA
-      value: 1
-    - name: TimerB
-      value: 2
-    - name: TimerC
-      value: 3
-    - name: TimerD
-      value: 4
-    - name: TimerE
-      value: 5
-

--- a/data/registers/hrtim_v2.yaml
+++ b/data/registers/hrtim_v2.yaml
@@ -699,10 +699,6 @@ fieldset/HRTIM_ADC1R:
       array:
         offsets:
           - 0
-          - 5
-          - 10
-          - 14
-          - 18
     - name: ADCTC3
       description: ADC trigger X on Timer Y Compare 3
       bit_offset: 11
@@ -725,6 +721,7 @@ fieldset/HRTIM_ADC1R:
           - 10
           - 14
           - 18
+          - 8
     - name: ADCTPER
       description: ADC trigger X on Timer Y Period
       bit_offset: 13
@@ -744,6 +741,7 @@ fieldset/HRTIM_ADC1R:
         offsets:
           - 0 
           - 5
+          - 14
 fieldset/HRTIM_ADC2R:
   description: "High Resolution Timer: ADC Trigger 2 Register"
   fields:
@@ -776,17 +774,15 @@ fieldset/HRTIM_ADC2R:
           - 8
           - 13
           - 18
+          - 1
     - name: ADCTC3
       description: ADC trigger X on Timer Y Compare 3
-      bit_offset: 11
+      bit_offset: 15
       bit_size: 1
       array:
         offsets:
+          - 14
           - 0 
-          - 4
-          - 8
-          - 13
-          - 18
     - name: ADCTC4
       description: ADC trigger X on Timer Y Compare 3
       bit_offset: 12
@@ -808,6 +804,7 @@ fieldset/HRTIM_ADC2R:
           - 4
           - 8
           - 13
+          - 11
     - name: ADCTRST
       description: ADC trigger X on Timer Y Reset
       bit_offset: 22
@@ -1842,37 +1839,40 @@ fieldset/TIMXRST:
         len: 10
         stride: 1
       enum: RESETEFFECT
-    - name: TIMXCMP
-      description: "Timer X Compare [1, 2, 4]"
-      bit_offset: 19
+    - name: TCMP1
+      description: Timer X compare 1 event
+      bit_offset: 0
       bit_size: 1
       array:
-        len: 3
-        stride: 1
+        offsets:
+          - 19
+          - 22
+          - 25
+          - 28
+          - 0
       enum: RESETEFFECT
-    - name: TIMYCMP
-      description: "Timer Y Compare [1, 2, 4]"
-      bit_offset: 22
+    - name: TCMP2
+      description: Timer X compare 2 event
+      bit_offset: 20
       bit_size: 1
       array:
-        len: 3
-        stride: 1
+        offsets:
+          - 0
+          - 3
+          - 6
+          - 9
+          - 11
       enum: RESETEFFECT
-    - name: TIMZCMP
-      description: "Timer Compare [1, 2, 4]"
-      bit_offset: 25
+    - name: TCMP4
+      description: Timer X compare 4 event
+      bit_offset: 21
       bit_size: 1
       array:
-        len: 3
-        stride: 1
-      enum: RESETEFFECT
-    - name: TIMTCMP
-      description: "Timer Compare [1, 2, 4]"
-      bit_offset: 28
-      bit_size: 1
-      array:
-        len: 3
-        stride: 1
+        offsets:
+          - 0
+          - 3
+          - 6
+          - 9
       enum: RESETEFFECT
 fieldset/TIMXRSTR:
   description: Timerx OutputX Reset Register

--- a/data/registers/hrtim_v2.yaml
+++ b/data/registers/hrtim_v2.yaml
@@ -1,0 +1,2344 @@
+---
+block/HRTIM:
+  description: "High Resolution Timer"
+  items:
+    - name: MCR
+      description: Master Timer Control Register
+      byte_offset: 0
+      fieldset: MCR
+    - name: MISR
+      description: Master Timer Interrupt Status Register
+      byte_offset: 4
+      access: Read
+      fieldset: MISR
+    - name: MICR
+      description: Master Timer Interrupt Clear Register
+      byte_offset: 8
+      access: Write
+      fieldset: MICR
+    - name: MDIER
+      description: Master Timer DMA / Interrupt Enable Register
+      byte_offset: 12
+      fieldset: MDIER
+    - name: MCNTR
+      description: Master Timer Counter Register
+      byte_offset: 16
+      fieldset: MCNTR
+    - name: MPER
+      description: Master Timer Period Register
+      byte_offset: 20
+      fieldset: MPER
+    - name: MREP
+      description: Master Timer Repetition Register
+      byte_offset: 24
+      fieldset: MREP
+    - name: MCMP
+      description: Master Timer Compare X Register
+      array:
+        offsets:
+          - 0
+          - 8
+          - 12
+          - 16
+      byte_offset: 28
+      fieldset: MCMPX
+    - name: TIM
+      description: "High Resolution Timer: Timing Unit"
+      array:
+        len: 6
+        stride: 128
+      byte_offset: 128
+      block: HRTIM_TIMX
+    - name: CR1
+      description: "High Resolution Timer: Control Register 1"
+      byte_offset: 0x380
+      fieldset: HRTIM_CR1
+    - name: CR2
+      description: "High Resolution Timer: Control Register 2"
+      byte_offset: 0x384
+      fieldset: HRTIM_CR2
+    - name: ISR
+      description: "High Resolution Timer: Interrupt Status Register"
+      byte_offset: 0x388
+      access: Read
+      fieldset: HRTIM_ISR
+    - name: ICR
+      description: "High Resolution Timer: Interrupt Clear Register"
+      byte_offset: 0x38c
+      access: Write
+      fieldset: HRTIM_ICR
+    - name: IER
+      description: "High Resolution Timer: Interrupt Enable Register"
+      byte_offset: 0x390
+      fieldset: HRTIM_IER
+    - name: OENR
+      description: "High Resolution Timer: Output Enable Register"
+      byte_offset: 0x394
+      fieldset: HRTIM_OENR
+    - name: ODISR
+      description: "High Resolution Timer: Output Disable Register"
+      byte_offset: 0x398
+      fieldset: HRTIM_ODISR
+    - name: ODSR
+      description: "High Resolution Timer: Output Disable Status Register"
+      byte_offset: 0x39c
+      fieldset: HRTIM_ODSR
+    - name: BMCR
+      description: "High Resolution Timer: Burst Mode Control Register"
+      byte_offset: 0x3a0
+      fieldset: HRTIM_BMCR
+    - name: BMTRGR
+      description: "High Resolution Timer: Burst Mode Trigger Register"
+      byte_offset: 0x3a4
+      fieldset: HRTIM_BMTRGR
+    - name: BMCMPR
+      description: "High Resolution Timer: Burst Mode Compare Register"
+      byte_offset: 0x3a8
+      fieldset: HRTIM_BMCMPR
+    - name: BMPER
+      description: "High Resolution Timer: Burst Mode Period Register"
+      byte_offset: 0x3ac
+      fieldset: HRTIM_BMPER
+    - name: EECR1
+      description: "High Resolution Timer: External Event Control Register 1"
+      byte_offset: 0x3b0
+      fieldset: HRTIM_EECR1
+    - name: EECR2
+      description: "High Resolution Timer: External Event Control Register 2"
+      byte_offset: 0x3b4
+      fieldset: HRTIM_EECR2
+    - name: EECR3
+      description: "High Resolution Timer: External Event Control Register 3"
+      byte_offset: 0x3b8
+      fieldset: HRTIM_EECR3
+    - name: ADC1R
+      description: "High Resolution Timer: ADC Trigger [1, 3] Register"
+      byte_offset: 0x3bc
+      fieldset: HRTIM_ADC1R
+      array:
+        offsets:
+          - 0
+          - 8
+    - name: ADC2R
+      description: "High Resolution Timer: ADC Trigger [2, 4] Register"
+      byte_offset: 0x3c0
+      fieldset: HRTIM_ADC2R
+      array:
+        offsets:
+          - 0
+          - 8
+    - name: DLLCR
+      description: "High Resolution Timer: DLL Control Register"
+      byte_offset: 0x3cc
+      fieldset: HRTIM_DLLCR
+    - name: FLTINR1
+      description: "High Resolution Timer: Fault Input Register 1"
+      byte_offset: 0x3d0
+      fieldset: HRTIM_FLTINR1
+    - name: FLTINR2
+      description: "High Resolution Timer: Fault Input Register 2"
+      byte_offset: 0x3d0
+      fieldset: HRTIM_FLTINR2
+    - name: BDMUPR
+      description: "High Resolution Timer: Burst DMA Master timer update Register"
+      byte_offset: 0x3d8
+      fieldset: HRTIM_BDMUPR
+    - name: BDTUPR
+      description: "High Resolution Timer: Burst DMA Timer X update Register"
+      byte_offset: 0x3dc
+      fieldset: HRTIM_BDTUPR
+      array:
+        len: 5
+        stride: 4
+    - name: BDMADR
+      description: "High Resolution Timer: Burst DMA Data Register"
+      byte_offset: 0x3f0
+      access: Write
+      fieldset: HRTIM_BDMADR
+block/HRTIM_TIMX:
+  description: "High Resolution Timer: Timing Unit"
+  items:
+    - name: CR
+      description: Timer X Control Register
+      byte_offset: 0
+      fieldset: TIMXCR
+    - name: ISR
+      description: Timer X Interrupt Status Register
+      byte_offset: 4
+      access: Read
+      fieldset: TIMXISR
+    - name: ICR
+      description: Timer X Interrupt Clear Register
+      byte_offset: 8
+      access: Write
+      fieldset: TIMXICR
+    - name: DIER
+      description: Timer X DMA / Interrupt Enable Register
+      byte_offset: 12
+      fieldset: TIMXDIER
+    - name: CNT
+      description: Timer X Counter Register
+      byte_offset: 16
+      fieldset: TIMXCNT
+    - name: PER
+      description: Timer X Period Register
+      byte_offset: 20
+      fieldset: TIMXPER
+    - name: REP
+      description: Timer X Repetition Register
+      byte_offset: 24
+      fieldset: TIMXREP
+    - name: CMP
+      description: Timer X Compare X Register
+      array:
+        offsets:
+          - 0
+          - 8
+          - 12
+          - 16
+      byte_offset: 28
+      fieldset: TIMXCMP
+    - name: CMPC
+      description: Timer X Compare X Compound Register
+      array:
+        offsets:
+          - 0
+      byte_offset: 32
+      fieldset: TIMXCMPC
+    - name: CPT
+      description: Timer X Capture X Register
+      array:
+        len: 2
+        stride: 4
+      byte_offset: 48
+      access: Read
+      fieldset: TIMXCPT
+    - name: DT
+      description: Timer X Deadtime Register
+      byte_offset: 56
+      fieldset: TIMXDT
+    - name: SETR
+      description: Timer X Output X Set Register
+      array:
+        offsets:
+          - 0
+          - 8
+      byte_offset: 60
+      fieldset: TIMXSETR
+    - name: RSTR
+      description: Timer X Output X Reset Register
+      array:
+        offsets:
+          - 0
+          - 8
+      byte_offset: 64
+      fieldset: TIMXRSTR
+    - name: EEF
+      description: Timer X External Event Filtering Register 1
+      array:
+        offsets:
+          - 0
+          - 4
+      byte_offset: 76
+      fieldset: TIMXEEF
+    - name: RST
+      description: Timer X Reset Register
+      byte_offset: 84
+      fieldset: TIMXRST
+    - name: CHP
+      description: Timer X Chopper Register
+      byte_offset: 88
+      fieldset: TIMXCHP
+    - name: CCR
+      description: Timer X Capture X Control Register
+      array:
+        offsets:
+          - 0
+          - 4
+      byte_offset: 92
+      fieldset: TIMXCCR
+    - name: OUTR
+      description: Timer X Output Register
+      byte_offset: 100
+      fieldset: TIMXOUTR
+    - name: FLT
+      description: Timer X Fault Register
+      byte_offset: 104
+      fieldset: TIMXFLT
+fieldset/HRTIM_CR1:
+  description: "High Resolution Timer: Control Register 1"
+  fields:
+    - name: MUDIS
+      description: Master Update Disable
+      bit_offset: 0
+      bit_size: 1
+    - name: TUDIS
+      description: Timer X Update Disable
+      bit_offset: 1
+      bit_size: 1
+      array:
+        len: 5
+        stride: 1
+    - name: ADUSRC
+      description: ADC Trigger X Update Source
+      bit_offset: 16
+      bit_size: 3
+      array:
+        len: 4
+        stride: 2
+fieldset/HRTIM_CR2:
+  description: "High Resolution Timer: Control Register 2"
+  fields:
+    - name: MSWU
+      description: Master Timer Software Update
+      bit_offset: 0
+      bit_size: 1
+    - name: TSWU
+      description: Timer X Software Update
+      bit_offset: 1
+      bit_size: 1
+      array:
+        len: 5
+        stride: 1
+    - name: MRST
+      description: Master Counter Software Reset
+      bit_offset: 8
+      bit_size: 1
+    - name: TRST
+      description: Timer X Counter Software Reset
+      bit_offset: 9
+      bit_size: 1
+      array:
+        len: 5
+        stride: 1
+fieldset/HRTIM_ISR:
+  description: "High Resolution Timer: Interrupt Status Register"
+  fields:
+    - name: FLT
+      description: Fault X Interrupt Flag
+      bit_offset: 0
+      bit_size: 1
+      array:
+        len: 5
+        stride: 1
+    - name: SYSFLT
+      description: System Fault Interrupt Flag
+      bit_offset: 5
+      bit_size: 1
+    - name: DLLRDY
+      description: DLL Ready Interrupt Flag
+      bit_offset: 16
+      bit_size: 1
+    - name: BMPER
+      description: Burst Mode Period Interrupt Flag
+      bit_offset: 17
+      bit_size: 1
+fieldset/HRTIM_ICR:
+  description: "High Resolution Timer: Interrupt Clear Register"
+  fields:
+    - name: FLT
+      description: Fault X Interrupt Flag Clear
+      bit_offset: 0
+      bit_size: 1
+      array:
+        len: 5
+        stride: 1
+    - name: SYSFLT
+      description: System Fault Interrupt Flag Clear
+      bit_offset: 5
+      bit_size: 1
+    - name: DLLRDY
+      description: DLL Ready Interrupt Flag Clear
+      bit_offset: 16
+      bit_size: 1
+    - name: BMPER
+      description: Burst Mode Period Interrupt Flag Clear
+      bit_offset: 17
+      bit_size: 1
+fieldset/HRTIM_IER:
+  description: "High Resolution Timer: Interrupt Enable Register"
+  fields:
+    - name: FLT
+      description: Fault X Interrupt Flag Enable
+      bit_offset: 0
+      bit_size: 1
+      array:
+        len: 5
+        stride: 1
+    - name: SYSFLT
+      description: System Fault Interrupt Flag Enable
+      bit_offset: 5
+      bit_size: 1
+    - name: DLLRDY
+      description: DLL Ready Interrupt Flag Enable
+      bit_offset: 16
+      bit_size: 1
+    - name: BMPER
+      description: Burst Mode Period Interrupt Flag Enable
+      bit_offset: 17
+      bit_size: 1
+fieldset/HRTIM_OENR:
+  description: "High Resolution Timer: Output Enable Register"
+  fields:
+    - name: T1OEN
+      description: "Timer X Output Enable"
+      bit_offset: 0
+      bit_size: 1
+      array:
+        offsets:
+          - 0
+          - 2
+          - 4
+          - 6
+          - 8
+    - name: T2OEN
+      description: "Timer X Complementary Output Enable"
+      bit_offset: 1
+      bit_size: 1
+      array:
+        offsets:
+          - 0
+          - 2
+          - 4
+          - 6
+          - 8
+fieldset/HRTIM_ODISR:
+  description: "High Resolution Timer: Output Disable Register"
+  fields:
+    - name: T1ODIS
+      description: "Timer X Output Disable"
+      bit_offset: 0
+      bit_size: 1
+      array:
+        offsets:
+          - 0
+          - 2
+          - 4
+          - 6
+          - 8
+    - name: T2ODIS
+      description: "Timer X Complementary Output Disable"
+      bit_offset: 1
+      bit_size: 1
+      array:
+        offsets:
+          - 0
+          - 2
+          - 4
+          - 6
+          - 8
+fieldset/HRTIM_ODSR:
+  description: "High Resolution Timer: Output Disable Status Register"
+  fields:
+    - name: T1ODIS
+      description: "Timer X Output Disable Status"
+      bit_offset: 0
+      bit_size: 1
+      array:
+        offsets:
+          - 0
+          - 2
+          - 4
+          - 6
+          - 8
+    - name: T2ODIS
+      description: "Timer X Complementary Output Disable Status"
+      bit_offset: 1
+      bit_size: 1
+      array:
+        offsets:
+          - 0
+          - 2
+          - 4
+          - 6
+          - 8
+fieldset/HRTIM_BMCR:
+  description: "High Resolution Timer: Burst Mode Control Register"
+  fields:
+    - name: BME
+      description: Burst Mode Enable
+      bit_offset: 0
+      bit_size: 1
+    - name: BMOM
+      description: Burst Mode Operating Mode
+      bit_offset: 1
+      bit_size: 1
+    - name: BMCLK
+      description: Burst Mode Clock source
+      bit_offset: 2
+      bit_size: 3
+    - name: BMPRSC
+      description: Burst Mode Prescaler
+      bit_offset: 6
+      bit_size: 3
+    - name: BMPREN
+      description: Burst Mode Preload Enable
+      bit_offset: 10
+      bit_size: 1
+    - name: MTBM
+      description: Master Timer Burst Mode
+      bit_offset: 16
+      bit_size: 1
+    - name: TBM
+      description: Timer X Burst Mode
+      bit_offset: 17
+      bit_size: 1
+      array:
+        len: 5
+        stride: 1
+    - name: BMSTAT
+      decription: Burst Mode Status
+      bit_offset: 31
+      bit_size: 1
+fieldset/HRTIM_BMTRGR:
+  description: "High Resolution Timer: Burst Mode Trigger Register"
+  fields:
+    - name: SW
+      description: Software start
+      bit_offset: 0
+      bit_size: 1
+    - name: MSTRST
+      description: Master reset or roll-over
+      bit_offset: 1
+      bit_size: 1
+    - name: MSTREP
+      description: Master repetition
+      bit_offset: 2
+      bit_size: 1
+    - name: MSTCMP
+      description: Master Compare X
+      bit_offset: 3
+      bit_size: 1
+      array:
+        len: 4
+        stride: 1
+    - name: TRST
+      description: Timer X reset or roll-over
+      bit_offset: 7
+      bit_size: 1
+      array:
+        offsets:
+          - 0
+          - 4
+          - 8
+          - 12
+          - 16
+    - name: TREP
+      description: Timer X repetition
+      bit_offset: 8
+      bit_size: 1
+      array:
+        offsets:
+          - 0
+          - 4
+          - 8
+          - 12
+          - 16
+    - name: TCMP1
+      description: Timer X compare 1 event
+      bit_offset: 9
+      bit_size: 1
+      array:
+        offsets:
+          - 0
+          - 4
+          - 8
+          - 12
+          - 16
+    - name: TCMP2
+      description: Timer X compare 2 event
+      bit_offset: 10
+      bit_size: 1
+      array:
+        offsets:
+          - 0
+          - 4
+          - 8
+          - 12
+          - 16
+fieldset/HRTIM_BMCMPR:
+  description: "High Resolution Timer: Burst Mode Compare Register"
+  fields:
+    - name: BMCMP
+      description: Burst mode compare value
+      bit_offset: 0 
+      bit_size: 16
+fieldset/HRTIM_BMPER:
+  description: "High Resolution Timer: Burst Mode Period Register"
+  fields:
+    - name: BMPER
+      description: Burst mode period value
+      bit_offset: 0 
+      bit_size: 16
+fieldset/HRTIM_EECR1:
+  description: "High Resolution Timer: External Events Control Register 1"
+  fields:
+    - name: EESRC
+      description: External Event X Source
+      bit_offset: 0
+      bit_size: 2
+      array:
+        offsets:
+          - 0
+          - 6
+          - 12
+          - 18
+          - 24
+    - name: EEPOL
+      description: External Event X Polarity
+      bit_offset: 2
+      bit_size: 1
+      array:
+        offsets:
+          - 0
+          - 6
+          - 12
+          - 18
+          - 24
+    - name: EESNS
+      description: External Event X Sensitivity
+      bit_offset: 3
+      bit_size: 2
+      array:
+        offsets:
+          - 0
+          - 6
+          - 12
+          - 18
+          - 24
+    - name: EEFAST
+      description: External Event X Fast Mode
+      bit_offset: 5
+      bit_size: 2
+      array:
+        offsets:
+          - 0
+          - 6
+          - 12
+          - 18
+          - 24
+fieldset/HRTIM_EECR2:
+  description: "High Resolution Timer: External Events Control Register 2"
+  fields:
+    - name: EESRC
+      description: External Event X Source
+      bit_offset: 0
+      bit_size: 2
+      array:
+        offsets:
+          - 0
+          - 6
+          - 12
+          - 18
+          - 24
+    - name: EEPOL
+      description: External Event X Polarity
+      bit_offset: 2
+      bit_size: 1
+      array:
+        offsets:
+          - 0
+          - 6
+          - 12
+          - 18
+          - 24
+    - name: EESNS
+      description: External Event X Sensitivity
+      bit_offset: 3
+      bit_size: 2
+      array:
+        offsets:
+          - 0
+          - 6
+          - 12
+          - 18
+          - 24
+fieldset/HRTIM_EECR3:
+  description: "High Resolution Timer: External Events Control Register 2"
+  fields:
+    - name: EEF
+      description: External Event X filter
+      bit_offset: 0
+      bit_size: 3
+      array:
+        offsets:
+          - 0
+          - 6 
+          - 12
+          - 18
+          - 24
+    - name: EEVSD
+      description: External Event Sampling Clock Division
+      bit_offset: 30
+      bit_size: 2
+fieldset/HRTIM_ADC1R:
+  description: "High Resolution Timer: ADC Trigger 1 Register"
+  fields:
+    - name: ADCMC
+      description: ADC trigger X on Master Compare Y
+      bit_offset: 0
+      bit_size: 1
+      array:
+        len: 4
+        stride: 1
+    - name: ADCMPER
+      description: ADC trigger X on Master Period
+      bit_offset: 4
+      bit_size: 1
+    - name: ADCEEV
+      description: ADC trigger X on External Event Y
+      bit_offset: 5
+      bit_size: 1
+      array:
+        len: 5
+        stride: 1
+    - name: ADCTC2
+      description: ADC trigger X on Timer Y Compare 2
+      bit_offset: 10
+      bit_size: 1
+      array:
+        offsets:
+          - 0
+          - 5
+          - 10
+          - 14
+          - 18
+    - name: ADCTC3
+      description: ADC trigger X on Timer Y Compare 3
+      bit_offset: 11
+      bit_size: 1
+      array:
+        offsets:
+          - 0 
+          - 5
+          - 10
+          - 14
+          - 18
+    - name: ADCTC4
+      description: ADC trigger X on Timer Y Compare 3
+      bit_offset: 12
+      bit_size: 1
+      array:
+        offsets:
+          - 0 
+          - 5
+          - 10
+          - 14
+          - 18
+    - name: ADCTPER
+      description: ADC trigger X on Timer Y Period
+      bit_offset: 13
+      bit_size: 1
+      array:
+        offsets:
+          - 0 
+          - 5
+          - 10
+          - 14
+          - 18
+    - name: ADCTRST
+      description: ADC trigger X on Timer Y Reset
+      bit_offset: 14
+      bit_size: 1
+      array:
+        offsets:
+          - 0 
+          - 5
+fieldset/HRTIM_ADC2R:
+  description: "High Resolution Timer: ADC Trigger 2 Register"
+  fields:
+    - name: ADCMC
+      description: ADC trigger X on Master Compare Y
+      bit_offset: 0
+      bit_size: 1
+      array:
+        len: 4
+        stride: 1
+    - name: ADCMPER
+      description: ADC trigger X on Master Period
+      bit_offset: 4
+      bit_size: 1
+    - name: ADCEEV
+      description: ADC trigger X on External Event Y
+      bit_offset: 5
+      bit_size: 1
+      array:
+        len: 5
+        stride: 1
+    - name: ADCTC2
+      description: ADC trigger X on Timer Y Compare 2
+      bit_offset: 10
+      bit_size: 1
+      array:
+        offsets:
+          - 0
+          - 4
+          - 8
+          - 13
+          - 18
+    - name: ADCTC3
+      description: ADC trigger X on Timer Y Compare 3
+      bit_offset: 11
+      bit_size: 1
+      array:
+        offsets:
+          - 0 
+          - 4
+          - 8
+          - 13
+          - 18
+    - name: ADCTC4
+      description: ADC trigger X on Timer Y Compare 3
+      bit_offset: 12
+      bit_size: 1
+      array:
+        offsets:
+          - 0
+          - 4
+          - 8
+          - 13
+          - 18
+    - name: ADCTPER
+      description: ADC trigger X on Timer Y Period
+      bit_offset: 13
+      bit_size: 1
+      array:
+        offsets:
+          - 0 
+          - 4
+          - 8
+          - 13
+    - name: ADCTRST
+      description: ADC trigger X on Timer Y Reset
+      bit_offset: 22
+      bit_size: 1
+      array:
+        offsets:
+          - 0 
+          - 5
+          - 9
+fieldset/HRTIM_DLLCR:
+  description: "High Resolution Timer: DLL Control Register"
+  fields:
+    - name: CAL
+      description: DLL Calibration Start
+      bit_offset: 0
+      bit_size: 1
+    - name: CALEN
+      description: DLL Calibration Enable
+      bit_offset: 1
+      bit_size: 1
+    - name: CALRTE
+      description: DLL Calibration Rate
+      bit_offset: 2
+      bit_size: 2
+fieldset/HRTIM_FLTINR1:
+  description: "High Resolution Timer: Fault Input Register 1"
+  fields:
+    - name: FLTE
+      description: Fault X enable
+      bit_offset: 0
+      bit_size: 1
+      array:
+        offsets:
+          - 0
+          - 8
+          - 16
+          - 24
+    - name: FLTP
+      description: Fault X polarity
+      bit_offset: 1
+      bit_size: 1
+      array:
+        offsets:
+          - 0
+          - 8
+          - 16
+          - 24
+    - name: FLTSRC
+      description: Fault X source
+      bit_offset: 2
+      bit_size: 1
+      array:
+        offsets:
+          - 0
+          - 8
+          - 16
+          - 24
+    - name: FLTF
+      description: Fault X filter
+      bit_offset: 3
+      bit_size: 4
+      array:
+        offsets:
+          - 0
+          - 8
+          - 16
+          - 24
+    - name: FLTLCK
+      description: Fault X Lock
+      bit_offset: 7
+      bit_size: 1
+      array:
+        offsets:
+          - 0
+          - 8
+          - 16
+          - 24
+fieldset/HRTIM_FLTINR2:
+  description: "High Resolution Timer: Fault Input Register 2"
+  fields:
+    - name: FLTE
+      description: Fault X enable
+      bit_offset: 0
+      bit_size: 1
+      array:
+        offsets:
+          - 0
+    - name: FLTP
+      description: Fault X polarity
+      bit_offset: 1
+      bit_size: 1
+      array:
+        offsets:
+          - 0
+    - name: FLTSRC
+      description: Fault X source
+      bit_offset: 2
+      bit_size: 1
+      array:
+        offsets:
+          - 0
+    - name: FLTF
+      description: Fault X filter
+      bit_offset: 3
+      bit_size: 4
+      array:
+        offsets:
+          - 0
+    - name: FLTLCK
+      description: Fault X Lock
+      bit_offset: 7
+      bit_size: 1
+      array:
+        offsets:
+          - 0
+    - name: FLTSD
+      description: Fault Sampling clock division
+      bit_offset: 24
+      bit_size: 2
+fieldset/HRTIM_BDMUPR:
+  description: "High Resolution Timer: Burst DMA Master timer update Register"
+  fields:
+    - name: MCR
+      description: MCR register update enable
+      bit_offset: 0
+      bit_size: 1
+    - name: MICR
+      description: MICR register update enable
+      bit_offset: 1
+      bit_size: 1
+    - name: MDIER
+      description: MDIER register update enable
+      bit_offset: 2
+      bit_size: 1
+    - name: MCNT
+      description: MCNT register update enable
+      bit_offset: 3
+      bit_size: 1
+    - name: MPER
+      description: MPER register update enable
+      bit_offset: 4
+      bit_size: 1
+    - name: MREP
+      description: MREP register update enable
+      bit_offset: 5
+      bit_size: 1
+    - name: MCMP
+      description: MCMP register X update enable
+      bit_offset: 6
+      bit_size: 1
+      array:
+        len: 4
+        stride: 1
+fieldset/HRTIM_BDTUPR:
+  description: "High Resolution Timer: Burst DMA Master timer update Register"
+  fields:
+    - name: CR
+      description: CR register update enable
+      bit_offset: 0
+      bit_size: 1
+    - name: ICR
+      description: ICR register update enable
+      bit_offset: 1
+      bit_size: 1
+    - name: DIER
+      description: DIER register update enable
+      bit_offset: 2
+      bit_size: 1
+    - name: CNT
+      description: CNT register update enable
+      bit_offset: 3
+      bit_size: 1
+    - name: PER
+      description: PER register update enable
+      bit_offset: 4
+      bit_size: 1
+    - name: REP
+      description: REP register update enable
+      bit_offset: 5
+      bit_size: 1
+    - name: CMP
+      description: CMP register X update enable
+      bit_offset: 6
+      bit_size: 1
+      array:
+        len: 4
+        stride: 1
+fieldset/HRTIM_BDMADR:
+  description: "High Resolution Timer:  Burst DMA Data Register"
+  fields:
+    - name: BDMADR
+      description: Burst DMA Data register
+      bit_offset: 0
+      bit_size: 31
+fieldset/MCMPX:
+  description: Master Timer Compare X Register
+  fields:
+    - name: MCMP
+      description: Master Timer Compare X value
+      bit_offset: 0
+      bit_size: 16
+fieldset/MCNTR:
+  description: Master Timer Counter Register
+  fields:
+    - name: MCNT
+      description: Counter value
+      bit_offset: 0
+      bit_size: 16
+fieldset/MCR:
+  description: Master Timer Control Register
+  fields:
+    - name: CKPSC
+      description: HRTIM Master Clock prescaler
+      bit_offset: 0
+      bit_size: 3
+    - name: CONT
+      description: Master Continuous mode
+      bit_offset: 3
+      bit_size: 1
+    - name: RETRIG
+      description: Master Re-triggerable mode
+      bit_offset: 4
+      bit_size: 1
+    - name: HALF
+      description: Half mode enable
+      bit_offset: 5
+      bit_size: 1
+    - name: SYNCIN
+      description: Synchronization input
+      bit_offset: 8
+      bit_size: 2
+      enum: SYNCIN
+    - name: SYNCRSTM
+      description: Synchronization Resets Master
+      bit_offset: 10
+      bit_size: 1
+    - name: SYNCSTRTM
+      description: Synchronization Starts Master
+      bit_offset: 11
+      bit_size: 1
+    - name: SYNCOUT
+      description: Synchronization output
+      bit_offset: 12
+      bit_size: 2
+      enum: SYNCOUT
+    - name: SYNCSRC
+      description: Synchronization source
+      bit_offset: 14
+      bit_size: 2
+      enum: SYNCSRC
+    - name: MCEN
+      description: Master Counter enable
+      bit_offset: 16
+      bit_size: 1
+    - name: TCEN
+      description: Timer X counter enable
+      bit_offset: 17
+      bit_size: 1
+      array:
+        len: 5
+        stride: 1
+    - name: DACSYNC
+      description: AC Synchronization
+      bit_offset: 25
+      bit_size: 2
+      enum: DACSYNC
+    - name: PREEN
+      description: Preload enable
+      bit_offset: 27
+      bit_size: 1
+    - name: MREPU
+      description: Master Timer Repetition update
+      bit_offset: 29
+      bit_size: 1
+    - name: BRSTDMA
+      description: Burst DMA Update
+      bit_offset: 30
+      bit_size: 2
+      enum: BRSTDMA
+fieldset/MDIER:
+  description: Master Timer DMA / Interrupt Enable Register
+  fields:
+    - name: MCMPIE
+      description: Master Compare X Interrupt Enable
+      bit_offset: 0
+      bit_size: 1
+      array:
+        len: 4
+        stride: 1
+    - name: MREPIE
+      description: Master Repetition Interrupt Enable
+      bit_offset: 4
+      bit_size: 1
+    - name: SYNCIE
+      description: Sync Input Interrupt Enable
+      bit_offset: 5
+      bit_size: 1
+    - name: MUPDIE
+      description: Master Update Interrupt Enable
+      bit_offset: 6
+      bit_size: 1
+    - name: MCMPDE
+      description: Master Compare X DMA request Enable
+      bit_offset: 16
+      bit_size: 1
+      array:
+        len: 4
+        stride: 1
+    - name: MREPDE
+      description: Master Repetition DMA request Enable
+      bit_offset: 20
+      bit_size: 1
+    - name: SYNCDE
+      description: Sync Input DMA request Enable
+      bit_offset: 21
+      bit_size: 1
+    - name: MUPDDE
+      description: Master Update DMA request Enable
+      bit_offset: 22
+      bit_size: 1
+fieldset/MICR:
+  description: Master Timer Interrupt Clear Register
+  fields:
+    - name: MCMPC
+      description: Master Compare X Interrupt flag clear
+      bit_offset: 0
+      bit_size: 1
+      array:
+        len: 4
+        stride: 1
+    - name: MREPC
+      description: Repetition Interrupt flag clear
+      bit_offset: 4
+      bit_size: 1
+    - name: SYNCC
+      description: Sync Input Interrupt flag clear
+      bit_offset: 5
+      bit_size: 1
+    - name: MUPDC
+      description: Master update Interrupt flag clear
+      bit_offset: 6
+      bit_size: 1
+fieldset/MISR:
+  description: Master Timer Interrupt Status Register
+  fields:
+    - name: MCMP
+      description: Master Compare X Interrupt Flag
+      bit_offset: 0
+      bit_size: 1
+      array:
+        len: 4
+        stride: 1
+      enum: EVENT
+    - name: MREP
+      description: Master Repetition Interrupt Flag
+      bit_offset: 4
+      bit_size: 1
+      enum: EVENT
+    - name: SYNC
+      description: Sync Input Interrupt Flag
+      bit_offset: 5
+      bit_size: 1
+      enum: EVENT
+    - name: MUPD
+      description: Master Update Interrupt Flag
+      bit_offset: 6
+      bit_size: 1
+      enum: EVENT
+fieldset/MPER:
+  description: Master Timer Period Register
+  fields:
+    - name: MPER
+      description: Master Timer Period value
+      bit_offset: 0
+      bit_size: 16
+fieldset/MREP:
+  description: Master Timer Repetition Register
+  fields:
+    - name: MREP
+      description: Master Timer Repetition counter value
+      bit_offset: 0
+      bit_size: 8
+fieldset/TIMXCCR:
+  description: Timerx Capture 2 Control Register
+  fields:
+    - name: SWCPT
+      description: Software Capture
+      bit_offset: 0
+      bit_size: 1
+      enum: CAPTUREEFFECT
+    - name: UPDCPT
+      description: Update Capture
+      bit_offset: 1
+      bit_size: 1
+      enum: CAPTUREEFFECT
+    - name: EXEVCPT
+      description: External Event X Capture
+      bit_offset: 2
+      bit_size: 1
+      array:
+        len: 10
+        stride: 1
+      enum: CAPTUREEFFECT
+    - name: TXSET
+      description: Timer X output Set
+      bit_offset: 16
+      bit_size: 1
+      enum: CAPTUREEFFECT
+    - name: TXRST
+      description: Timer X output Reset
+      bit_offset: 17
+      bit_size: 1
+      enum: CAPTUREEFFECT
+    - name: TXCMP
+      description: Timer X Compare X
+      bit_offset: 18
+      bit_size: 1
+      array:
+        len: 2
+        stride: 1
+      enum: CAPTUREEFFECT
+    - name: TYSET
+      description: Timer Y output Set
+      bit_offset: 20
+      bit_size: 1
+      enum: CAPTUREEFFECT
+    - name: TYRST
+      description: Timer Y output Reset
+      bit_offset: 21
+      bit_size: 1
+      enum: CAPTUREEFFECT
+    - name: TYCMP
+      description: Timer Y Compare X
+      bit_offset: 22
+      bit_size: 1
+      array:
+        len: 2
+        stride: 1
+      enum: CAPTUREEFFECT
+    - name: TZSET
+      description: Timer Z output Set
+      bit_offset: 24
+      bit_size: 1
+      enum: CAPTUREEFFECT
+    - name: TZRST
+      description: Timer Z output Reset
+      bit_offset: 25
+      bit_size: 1
+      enum: CAPTUREEFFECT
+    - name: TZCMP
+      description: Timer Z Compare X
+      bit_offset: 26
+      bit_size: 1
+      array:
+        len: 2
+        stride: 1
+      enum: CAPTUREEFFECT
+    - name: TTSET
+      description: Timer T output Set
+      bit_offset: 28
+      bit_size: 1
+      enum: CAPTUREEFFECT
+    - name: TTRST
+      description: Timer T output Reset
+      bit_offset: 29
+      bit_size: 1
+      enum: CAPTUREEFFECT
+    - name: TTCMP
+      description: Timer T Compare X
+      bit_offset: 30
+      bit_size: 1
+      array:
+        len: 2
+        stride: 1
+      enum: CAPTUREEFFECT
+fieldset/TIMXCHP:
+  description: Timerx Chopper Register
+  fields:
+    - name: CARFRQ
+      description: Timerx carrier frequency value
+      bit_offset: 0
+      bit_size: 4
+    - name: CARDTY
+      description: Timerx chopper duty cycle value
+      bit_offset: 4
+      bit_size: 3
+    - name: STRTPW
+      description: Timerx start pulsewidth
+      bit_offset: 7
+      bit_size: 4
+fieldset/TIMXCMP:
+  description: Timerx Compare X Register
+  fields:
+    - name: CMP
+      description: Timerx Compare X value
+      bit_offset: 0
+      bit_size: 16
+fieldset/TIMXCMPC:
+  description: Timerx Compare X Compound Register
+  fields:
+    - name: CMP
+      description: Timerx Compare X value
+      bit_offset: 0
+      bit_size: 16
+    - name: REP
+      description: Timerx Repetition value (aliased from HRTIM_REPx register)
+      bit_offset: 16
+      bit_size: 8
+fieldset/TIMXCNT:
+  description: Timerx Counter Register
+  fields:
+    - name: CNT
+      description: Timerx Counter value
+      bit_offset: 0
+      bit_size: 16
+fieldset/TIMXCPT:
+  description: Timerx Capture X Register
+  fields:
+    - name: CPT
+      description: Timerx Capture X value
+      bit_offset: 0
+      bit_size: 16
+fieldset/TIMXCR:
+  description: Timerx Control Register
+  fields:
+    - name: CKPSC
+      description: HRTIM Timer x Clock prescaler
+      bit_offset: 0
+      bit_size: 3
+    - name: CONT
+      description: Continuous mode
+      bit_offset: 3
+      bit_size: 1
+    - name: RETRIG
+      description: Re-triggerable mode
+      bit_offset: 4
+      bit_size: 1
+    - name: HALF
+      description: Half mode enable
+      bit_offset: 5
+      bit_size: 1
+    - name: PSHPLL
+      description: Push-Pull mode enable
+      bit_offset: 6
+      bit_size: 1
+    - name: SYNCRST
+      description: Synchronization Resets Timer X
+      bit_offset: 10
+      bit_size: 1
+      enum: SYNCRST
+    - name: SYNCSTRT
+      description: Synchronization Starts Timer X
+      bit_offset: 11
+      bit_size: 1
+      enum: SYNCSTRT
+    - name: DELCMP2
+      description: Delayed CMP2 mode
+      bit_offset: 12
+      bit_size: 2
+      enum: DELCMP
+    - name: DELCMP4
+      description: Delayed CMP4 mode
+      bit_offset: 14
+      bit_size: 2
+      enum: DELCMP
+    - name: REPU
+      description: Timer X Repetition update
+      bit_offset: 17
+      bit_size: 1
+    - name: RSTU
+      description: Timer X reset update
+      bit_offset: 18
+      bit_size: 1
+    - name: TAU
+      description: Timer A update
+      bit_offset: 19
+      bit_size: 1
+    - name: TBU
+      description: Timer B update
+      bit_offset: 20
+      bit_size: 1
+    - name: TCU
+      description: Timer C update
+      bit_offset: 21
+      bit_size: 1
+    - name: TDU
+      description: Timer D update
+      bit_offset: 22
+      bit_size: 1
+    - name: TEU
+      description: Timer E update
+      bit_offset: 23
+      bit_size: 1
+    - name: MSTU
+      description: Master Timer update
+      bit_offset: 24
+      bit_size: 1
+    - name: DACSYNC
+      description: AC Synchronization
+      bit_offset: 25
+      bit_size: 2
+      enum: DACSYNC
+    - name: PREEN
+      description: Preload enable
+      bit_offset: 27
+      bit_size: 1
+    - name: UPDGAT
+      description: Update Gating
+      bit_offset: 28
+      bit_size: 4
+      enum: UPDGAT
+fieldset/TIMXDIER:
+  description: Timerx DMA / Interrupt Enable Register
+  fields:
+    - name: CMPIE
+      description: Compare X Interrupt Enable
+      bit_offset: 0
+      bit_size: 1
+      array:
+        len: 4
+        stride: 1
+    - name: REPIE
+      description: Repetition Interrupt Enable
+      bit_offset: 4
+      bit_size: 1
+    - name: UPDIE
+      description: Update Interrupt Enable
+      bit_offset: 6
+      bit_size: 1
+    - name: CPTIE
+      description: Capture Interrupt Enable
+      bit_offset: 7
+      bit_size: 1
+      array:
+        len: 2
+        stride: 1
+    - name: SETRIE
+      description: Output X Set Interrupt Enable
+      bit_offset: 9
+      bit_size: 1
+      array:
+        offsets:
+          - 0
+          - 2
+    - name: RSTRIE
+      description: Output X Reset Interrupt Enable
+      bit_offset: 10
+      bit_size: 1
+      array:
+        offsets:
+          - 0
+          - 2
+    - name: RSTIE
+      description: Reset/roll-over Interrupt Enable
+      bit_offset: 13
+      bit_size: 1
+    - name: DLYPRTIE
+      description: Delayed Protection Interrupt Enable
+      bit_offset: 14
+      bit_size: 1
+    - name: CMPDE
+      description: Compare X DMA request Enable
+      bit_offset: 16
+      bit_size: 1
+      array:
+        len: 4
+        stride: 1
+    - name: REPDE
+      description: Repetition DMA request Enable
+      bit_offset: 20
+      bit_size: 1
+    - name: UPDDE
+      description: Update DMA request Enable
+      bit_offset: 22
+      bit_size: 1
+    - name: CPTDE
+      description: Capture X DMA request Enable
+      bit_offset: 23
+      bit_size: 1
+      array:
+        len: 2
+        stride: 1
+    - name: SETRDE
+      description: Output X Set DMA request Enable
+      bit_offset: 25
+      bit_size: 1
+      array:
+        offsets:
+          - 0
+          - 2
+    - name: RSTRDE
+      description: Output X Reset DMA request Enable
+      bit_offset: 26
+      bit_size: 1
+      array:
+        offsets:
+          - 0
+          - 2
+    - name: RSTDE
+      description: Reset/roll-over DMA request Enable
+      bit_offset: 29
+      bit_size: 1
+    - name: DLYPRTDE
+      description: Delayed Protection DMA request Enable
+      bit_offset: 30
+      bit_size: 1
+fieldset/TIMXDT:
+  description: Timerx Deadtime Register
+  fields:
+    - name: DTR
+      description: Deadtime Rising value
+      bit_offset: 0
+      bit_size: 9
+    - name: SDTR
+      description: Sign Deadtime Rising value
+      bit_offset: 9
+      bit_size: 1
+      enum: SDTR
+    - name: DTPRSC
+      description: Deadtime Prescaler
+      bit_offset: 10
+      bit_size: 3
+    - name: DTRSLK
+      description: Deadtime Rising Sign Lock
+      bit_offset: 14
+      bit_size: 1
+      enum: LOCKED
+    - name: DTRLK
+      description: Deadtime Rising Lock
+      bit_offset: 15
+      bit_size: 1
+      enum: LOCKED
+    - name: DTF
+      description: Deadtime Falling value
+      bit_offset: 16
+      bit_size: 9
+    - name: SDTF
+      description: Sign Deadtime Falling value
+      bit_offset: 25
+      bit_size: 1
+      enum: SDTF
+    - name: DTFSLK
+      description: Deadtime Falling Sign Lock
+      bit_offset: 30
+      bit_size: 1
+      enum: LOCKED
+    - name: DTFLK
+      description: Deadtime Falling Lock
+      bit_offset: 31
+      bit_size: 1
+      enum: LOCKED
+fieldset/TIMXEEF:
+  description: Timer X External Event Filtering Register
+  fields:
+    - name: LTCH
+      description: External Event X latch
+      bit_offset: 0
+      bit_size: 1
+      array:
+        len: 5
+        stride: 6
+    - name: FLTR
+      description: External Event X filter
+      bit_offset: 1
+      bit_size: 4
+      array:
+        len: 5
+        stride: 6
+      enum: EEFLTR
+fieldset/TIMXFLT:
+  description: Timerx Fault Register
+  fields:
+    - name: FLTEN
+      description: Fault X enable
+      bit_offset: 0
+      bit_size: 1
+      array:
+        len: 5
+        stride: 1
+      enum: FLTEN
+    - name: FLTLCK
+      description: Fault sources Lock
+      bit_offset: 31
+      bit_size: 1
+      enum: LOCKED
+fieldset/TIMXICR:
+  description: Timerx Interrupt Clear Register
+  fields:
+    - name: CMPC
+      description: Compare X Interrupt flag Clear
+      bit_offset: 0
+      bit_size: 1
+      array:
+        len: 4
+        stride: 1
+    - name: REPC
+      description: Repetition Interrupt flag Clear
+      bit_offset: 4
+      bit_size: 1
+    - name: UPDC
+      description: Update Interrupt flag Clear
+      bit_offset: 6
+      bit_size: 1
+    - name: CPTC
+      description: Capture X Interrupt flag Clear
+      bit_offset: 7
+      bit_size: 1
+      array:
+        len: 2
+        stride: 1
+    - name: SETRC
+      description: Output X Set flag Clear
+      bit_offset: 9
+      bit_size: 1
+      array:
+        offsets:
+          - 0
+          - 2
+    - name: RSTRC
+      description: Output X Reset flag Clear
+      bit_offset: 10
+      bit_size: 1
+      array:
+        offsets:
+          - 0
+          - 2
+    - name: RSTC
+      description: Reset Interrupt flag Clear
+      bit_offset: 13
+      bit_size: 1
+    - name: DLYPRTC
+      description: Delayed Protection Flag Clear
+      bit_offset: 14
+      bit_size: 1
+fieldset/TIMXISR:
+  description: Timerx Interrupt Status Register
+  fields:
+    - name: CMP
+      description: Compare X Interrupt Flag
+      bit_offset: 0
+      bit_size: 1
+      array:
+        len: 4
+        stride: 1
+      enum: EVENT
+    - name: REP
+      description: Repetition Interrupt Flag
+      bit_offset: 4
+      bit_size: 1
+      enum: EVENT
+    - name: UPD
+      description: Update Interrupt Flag
+      bit_offset: 6
+      bit_size: 1
+      enum: EVENT
+    - name: CPT
+      description: Capture X Interrupt Flag
+      bit_offset: 7
+      bit_size: 1
+      array:
+        len: 2
+        stride: 1
+      enum: EVENT
+    - name: SETR
+      description: Output X Set Interrupt Flag
+      bit_offset: 9
+      bit_size: 1
+      array:
+        offsets:
+          - 0
+          - 2
+      enum: EVENT
+    - name: RSTR
+      description: Output X Reset Interrupt Flag
+      bit_offset: 10
+      bit_size: 1
+      array:
+        offsets:
+          - 0
+          - 2
+      enum: EVENT
+    - name: RST
+      description: Reset Interrupt Flag
+      bit_offset: 13
+      bit_size: 1
+      enum: EVENT
+    - name: DLYPRT
+      description: Delayed Protection Flag
+      bit_offset: 14
+      bit_size: 1
+      enum: TIMAISR_DLYPRT
+    - name: CPPSTAT
+      description: Current Push Pull Status
+      bit_offset: 16
+      bit_size: 1
+      enum: CPPSTAT
+    - name: IPPSTAT
+      description: Idle Push Pull Status
+      bit_offset: 17
+      bit_size: 1
+      enum: IPPSTAT
+    - name: OSTAT
+      description: Output X State
+      bit_offset: 18
+      bit_size: 1
+      array:
+        len: 2
+        stride: 1
+      enum: OUTPUTSTATE
+    - name: OCPY
+      description: Output X Copy
+      bit_offset: 20
+      bit_size: 1
+      array:
+        len: 2
+        stride: 1
+      enum: OUTPUTSTATE
+fieldset/TIMXOUTR:
+  description: Timerx Output Register
+  fields:
+    - name: POL
+      description: Output 1 polarity
+      bit_offset: 1
+      bit_size: 1
+      array:
+        offsets:
+          - 0
+          - 16
+      enum: POL
+    - name: IDLEM
+      description: Output X Idle mode
+      bit_offset: 2
+      bit_size: 1
+      array:
+        offsets:
+          - 0
+          - 16
+    - name: IDLES
+      description: Output X Idle State
+      bit_offset: 3
+      bit_size: 1
+      array:
+        offsets:
+          - 0
+          - 16
+    - name: FAULTX
+      description: Output X Fault state
+      bit_offset: 4
+      bit_size: 2
+      array:
+        offsets:
+          - 0
+          - 16
+      enum: FAULT
+    - name: CHP
+      description: Output X Chopper enable
+      bit_offset: 6
+      bit_size: 1
+      array:
+        offsets:
+          - 0
+          - 16
+    - name: DIDL
+      description: Output X Deadtime upon burst mode Idle entry
+      bit_offset: 7
+      bit_size: 1
+      array:
+        offsets:
+          - 0
+          - 16
+    - name: DTEN
+      description: Deadtime enable
+      bit_offset: 8
+      bit_size: 1
+    - name: DLYPRTEN
+      description: Delayed Protection Enable
+      bit_offset: 9
+      bit_size: 1
+    - name: DLYPRT
+      description: Delayed Protection
+      bit_offset: 10
+      bit_size: 3
+      enum: DLYPRT
+fieldset/TIMXPER:
+  description: Timerx Period Register
+  fields:
+    - name: PER
+      description: Timerx Period value
+      bit_offset: 0
+      bit_size: 16
+fieldset/TIMXREP:
+  description: Timerx Repetition Register
+  fields:
+    - name: REP
+      description: Timerx Repetition counter value
+      bit_offset: 0
+      bit_size: 8
+fieldset/TIMXRST:
+  description: Timerx Reset Register
+  fields:
+    - name: UPDT
+      description: Timer X Update reset
+      bit_offset: 1
+      bit_size: 1
+      enum: RESETEFFECT
+    - name: CMP
+      description: Timer X compare X reset
+      bit_offset: 2
+      bit_size: 1
+      array:
+        len: 2
+        stride: 1
+      enum: RESETEFFECT
+    - name: MSTPER
+      description: Master timer Period
+      bit_offset: 4
+      bit_size: 1
+      enum: RESETEFFECT
+    - name: MSTCMP
+      description: Master compare X
+      bit_offset: 5
+      bit_size: 1
+      array:
+        len: 4
+        stride: 1
+      enum: RESETEFFECT
+    - name: EXTEVNT
+      description: External Event X
+      bit_offset: 9
+      bit_size: 1
+      array:
+        len: 10
+        stride: 1
+      enum: RESETEFFECT
+    - name: TIMXCMP
+      description: "Timer X Compare [1, 2, 4]"
+      bit_offset: 19
+      bit_size: 1
+      array:
+        len: 3
+        stride: 1
+      enum: RESETEFFECT
+    - name: TIMYCMP
+      description: "Timer Y Compare [1, 2, 4]"
+      bit_offset: 22
+      bit_size: 1
+      array:
+        len: 3
+        stride: 1
+      enum: RESETEFFECT
+    - name: TIMZCMP
+      description: "Timer Compare [1, 2, 4]"
+      bit_offset: 25
+      bit_size: 1
+      array:
+        len: 3
+        stride: 1
+      enum: RESETEFFECT
+    - name: TIMTCMP
+      description: "Timer Compare [1, 2, 4]"
+      bit_offset: 28
+      bit_size: 1
+      array:
+        len: 3
+        stride: 1
+      enum: RESETEFFECT
+fieldset/TIMXRSTR:
+  description: Timerx OutputX Reset Register
+  fields:
+    - name: SRT
+      description: Software Reset trigger
+      bit_offset: 0
+      bit_size: 1
+      enum: INACTIVEEFFECT
+    - name: RESYNC
+      description: Timer X resynchronizaton
+      bit_offset: 1
+      bit_size: 1
+      enum: INACTIVEEFFECT
+    - name: PER
+      description: Timer X Period
+      bit_offset: 2
+      bit_size: 1
+      enum: INACTIVEEFFECT
+    - name: CMP
+      description: Timer X compare X
+      bit_offset: 3
+      bit_size: 1
+      array:
+        len: 4
+        stride: 1
+      enum: INACTIVEEFFECT
+    - name: MSTPER
+      description: Master Period
+      bit_offset: 7
+      bit_size: 1
+      enum: INACTIVEEFFECT
+    - name: MSTCMP
+      description: Master Compare X
+      bit_offset: 8
+      bit_size: 1
+      array:
+        len: 4
+        stride: 1
+      enum: INACTIVEEFFECT
+    - name: TIMEVNT
+      description: Timer Event X
+      bit_offset: 12
+      bit_size: 1
+      array:
+        len: 9
+        stride: 1
+      enum: INACTIVEEFFECT
+    - name: EXTEVNT
+      description: External Event X
+      bit_offset: 21
+      bit_size: 1
+      array:
+        len: 10
+        stride: 1
+      enum: INACTIVEEFFECT
+    - name: UPDATE
+      description: Registers update (transfer preload to active)
+      bit_offset: 31
+      bit_size: 1
+      enum: INACTIVEEFFECT
+fieldset/TIMXSETR:
+  description: Timerx OutputX Set Register
+  fields:
+    - name: SST
+      description: Software Set trigger
+      bit_offset: 0
+      bit_size: 1
+      enum: ACTIVEEFFECT
+    - name: RESYNC
+      description: Timer X resynchronizaton
+      bit_offset: 1
+      bit_size: 1
+      enum: ACTIVEEFFECT
+    - name: PER
+      description: Timer X Period
+      bit_offset: 2
+      bit_size: 1
+      enum: ACTIVEEFFECT
+    - name: CMP
+      description: Timer X compare X
+      bit_offset: 3
+      bit_size: 1
+      array:
+        len: 4
+        stride: 1
+      enum: ACTIVEEFFECT
+    - name: MSTPER
+      description: Master Period
+      bit_offset: 7
+      bit_size: 1
+      enum: ACTIVEEFFECT
+    - name: MSTCMPX
+      description: Master Compare X
+      bit_offset: 8
+      bit_size: 1
+      array:
+        len: 4
+        stride: 1
+      enum: ACTIVEEFFECT
+    - name: TIMEVNT
+      description: Timer Event X
+      bit_offset: 12
+      bit_size: 1
+      array:
+        len: 9
+        stride: 1
+      enum: ACTIVEEFFECT
+    - name: EXTEVNT
+      description: External Event X
+      bit_offset: 21
+      bit_size: 1
+      array:
+        len: 10
+        stride: 1
+      enum: ACTIVEEFFECT
+    - name: UPDATE
+      description: Registers update (transfer preload to active)
+      bit_offset: 31
+      bit_size: 1
+      enum: ACTIVEEFFECT
+enum/ACTIVEEFFECT:
+  bit_size: 1
+  variants:
+    - name: NoEffect
+      description: Timer event has no effect
+      value: 0
+    - name: SetActive
+      description: Timer event forces the output to its active state
+      value: 1
+enum/BRSTDMA:
+  bit_size: 2
+  variants:
+    - name: Independent
+      description: Update done independently from the DMA burst transfer completion
+      value: 0
+    - name: Completion
+      description: Update done when the DMA burst transfer is completed
+      value: 1
+    - name: Rollover
+      description: Update done on master timer roll-over following a DMA burst transfer completion
+      value: 2
+enum/CAPTUREEFFECT:
+  bit_size: 1
+  variants:
+    - name: NoEffect
+      description: Timer event has no effect
+      value: 0
+    - name: TriggerCapture
+      description: Timer event triggers capture
+      value: 1
+enum/CPPSTAT:
+  bit_size: 1
+  variants:
+    - name: Output1Active
+      description: Signal applied on output 1 and output 2 forced inactive
+      value: 0
+    - name: Output2Active
+      description: Signal applied on output 2 and output 1 forced inactive
+      value: 1
+enum/DACSYNC:
+  bit_size: 2
+  variants:
+    - name: Disabled
+      description: No DAC trigger generated
+      value: 0
+    - name: DACSync1
+      description: Trigger generated on DACSync1
+      value: 1
+    - name: DACSync2
+      description: Trigger generated on DACSync2
+      value: 2
+    - name: DACSync3
+      description: Trigger generated on DACSync3
+      value: 3
+enum/DELCMP:
+  bit_size: 2
+  variants:
+    - name: Standard
+      description: CMP register is always active (standard compare mode)
+      value: 0
+    - name: Capture1
+      description: CMP is recomputed and is active following a capture 1 event
+      value: 1
+    - name: CaptureX_Compare1
+      description: CMP is recomputed and is active following a capture 1 event or a Compare 1 match
+      value: 2
+    - name: CaptureX_Compare3
+      description: CMP is recomputed and is active following a capture 1 event or a Compare 3 match
+      value: 3
+enum/DLYPRT:
+  bit_size: 3
+  variants:
+    - name: Output1_EE6
+      description: Output 1 delayed idle on external event 6
+      value: 0
+    - name: Output2_EE6
+      description: Output 2 delayed idle on external event 6
+      value: 1
+    - name: Output1_2_EE6
+      description: Output 1 and 2 delayed idle on external event 6
+      value: 2
+    - name: Balanced_EE6
+      description: Balanced idle on external event 6
+      value: 3
+    - name: Output1_EE7
+      description: Output 1 delayed idle on external event 7
+      value: 4
+    - name: Output2_EE7
+      description: Output 2 delayed idle on external event 7
+      value: 5
+    - name: Output1_2_EE7
+      description: Output 1 and 2 delayed idle on external event 7
+      value: 6
+    - name: Balanced_EE7
+      description: Balanced idle on external event 7
+      value: 7
+enum/EEFLTR:
+  bit_size: 4
+  variants:
+    - name: Disabled
+      description: No filtering
+      value: 0
+    - name: BlankResetToCompare1
+      description: Blanking from counter reset/roll-over to Compare 1
+      value: 1
+    - name: BlankResetToCompare2
+      description: Blanking from counter reset/roll-over to Compare 2
+      value: 2
+    - name: BlankResetToCompare3
+      description: Blanking from counter reset/roll-over to Compare 3
+      value: 3
+    - name: BlankResetToCompare4
+      description: Blanking from counter reset/roll-over to Compare 4
+      value: 4
+    - name: BlankTIMFLTR1
+      description: "Blanking from another timing unit: TIMFLTR1 source"
+      value: 5
+    - name: BlankTIMFLTR2
+      description: "Blanking from another timing unit: TIMFLTR2 source"
+      value: 6
+    - name: BlankTIMFLTR3
+      description: "Blanking from another timing unit: TIMFLTR3 source"
+      value: 7
+    - name: BlankTIMFLTR4
+      description: "Blanking from another timing unit: TIMFLTR4 source"
+      value: 8
+    - name: BlankTIMFLTR5
+      description: "Blanking from another timing unit: TIMFLTR5 source"
+      value: 9
+    - name: BlankTIMFLTR6
+      description: "Blanking from another timing unit: TIMFLTR6 source"
+      value: 10
+    - name: BlankTIMFLTR7
+      description: "Blanking from another timing unit: TIMFLTR7 source"
+      value: 11
+    - name: BlankTIMFLTR8
+      description: "Blanking from another timing unit: TIMFLTR8 source"
+      value: 12
+    - name: WindowResetToCompare2
+      description: Windowing from counter reset/roll-over to compare 2
+      value: 13
+    - name: WindowResetToCompare3
+      description: Windowing from counter reset/roll-over to compare 3
+      value: 14
+    - name: WindowTIMWIN
+      description: "Windowing from another timing unit: TIMWIN source"
+      value: 15
+enum/EVENT:
+  bit_size: 1
+  variants:
+    - name: NoEvent
+      description: No compare interrupt occurred
+      value: 0
+    - name: Event
+      description: Compare interrupt occurred
+      value: 1
+enum/FAULT:
+  bit_size: 2
+  variants:
+    - name: Disabled
+      description: "No action: the output is not affected by the fault input and stays in run mode"
+      value: 0
+    - name: SetActive
+      description: Output goes to active state after a fault event
+      value: 1
+    - name: SetInactive
+      description: Output goes to inactive state after a fault event
+      value: 2
+    - name: SetHighZ
+      description: Output goes to high-z state after a fault event
+      value: 3
+enum/FLTEN:
+  bit_size: 1
+  variants:
+    - name: Ignored
+      description: Fault input ignored
+      value: 0
+    - name: Active
+      description: Fault input is active and can disable HRTIM outputs
+      value: 1
+enum/INACTIVEEFFECT:
+  bit_size: 1
+  variants:
+    - name: NoEffect
+      description: Timer event has no effect
+      value: 0
+    - name: SetInactive
+      description: Timer event forces the output to its inactive state
+      value: 1
+enum/IPPSTAT:
+  bit_size: 1
+  variants:
+    - name: Output1Active
+      description: Protection occurred when the output 1 was active and output 2 forced inactive
+      value: 0
+    - name: Output2Active
+      description: Protection occurred when the output 2 was active and output 1 forced inactive
+      value: 1
+enum/LOCKED:
+  bit_size: 1
+  variants:
+    - name: Unlocked
+      description: Bits are writeable
+      value: 0
+    - name: Locked
+      description: Bits are read-only
+      value: 1
+enum/OUTPUTSTATE:
+  bit_size: 1
+  variants:
+    - name: Inactive
+      description: Output is or was inactive
+      value: 0
+    - name: Active
+      description: Output is or was active
+      value: 1
+enum/POL:
+  bit_size: 1
+  variants:
+    - name: ActiveHigh
+      description: Positive polarity (output active high)
+      value: 0
+    - name: ActiveLow
+      description: Negative polarity (output active low)
+      value: 1
+enum/RESETEFFECT:
+  bit_size: 1
+  variants:
+    - name: NoEffect
+      description: Timer Y compare Z event has no effect
+      value: 0
+    - name: ResetCounter
+      description: Timer X counter is reset upon timer Y compare Z event
+      value: 1
+enum/SDTF:
+  bit_size: 1
+  variants:
+    - name: Positive
+      description: Positive deadtime on falling edge
+      value: 0
+    - name: Negative
+      description: Negative deadtime on falling edge
+      value: 1
+enum/SDTR:
+  bit_size: 1
+  variants:
+    - name: Positive
+      description: Positive deadtime on rising edge
+      value: 0
+    - name: Negative
+      description: Negative deadtime on rising edge
+      value: 1
+enum/SYNCIN:
+  bit_size: 2
+  variants:
+    - name: Disabled
+      description: Disabled. HRTIM is not synchronized and runs in standalone mode
+      value: 0
+    - name: Internal
+      description: "Internal event: the HRTIM is synchronized with the on-chip timer"
+      value: 2
+    - name: External
+      description: "External event: a positive pulse on HRTIM_SCIN input triggers the HRTIM"
+      value: 3
+enum/SYNCOUT:
+  bit_size: 2
+  variants:
+    - name: Disabled
+      description: Disabled
+      value: 0
+    - name: PositivePulse
+      description: Positive pulse on SCOUT output (16x f_HRTIM clock cycles)
+      value: 2
+    - name: NegativePulse
+      description: Negative pulse on SCOUT output (16x f_HRTIM clock cycles)
+      value: 3
+enum/SYNCRST:
+  bit_size: 1
+  variants:
+    - name: Disabled
+      description: Synchronization event has no effect on Timer x
+      value: 0
+    - name: Reset
+      description: Synchronization event resets Timer x
+      value: 1
+enum/SYNCSRC:
+  bit_size: 2
+  variants:
+    - name: MasterStart
+      description: Master timer Start
+      value: 0
+    - name: MasterCompare1
+      description: Master timer Compare 1 event
+      value: 1
+    - name: TimerAStart
+      description: Timer A start/reset
+      value: 2
+    - name: TimerACompare1
+      description: Timer A Compare 1 event
+      value: 3
+enum/SYNCSTRT:
+  bit_size: 1
+  variants:
+    - name: Disabled
+      description: Synchronization event has no effect on Timer x
+      value: 0
+    - name: Start
+      description: Synchronization event starts Timer x
+      value: 1
+enum/TIMAISR_DLYPRT:
+  bit_size: 1
+  variants:
+    - name: Inactive
+      description: Not in delayed idle or balanced idle mode
+      value: 0
+    - name: Active
+      description: Delayed idle or balanced idle mode entry
+      value: 1
+enum/UPDGAT:
+  bit_size: 4
+  variants:
+    - name: Independent
+      description: Update occurs independently from the DMA burst transfer
+      value: 0
+    - name: DMABurst
+      description: Update occurs when the DMA burst transfer is completed
+      value: 1
+    - name: DMABurst_Update
+      description: Update occurs on the update event following DMA burst transfer completion
+      value: 2
+    - name: Input1
+      description: Update occurs on a rising edge of HRTIM update enable input 1
+      value: 3
+    - name: Input2
+      description: Update occurs on a rising edge of HRTIM update enable input 2
+      value: 4
+    - name: Input3
+      description: Update occurs on a rising edge of HRTIM update enable input 3
+      value: 5
+    - name: Input1_Update
+      description: Update occurs on the update event following a rising edge of HRTIM update enable input 1
+      value: 6
+    - name: Input2_Update
+      description: Update occurs on the update event following a rising edge of HRTIM update enable input 2
+      value: 7
+    - name: Input3_Update
+      description: Update occurs on the update event following a rising edge of HRTIM update enable input 3
+      value: 8

--- a/stm32-data-gen/src/chips.rs
+++ b/stm32-data-gen/src/chips.rs
@@ -203,6 +203,7 @@ impl PeriMatcher {
             (".*:LPTIM:F7_lptimer1_v1_1", ("lptim", "v1", "LPTIM")),
             (".*:HRTIM:hrtim_v1_0", ("hrtim", "v1", "HRTIM")),
             (".*:HRTIM:hrtim_H7", ("hrtim", "v1", "HRTIM")),
+            (".*:HRTIM:hrtim_G4", ("hrtim", "v1", "HRTIM")),
             (".*:LTDC:lcdtft1_v1_1", ("ltdc", "v1", "LTDC")),
             (".*:MDIOS:mdios1_v1_0", ("mdios", "v1", "MDIOS")),
             (".*:QUADSPI:quadspi1_v1_0", ("quadspi", "v1", "QUADSPI")),

--- a/stm32-data-gen/src/chips.rs
+++ b/stm32-data-gen/src/chips.rs
@@ -202,6 +202,7 @@ impl PeriMatcher {
             (".*:JPEG:jpeg1_v1_0", ("jpeg", "v1", "JPEG")),
             (".*:LPTIM:F7_lptimer1_v1_1", ("lptim", "v1", "LPTIM")),
             (".*:HRTIM:hrtim_v1_0", ("hrtim", "v1", "HRTIM")),
+            (".*:HRTIM:hrtim_H7", ("hrtim", "v1", "HRTIM")),
             (".*:LTDC:lcdtft1_v1_1", ("ltdc", "v1", "LTDC")),
             (".*:MDIOS:mdios1_v1_0", ("mdios", "v1", "MDIOS")),
             (".*:QUADSPI:quadspi1_v1_0", ("quadspi", "v1", "QUADSPI")),
@@ -876,6 +877,8 @@ fn process_core(
 
         let addr = if chip_name.starts_with("STM32F0") && pname == "ADC" {
             defines.get_peri_addr("ADC1")
+        } else if chip_name.starts_with("STM32H7") && pname == "HRTIM" {
+            defines.get_peri_addr("HRTIM1")
         } else {
             defines.get_peri_addr(&pname)
         };

--- a/stm32-data-gen/src/chips.rs
+++ b/stm32-data-gen/src/chips.rs
@@ -203,7 +203,7 @@ impl PeriMatcher {
             (".*:LPTIM:F7_lptimer1_v1_1", ("lptim", "v1", "LPTIM")),
             (".*:HRTIM:hrtim_v1_0", ("hrtim", "v1", "HRTIM")),
             (".*:HRTIM:hrtim_H7", ("hrtim", "v1", "HRTIM")),
-            (".*:HRTIM:hrtim_G4", ("hrtim", "v1", "HRTIM")),
+            (".*:HRTIM:hrtim_G4", ("hrtim", "v2", "HRTIM")),
             (".*:LTDC:lcdtft1_v1_1", ("ltdc", "v1", "LTDC")),
             (".*:MDIOS:mdios1_v1_0", ("mdios", "v1", "MDIOS")),
             (".*:QUADSPI:quadspi1_v1_0", ("quadspi", "v1", "QUADSPI")),


### PR DESCRIPTION
this pr *is* complete and aims to add the rest of the common registers and hrtim v2

v1.1 is binary compatible, but accessing the DLL is UB. However, that can be handled in the HAL.

closes #210 