### PR TITLE
Clean up on aisle rcc-f3

### DIFF
--- a/data/registers/rcc_f3.yaml
+++ b/data/registers/rcc_f3.yaml
@@ -121,10 +121,6 @@ fieldset/AHBENR:
       description: ADC1 and ADC2 clock enable
       bit_offset: 28
       bit_size: 1
-    - name: ADC1EN
-      description: ADC 1
-      bit_offset: 28
-      bit_size: 1
     - name: ADC34EN
       description: ADC3 and ADC4 clock enable
       bit_offset: 29
@@ -176,10 +172,6 @@ fieldset/AHBRSTR:
       description: ADC1 and ADC2 reset
       bit_offset: 28
       bit_size: 1
-    - name: ADC1RST
-      description: ADC1 reset
-      bit_offset: 28
-      bit_size: 1
     - name: ADC34RST
       description: ADC3 and ADC4 reset
       bit_offset: 29
@@ -199,10 +191,6 @@ fieldset/APB1ENR:
       description: Timer 4 clock enable
       bit_offset: 2
       bit_size: 1
-    - name: TIM5EN
-      description: Timer 5 clock enable
-      bit_offset: 3
-      bit_size: 1
     - name: TIM6EN
       description: Timer 6 clock enable
       bit_offset: 4
@@ -210,22 +198,6 @@ fieldset/APB1ENR:
     - name: TIM7EN
       description: Timer 7 clock enable
       bit_offset: 5
-      bit_size: 1
-    - name: TIM12EN
-      description: Timer 12 clock enable
-      bit_offset: 6
-      bit_size: 1
-    - name: TIM13EN
-      description: Timer 13 clock enable
-      bit_offset: 7
-      bit_size: 1
-    - name: TIM14EN
-      description: Timer 14 clock enable
-      bit_offset: 8
-      bit_size: 1
-    - name: TIM18EN
-      description: Timer 18 clock enable
-      bit_offset: 9
       bit_size: 1
     - name: WWDGEN
       description: Window watchdog clock enable
@@ -283,10 +255,6 @@ fieldset/APB1ENR:
       description: DAC interface clock enable
       bit_offset: 29
       bit_size: 1
-    - name: CECEN
-      description: HDMI CEC interface clock enable
-      bit_offset: 30
-      bit_size: 1
     - name: I2C3EN
       description: I2C3 clock enable
       bit_offset: 30
@@ -303,12 +271,8 @@ fieldset/APB1RSTR:
       bit_offset: 1
       bit_size: 1
     - name: TIM4RST
-      description: Timer 14 reset
+      description: Timer 4 reset
       bit_offset: 2
-      bit_size: 1
-    - name: TIM5RST
-      description: Timer 5 reset
-      bit_offset: 3
       bit_size: 1
     - name: TIM6RST
       description: Timer 6 reset
@@ -317,22 +281,6 @@ fieldset/APB1RSTR:
     - name: TIM7RST
       description: Timer 7 reset
       bit_offset: 5
-      bit_size: 1
-    - name: TIM12RST
-      description: Timer 12 reset
-      bit_offset: 6
-      bit_size: 1
-    - name: TIM13RST
-      description: Timer 13 reset
-      bit_offset: 7
-      bit_size: 1
-    - name: TIM14RST
-      description: Timer 14 reset
-      bit_offset: 8
-      bit_size: 1
-    - name: TIM18RST
-      description: Timer 18 reset
-      bit_offset: 9
       bit_size: 1
     - name: WWDGRST
       description: Window watchdog reset
@@ -390,10 +338,6 @@ fieldset/APB1RSTR:
       description: DAC interface reset
       bit_offset: 29
       bit_size: 1
-    - name: CECRST
-      description: HDMI CEC reset
-      bit_offset: 30
-      bit_size: 1
     - name: I2C3RST
       description: I2C3 reset
       bit_offset: 30
@@ -404,10 +348,6 @@ fieldset/APB2ENR:
     - name: SYSCFGEN
       description: SYSCFG clock enable
       bit_offset: 0
-      bit_size: 1
-    - name: ADCEN
-      description: ADC 1 interface clock enable
-      bit_offset: 9
       bit_size: 1
     - name: TIM1EN
       description: TIM1 Timer clock enable
@@ -441,33 +381,9 @@ fieldset/APB2ENR:
       description: TIM17 timer clock enable
       bit_offset: 18
       bit_size: 1
-    - name: TIM19EN
-      description: TIM19 timer clock enable
-      bit_offset: 19
-      bit_size: 1
     - name: TIM20EN
       description: TIM20 timer clock enable
       bit_offset: 20
-      bit_size: 1
-    - name: DBGMCUEN
-      description: MCU debug module clock enable
-      bit_offset: 22
-      bit_size: 1
-    - name: SDADC1EN
-      description: SDADC1 (Sigma Delta ADC 1) clock enable
-      bit_offset: 24
-      bit_size: 1
-    - name: SDADC2EN
-      description: SDADC2 (Sigma Delta ADC 2) clock enable
-      bit_offset: 25
-      bit_size: 1
-    - name: SDADC3EN
-      description: SDADC3 (Sigma Delta ADC 3) clock enable
-      bit_offset: 26
-      bit_size: 1
-    - name: HRTIM1EN
-      description: High Resolution Timer 1 clock enable
-      bit_offset: 29
       bit_size: 1
 fieldset/APB2RSTR:
   description: APB2 peripheral reset register (RCC_APB2RSTR)
@@ -475,10 +391,6 @@ fieldset/APB2RSTR:
     - name: SYSCFGRST
       description: SYSCFG and COMP reset
       bit_offset: 0
-      bit_size: 1
-    - name: ADCRST
-      description: ADC interface reset
-      bit_offset: 9
       bit_size: 1
     - name: TIM1RST
       description: TIM1 timer reset
@@ -512,29 +424,9 @@ fieldset/APB2RSTR:
       description: TIM17 timer reset
       bit_offset: 18
       bit_size: 1
-    - name: TIM19RST
-      description: TIM19 timer reset
-      bit_offset: 19
-      bit_size: 1
     - name: TIM20RST
       description: TIM20 timer reset
       bit_offset: 20
-      bit_size: 1
-    - name: SDADC1RST
-      description: SDADC1 (Sigma delta ADC 1) reset
-      bit_offset: 24
-      bit_size: 1
-    - name: SDADC2RST
-      description: SDADC2 (Sigma delta ADC 2) reset
-      bit_offset: 25
-      bit_size: 1
-    - name: SDADC3RST
-      description: SDADC3 (Sigma delta ADC 3) reset
-      bit_offset: 26
-      bit_size: 1
-    - name: HRTIM1RST
-      description: High Resolution Timer1 reset
-      bit_offset: 29
       bit_size: 1
 fieldset/BDCR:
   description: Backup domain control register (RCC_BDCR)
@@ -657,11 +549,6 @@ fieldset/CFGR2:
       enum: PREDIV
     - name: ADC12PRES
       description: ADC1 and ADC2 prescaler
-      bit_offset: 4
-      bit_size: 5
-      enum: ADCPRES
-    - name: ADC1PRES
-      description: ADC1 prescaler
       bit_offset: 4
       bit_size: 5
       enum: ADCPRES


### PR DESCRIPTION
- Removed duplicate ADC registers that were causing issues.
- Cleaned out APB(1/2)(RSTR/ENR) of registers that are marked "Reserved" per RM0316
- Probably more registers to clean out in other fieldsets, but this is all for now.