### PR TITLE
Add enums MCOPRE & MCOSEL to wl5 & wle targets

### DIFF
--- a/data/registers/rcc_wl5.yaml
+++ b/data/registers/rcc_wl5.yaml
@@ -1110,10 +1110,12 @@ fieldset/CFGR:
     description: Microcontroller clock output
     bit_offset: 24
     bit_size: 4
+    enum: MCOSEL
   - name: MCOPRE
     description: Microcontroller clock output prescaler
     bit_offset: 28
     bit_size: 3
+    enum: MCOPRE
 fieldset/CICR:
   description: Clock interrupt clear register
   fields:
@@ -1483,6 +1485,57 @@ enum/HPRE:
   - name: Div512
     description: hclk = SYSCLK divided by 256
     value: 15
+enum/MCOPRE:
+  bit_size: 3
+  variants:
+  - name: Div1
+    description: No division
+    value: 0
+  - name: Div2
+    description: Division by 2
+    value: 1
+  - name: Div4
+    description: Division by 4
+    value: 2
+  - name: Div8
+    description: Division by 8
+    value: 3
+  - name: Div16
+    description: Division by 16
+    value: 4
+enum/MCOSEL:
+  bit_size: 4
+  variants:
+  - name: NoClock
+    description: No clock
+    value: 0
+  - name: SYSCLK
+    description: SYSCLK clock selected
+    value: 1
+  - name: MSI
+    description: MSI oscillator clock selected
+    value: 2
+  - name: HSI16
+    description: HSI oscillator clock selected
+    value: 3
+  - name: HSE32
+    description: HSE32 oscillator clock selected
+    value: 4
+  - name: PLLRCLK
+    description: Main PLLRCLK clock selected
+    value: 5
+  - name: LSI
+    description: LSI oscillator clock selected
+    value: 6
+  - name: LSE
+    description: LSE oscillator clock selected
+    value: 8
+  - name: PLLPCLK
+    description: Main PLLCLK oscillator clock selected
+    value: 13
+  - name: PLLQCLK
+    description: Main PLLQCLK oscillator clock selected
+    value: 14
 enum/PPRE:
   bit_size: 3
   variants:

--- a/data/registers/rcc_wle.yaml
+++ b/data/registers/rcc_wle.yaml
@@ -740,10 +740,12 @@ fieldset/CFGR:
     description: Microcontroller clock output
     bit_offset: 24
     bit_size: 4
+    enum: MCOSEL
   - name: MCOPRE
     description: Microcontroller clock output prescaler
     bit_offset: 28
     bit_size: 3
+    enum: MCOPRE
 fieldset/CICR:
   description: Clock interrupt clear register
   fields:
@@ -1105,6 +1107,57 @@ enum/HPRE:
   - name: Div512
     description: hclk = SYSCLK divided by 256
     value: 15
+enum/MCOPRE:
+  bit_size: 3
+  variants:
+  - name: Div1
+    description: No division
+    value: 0
+  - name: Div2
+    description: Division by 2
+    value: 1
+  - name: Div4
+    description: Division by 4
+    value: 2
+  - name: Div8
+    description: Division by 8
+    value: 3
+  - name: Div16
+    description: Division by 16
+    value: 4
+enum/MCOSEL:
+  bit_size: 4
+  variants:
+  - name: NoClock
+    description: No clock
+    value: 0
+  - name: SYSCLK
+    description: SYSCLK clock selected
+    value: 1
+  - name: MSI
+    description: MSI oscillator clock selected
+    value: 2
+  - name: HSI16
+    description: HSI oscillator clock selected
+    value: 3
+  - name: HSE32
+    description: HSE32 oscillator clock selected
+    value: 4
+  - name: PLLRCLK
+    description: Main PLLRCLK clock selected
+    value: 5
+  - name: LSI
+    description: LSI oscillator clock selected
+    value: 6
+  - name: LSE
+    description: LSE oscillator clock selected
+    value: 8
+  - name: PLLPCLK
+    description: Main PLLCLK oscillator clock selected
+    value: 13
+  - name: PLLQCLK
+    description: Main PLLQCLK oscillator clock selected
+    value: 14
 enum/PPRE:
   bit_size: 3
   variants:


### PR DESCRIPTION
This adds the MCOPRE & MCOSEL enums to the wl5 & wle targets. These both have an m4 core derived from the stm32l4, although with a slightly different set of clocks supporting the SubGHz radio. (The wl5 differs from the wle by also having an m0 core and some security support.)