### PR TITLE
Add free-running clock mode for quadspi

### DIFF
--- a/data/registers/quadspi_v1.yaml
+++ b/data/registers/quadspi_v1.yaml
@@ -112,6 +112,10 @@ fieldset/CCR:
       description: Send instruction only once mode
       bit_offset: 28
       bit_size: 1
+    - name: FRCM
+      description: Free-running clock mode (not available on all chips!)
+      bit_offset: 29
+      bit_size: 1
     - name: DHHC
       description: DDR hold half cycle
       bit_offset: 30
@@ -132,7 +136,7 @@ fieldset/CR:
       bit_offset: 1
       bit_size: 1
     - name: DMAEN
-      description: DMA enable
+      description: DMA enable (not available on all chips!)
       bit_offset: 2
       bit_size: 1
     - name: TCEN


### PR DESCRIPTION
Currently the FRCM (free-running clock mode) field is not supported in quadspi. However, on (some?) STM32H7 chips it is available.
On the other hand, they might not have a DMAEN field.

This PR adds the FRCM field and adds a hint that these fields are not available on all chips to the FRCM and DMAEN fields.
Their use should then be handled in the HAL, as discussed on the matrix chat.