### PR TITLE
Fix Issue #225. Add CRS v1 to STM32U5 chips.

### DIFF
--- a/stm32-data-gen/src/chips.rs
+++ b/stm32-data-gen/src/chips.rs
@@ -298,6 +298,7 @@ impl PeriMatcher {
             ("STM32G0B1.*:CRS:.*", ("crs", "v1", "CRS")),
             ("STM32G0C1.*:CRS:.*", ("crs", "v1", "CRS")),
             ("STM32G4.*:CRS:.*", ("crs", "v1", "CRS")),
+            ("STM32U5.*:CRS:.*", ("crs", "v1", "CRS")),
             (".*SDMMC:sdmmc2_v1_0", ("sdmmc", "v2", "SDMMC")),
             ("STM32C0.*:PWR:.*", ("pwr", "c0", "PWR")),
             ("STM32G0.*:PWR:.*", ("pwr", "g0", "PWR")),


### PR DESCRIPTION
The STM32U5 uses the same CRS peripheral as the L0, G0, and G4 products. This adds the association of the CRS v1 peripheral to the U5 CRS registers.