### PR TITLE
Add aditf5_v3_1 ADC

### DIFF
--- a/stm32-data-gen/src/chips.rs
+++ b/stm32-data-gen/src/chips.rs
@@ -175,6 +175,7 @@ impl PeriMatcher {
             (".*:ADC:aditf5_v2_0", ("adc", "v3", "ADC")),
             (".*:ADC:aditf5_v2_2", ("adc", "v3", "ADC")),
             (".*:ADC:aditf5_v3_0", ("adc", "v4", "ADC")),
+            (".*:ADC:aditf5_v3_1", ("adc", "v4", "ADC")),
             ("STM32G0.*:ADC:.*", ("adc", "g0", "ADC")),
             ("STM32G0.*:ADC_COMMON:.*", ("adccommon", "v3", "ADC_COMMON")),
             (".*:ADC_COMMON:aditf2_v1_1", ("adccommon", "v2", "ADC_COMMON")),


### PR DESCRIPTION
ADC is currently unavailable for some STM32H7 chips like the H7A3. The registers seem to be the same across RM0455 and RM0399 and the ADC is working on a Nucleo H7A3ZI-Q board.

This PR therefore adds aditf5_v3_1 as a v4 ADC.