### PR TITLE
fix adc_f3 resolution namings to match existing convention across

### DIFF
--- a/data/registers/adc_f3.yaml
+++ b/data/registers/adc_f3.yaml
@@ -735,17 +735,17 @@ enum/JQM:
 enum/RES:
   bit_size: 2
   variants:
-    - name: Bits12
-      description: 12-bit
+    - name: TwelveBit
+      description: 12-bit resolution
       value: 0
-    - name: Bits10
-      description: 10-bit
+    - name: TenBit
+      description: 10-bit resolution
       value: 1
-    - name: Bits8
-      description: 8-bit
+    - name: EightBit
+      description: 8-bit resolution
       value: 2
-    - name: Bits6
-      description: 6-bit
+    - name: SixBit
+      description: 6-bit resolution
       value: 3
 enum/SAMPLE_TIME:
   bit_size: 3


### PR DESCRIPTION
Fix res enum  naming in adc_f3.yaml to match res enum naming in other chips