### PR TITLE
Support STM32G4 ADC peripheral

### DIFF
--- a/stm32-data-gen/src/chips.rs
+++ b/stm32-data-gen/src/chips.rs
@@ -180,6 +180,8 @@ impl PeriMatcher {
             (".*:ADC:aditf5_v3_1", ("adc", "v4", "ADC")),
             ("STM32G0.*:ADC:.*", ("adc", "g0", "ADC")),
             ("STM32G0.*:ADC_COMMON:.*", ("adccommon", "v3", "ADC_COMMON")),
+            ("STM32G4.*:ADC:.*", ("adc", "v4", "ADC")),
+            ("STM32G4.*:ADC_COMMON:.*", ("adccommon", "v4", "ADC_COMMON")),
             (".*:ADC_COMMON:aditf2_v1_1", ("adccommon", "v2", "ADC_COMMON")),
             (".*:ADC_COMMON:aditf5_v2_0", ("adccommon", "v3", "ADC_COMMON")),
             (".*:ADC_COMMON:aditf5_v2_2", ("adccommon", "v3", "ADC_COMMON")),


### PR DESCRIPTION
 STM32G4 ADC is  missed. 
 https://docs.embassy.dev/embassy-stm32/git/stm32g441kb/index.html

 Mapping G4's ADC and ADC_COMMON as v4.


 