### PR TITLE
Support STM32WLEx ADC peripheral

### DIFF
--- a/data/registers/rcc_wl5.yaml
+++ b/data/registers/rcc_wl5.yaml
@@ -1059,6 +1059,7 @@ fieldset/CCIPR:
       description: ADC clock source selection
       bit_offset: 28
       bit_size: 2
+      enum: ADCSEL
     - name: RNGSEL
       description: RNG clock source selection
       bit_offset: 30
@@ -1422,3 +1423,15 @@ fieldset/PLLCFGR:
       description: Main PLL division factor for PLLRCLK
       bit_offset: 29
       bit_size: 3
+enum/ADCSEL:
+  bit_size: 2
+  variants:
+    - name: HSI16
+      description: HSI16 used as ADC clock source
+      value: 1
+    - name: PLLPCLK
+      description: PLLPCLK used as ADC clock source
+      value: 2
+    - name: SYSCLK
+      description: SYSCLK used as ADC clock source
+      value: 3

--- a/data/registers/rcc_wle.yaml
+++ b/data/registers/rcc_wle.yaml
@@ -689,6 +689,7 @@ fieldset/CCIPR:
       description: ADC clock source selection
       bit_offset: 28
       bit_size: 2
+      enum: ADCSEL
     - name: RNGSEL
       description: RNG clock source selection
       bit_offset: 30
@@ -1044,3 +1045,15 @@ fieldset/PLLCFGR:
       description: Main PLL division factor for PLLRCLK
       bit_offset: 29
       bit_size: 3
+enum/ADCSEL:
+  bit_size: 2
+  variants:
+    - name: HSI16
+      description: HSI16 used as ADC clock source
+      value: 1
+    - name: PLLPCLK
+      description: PLLPCLK used as ADC clock source
+      value: 2
+    - name: SYSCLK
+      description: SYSCLK used as ADC clock source
+      value: 3

--- a/stm32-data-gen/src/chips.rs
+++ b/stm32-data-gen/src/chips.rs
@@ -207,6 +207,7 @@ impl PeriMatcher {
             ("STM32U5.*:SYSCFG:.*", ("syscfg", "u5", "SYSCFG")),
             ("STM32WB.*:SYSCFG:.*", ("syscfg", "wb", "SYSCFG")),
             ("STM32WL5.*:SYSCFG:.*", ("syscfg", "wl5", "SYSCFG")),
+            ("STM32WL5.*:ADC:.*", ("adc", "g0", "ADC")),
             ("STM32WLE.*:SYSCFG:.*", ("syscfg", "wle", "SYSCFG")),
             ("STM32WLE.*:ADC:.*", ("adc", "g0", "ADC")),
             ("STM32H50.*:SBS:.*", ("sbs", "h50", "SBS")),

--- a/stm32-data-gen/src/chips.rs
+++ b/stm32-data-gen/src/chips.rs
@@ -208,6 +208,7 @@ impl PeriMatcher {
             ("STM32WB.*:SYSCFG:.*", ("syscfg", "wb", "SYSCFG")),
             ("STM32WL5.*:SYSCFG:.*", ("syscfg", "wl5", "SYSCFG")),
             ("STM32WLE.*:SYSCFG:.*", ("syscfg", "wle", "SYSCFG")),
+            ("STM32WLE.*:ADC:.*", ("adc", "g0", "ADC")),
             ("STM32H50.*:SBS:.*", ("sbs", "h50", "SBS")),
             ("STM32H5.*:SBS:.*", ("sbs", "h5", "SBS")),
             (".*:IWDG:iwdg1_v1_1", ("iwdg", "v1", "IWDG")),


### PR DESCRIPTION
Use adc_g0 since very similar to the WLE one.

edit: added for STM32WL5x too (9c71725), since looks similar enough.