### PR TITLE
adc/f3: fix sample time enum

### DIFF
--- a/data/registers/adc_f3.yaml
+++ b/data/registers/adc_f3.yaml
@@ -472,7 +472,7 @@ fieldset/SMPR1:
       description: Channel x sampling time selection
       bit_offset: 3
       bit_size: 3
-      enum: SMP
+      enum: SAMPLE_TIME
       array:
         len: 9
         stride: 3
@@ -483,7 +483,7 @@ fieldset/SMPR2:
       description: Channel x sampling time selection
       bit_offset: 0
       bit_size: 3
-      enum: SMP
+      enum: SAMPLE_TIME
       array:
         len: 9
         stride: 3
@@ -747,7 +747,7 @@ enum/RES:
     - name: Bits6
       description: 6-bit
       value: 3
-enum/SMP:
+enum/SAMPLE_TIME:
   bit_size: 3
   variants:
     - name: Cycles1_5


### PR DESCRIPTION
the sample_time file depends on naming consistency