### PR TITLE
add TAMP register block for g0, g4, l5, u5 and wl

### DIFF
--- a/.github/ci/build.sh
+++ b/.github/ci/build.sh
@@ -16,7 +16,7 @@ cargo fmt -- --check
 # clone stm32-data-generated at the merge base
 # so the diff will show this PR's effect
 git remote add upstream https://github.com/embassy-rs/stm32-data
-git fetch --depth 1 upstream main
+git fetch --depth 15 upstream main
 git clone --depth 1 --branch stm32-data-$(git merge-base HEAD upstream/main) https://github.com/embassy-rs/stm32-data-generated/ build
 
 ./d ci

--- a/data/extra/family/STM32G0.yaml
+++ b/data/extra/family/STM32G0.yaml
@@ -1,0 +1,8 @@
+---
+peripherals:
+  - name: TAMP
+    address: 0x4000B000
+    registers:
+      kind: tamp
+      version: g0
+      block: TAMP

--- a/data/extra/family/STM32G4.yaml
+++ b/data/extra/family/STM32G4.yaml
@@ -1,0 +1,8 @@
+---
+peripherals:
+  - name: TAMP
+    address: 0x40002400
+    registers:
+      kind: tamp
+      version: g4
+      block: TAMP

--- a/data/extra/family/STM32WL.yaml
+++ b/data/extra/family/STM32WL.yaml
@@ -1,0 +1,8 @@
+---
+peripherals:
+  - name: TAMP
+    address: 0x4000B000
+    registers:
+      kind: tamp
+      version: wl
+      block: TAMP

--- a/data/registers/tamp_g0.yaml
+++ b/data/registers/tamp_g0.yaml
@@ -1,0 +1,337 @@
+block/TAMP:
+  description: Tamper and backup registers
+  items:
+    - name: CR1
+      description: control register 1
+      byte_offset: 0
+      fieldset: CR1
+    - name: CR2
+      description: control register 2
+      byte_offset: 4
+      fieldset: CR2
+    - name: FLTCR
+      description: TAMP filter control register
+      byte_offset: 12
+      fieldset: FLTCR
+    - name: IER
+      description: TAMP interrupt enable register
+      byte_offset: 44
+      fieldset: IER
+    - name: SR
+      description: TAMP status register
+      byte_offset: 48
+      access: Read
+      fieldset: SR
+    - name: MISR
+      description: TAMP masked interrupt status register
+      byte_offset: 52
+      access: Read
+      fieldset: MISR
+    - name: SCR
+      description: TAMP status clear register
+      byte_offset: 60
+      access: Write
+      fieldset: SCR
+    - name: BKPR
+      description: TAMP backup register
+      array:
+        len: 5
+        stride: 4
+      byte_offset: 256
+      fieldset: BKPR
+    - name: HWCFGR2
+      description: TAMP hardware configuration register 2
+      byte_offset: 1004
+      access: Read
+      fieldset: HWCFGR2
+    - name: HWCFGR1
+      description: TAMP hardware configuration register 1
+      byte_offset: 1008
+      access: Read
+      fieldset: HWCFGR1
+    - name: VERR
+      description: EXTI IP Version register
+      byte_offset: 1012
+      access: Read
+      fieldset: VERR
+    - name: IPIDR
+      description: EXTI Identification register
+      byte_offset: 1016
+      access: Read
+      fieldset: IPIDR
+    - name: SIDR
+      description: EXTI Size ID register
+      byte_offset: 1020
+      access: Read
+      fieldset: SIDR
+fieldset/BKPR:
+  description: TAMP backup register
+  fields:
+    - name: BKP
+      description: BKP
+      bit_offset: 0
+      bit_size: 32
+fieldset/CR1:
+  description: control register 1
+  fields:
+    - name: TAMP1E
+      description: TAMP1E
+      bit_offset: 0
+      bit_size: 1
+    - name: TAMP2E
+      description: TAMP2E
+      bit_offset: 1
+      bit_size: 1
+    - name: ITAMP1E
+      description: ITAMP1E
+      bit_offset: 16
+      bit_size: 1
+    - name: ITAMP3E
+      description: ITAMP3E
+      bit_offset: 18
+      bit_size: 1
+    - name: ITAMP4E
+      description: ITAMP4E
+      bit_offset: 19
+      bit_size: 1
+    - name: ITAMP5E
+      description: ITAMP5E
+      bit_offset: 20
+      bit_size: 1
+    - name: ITAMP6E
+      description: ITAMP6E
+      bit_offset: 21
+      bit_size: 1
+fieldset/CR2:
+  description: control register 2
+  fields:
+    - name: TAMP1NOER
+      description: TAMP1NOER
+      bit_offset: 0
+      bit_size: 1
+    - name: TAMP2NOER
+      description: TAMP2NOER
+      bit_offset: 1
+      bit_size: 1
+    - name: TAMP1MSK
+      description: TAMP1MSK
+      bit_offset: 16
+      bit_size: 1
+    - name: TAMP2MSK
+      description: TAMP2MSK
+      bit_offset: 17
+      bit_size: 1
+    - name: TAMP1TRG
+      description: TAMP1TRG
+      bit_offset: 24
+      bit_size: 1
+    - name: TAMP2TRG
+      description: TAMP2TRG
+      bit_offset: 25
+      bit_size: 1
+fieldset/FLTCR:
+  description: TAMP filter control register
+  fields:
+    - name: TAMPFREQ
+      description: TAMPFREQ
+      bit_offset: 0
+      bit_size: 3
+    - name: TAMPFLT
+      description: TAMPFLT
+      bit_offset: 3
+      bit_size: 2
+    - name: TAMPPRCH
+      description: TAMPPRCH
+      bit_offset: 5
+      bit_size: 2
+    - name: TAMPPUDIS
+      description: TAMPPUDIS
+      bit_offset: 7
+      bit_size: 1
+fieldset/HWCFGR1:
+  description: TAMP hardware configuration register 1
+  fields:
+    - name: BACKUP_REGS
+      description: BACKUP_REGS
+      bit_offset: 0
+      bit_size: 8
+    - name: TAMPER
+      description: TAMPER
+      bit_offset: 8
+      bit_size: 4
+    - name: ACTIVE_TAMPER
+      description: ACTIVE_TAMPER
+      bit_offset: 12
+      bit_size: 4
+    - name: INT_TAMPER
+      description: INT_TAMPER
+      bit_offset: 16
+      bit_size: 16
+fieldset/HWCFGR2:
+  description: TAMP hardware configuration register 2
+  fields:
+    - name: PTIONREG_OUT
+      description: PTIONREG_OUT
+      bit_offset: 0
+      bit_size: 8
+    - name: TRUST_ZONE
+      description: TRUST_ZONE
+      bit_offset: 8
+      bit_size: 4
+fieldset/IER:
+  description: TAMP interrupt enable register
+  fields:
+    - name: TAMP1IE
+      description: TAMP1IE
+      bit_offset: 0
+      bit_size: 1
+    - name: TAMP2IE
+      description: TAMP2IE
+      bit_offset: 1
+      bit_size: 1
+    - name: ITAMP1IE
+      description: ITAMP1IE
+      bit_offset: 16
+      bit_size: 1
+    - name: ITAMP3IE
+      description: ITAMP3IE
+      bit_offset: 18
+      bit_size: 1
+    - name: ITAMP4IE
+      description: ITAMP4IE
+      bit_offset: 19
+      bit_size: 1
+    - name: ITAMP5IE
+      description: ITAMP5IE
+      bit_offset: 20
+      bit_size: 1
+    - name: ITAMP6IE
+      description: ITAMP6IE
+      bit_offset: 21
+      bit_size: 1
+fieldset/IPIDR:
+  description: EXTI Identification register
+  fields:
+    - name: IPID
+      description: IP Identification
+      bit_offset: 0
+      bit_size: 32
+fieldset/MISR:
+  description: TAMP masked interrupt status register
+  fields:
+    - name: TAMP1MF
+      description: "TAMP1MF:"
+      bit_offset: 0
+      bit_size: 1
+    - name: TAMP2MF
+      description: TAMP2MF
+      bit_offset: 1
+      bit_size: 1
+    - name: ITAMP1MF
+      description: ITAMP1MF
+      bit_offset: 16
+      bit_size: 1
+    - name: ITAMP3MF
+      description: ITAMP3MF
+      bit_offset: 18
+      bit_size: 1
+    - name: ITAMP4MF
+      description: ITAMP4MF
+      bit_offset: 19
+      bit_size: 1
+    - name: ITAMP5MF
+      description: ITAMP5MF
+      bit_offset: 20
+      bit_size: 1
+    - name: ITAMP6MF
+      description: ITAMP6MF
+      bit_offset: 21
+      bit_size: 1
+fieldset/SCR:
+  description: TAMP status clear register
+  fields:
+    - name: CTAMP1F
+      description: CTAMP1F
+      bit_offset: 0
+      bit_size: 1
+    - name: CTAMP2F
+      description: CTAMP2F
+      bit_offset: 1
+      bit_size: 1
+    - name: CITAMP1F
+      description: CITAMP1F
+      bit_offset: 16
+      bit_size: 1
+    - name: CITAMP3F
+      description: CITAMP3F
+      bit_offset: 18
+      bit_size: 1
+    - name: CITAMP4F
+      description: CITAMP4F
+      bit_offset: 19
+      bit_size: 1
+    - name: CITAMP5F
+      description: CITAMP5F
+      bit_offset: 20
+      bit_size: 1
+    - name: CITAMP6F
+      description: CITAMP6F
+      bit_offset: 21
+      bit_size: 1
+    - name: CITAMP7F
+      description: CITAMP7F
+      bit_offset: 22
+      bit_size: 1
+fieldset/SIDR:
+  description: EXTI Size ID register
+  fields:
+    - name: SID
+      description: Size Identification
+      bit_offset: 0
+      bit_size: 32
+fieldset/SR:
+  description: TAMP status register
+  fields:
+    - name: TAMP1F
+      description: TAMP1F
+      bit_offset: 0
+      bit_size: 1
+    - name: TAMP2F
+      description: TAMP2F
+      bit_offset: 1
+      bit_size: 1
+    - name: ITAMP1F
+      description: ITAMP1F
+      bit_offset: 16
+      bit_size: 1
+    - name: ITAMP3F
+      description: ITAMP3F
+      bit_offset: 18
+      bit_size: 1
+    - name: ITAMP4F
+      description: ITAMP4F
+      bit_offset: 19
+      bit_size: 1
+    - name: ITAMP5F
+      description: ITAMP5F
+      bit_offset: 20
+      bit_size: 1
+    - name: ITAMP6F
+      description: ITAMP6F
+      bit_offset: 21
+      bit_size: 1
+    - name: ITAMP7F
+      description: ITAMP7F
+      bit_offset: 22
+      bit_size: 1
+fieldset/VERR:
+  description: EXTI IP Version register
+  fields:
+    - name: MINREV
+      description: Minor Revision number
+      bit_offset: 0
+      bit_size: 4
+    - name: MAJREV
+      description: Major Revision number
+      bit_offset: 4
+      bit_size: 4

--- a/data/registers/tamp_g0.yaml
+++ b/data/registers/tamp_g0.yaml
@@ -74,78 +74,61 @@ fieldset/BKPR:
 fieldset/CR1:
   description: control register 1
   fields:
-    - name: TAMP1E
-      description: TAMP1E
+    - name: TAMPE
+      description: Tamper detection on IN X enable
       bit_offset: 0
       bit_size: 1
-    - name: TAMP2E
-      description: TAMP2E
-      bit_offset: 1
-      bit_size: 1
-    - name: ITAMP1E
-      description: ITAMP1E
+      array:
+        len: 2
+        stride: 1
+    - name: ITAMPE
+      description: Internal tamper X enable
       bit_offset: 16
       bit_size: 1
-    - name: ITAMP3E
-      description: ITAMP3E
-      bit_offset: 18
-      bit_size: 1
-    - name: ITAMP4E
-      description: ITAMP4E
-      bit_offset: 19
-      bit_size: 1
-    - name: ITAMP5E
-      description: ITAMP5E
-      bit_offset: 20
-      bit_size: 1
-    - name: ITAMP6E
-      description: ITAMP6E
-      bit_offset: 21
-      bit_size: 1
+      array:
+        len: 6
+        stride: 1
 fieldset/CR2:
   description: control register 2
   fields:
-    - name: TAMP1NOER
-      description: TAMP1NOER
+    - name: TAMPNOER
+      description: Tamper X no erase
       bit_offset: 0
       bit_size: 1
-    - name: TAMP2NOER
-      description: TAMP2NOER
-      bit_offset: 1
-      bit_size: 1
-    - name: TAMP1MSK
-      description: TAMP1MSK
+      array:
+        len: 2
+        stride: 1
+    - name: TAMPMSK
+      description: Tamper X mask
       bit_offset: 16
       bit_size: 1
-    - name: TAMP2MSK
-      description: TAMP2MSK
-      bit_offset: 17
-      bit_size: 1
-    - name: TAMP1TRG
-      description: TAMP1TRG
+      array:
+        len: 2
+        stride: 1
+    - name: TAMPTRG
+      description: Active level for tamper X input
       bit_offset: 24
       bit_size: 1
-    - name: TAMP2TRG
-      description: TAMP2TRG
-      bit_offset: 25
-      bit_size: 1
+      array:
+        len: 2
+        stride: 1
 fieldset/FLTCR:
   description: TAMP filter control register
   fields:
     - name: TAMPFREQ
-      description: TAMPFREQ
+      description: "Tamper sampling frequency. Determines the frequency at which each of the INx inputs are sampled."
       bit_offset: 0
       bit_size: 3
     - name: TAMPFLT
-      description: TAMPFLT
+      description: "INx filter count. These bits determines the number of consecutive samples at the specified level (TAMP*TRG) needed to activate a tamper event. TAMPFLT is valid for each of the INx inputs."
       bit_offset: 3
       bit_size: 2
     - name: TAMPPRCH
-      description: TAMPPRCH
+      description: "INx precharge duration. These bit determines the duration of time during which the pull-up/is activated before each sample. TAMPPRCH is valid for each of the INx inputs."
       bit_offset: 5
       bit_size: 2
     - name: TAMPPUDIS
-      description: TAMPPUDIS
+      description: "INx pull-up disable. This bit determines if each of the TAMPx pins are precharged before each sample."
       bit_offset: 7
       bit_size: 1
 fieldset/HWCFGR1:
@@ -181,34 +164,20 @@ fieldset/HWCFGR2:
 fieldset/IER:
   description: TAMP interrupt enable register
   fields:
-    - name: TAMP1IE
-      description: TAMP1IE
+    - name: TAMPIE
+      description: Tamper X interrupt enable
       bit_offset: 0
       bit_size: 1
-    - name: TAMP2IE
-      description: TAMP2IE
-      bit_offset: 1
-      bit_size: 1
-    - name: ITAMP1IE
-      description: ITAMP1IE
+      array:
+        len: 2
+        stride: 1
+    - name: ITAMPIE
+      description: Internal tamper X interrupt enable
       bit_offset: 16
       bit_size: 1
-    - name: ITAMP3IE
-      description: ITAMP3IE
-      bit_offset: 18
-      bit_size: 1
-    - name: ITAMP4IE
-      description: ITAMP4IE
-      bit_offset: 19
-      bit_size: 1
-    - name: ITAMP5IE
-      description: ITAMP5IE
-      bit_offset: 20
-      bit_size: 1
-    - name: ITAMP6IE
-      description: ITAMP6IE
-      bit_offset: 21
-      bit_size: 1
+      array:
+        len: 6
+        stride: 1
 fieldset/IPIDR:
   description: EXTI Identification register
   fields:
@@ -219,69 +188,37 @@ fieldset/IPIDR:
 fieldset/MISR:
   description: TAMP masked interrupt status register
   fields:
-    - name: TAMP1MF
-      description: "TAMP1MF:"
+    - name: TAMPMF
+      description: Tamper X interrupt masked flag
       bit_offset: 0
       bit_size: 1
-    - name: TAMP2MF
-      description: TAMP2MF
-      bit_offset: 1
-      bit_size: 1
-    - name: ITAMP1MF
-      description: ITAMP1MF
+      array:
+        len: 2
+        stride: 1
+    - name: ITAMPMF
+      description: Internal tamper X interrupt masked flag
       bit_offset: 16
       bit_size: 1
-    - name: ITAMP3MF
-      description: ITAMP3MF
-      bit_offset: 18
-      bit_size: 1
-    - name: ITAMP4MF
-      description: ITAMP4MF
-      bit_offset: 19
-      bit_size: 1
-    - name: ITAMP5MF
-      description: ITAMP5MF
-      bit_offset: 20
-      bit_size: 1
-    - name: ITAMP6MF
-      description: ITAMP6MF
-      bit_offset: 21
-      bit_size: 1
+      array:
+        len: 6
+        stride: 1
 fieldset/SCR:
   description: TAMP status clear register
   fields:
-    - name: CTAMP1F
-      description: CTAMP1F
+    - name: CTAMPF
+      description: Clear tamper X detection flag
       bit_offset: 0
       bit_size: 1
-    - name: CTAMP2F
-      description: CTAMP2F
-      bit_offset: 1
-      bit_size: 1
-    - name: CITAMP1F
-      description: CITAMP1F
+      array:
+        len: 2
+        stride: 1
+    - name: CITAMPF
+      description: Clear internal tamper X detection flag
       bit_offset: 16
       bit_size: 1
-    - name: CITAMP3F
-      description: CITAMP3F
-      bit_offset: 18
-      bit_size: 1
-    - name: CITAMP4F
-      description: CITAMP4F
-      bit_offset: 19
-      bit_size: 1
-    - name: CITAMP5F
-      description: CITAMP5F
-      bit_offset: 20
-      bit_size: 1
-    - name: CITAMP6F
-      description: CITAMP6F
-      bit_offset: 21
-      bit_size: 1
-    - name: CITAMP7F
-      description: CITAMP7F
-      bit_offset: 22
-      bit_size: 1
+      array:
+        len: 7
+        stride: 1
 fieldset/SIDR:
   description: EXTI Size ID register
   fields:
@@ -292,38 +229,20 @@ fieldset/SIDR:
 fieldset/SR:
   description: TAMP status register
   fields:
-    - name: TAMP1F
-      description: TAMP1F
+    - name: TAMPF
+      description: Tamper X detection flag
       bit_offset: 0
       bit_size: 1
-    - name: TAMP2F
-      description: TAMP2F
-      bit_offset: 1
-      bit_size: 1
-    - name: ITAMP1F
-      description: ITAMP1F
+      array:
+        len: 2
+        stride: 1
+    - name: ITAMPF
+      description: Internal tamper X detection flag
       bit_offset: 16
       bit_size: 1
-    - name: ITAMP3F
-      description: ITAMP3F
-      bit_offset: 18
-      bit_size: 1
-    - name: ITAMP4F
-      description: ITAMP4F
-      bit_offset: 19
-      bit_size: 1
-    - name: ITAMP5F
-      description: ITAMP5F
-      bit_offset: 20
-      bit_size: 1
-    - name: ITAMP6F
-      description: ITAMP6F
-      bit_offset: 21
-      bit_size: 1
-    - name: ITAMP7F
-      description: ITAMP7F
-      bit_offset: 22
-      bit_size: 1
+      array:
+        len: 7
+        stride: 1
 fieldset/VERR:
   description: EXTI IP Version register
   fields:

--- a/data/registers/tamp_g4.yaml
+++ b/data/registers/tamp_g4.yaml
@@ -1,0 +1,260 @@
+block/TAMP:
+  description: Tamper and backup registers
+  items:
+    - name: CR1
+      description: control register 1
+      byte_offset: 0
+      fieldset: CR1
+    - name: CR2
+      description: control register 2
+      byte_offset: 4
+      fieldset: CR2
+    - name: FLTCR
+      description: TAMP filter control register
+      byte_offset: 12
+      fieldset: FLTCR
+    - name: IER
+      description: TAMP interrupt enable register
+      byte_offset: 44
+      fieldset: IER
+    - name: SR
+      description: TAMP status register
+      byte_offset: 48
+      access: Read
+      fieldset: SR
+    - name: MISR
+      description: TAMP masked interrupt status register
+      byte_offset: 52
+      access: Read
+      fieldset: MISR
+    - name: SCR
+      description: TAMP status clear register
+      byte_offset: 60
+      fieldset: SCR
+    - name: BKPR
+      description: TAMP backup register
+      array:
+        len: 32
+        stride: 4
+      byte_offset: 256
+      fieldset: BKPR
+fieldset/BKPR:
+  description: TAMP backup register
+  fields:
+    - name: BKP
+      description: BKP
+      bit_offset: 0
+      bit_size: 32
+fieldset/CR1:
+  description: control register 1
+  fields:
+    - name: TAMP1E
+      description: TAMP1E
+      bit_offset: 0
+      bit_size: 1
+    - name: TAMP2E
+      description: TAMP2E
+      bit_offset: 1
+      bit_size: 1
+    - name: TAMP3E
+      description: TAMP2E
+      bit_offset: 2
+      bit_size: 1
+    - name: ITAMP3E
+      description: ITAMP3E
+      bit_offset: 18
+      bit_size: 1
+    - name: ITAMP4E
+      description: ITAMP4E
+      bit_offset: 19
+      bit_size: 1
+    - name: ITAMP5E
+      description: ITAMP5E
+      bit_offset: 20
+      bit_size: 1
+    - name: ITAMP6E
+      description: ITAMP6E
+      bit_offset: 21
+      bit_size: 1
+fieldset/CR2:
+  description: control register 2
+  fields:
+    - name: TAMP1NOER
+      description: TAMP1NOER
+      bit_offset: 0
+      bit_size: 1
+    - name: TAMP2NOER
+      description: TAMP2NOER
+      bit_offset: 1
+      bit_size: 1
+    - name: TAMP3NOER
+      description: TAMP3NOER
+      bit_offset: 2
+      bit_size: 1
+    - name: TAMP1MSK
+      description: TAMP1MSK
+      bit_offset: 16
+      bit_size: 1
+    - name: TAMP2MSK
+      description: TAMP2MSK
+      bit_offset: 17
+      bit_size: 1
+    - name: TAMP3MSK
+      description: TAMP3MSK
+      bit_offset: 18
+      bit_size: 1
+    - name: TAMP1TRG
+      description: TAMP1TRG
+      bit_offset: 24
+      bit_size: 1
+    - name: TAMP2TRG
+      description: TAMP2TRG
+      bit_offset: 25
+      bit_size: 1
+    - name: TAMP3TRG
+      description: TAMP3TRG
+      bit_offset: 26
+      bit_size: 1
+fieldset/FLTCR:
+  description: TAMP filter control register
+  fields:
+    - name: TAMPFREQ
+      description: TAMPFREQ
+      bit_offset: 0
+      bit_size: 3
+    - name: TAMPFLT
+      description: TAMPFLT
+      bit_offset: 3
+      bit_size: 2
+    - name: TAMPPRCH
+      description: TAMPPRCH
+      bit_offset: 5
+      bit_size: 2
+    - name: TAMPPUDIS
+      description: TAMPPUDIS
+      bit_offset: 7
+      bit_size: 1
+fieldset/IER:
+  description: TAMP interrupt enable register
+  fields:
+    - name: TAMP1IE
+      description: TAMP1IE
+      bit_offset: 0
+      bit_size: 1
+    - name: TAMP2IE
+      description: TAMP2IE
+      bit_offset: 1
+      bit_size: 1
+    - name: TAMP3IE
+      description: TAMP3IE
+      bit_offset: 2
+      bit_size: 1
+    - name: ITAMP3IE
+      description: ITAMP3IE
+      bit_offset: 18
+      bit_size: 1
+    - name: ITAMP4IE
+      description: ITAMP4IE
+      bit_offset: 19
+      bit_size: 1
+    - name: ITAMP5IE
+      description: ITAMP5IE
+      bit_offset: 20
+      bit_size: 1
+    - name: ITAMP6IE
+      description: ITAMP6IE
+      bit_offset: 21
+      bit_size: 1
+fieldset/MISR:
+  description: TAMP masked interrupt status register
+  fields:
+    - name: TAMP1MF
+      description: "TAMP1MF:"
+      bit_offset: 0
+      bit_size: 1
+    - name: TAMP2MF
+      description: TAMP2MF
+      bit_offset: 1
+      bit_size: 1
+    - name: TAMP3MF
+      description: TAMP3MF
+      bit_offset: 2
+      bit_size: 1
+    - name: ITAMP3MF
+      description: ITAMP3MF
+      bit_offset: 18
+      bit_size: 1
+    - name: ITAMP4MF
+      description: ITAMP4MF
+      bit_offset: 19
+      bit_size: 1
+    - name: ITAMP5MF
+      description: ITAMP5MF
+      bit_offset: 20
+      bit_size: 1
+    - name: ITAMP6MF
+      description: ITAMP6MF
+      bit_offset: 21
+      bit_size: 1
+fieldset/SCR:
+  description: TAMP status clear register
+  fields:
+    - name: CTAMP1F
+      description: CTAMP1F
+      bit_offset: 0
+      bit_size: 1
+    - name: CTAMP2F
+      description: CTAMP2F
+      bit_offset: 1
+      bit_size: 1
+    - name: CTAMP3F
+      description: CTAMP3F
+      bit_offset: 2
+      bit_size: 1
+    - name: CITAMP3F
+      description: CITAMP3F
+      bit_offset: 18
+      bit_size: 1
+    - name: CITAMP4F
+      description: CITAMP4F
+      bit_offset: 19
+      bit_size: 1
+    - name: CITAMP5F
+      description: CITAMP5F
+      bit_offset: 20
+      bit_size: 1
+    - name: CITAMP6F
+      description: CITAMP6F
+      bit_offset: 21
+      bit_size: 1
+fieldset/SR:
+  description: TAMP status register
+  fields:
+    - name: TAMP1F
+      description: TAMP1F
+      bit_offset: 0
+      bit_size: 1
+    - name: TAMP2F
+      description: TAMP2F
+      bit_offset: 1
+      bit_size: 1
+    - name: TAMP3F
+      description: TAMP3F
+      bit_offset: 2
+      bit_size: 1
+    - name: ITAMP3F
+      description: ITAMP3F
+      bit_offset: 18
+      bit_size: 1
+    - name: ITAMP4F
+      description: ITAMP4F
+      bit_offset: 19
+      bit_size: 1
+    - name: ITAMP5F
+      description: ITAMP5F
+      bit_offset: 20
+      bit_size: 1
+    - name: ITAMP6F
+      description: ITAMP6F
+      bit_offset: 21
+      bit_size: 1

--- a/data/registers/tamp_g4.yaml
+++ b/data/registers/tamp_g4.yaml
@@ -48,213 +48,128 @@ fieldset/BKPR:
 fieldset/CR1:
   description: control register 1
   fields:
-    - name: TAMP1E
-      description: TAMP1E
+    - name: TAMPE
+      description: Tamper detection on IN X enable
       bit_offset: 0
       bit_size: 1
-    - name: TAMP2E
-      description: TAMP2E
-      bit_offset: 1
+      array:
+        len: 3
+        stride: 1
+    - name: ITAMPE
+      description: Internal tamper X enable
+      bit_offset: 16
       bit_size: 1
-    - name: TAMP3E
-      description: TAMP2E
-      bit_offset: 2
-      bit_size: 1
-    - name: ITAMP3E
-      description: ITAMP3E
-      bit_offset: 18
-      bit_size: 1
-    - name: ITAMP4E
-      description: ITAMP4E
-      bit_offset: 19
-      bit_size: 1
-    - name: ITAMP5E
-      description: ITAMP5E
-      bit_offset: 20
-      bit_size: 1
-    - name: ITAMP6E
-      description: ITAMP6E
-      bit_offset: 21
-      bit_size: 1
+      array:
+        len: 6
+        stride: 1
 fieldset/CR2:
   description: control register 2
   fields:
-    - name: TAMP1NOER
-      description: TAMP1NOER
+    - name: TAMPNOER
+      description: Tamper X no erase
       bit_offset: 0
       bit_size: 1
-    - name: TAMP2NOER
-      description: TAMP2NOER
-      bit_offset: 1
-      bit_size: 1
-    - name: TAMP3NOER
-      description: TAMP3NOER
-      bit_offset: 2
-      bit_size: 1
-    - name: TAMP1MSK
-      description: TAMP1MSK
+      array:
+        len: 3
+        stride: 1
+    - name: TAMPMSK
+      description: Tamper X mask.
       bit_offset: 16
       bit_size: 1
-    - name: TAMP2MSK
-      description: TAMP2MSK
-      bit_offset: 17
-      bit_size: 1
-    - name: TAMP3MSK
-      description: TAMP3MSK
-      bit_offset: 18
-      bit_size: 1
-    - name: TAMP1TRG
-      description: TAMP1TRG
+      array:
+        len: 3
+        stride: 1
+    - name: TAMPTRG
+      description: Active level for tamper X input.
       bit_offset: 24
       bit_size: 1
-    - name: TAMP2TRG
-      description: TAMP2TRG
-      bit_offset: 25
-      bit_size: 1
-    - name: TAMP3TRG
-      description: TAMP3TRG
-      bit_offset: 26
-      bit_size: 1
+      array:
+        len: 3
+        stride: 1
 fieldset/FLTCR:
   description: TAMP filter control register
   fields:
     - name: TAMPFREQ
-      description: TAMPFREQ
+      description: "Tamper sampling frequency. Determines the frequency at which each of the INx inputs are sampled."
       bit_offset: 0
       bit_size: 3
     - name: TAMPFLT
-      description: TAMPFLT
+      description: "INx filter count. These bits determines the number of consecutive samples at the specified level (TAMP*TRG) needed to activate a tamper event. TAMPFLT is valid for each of the INx inputs."
       bit_offset: 3
       bit_size: 2
     - name: TAMPPRCH
-      description: TAMPPRCH
+      description: "INx precharge duration. These bit determines the duration of time during which the pull-up/is activated before each sample. TAMPPRCH is valid for each of the INx inputs."
       bit_offset: 5
       bit_size: 2
     - name: TAMPPUDIS
-      description: TAMPPUDIS
+      description: "INx pull-up disable. This bit determines if each of the TAMPx pins are precharged before each sample."
       bit_offset: 7
       bit_size: 1
 fieldset/IER:
   description: TAMP interrupt enable register
   fields:
-    - name: TAMP1IE
-      description: TAMP1IE
+    - name: TAMPIE
+      description: Tamper X interrupt enable
       bit_offset: 0
       bit_size: 1
-    - name: TAMP2IE
-      description: TAMP2IE
-      bit_offset: 1
+      array:
+        len: 3
+        stride: 1
+    - name: ITAMPIE
+      description: Internal tamper X interrupt enable
+      bit_offset: 16
       bit_size: 1
-    - name: TAMP3IE
-      description: TAMP3IE
-      bit_offset: 2
-      bit_size: 1
-    - name: ITAMP3IE
-      description: ITAMP3IE
-      bit_offset: 18
-      bit_size: 1
-    - name: ITAMP4IE
-      description: ITAMP4IE
-      bit_offset: 19
-      bit_size: 1
-    - name: ITAMP5IE
-      description: ITAMP5IE
-      bit_offset: 20
-      bit_size: 1
-    - name: ITAMP6IE
-      description: ITAMP6IE
-      bit_offset: 21
-      bit_size: 1
+      array:
+        len: 6
+        stride: 1
 fieldset/MISR:
   description: TAMP masked interrupt status register
   fields:
-    - name: TAMP1MF
-      description: "TAMP1MF:"
+    - name: TAMPMF
+      description: Tamper X interrupt masked flag
       bit_offset: 0
       bit_size: 1
-    - name: TAMP2MF
-      description: TAMP2MF
-      bit_offset: 1
+      array:
+        len: 3
+        stride: 1
+    - name: ITAMPMF
+      description: Internal tamper X interrupt masked flag
+      bit_offset: 16
       bit_size: 1
-    - name: TAMP3MF
-      description: TAMP3MF
-      bit_offset: 2
-      bit_size: 1
-    - name: ITAMP3MF
-      description: ITAMP3MF
-      bit_offset: 18
-      bit_size: 1
-    - name: ITAMP4MF
-      description: ITAMP4MF
-      bit_offset: 19
-      bit_size: 1
-    - name: ITAMP5MF
-      description: ITAMP5MF
-      bit_offset: 20
-      bit_size: 1
-    - name: ITAMP6MF
-      description: ITAMP6MF
-      bit_offset: 21
-      bit_size: 1
+      array:
+        len: 6
+        stride: 1
 fieldset/SCR:
   description: TAMP status clear register
   fields:
-    - name: CTAMP1F
-      description: CTAMP1F
+    - name: CTAMPF
+      description: Clear tamper X detection flag
       bit_offset: 0
       bit_size: 1
-    - name: CTAMP2F
-      description: CTAMP2F
-      bit_offset: 1
+      array:
+        len: 3
+        stride: 1
+    - name: CITAMPF
+      description: Clear internal tamper X detection flag
+      bit_offset: 16
       bit_size: 1
-    - name: CTAMP3F
-      description: CTAMP3F
-      bit_offset: 2
-      bit_size: 1
-    - name: CITAMP3F
-      description: CITAMP3F
-      bit_offset: 18
-      bit_size: 1
-    - name: CITAMP4F
-      description: CITAMP4F
-      bit_offset: 19
-      bit_size: 1
-    - name: CITAMP5F
-      description: CITAMP5F
-      bit_offset: 20
-      bit_size: 1
-    - name: CITAMP6F
-      description: CITAMP6F
-      bit_offset: 21
-      bit_size: 1
+      array:
+        len: 6
+        stride: 1
 fieldset/SR:
   description: TAMP status register
   fields:
-    - name: TAMP1F
-      description: TAMP1F
+    - name: TAMPF
+      description: Tamper X detection flag
       bit_offset: 0
       bit_size: 1
-    - name: TAMP2F
-      description: TAMP2F
-      bit_offset: 1
+      array:
+        len: 3
+        stride: 1
+    - name: ITAMPF
+      description: Internal tamper X detection flag
+      bit_offset: 16
       bit_size: 1
-    - name: TAMP3F
-      description: TAMP3F
-      bit_offset: 2
-      bit_size: 1
-    - name: ITAMP3F
-      description: ITAMP3F
-      bit_offset: 18
-      bit_size: 1
-    - name: ITAMP4F
-      description: ITAMP4F
-      bit_offset: 19
-      bit_size: 1
-    - name: ITAMP5F
-      description: ITAMP5F
-      bit_offset: 20
-      bit_size: 1
-    - name: ITAMP6F
-      description: ITAMP6F
-      bit_offset: 21
-      bit_size: 1
+      array:
+        len: 6
+        stride: 1

--- a/data/registers/tamp_l5.yaml
+++ b/data/registers/tamp_l5.yaml
@@ -1,0 +1,723 @@
+block/TAMP:
+  description: Tamper and backup registers
+  items:
+    - name: CR1
+      description: control register 1
+      byte_offset: 0
+      fieldset: CR1
+    - name: CR2
+      description: control register 2
+      byte_offset: 4
+      fieldset: CR2
+    - name: CR3
+      description: control register 3
+      byte_offset: 8
+      fieldset: CR3
+    - name: FLTCR
+      description: TAMP filter control register
+      byte_offset: 12
+      fieldset: FLTCR
+    - name: ATCR1
+      description: TAMP active tamper control register 1
+      byte_offset: 16
+      fieldset: ATCR1
+    - name: ATSEEDR
+      description: TAMP active tamper seed register
+      byte_offset: 20
+      access: Write
+      fieldset: ATSEEDR
+    - name: ATOR
+      description: TAMP active tamper output register
+      byte_offset: 24
+      access: Read
+      fieldset: ATOR
+    - name: ATCR2
+      description: TAMP active tamper control register 2
+      byte_offset: 28
+      fieldset: ATCR2
+    - name: SMCR
+      description: TAMP secure mode register
+      byte_offset: 32
+      fieldset: SMCR
+    - name: PRIVCR
+      description: TAMP privilege mode control register
+      byte_offset: 36
+      fieldset: PRIVCR
+    - name: IER
+      description: TAMP interrupt enable register
+      byte_offset: 44
+      fieldset: IER
+    - name: SR
+      description: TAMP status register
+      byte_offset: 48
+      access: Read
+      fieldset: SR
+    - name: MISR
+      description: " TAMP masked interrupt status register "
+      byte_offset: 52
+      access: Read
+      fieldset: MISR
+    - name: SMISR
+      description: TAMP secure masked interrupt status register
+      byte_offset: 56
+      access: Read
+      fieldset: SMISR
+    - name: SCR
+      description: TAMP status clear register
+      byte_offset: 60
+      access: Write
+      fieldset: SCR
+    - name: COUNTR
+      description: TAMP monotonic counter register
+      byte_offset: 64
+      access: Read
+      fieldset: COUNTR
+    - name: CFGR
+      description: TAMP configuration register
+      byte_offset: 80
+      fieldset: CFGR
+    - name: BKPR
+      description: TAMP backup register
+      array:
+        len: 32
+        stride: 4
+      byte_offset: 256
+      fieldset: BKPR
+fieldset/ATCR1:
+  description: TAMP active tamper control register 1
+  fields:
+    - name: TAMP1AM
+      description: TAMP1AM
+      bit_offset: 0
+      bit_size: 1
+    - name: TAMP2AM
+      description: TAMP2AM
+      bit_offset: 1
+      bit_size: 1
+    - name: TAMP3AM
+      description: TAMP3AM
+      bit_offset: 2
+      bit_size: 1
+    - name: TAMP4AM
+      description: TAMP4AM
+      bit_offset: 3
+      bit_size: 1
+    - name: TAMP5AM
+      description: TAMP5AM
+      bit_offset: 4
+      bit_size: 1
+    - name: TAMP6AM
+      description: TAMP6AM
+      bit_offset: 5
+      bit_size: 1
+    - name: TAMP7AM
+      description: TAMP7AM
+      bit_offset: 6
+      bit_size: 1
+    - name: TAMP8AM
+      description: TAMP8AM
+      bit_offset: 7
+      bit_size: 1
+    - name: ATOSEL1
+      description: ATOSEL1
+      bit_offset: 8
+      bit_size: 2
+    - name: ATOSEL2
+      description: ATOSEL2
+      bit_offset: 10
+      bit_size: 2
+    - name: ATOSEL3
+      description: ATOSEL3
+      bit_offset: 12
+      bit_size: 2
+    - name: ATOSEL4
+      description: ATOSEL4
+      bit_offset: 14
+      bit_size: 2
+    - name: ATCKSEL
+      description: ATCKSEL
+      bit_offset: 16
+      bit_size: 2
+    - name: ATPER
+      description: ATPER
+      bit_offset: 24
+      bit_size: 2
+    - name: ATOSHARE
+      description: ATOSHARE
+      bit_offset: 30
+      bit_size: 1
+    - name: FLTEN
+      description: FLTEN
+      bit_offset: 31
+      bit_size: 1
+fieldset/ATCR2:
+  description: TAMP active tamper control register 2
+  fields:
+    - name: ATOSEL1
+      description: ATOSEL1
+      bit_offset: 8
+      bit_size: 3
+    - name: ATOSEL2
+      description: ATOSEL2
+      bit_offset: 11
+      bit_size: 3
+    - name: ATOSEL3
+      description: ATOSEL3
+      bit_offset: 14
+      bit_size: 3
+    - name: ATOSEL4
+      description: ATOSEL4
+      bit_offset: 17
+      bit_size: 3
+    - name: ATOSEL5
+      description: ATOSEL5
+      bit_offset: 20
+      bit_size: 3
+    - name: ATOSEL6
+      description: ATOSEL6
+      bit_offset: 23
+      bit_size: 3
+    - name: ATOSEL7
+      description: ATOSEL7
+      bit_offset: 26
+      bit_size: 3
+    - name: ATOSEL8
+      description: ATOSEL8
+      bit_offset: 29
+      bit_size: 3
+fieldset/ATOR:
+  description: TAMP active tamper output register
+  fields:
+    - name: PRNG
+      description: Pseudo-random generator value
+      bit_offset: 0
+      bit_size: 8
+    - name: SEEDF
+      description: Seed running flag
+      bit_offset: 14
+      bit_size: 1
+    - name: INITS
+      description: Active tamper initialization status
+      bit_offset: 15
+      bit_size: 1
+fieldset/ATSEEDR:
+  description: TAMP active tamper seed register
+  fields:
+    - name: SEED
+      description: Pseudo-random generator seed value
+      bit_offset: 0
+      bit_size: 32
+fieldset/BKPR:
+  description: TAMP backup register
+  fields:
+    - name: BKP
+      description: BKP
+      bit_offset: 0
+      bit_size: 32
+fieldset/CFGR:
+  description: TAMP configuration register
+  fields:
+    - name: TMONEN
+      description: TMONEN
+      bit_offset: 1
+      bit_size: 1
+    - name: VMONEN
+      description: VMONEN
+      bit_offset: 2
+      bit_size: 1
+    - name: WUTMONEN
+      description: WUTMONEN
+      bit_offset: 3
+      bit_size: 1
+fieldset/COUNTR:
+  description: TAMP monotonic counter register
+  fields:
+    - name: COUNT
+      description: COUNT
+      bit_offset: 0
+      bit_size: 32
+fieldset/CR1:
+  description: control register 1
+  fields:
+    - name: TAMP1E
+      description: TAMP1E
+      bit_offset: 0
+      bit_size: 1
+    - name: TAMP2E
+      description: TAMP2E
+      bit_offset: 1
+      bit_size: 1
+    - name: TAMP3E
+      description: TAMP3E
+      bit_offset: 2
+      bit_size: 1
+    - name: TAMP4E
+      description: TAMP4E
+      bit_offset: 3
+      bit_size: 1
+    - name: TAMP5E
+      description: TAMP5E
+      bit_offset: 4
+      bit_size: 1
+    - name: TAMP6E
+      description: TAMP6E
+      bit_offset: 5
+      bit_size: 1
+    - name: TAMP7E
+      description: TAMP7E
+      bit_offset: 6
+      bit_size: 1
+    - name: TAMP8E
+      description: TAMP8E
+      bit_offset: 7
+      bit_size: 1
+    - name: ITAMP1E
+      description: ITAMP1E
+      bit_offset: 16
+      bit_size: 1
+    - name: ITAMP2E
+      description: ITAMP2E
+      bit_offset: 17
+      bit_size: 1
+    - name: ITAMP3E
+      description: ITAMP3E
+      bit_offset: 18
+      bit_size: 1
+    - name: ITAMP5E
+      description: ITAMP5E
+      bit_offset: 20
+      bit_size: 1
+    - name: ITAMP8E
+      description: ITAMP5E
+      bit_offset: 23
+      bit_size: 1
+fieldset/CR2:
+  description: control register 2
+  fields:
+    - name: TAMP1NOER
+      description: TAMP1NOER
+      bit_offset: 0
+      bit_size: 1
+    - name: TAMP2NOER
+      description: TAMP2NOER
+      bit_offset: 1
+      bit_size: 1
+    - name: TAMP3NOER
+      description: TAMP3NOER
+      bit_offset: 2
+      bit_size: 1
+    - name: TAMP4NOER
+      description: TAMP4NOER
+      bit_offset: 3
+      bit_size: 1
+    - name: TAMP5NOER
+      description: TAMP5NOER
+      bit_offset: 4
+      bit_size: 1
+    - name: TAMP6NOER
+      description: TAMP6NOER
+      bit_offset: 5
+      bit_size: 1
+    - name: TAMP7NOER
+      description: TAMP7NOER
+      bit_offset: 6
+      bit_size: 1
+    - name: TAMP8NOER
+      description: TAMP8NOER
+      bit_offset: 7
+      bit_size: 1
+    - name: TAMP1MSK
+      description: TAMP1MSK
+      bit_offset: 16
+      bit_size: 1
+    - name: TAMP2MSK
+      description: TAMP2MSK
+      bit_offset: 17
+      bit_size: 1
+    - name: TAMP3MSK
+      description: TAMP3MSK
+      bit_offset: 18
+      bit_size: 1
+    - name: BKERASE
+      description: BKERASE
+      bit_offset: 23
+      bit_size: 1
+    - name: TAMP1TRG
+      description: TAMP1TRG
+      bit_offset: 24
+      bit_size: 1
+    - name: TAMP2TRG
+      description: TAMP2TRG
+      bit_offset: 25
+      bit_size: 1
+    - name: TAMP3TRG
+      description: TAMP3TRG
+      bit_offset: 26
+      bit_size: 1
+    - name: TAMP4TRG
+      description: TAMP4TRG
+      bit_offset: 27
+      bit_size: 1
+    - name: TAMP5TRG
+      description: TAMP5TRG
+      bit_offset: 28
+      bit_size: 1
+    - name: TAMP6TRG
+      description: TAMP6TRG
+      bit_offset: 29
+      bit_size: 1
+    - name: TAMP7TRG
+      description: TAMP7TRG
+      bit_offset: 30
+      bit_size: 1
+    - name: TAMP8TRG
+      description: TAMP8TRG
+      bit_offset: 31
+      bit_size: 1
+fieldset/CR3:
+  description: control register 3
+  fields:
+    - name: ITAMP1NOER
+      description: ITAMP1NOER
+      bit_offset: 0
+      bit_size: 1
+    - name: ITAMP2NOER
+      description: ITAMP2NOER
+      bit_offset: 1
+      bit_size: 1
+    - name: ITAMP3NOER
+      description: ITAMP3NOER
+      bit_offset: 2
+      bit_size: 1
+    - name: ITAMP5NOER
+      description: ITAMP5NOER
+      bit_offset: 4
+      bit_size: 1
+    - name: ITAMP8NOER
+      description: ITAMP8NOER
+      bit_offset: 7
+      bit_size: 1
+fieldset/FLTCR:
+  description: TAMP filter control register
+  fields:
+    - name: TAMPFREQ
+      description: TAMPFREQ
+      bit_offset: 0
+      bit_size: 3
+    - name: TAMPFLT
+      description: TAMPFLT
+      bit_offset: 3
+      bit_size: 2
+    - name: TAMPPRCH
+      description: TAMPPRCH
+      bit_offset: 5
+      bit_size: 2
+    - name: TAMPPUDIS
+      description: TAMPPUDIS
+      bit_offset: 7
+      bit_size: 1
+fieldset/IER:
+  description: TAMP interrupt enable register
+  fields:
+    - name: TAMP1IE
+      description: TAMP1IE
+      bit_offset: 0
+      bit_size: 1
+    - name: TAMP2IE
+      description: TAMP2IE
+      bit_offset: 1
+      bit_size: 1
+    - name: TAMP3IE
+      description: TAMP3IE
+      bit_offset: 2
+      bit_size: 1
+    - name: TAMP4IE
+      description: TAMP4IE
+      bit_offset: 3
+      bit_size: 1
+    - name: TAMP5IE
+      description: TAMP5IE
+      bit_offset: 4
+      bit_size: 1
+    - name: TAMP6IE
+      description: TAMP6IE
+      bit_offset: 5
+      bit_size: 1
+    - name: TAMP7IE
+      description: TAMP7IE
+      bit_offset: 6
+      bit_size: 1
+    - name: TAMP8IE
+      description: TAMP8IE
+      bit_offset: 7
+      bit_size: 1
+    - name: ITAMP1IE
+      description: ITAMP1IE
+      bit_offset: 16
+      bit_size: 1
+    - name: ITAMP2IE
+      description: ITAMP2IE
+      bit_offset: 17
+      bit_size: 1
+    - name: ITAMP3IE
+      description: ITAMP3IE
+      bit_offset: 18
+      bit_size: 1
+    - name: ITAMP5IE
+      description: ITAMP5IE
+      bit_offset: 20
+      bit_size: 1
+    - name: ITAMP8IE
+      description: ITAMP8IE
+      bit_offset: 23
+      bit_size: 1
+fieldset/MISR:
+  description: " TAMP masked interrupt status register "
+  fields:
+    - name: TAMP1MF
+      description: "TAMP1MF:"
+      bit_offset: 0
+      bit_size: 1
+    - name: TAMP2MF
+      description: TAMP2MF
+      bit_offset: 1
+      bit_size: 1
+    - name: TAMP3MF
+      description: TAMP3MF
+      bit_offset: 2
+      bit_size: 1
+    - name: TAMP4MF
+      description: TAMP4MF
+      bit_offset: 3
+      bit_size: 1
+    - name: TAMP5MF
+      description: TAMP5MF
+      bit_offset: 4
+      bit_size: 1
+    - name: TAMP6MF
+      description: TAMP6MF
+      bit_offset: 5
+      bit_size: 1
+    - name: TAMP7MF
+      description: "TAMP7MF:"
+      bit_offset: 6
+      bit_size: 1
+    - name: TAMP8MF
+      description: TAMP8MF
+      bit_offset: 7
+      bit_size: 1
+    - name: ITAMP1MF
+      description: ITAMP1MF
+      bit_offset: 16
+      bit_size: 1
+    - name: ITAMP2MF
+      description: ITAMP2MF
+      bit_offset: 17
+      bit_size: 1
+    - name: ITAMP3MF
+      description: ITAMP3MF
+      bit_offset: 18
+      bit_size: 1
+    - name: ITAMP5MF
+      description: ITAMP5MF
+      bit_offset: 20
+      bit_size: 1
+    - name: ITAMP8MF
+      description: ITAMP8MF
+      bit_offset: 23
+      bit_size: 1
+fieldset/PRIVCR:
+  description: TAMP privilege mode control register
+  fields:
+    - name: BKPRWPRIV
+      description: Backup registers zone 1 privilege protection
+      bit_offset: 29
+      bit_size: 1
+    - name: BKPWPRIV
+      description: Backup registers zone 2 privilege protection
+      bit_offset: 30
+      bit_size: 1
+    - name: TAMPPRIV
+      description: Tamper privilege protection
+      bit_offset: 31
+      bit_size: 1
+fieldset/SCR:
+  description: TAMP status clear register
+  fields:
+    - name: CTAMP1F
+      description: CTAMP1F
+      bit_offset: 0
+      bit_size: 1
+    - name: CTAMP2F
+      description: CTAMP2F
+      bit_offset: 1
+      bit_size: 1
+    - name: CTAMP3F
+      description: CTAMP3F
+      bit_offset: 2
+      bit_size: 1
+    - name: CTAMP4F
+      description: CTAMP4F
+      bit_offset: 3
+      bit_size: 1
+    - name: CTAMP5F
+      description: CTAMP5F
+      bit_offset: 4
+      bit_size: 1
+    - name: CTAMP6F
+      description: CTAMP6F
+      bit_offset: 5
+      bit_size: 1
+    - name: CTAMP7F
+      description: CTAMP7F
+      bit_offset: 6
+      bit_size: 1
+    - name: CTAMP8F
+      description: CTAMP8F
+      bit_offset: 7
+      bit_size: 1
+    - name: CITAMP1F
+      description: CITAMP1F
+      bit_offset: 16
+      bit_size: 1
+    - name: CITAMP2F
+      description: CITAMP2F
+      bit_offset: 17
+      bit_size: 1
+    - name: CITAMP3F
+      description: CITAMP3F
+      bit_offset: 18
+      bit_size: 1
+    - name: CITAMP5F
+      description: CITAMP5F
+      bit_offset: 20
+      bit_size: 1
+    - name: CITAMP8F
+      description: CITAMP8F
+      bit_offset: 23
+      bit_size: 1
+fieldset/SMCR:
+  description: TAMP secure mode register
+  fields:
+    - name: BKPRWDPROT
+      description: Backup registers read/write protection offset
+      bit_offset: 0
+      bit_size: 8
+    - name: BKPWDPROT
+      description: Backup registers write protection offset
+      bit_offset: 16
+      bit_size: 8
+    - name: TAMPDPROT
+      description: Tamper protection
+      bit_offset: 31
+      bit_size: 1
+fieldset/SMISR:
+  description: TAMP secure masked interrupt status register
+  fields:
+    - name: TAMP1MF
+      description: "TAMP1MF:"
+      bit_offset: 0
+      bit_size: 1
+    - name: TAMP2MF
+      description: TAMP2MF
+      bit_offset: 1
+      bit_size: 1
+    - name: TAMP3MF
+      description: TAMP3MF
+      bit_offset: 2
+      bit_size: 1
+    - name: TAMP4MF
+      description: TAMP4MF
+      bit_offset: 3
+      bit_size: 1
+    - name: TAMP5MF
+      description: TAMP5MF
+      bit_offset: 4
+      bit_size: 1
+    - name: TAMP6MF
+      description: TAMP6MF
+      bit_offset: 5
+      bit_size: 1
+    - name: TAMP7MF
+      description: "TAMP7MF:"
+      bit_offset: 6
+      bit_size: 1
+    - name: TAMP8MF
+      description: TAMP8MF
+      bit_offset: 7
+      bit_size: 1
+    - name: ITAMP1MF
+      description: ITAMP1MF
+      bit_offset: 16
+      bit_size: 1
+    - name: ITAMP2MF
+      description: ITAMP2MF
+      bit_offset: 17
+      bit_size: 1
+    - name: ITAMP3MF
+      description: ITAMP3MF
+      bit_offset: 18
+      bit_size: 1
+    - name: ITAMP5MF
+      description: ITAMP5MF
+      bit_offset: 20
+      bit_size: 1
+    - name: ITAMP8MF
+      description: ITAMP8MF
+      bit_offset: 23
+      bit_size: 1
+fieldset/SR:
+  description: TAMP status register
+  fields:
+    - name: TAMP1F
+      description: TAMP1F
+      bit_offset: 0
+      bit_size: 1
+    - name: TAMP2F
+      description: TAMP2F
+      bit_offset: 1
+      bit_size: 1
+    - name: TAMP3F
+      description: TAMP3F
+      bit_offset: 2
+      bit_size: 1
+    - name: TAMP4F
+      description: TAMP4F
+      bit_offset: 3
+      bit_size: 1
+    - name: TAMP5F
+      description: TAMP5F
+      bit_offset: 4
+      bit_size: 1
+    - name: TAMP6F
+      description: TAMP6F
+      bit_offset: 5
+      bit_size: 1
+    - name: TAMP7F
+      description: TAMP7F
+      bit_offset: 6
+      bit_size: 1
+    - name: TAMP8F
+      description: TAMP8F
+      bit_offset: 7
+      bit_size: 1
+    - name: ITAMP1F
+      description: ITAMP1F
+      bit_offset: 16
+      bit_size: 1
+    - name: ITAMP2F
+      description: ITAMP2F
+      bit_offset: 17
+      bit_size: 1
+    - name: ITAMP3F
+      description: ITAMP3F
+      bit_offset: 18
+      bit_size: 1
+    - name: ITAMP5F
+      description: ITAMP5F
+      bit_offset: 20
+      bit_size: 1
+    - name: ITAMP8F
+      description: ITAMP8F
+      bit_offset: 23
+      bit_size: 1

--- a/data/registers/tamp_l5.yaml
+++ b/data/registers/tamp_l5.yaml
@@ -86,54 +86,20 @@ block/TAMP:
 fieldset/ATCR1:
   description: TAMP active tamper control register 1
   fields:
-    - name: TAMP1AM
-      description: TAMP1AM
+    - name: TAMPAM
+      description: TAMPAM
       bit_offset: 0
       bit_size: 1
-    - name: TAMP2AM
-      description: TAMP2AM
-      bit_offset: 1
-      bit_size: 1
-    - name: TAMP3AM
-      description: TAMP3AM
-      bit_offset: 2
-      bit_size: 1
-    - name: TAMP4AM
-      description: TAMP4AM
-      bit_offset: 3
-      bit_size: 1
-    - name: TAMP5AM
-      description: TAMP5AM
-      bit_offset: 4
-      bit_size: 1
-    - name: TAMP6AM
-      description: TAMP6AM
-      bit_offset: 5
-      bit_size: 1
-    - name: TAMP7AM
-      description: TAMP7AM
-      bit_offset: 6
-      bit_size: 1
-    - name: TAMP8AM
-      description: TAMP8AM
-      bit_offset: 7
-      bit_size: 1
-    - name: ATOSEL1
-      description: ATOSEL1
+      array:
+        len: 8
+        stride: 1
+    - name: ATOSEL
+      description: ATOSEL
       bit_offset: 8
       bit_size: 2
-    - name: ATOSEL2
-      description: ATOSEL2
-      bit_offset: 10
-      bit_size: 2
-    - name: ATOSEL3
-      description: ATOSEL3
-      bit_offset: 12
-      bit_size: 2
-    - name: ATOSEL4
-      description: ATOSEL4
-      bit_offset: 14
-      bit_size: 2
+      array:
+        len: 4
+        stride: 2
     - name: ATCKSEL
       description: ATCKSEL
       bit_offset: 16
@@ -153,38 +119,13 @@ fieldset/ATCR1:
 fieldset/ATCR2:
   description: TAMP active tamper control register 2
   fields:
-    - name: ATOSEL1
-      description: ATOSEL1
+    - name: ATOSEL
+      description: ATOSEL
       bit_offset: 8
       bit_size: 3
-    - name: ATOSEL2
-      description: ATOSEL2
-      bit_offset: 11
-      bit_size: 3
-    - name: ATOSEL3
-      description: ATOSEL3
-      bit_offset: 14
-      bit_size: 3
-    - name: ATOSEL4
-      description: ATOSEL4
-      bit_offset: 17
-      bit_size: 3
-    - name: ATOSEL5
-      description: ATOSEL5
-      bit_offset: 20
-      bit_size: 3
-    - name: ATOSEL6
-      description: ATOSEL6
-      bit_offset: 23
-      bit_size: 3
-    - name: ATOSEL7
-      description: ATOSEL7
-      bit_offset: 26
-      bit_size: 3
-    - name: ATOSEL8
-      description: ATOSEL8
-      bit_offset: 29
-      bit_size: 3
+      array:
+        len: 8
+        stride: 3
 fieldset/ATOR:
   description: TAMP active tamper output register
   fields:
@@ -239,164 +180,58 @@ fieldset/COUNTR:
 fieldset/CR1:
   description: control register 1
   fields:
-    - name: TAMP1E
-      description: TAMP1E
+    - name: TAMPE
+      description: TAMPE
       bit_offset: 0
       bit_size: 1
-    - name: TAMP2E
-      description: TAMP2E
-      bit_offset: 1
-      bit_size: 1
-    - name: TAMP3E
-      description: TAMP3E
-      bit_offset: 2
-      bit_size: 1
-    - name: TAMP4E
-      description: TAMP4E
-      bit_offset: 3
-      bit_size: 1
-    - name: TAMP5E
-      description: TAMP5E
-      bit_offset: 4
-      bit_size: 1
-    - name: TAMP6E
-      description: TAMP6E
-      bit_offset: 5
-      bit_size: 1
-    - name: TAMP7E
-      description: TAMP7E
-      bit_offset: 6
-      bit_size: 1
-    - name: TAMP8E
-      description: TAMP8E
-      bit_offset: 7
-      bit_size: 1
-    - name: ITAMP1E
-      description: ITAMP1E
+      array:
+        len: 8
+        stride: 1
+    - name: ITAMPE
+      description: ITAMPE
       bit_offset: 16
       bit_size: 1
-    - name: ITAMP2E
-      description: ITAMP2E
-      bit_offset: 17
-      bit_size: 1
-    - name: ITAMP3E
-      description: ITAMP3E
-      bit_offset: 18
-      bit_size: 1
-    - name: ITAMP5E
-      description: ITAMP5E
-      bit_offset: 20
-      bit_size: 1
-    - name: ITAMP8E
-      description: ITAMP5E
-      bit_offset: 23
-      bit_size: 1
+      array:
+        len: 8
+        stride: 1
 fieldset/CR2:
   description: control register 2
   fields:
-    - name: TAMP1NOER
-      description: TAMP1NOER
+    - name: TAMPNOER
+      description: Tamper X no erase
       bit_offset: 0
       bit_size: 1
-    - name: TAMP2NOER
-      description: TAMP2NOER
-      bit_offset: 1
-      bit_size: 1
-    - name: TAMP3NOER
-      description: TAMP3NOER
-      bit_offset: 2
-      bit_size: 1
-    - name: TAMP4NOER
-      description: TAMP4NOER
-      bit_offset: 3
-      bit_size: 1
-    - name: TAMP5NOER
-      description: TAMP5NOER
-      bit_offset: 4
-      bit_size: 1
-    - name: TAMP6NOER
-      description: TAMP6NOER
-      bit_offset: 5
-      bit_size: 1
-    - name: TAMP7NOER
-      description: TAMP7NOER
-      bit_offset: 6
-      bit_size: 1
-    - name: TAMP8NOER
-      description: TAMP8NOER
-      bit_offset: 7
-      bit_size: 1
-    - name: TAMP1MSK
-      description: TAMP1MSK
+      array:
+        len: 8
+        stride: 1
+    - name: TAMPMSK
+      description: Tamper X mask
       bit_offset: 16
       bit_size: 1
-    - name: TAMP2MSK
-      description: TAMP2MSK
-      bit_offset: 17
-      bit_size: 1
-    - name: TAMP3MSK
-      description: TAMP3MSK
-      bit_offset: 18
-      bit_size: 1
+      array:
+        len: 3
+        stride: 1
     - name: BKERASE
       description: BKERASE
       bit_offset: 23
       bit_size: 1
-    - name: TAMP1TRG
-      description: TAMP1TRG
+    - name: TAMPTRG
+      description: Active level for tamper X input
       bit_offset: 24
       bit_size: 1
-    - name: TAMP2TRG
-      description: TAMP2TRG
-      bit_offset: 25
-      bit_size: 1
-    - name: TAMP3TRG
-      description: TAMP3TRG
-      bit_offset: 26
-      bit_size: 1
-    - name: TAMP4TRG
-      description: TAMP4TRG
-      bit_offset: 27
-      bit_size: 1
-    - name: TAMP5TRG
-      description: TAMP5TRG
-      bit_offset: 28
-      bit_size: 1
-    - name: TAMP6TRG
-      description: TAMP6TRG
-      bit_offset: 29
-      bit_size: 1
-    - name: TAMP7TRG
-      description: TAMP7TRG
-      bit_offset: 30
-      bit_size: 1
-    - name: TAMP8TRG
-      description: TAMP8TRG
-      bit_offset: 31
-      bit_size: 1
+      array:
+        len: 8
+        stride: 1
 fieldset/CR3:
   description: control register 3
   fields:
-    - name: ITAMP1NOER
-      description: ITAMP1NOER
+    - name: ITAMPNOER
+      description: Internal Tamper X no erase
       bit_offset: 0
       bit_size: 1
-    - name: ITAMP2NOER
-      description: ITAMP2NOER
-      bit_offset: 1
-      bit_size: 1
-    - name: ITAMP3NOER
-      description: ITAMP3NOER
-      bit_offset: 2
-      bit_size: 1
-    - name: ITAMP5NOER
-      description: ITAMP5NOER
-      bit_offset: 4
-      bit_size: 1
-    - name: ITAMP8NOER
-      description: ITAMP8NOER
-      bit_offset: 7
-      bit_size: 1
+      array:
+        len: 8
+        stride: 1
 fieldset/FLTCR:
   description: TAMP filter control register
   fields:
@@ -419,113 +254,37 @@ fieldset/FLTCR:
 fieldset/IER:
   description: TAMP interrupt enable register
   fields:
-    - name: TAMP1IE
-      description: TAMP1IE
+    - name: TAMPIE
+      description: Tamper X interrupt enable
       bit_offset: 0
       bit_size: 1
-    - name: TAMP2IE
-      description: TAMP2IE
-      bit_offset: 1
-      bit_size: 1
-    - name: TAMP3IE
-      description: TAMP3IE
-      bit_offset: 2
-      bit_size: 1
-    - name: TAMP4IE
-      description: TAMP4IE
-      bit_offset: 3
-      bit_size: 1
-    - name: TAMP5IE
-      description: TAMP5IE
-      bit_offset: 4
-      bit_size: 1
-    - name: TAMP6IE
-      description: TAMP6IE
-      bit_offset: 5
-      bit_size: 1
-    - name: TAMP7IE
-      description: TAMP7IE
-      bit_offset: 6
-      bit_size: 1
-    - name: TAMP8IE
-      description: TAMP8IE
-      bit_offset: 7
-      bit_size: 1
-    - name: ITAMP1IE
-      description: ITAMP1IE
+      array:
+        len: 8
+        stride: 1
+    - name: ITAMPIE
+      description: Internal tamper X interrupt enable
       bit_offset: 16
       bit_size: 1
-    - name: ITAMP2IE
-      description: ITAMP2IE
-      bit_offset: 17
-      bit_size: 1
-    - name: ITAMP3IE
-      description: ITAMP3IE
-      bit_offset: 18
-      bit_size: 1
-    - name: ITAMP5IE
-      description: ITAMP5IE
-      bit_offset: 20
-      bit_size: 1
-    - name: ITAMP8IE
-      description: ITAMP8IE
-      bit_offset: 23
-      bit_size: 1
+      array:
+        len: 8
+        stride: 1
 fieldset/MISR:
   description: " TAMP masked interrupt status register "
   fields:
-    - name: TAMP1MF
-      description: "TAMP1MF:"
+    - name: TAMPMF
+      description: Tamper X interrupt masked flag
       bit_offset: 0
       bit_size: 1
-    - name: TAMP2MF
-      description: TAMP2MF
-      bit_offset: 1
-      bit_size: 1
-    - name: TAMP3MF
-      description: TAMP3MF
-      bit_offset: 2
-      bit_size: 1
-    - name: TAMP4MF
-      description: TAMP4MF
-      bit_offset: 3
-      bit_size: 1
-    - name: TAMP5MF
-      description: TAMP5MF
-      bit_offset: 4
-      bit_size: 1
-    - name: TAMP6MF
-      description: TAMP6MF
-      bit_offset: 5
-      bit_size: 1
-    - name: TAMP7MF
-      description: "TAMP7MF:"
-      bit_offset: 6
-      bit_size: 1
-    - name: TAMP8MF
-      description: TAMP8MF
-      bit_offset: 7
-      bit_size: 1
-    - name: ITAMP1MF
-      description: ITAMP1MF
+      array:
+        len: 8
+        stride: 1
+    - name: ITAMPMF
+      description: Internal tamper X interrupt masked flag
       bit_offset: 16
       bit_size: 1
-    - name: ITAMP2MF
-      description: ITAMP2MF
-      bit_offset: 17
-      bit_size: 1
-    - name: ITAMP3MF
-      description: ITAMP3MF
-      bit_offset: 18
-      bit_size: 1
-    - name: ITAMP5MF
-      description: ITAMP5MF
-      bit_offset: 20
-      bit_size: 1
-    - name: ITAMP8MF
-      description: ITAMP8MF
-      bit_offset: 23
-      bit_size: 1
+      array:
+        len: 8
+        stride: 1
 fieldset/PRIVCR:
   description: TAMP privilege mode control register
   fields:
@@ -544,58 +303,20 @@ fieldset/PRIVCR:
 fieldset/SCR:
   description: TAMP status clear register
   fields:
-    - name: CTAMP1F
-      description: CTAMP1F
+    - name: CTAMPF
+      description: Clear tamper X detection flag
       bit_offset: 0
       bit_size: 1
-    - name: CTAMP2F
-      description: CTAMP2F
-      bit_offset: 1
-      bit_size: 1
-    - name: CTAMP3F
-      description: CTAMP3F
-      bit_offset: 2
-      bit_size: 1
-    - name: CTAMP4F
-      description: CTAMP4F
-      bit_offset: 3
-      bit_size: 1
-    - name: CTAMP5F
-      description: CTAMP5F
-      bit_offset: 4
-      bit_size: 1
-    - name: CTAMP6F
-      description: CTAMP6F
-      bit_offset: 5
-      bit_size: 1
-    - name: CTAMP7F
-      description: CTAMP7F
-      bit_offset: 6
-      bit_size: 1
-    - name: CTAMP8F
-      description: CTAMP8F
-      bit_offset: 7
-      bit_size: 1
-    - name: CITAMP1F
-      description: CITAMP1F
+      array:
+        len: 8
+        stride: 1
+    - name: CITAMPF
+      description: Clear internal tamper X detection flag
       bit_offset: 16
       bit_size: 1
-    - name: CITAMP2F
-      description: CITAMP2F
-      bit_offset: 17
-      bit_size: 1
-    - name: CITAMP3F
-      description: CITAMP3F
-      bit_offset: 18
-      bit_size: 1
-    - name: CITAMP5F
-      description: CITAMP5F
-      bit_offset: 20
-      bit_size: 1
-    - name: CITAMP8F
-      description: CITAMP8F
-      bit_offset: 23
-      bit_size: 1
+      array:
+        len: 8
+        stride: 1
 fieldset/SMCR:
   description: TAMP secure mode register
   fields:
@@ -614,110 +335,34 @@ fieldset/SMCR:
 fieldset/SMISR:
   description: TAMP secure masked interrupt status register
   fields:
-    - name: TAMP1MF
-      description: "TAMP1MF:"
+    - name: TAMPMF
+      description: Tamper X interrupt masked flag
       bit_offset: 0
       bit_size: 1
-    - name: TAMP2MF
-      description: TAMP2MF
-      bit_offset: 1
-      bit_size: 1
-    - name: TAMP3MF
-      description: TAMP3MF
-      bit_offset: 2
-      bit_size: 1
-    - name: TAMP4MF
-      description: TAMP4MF
-      bit_offset: 3
-      bit_size: 1
-    - name: TAMP5MF
-      description: TAMP5MF
-      bit_offset: 4
-      bit_size: 1
-    - name: TAMP6MF
-      description: TAMP6MF
-      bit_offset: 5
-      bit_size: 1
-    - name: TAMP7MF
-      description: "TAMP7MF:"
-      bit_offset: 6
-      bit_size: 1
-    - name: TAMP8MF
-      description: TAMP8MF
-      bit_offset: 7
-      bit_size: 1
-    - name: ITAMP1MF
-      description: ITAMP1MF
+      array:
+        len: 8
+        stride: 1
+    - name: ITAMPMF
+      description: Internal tamper X interrupt masked flag
       bit_offset: 16
       bit_size: 1
-    - name: ITAMP2MF
-      description: ITAMP2MF
-      bit_offset: 17
-      bit_size: 1
-    - name: ITAMP3MF
-      description: ITAMP3MF
-      bit_offset: 18
-      bit_size: 1
-    - name: ITAMP5MF
-      description: ITAMP5MF
-      bit_offset: 20
-      bit_size: 1
-    - name: ITAMP8MF
-      description: ITAMP8MF
-      bit_offset: 23
-      bit_size: 1
+      array:
+        len: 8
+        stride: 1
 fieldset/SR:
   description: TAMP status register
   fields:
-    - name: TAMP1F
-      description: TAMP1F
+    - name: TAMPF
+      description: Tamper X detection flag
       bit_offset: 0
       bit_size: 1
-    - name: TAMP2F
-      description: TAMP2F
-      bit_offset: 1
-      bit_size: 1
-    - name: TAMP3F
-      description: TAMP3F
-      bit_offset: 2
-      bit_size: 1
-    - name: TAMP4F
-      description: TAMP4F
-      bit_offset: 3
-      bit_size: 1
-    - name: TAMP5F
-      description: TAMP5F
-      bit_offset: 4
-      bit_size: 1
-    - name: TAMP6F
-      description: TAMP6F
-      bit_offset: 5
-      bit_size: 1
-    - name: TAMP7F
-      description: TAMP7F
-      bit_offset: 6
-      bit_size: 1
-    - name: TAMP8F
-      description: TAMP8F
-      bit_offset: 7
-      bit_size: 1
-    - name: ITAMP1F
-      description: ITAMP1F
+      array:
+        len: 8
+        stride: 1
+    - name: ITAMPF
+      description: Internal tamper X detection flag
       bit_offset: 16
       bit_size: 1
-    - name: ITAMP2F
-      description: ITAMP2F
-      bit_offset: 17
-      bit_size: 1
-    - name: ITAMP3F
-      description: ITAMP3F
-      bit_offset: 18
-      bit_size: 1
-    - name: ITAMP5F
-      description: ITAMP5F
-      bit_offset: 20
-      bit_size: 1
-    - name: ITAMP8F
-      description: ITAMP8F
-      bit_offset: 23
-      bit_size: 1
+      array:
+        len: 8
+        stride: 1

--- a/data/registers/tamp_u5.yaml
+++ b/data/registers/tamp_u5.yaml
@@ -2,264 +2,97 @@ block/TAMP:
   description: Tamper and backup registers
   items:
     - name: CR1
-      description: "TAMP control register 1 "
+      description: "TAMP control register 1"
       byte_offset: 0
       fieldset: CR1
     - name: CR2
-      description: "TAMP control register 2 "
+      description: "TAMP control register 2"
       byte_offset: 4
       fieldset: CR2
     - name: CR3
-      description: "TAMP control register 3 "
+      description: "TAMP control register 3"
       byte_offset: 8
       fieldset: CR3
     - name: FLTCR
-      description: "TAMP filter control register "
+      description: "TAMP filter control register"
       byte_offset: 12
       fieldset: FLTCR
     - name: ATCR1
-      description: "TAMP active tamper control register 1 "
+      description: "TAMP active tamper control register 1"
       byte_offset: 16
       fieldset: ATCR1
     - name: ATSEEDR
-      description: "TAMP active tamper seed register "
+      description: "TAMP active tamper seed register"
       byte_offset: 20
       fieldset: ATSEEDR
     - name: ATOR
-      description: "TAMP active tamper output register "
+      description: "TAMP active tamper output register"
       byte_offset: 24
       fieldset: ATOR
     - name: ATCR2
-      description: "TAMP active tamper control register 2 "
+      description: "TAMP active tamper control register 2"
       byte_offset: 28
       fieldset: ATCR2
     - name: SECCFGR
-      description: "TAMP secure mode register "
+      description: "TAMP secure mode register"
       byte_offset: 32
       fieldset: SECCFGR
     - name: PRIVCR
-      description: "TAMP privilege mode control register "
+      description: "TAMP privilege mode control register"
       byte_offset: 36
       fieldset: PRIVCR
     - name: IER
-      description: "TAMP interrupt enable register "
+      description: "TAMP interrupt enable register"
       byte_offset: 44
       fieldset: IER
     - name: SR
-      description: "TAMP status register "
+      description: "TAMP status register"
       byte_offset: 48
       fieldset: SR
     - name: MISR
-      description: "TAMP non-secure masked interrupt status register "
+      description: "TAMP non-secure masked interrupt status register"
       byte_offset: 52
       fieldset: MISR
     - name: SMISR
-      description: "TAMP secure masked interrupt status register "
+      description: "TAMP secure masked interrupt status register"
       byte_offset: 56
       fieldset: SMISR
     - name: SCR
-      description: "TAMP status clear register "
+      description: "TAMP status clear register"
       byte_offset: 60
       fieldset: SCR
     - name: COUNTR
-      description: "TAMP monotonic counter 1 register "
+      description: "TAMP monotonic counter 1 register"
       byte_offset: 64
       fieldset: COUNTR
     - name: ERCFGR
-      description: "TAMP erase configuration register "
+      description: "TAMP erase configuration register"
       byte_offset: 84
       fieldset: ERCFGR
-    - name: BKP0R
-      description: TAMP backup 0 register
+    - name: BKPR
+      description: TAMP backup X register
+      array:
+        len: 32
+        stride: 4
       byte_offset: 256
-      fieldset: BKP0R
-    - name: BKP1R
-      description: TAMP backup 1 register
-      byte_offset: 260
-      fieldset: BKP1R
-    - name: BKP2R
-      description: TAMP backup 2 register
-      byte_offset: 264
-      fieldset: BKP2R
-    - name: BKP3R
-      description: TAMP backup 3 register
-      byte_offset: 268
-      fieldset: BKP3R
-    - name: BKP4R
-      description: TAMP backup 4 register
-      byte_offset: 272
-      fieldset: BKP4R
-    - name: BKP5R
-      description: TAMP backup 5 register
-      byte_offset: 276
-      fieldset: BKP5R
-    - name: BKP6R
-      description: TAMP backup 6 register
-      byte_offset: 280
-      fieldset: BKP6R
-    - name: BKP7R
-      description: TAMP backup 7 register
-      byte_offset: 284
-      fieldset: BKP7R
-    - name: BKP8R
-      description: TAMP backup 8 register
-      byte_offset: 288
-      fieldset: BKP8R
-    - name: BKP9R
-      description: TAMP backup 9 register
-      byte_offset: 292
-      fieldset: BKP9R
-    - name: BKP10R
-      description: TAMP backup 10 register
-      byte_offset: 296
-      fieldset: BKP10R
-    - name: BKP11R
-      description: TAMP backup 11 register
-      byte_offset: 300
-      fieldset: BKP11R
-    - name: BKP12R
-      description: TAMP backup 12 register
-      byte_offset: 304
-      fieldset: BKP12R
-    - name: BKP13R
-      description: TAMP backup 13 register
-      byte_offset: 308
-      fieldset: BKP13R
-    - name: BKP14R
-      description: TAMP backup 14 register
-      byte_offset: 312
-      fieldset: BKP14R
-    - name: BKP15R
-      description: TAMP backup 15 register
-      byte_offset: 316
-      fieldset: BKP15R
-    - name: BKP16R
-      description: TAMP backup 16 register
-      byte_offset: 320
-      fieldset: BKP16R
-    - name: BKP17R
-      description: TAMP backup 17 register
-      byte_offset: 324
-      fieldset: BKP17R
-    - name: BKP18R
-      description: TAMP backup 18 register
-      byte_offset: 328
-      fieldset: BKP18R
-    - name: BKP19R
-      description: TAMP backup 19 register
-      byte_offset: 332
-      fieldset: BKP19R
-    - name: BKP20R
-      description: TAMP backup 20 register
-      byte_offset: 336
-      fieldset: BKP20R
-    - name: BKP21R
-      description: TAMP backup 21 register
-      byte_offset: 340
-      fieldset: BKP21R
-    - name: BKP22R
-      description: TAMP backup 22 register
-      byte_offset: 344
-      fieldset: BKP22R
-    - name: BKP23R
-      description: TAMP backup 23 register
-      byte_offset: 348
-      fieldset: BKP23R
-    - name: BKP24R
-      description: TAMP backup 24 register
-      byte_offset: 352
-      fieldset: BKP24R
-    - name: BKP25R
-      description: TAMP backup 25 register
-      byte_offset: 356
-      fieldset: BKP25R
-    - name: BKP26R
-      description: TAMP backup 26 register
-      byte_offset: 360
-      fieldset: BKP26R
-    - name: BKP27R
-      description: TAMP backup 27 register
-      byte_offset: 364
-      fieldset: BKP27R
-    - name: BKP28R
-      description: TAMP backup 28 register
-      byte_offset: 368
-      fieldset: BKP28R
-    - name: BKP29R
-      description: TAMP backup 29 register
-      byte_offset: 372
-      fieldset: BKP29R
-    - name: BKP30R
-      description: TAMP backup 30 register
-      byte_offset: 376
-      fieldset: BKP30R
-    - name: BKP31R
-      description: TAMP backup 31 register
-      byte_offset: 380
-      fieldset: BKP31R
+      fieldset: BKPR
 fieldset/ATCR1:
-  description: "TAMP active tamper control register 1 "
+  description: "TAMP active tamper control register 1"
   fields:
-    - name: TAMP1AM
-      description: Tamper 1 active mode
+    - name: TAMPAM
+      description: Tamper X active mode
       bit_offset: 0
       bit_size: 1
-      enum: TAMPAM
-    - name: TAMP2AM
-      description: Tamper 2 active mode
-      bit_offset: 1
-      bit_size: 1
-      enum: TAMPAM
-    - name: TAMP3AM
-      description: Tamper 3 active mode
-      bit_offset: 2
-      bit_size: 1
-      enum: TAMPAM
-    - name: TAMP4AM
-      description: Tamper 4 active mode
-      bit_offset: 3
-      bit_size: 1
-      enum: TAMPAM
-    - name: TAMP5AM
-      description: Tamper 5 active mode
-      bit_offset: 4
-      bit_size: 1
-      enum: TAMPAM
-    - name: TAMP6AM
-      description: Tamper 6 active mode
-      bit_offset: 5
-      bit_size: 1
-      enum: TAMPAM
-    - name: TAMP7AM
-      description: Tamper 7 active mode
-      bit_offset: 6
-      bit_size: 1
-      enum: TAMPAM
-    - name: TAMP8AM
-      description: Tamper 8 active mode
-      bit_offset: 7
-      bit_size: 1
-      enum: TAMPAM
-    - name: ATOSEL1
-      description: "Active tamper shared output 1 selection. The selected output must be available in the package pinout"
+      array:
+        len: 8
+        stride: 1
+    - name: ATOSEL
+      description: "Active tamper shared output X selection. The selected output must be available in the package pinout"
       bit_offset: 8
       bit_size: 2
-      enum: ATCR1_ATOSEL1
-    - name: ATOSEL2
-      description: "Active tamper shared output 2 selection. The selected output must be available in the package pinout"
-      bit_offset: 10
-      bit_size: 2
-      enum: ATCR1_ATOSEL2
-    - name: ATOSEL3
-      description: "Active tamper shared output 3 selection. The selected output must be available in the package pinout"
-      bit_offset: 12
-      bit_size: 2
-      enum: ATCR1_ATOSEL3
-    - name: ATOSEL4
-      description: "Active tamper shared output 4 selection. The selected output must be available in the package pinout."
-      bit_offset: 14
-      bit_size: 2
-      enum: ATCR1_ATOSEL4
+      array:
+        len: 4
+        stride: 2
     - name: ATCKSEL
       description: "Active tamper RTC asynchronous prescaler clock selection. These bits selects the RTC asynchronous prescaler stage output.The selected clock is CK_ATPRE.. fCK_ATPRE = fRTCCLK / 2ATCKSEL when (PREDIV_A+1) = 128.. .... These bits can be written only when all active tampers are disabled. The write protection remains for up to 1.5 ck_atpre cycles after all the active tampers are disable."
       bit_offset: 16
@@ -273,57 +106,22 @@ fieldset/ATCR1:
       description: "Active tamper output sharing. IN1 is compared with TAMPOUTSEL1. IN2 is compared with TAMPOUTSEL2. IN3 is compared with TAMPOUTSEL3. IN4 is compared with TAMPOUTSEL4. IN5 is compared with TAMPOUTSEL5. IN6 is compared with TAMPOUTSEL6. IN7 is compared with TAMPOUTSEL7. IN8 is compared with TAMPOUTSEL8"
       bit_offset: 30
       bit_size: 1
-      enum: ATOSHARE
     - name: FLTEN
       description: Active tamper filter enable
       bit_offset: 31
       bit_size: 1
-      enum: FLTEN
 fieldset/ATCR2:
-  description: "TAMP active tamper control register 2 "
+  description: "TAMP active tamper control register 2"
   fields:
-    - name: ATOSEL1
-      description: "Active tamper shared output 1 selection. The selected output must be available in the package pinout. Bits 9:8 are the mirror of ATOSEL1[1:0] in the ATCR1, and so can also be read or. written through ATCR1."
+    - name: ATOSEL
+      description: "Active tamper shared output X selection. The selected output must be available in the package pinout. Bits 9:8 are the mirror of ATOSEL1[1:0] in the ATCR1, and so can also be read or. written through ATCR1."
       bit_offset: 8
       bit_size: 3
-      enum: ATCR2_ATOSEL1
-    - name: ATOSEL2
-      description: "Active tamper shared output 2 selection. The selected output must be available in the package pinout. Bits 12:11 are the mirror of ATOSEL2[1:0] in the ATCR1, and so can also be read or written through ATCR1."
-      bit_offset: 11
-      bit_size: 3
-      enum: ATCR2_ATOSEL2
-    - name: ATOSEL3
-      description: "Active tamper shared output 3 selection. The selected output must be available in the package pinout. Bits 15:14 are the mirror of ATOSEL3[1:0] in the ATCR1, and so can also be read or written through ATCR1."
-      bit_offset: 14
-      bit_size: 3
-      enum: ATCR2_ATOSEL3
-    - name: ATOSEL4
-      description: "Active tamper shared output 4 selection. The selected output must be available in the package pinout. Bits 18:17 are the mirror of ATOSEL2[1:0] in the ATCR1, and so can also be read or written through ATCR1."
-      bit_offset: 17
-      bit_size: 3
-      enum: ATCR2_ATOSEL4
-    - name: ATOSEL5
-      description: "Active tamper shared output 5 selection. The selected output must be available in the package pinout."
-      bit_offset: 20
-      bit_size: 3
-      enum: ATOSEL
-    - name: ATOSEL6
-      description: "Active tamper shared output 6 selection. The selected output must be available in the package pinout."
-      bit_offset: 23
-      bit_size: 3
-      enum: ATOSEL
-    - name: ATOSEL7
-      description: "Active tamper shared output 7 selection. The selected output must be available in the package pinout."
-      bit_offset: 26
-      bit_size: 3
-      enum: ATOSEL
-    - name: ATOSEL8
-      description: "Active tamper shared output 8 selection. The selected output must be available in the package pinout."
-      bit_offset: 29
-      bit_size: 3
-      enum: ATOSEL
+      array:
+        len: 8
+        stride: 3
 fieldset/ATOR:
-  description: "TAMP active tamper output register "
+  description: "TAMP active tamper output register"
   fields:
     - name: PRNG
       description: "Pseudo-random generator value. This field provides the values of the PRNG output. Because of potential inconsistencies due to synchronization delays, PRNG must be read at least twice. The read value is correct if it is equal to previous read value. This field can only be read when the APB is in secure mode."
@@ -338,238 +136,21 @@ fieldset/ATOR:
       bit_offset: 15
       bit_size: 1
 fieldset/ATSEEDR:
-  description: "TAMP active tamper seed register "
+  description: "TAMP active tamper seed register"
   fields:
     - name: SEED
       description: "Pseudo-random generator seed value. This register must be written four times with 32-bit values to provide the 128-bit seed to the PRNG. Writing to this register automatically sends the seed value to the PRNG."
       bit_offset: 0
       bit_size: 32
-fieldset/BKP0R:
-  description: TAMP backup 0 register
-  fields:
-    - name: BKP
-      description: "The application can write or read data to and from these registers. In the default (ERASE) configuration this register is reset on a tamper detection event. It is forced to reset value as long as there is at least one internal or external tamper flag being set. This register is also reset when the readout protection (RDP) is disabled."
-      bit_offset: 0
-      bit_size: 32
-fieldset/BKP10R:
-  description: TAMP backup 10 register
-  fields:
-    - name: BKP
-      description: "The application can write or read data to and from these registers. In the default (ERASE) configuration this register is reset on a tamper detection event. It is forced to reset value as long as there is at least one internal or external tamper flag being set. This register is also reset when the readout protection (RDP) is disabled."
-      bit_offset: 0
-      bit_size: 32
-fieldset/BKP11R:
-  description: TAMP backup 11 register
-  fields:
-    - name: BKP
-      description: "The application can write or read data to and from these registers. In the default (ERASE) configuration this register is reset on a tamper detection event. It is forced to reset value as long as there is at least one internal or external tamper flag being set. This register is also reset when the readout protection (RDP) is disabled."
-      bit_offset: 0
-      bit_size: 32
-fieldset/BKP12R:
-  description: TAMP backup 12 register
-  fields:
-    - name: BKP
-      description: "The application can write or read data to and from these registers. In the default (ERASE) configuration this register is reset on a tamper detection event. It is forced to reset value as long as there is at least one internal or external tamper flag being set. This register is also reset when the readout protection (RDP) is disabled."
-      bit_offset: 0
-      bit_size: 32
-fieldset/BKP13R:
-  description: TAMP backup 13 register
-  fields:
-    - name: BKP
-      description: "The application can write or read data to and from these registers. In the default (ERASE) configuration this register is reset on a tamper detection event. It is forced to reset value as long as there is at least one internal or external tamper flag being set. This register is also reset when the readout protection (RDP) is disabled."
-      bit_offset: 0
-      bit_size: 32
-fieldset/BKP14R:
-  description: TAMP backup 14 register
-  fields:
-    - name: BKP
-      description: "The application can write or read data to and from these registers. In the default (ERASE) configuration this register is reset on a tamper detection event. It is forced to reset value as long as there is at least one internal or external tamper flag being set. This register is also reset when the readout protection (RDP) is disabled."
-      bit_offset: 0
-      bit_size: 32
-fieldset/BKP15R:
-  description: TAMP backup 15 register
-  fields:
-    - name: BKP
-      description: "The application can write or read data to and from these registers. In the default (ERASE) configuration this register is reset on a tamper detection event. It is forced to reset value as long as there is at least one internal or external tamper flag being set. This register is also reset when the readout protection (RDP) is disabled."
-      bit_offset: 0
-      bit_size: 32
-fieldset/BKP16R:
-  description: TAMP backup 16 register
-  fields:
-    - name: BKP
-      description: "The application can write or read data to and from these registers. In the default (ERASE) configuration this register is reset on a tamper detection event. It is forced to reset value as long as there is at least one internal or external tamper flag being set. This register is also reset when the readout protection (RDP) is disabled."
-      bit_offset: 0
-      bit_size: 32
-fieldset/BKP17R:
-  description: TAMP backup 17 register
-  fields:
-    - name: BKP
-      description: "The application can write or read data to and from these registers. In the default (ERASE) configuration this register is reset on a tamper detection event. It is forced to reset value as long as there is at least one internal or external tamper flag being set. This register is also reset when the readout protection (RDP) is disabled."
-      bit_offset: 0
-      bit_size: 32
-fieldset/BKP18R:
-  description: TAMP backup 18 register
-  fields:
-    - name: BKP
-      description: "The application can write or read data to and from these registers. In the default (ERASE) configuration this register is reset on a tamper detection event. It is forced to reset value as long as there is at least one internal or external tamper flag being set. This register is also reset when the readout protection (RDP) is disabled."
-      bit_offset: 0
-      bit_size: 32
-fieldset/BKP19R:
-  description: TAMP backup 19 register
-  fields:
-    - name: BKP
-      description: "The application can write or read data to and from these registers. In the default (ERASE) configuration this register is reset on a tamper detection event. It is forced to reset value as long as there is at least one internal or external tamper flag being set. This register is also reset when the readout protection (RDP) is disabled."
-      bit_offset: 0
-      bit_size: 32
-fieldset/BKP1R:
-  description: TAMP backup 1 register
-  fields:
-    - name: BKP
-      description: "The application can write or read data to and from these registers. In the default (ERASE) configuration this register is reset on a tamper detection event. It is forced to reset value as long as there is at least one internal or external tamper flag being set. This register is also reset when the readout protection (RDP) is disabled."
-      bit_offset: 0
-      bit_size: 32
-fieldset/BKP20R:
-  description: TAMP backup 20 register
-  fields:
-    - name: BKP
-      description: "The application can write or read data to and from these registers. In the default (ERASE) configuration this register is reset on a tamper detection event. It is forced to reset value as long as there is at least one internal or external tamper flag being set. This register is also reset when the readout protection (RDP) is disabled."
-      bit_offset: 0
-      bit_size: 32
-fieldset/BKP21R:
-  description: TAMP backup 21 register
-  fields:
-    - name: BKP
-      description: "The application can write or read data to and from these registers. In the default (ERASE) configuration this register is reset on a tamper detection event. It is forced to reset value as long as there is at least one internal or external tamper flag being set. This register is also reset when the readout protection (RDP) is disabled."
-      bit_offset: 0
-      bit_size: 32
-fieldset/BKP22R:
-  description: TAMP backup 22 register
-  fields:
-    - name: BKP
-      description: "The application can write or read data to and from these registers. In the default (ERASE) configuration this register is reset on a tamper detection event. It is forced to reset value as long as there is at least one internal or external tamper flag being set. This register is also reset when the readout protection (RDP) is disabled."
-      bit_offset: 0
-      bit_size: 32
-fieldset/BKP23R:
-  description: TAMP backup 23 register
-  fields:
-    - name: BKP
-      description: "The application can write or read data to and from these registers. In the default (ERASE) configuration this register is reset on a tamper detection event. It is forced to reset value as long as there is at least one internal or external tamper flag being set. This register is also reset when the readout protection (RDP) is disabled."
-      bit_offset: 0
-      bit_size: 32
-fieldset/BKP24R:
-  description: TAMP backup 24 register
-  fields:
-    - name: BKP
-      description: "The application can write or read data to and from these registers. In the default (ERASE) configuration this register is reset on a tamper detection event. It is forced to reset value as long as there is at least one internal or external tamper flag being set. This register is also reset when the readout protection (RDP) is disabled."
-      bit_offset: 0
-      bit_size: 32
-fieldset/BKP25R:
-  description: TAMP backup 25 register
-  fields:
-    - name: BKP
-      description: "The application can write or read data to and from these registers. In the default (ERASE) configuration this register is reset on a tamper detection event. It is forced to reset value as long as there is at least one internal or external tamper flag being set. This register is also reset when the readout protection (RDP) is disabled."
-      bit_offset: 0
-      bit_size: 32
-fieldset/BKP26R:
-  description: TAMP backup 26 register
-  fields:
-    - name: BKP
-      description: "The application can write or read data to and from these registers. In the default (ERASE) configuration this register is reset on a tamper detection event. It is forced to reset value as long as there is at least one internal or external tamper flag being set. This register is also reset when the readout protection (RDP) is disabled."
-      bit_offset: 0
-      bit_size: 32
-fieldset/BKP27R:
-  description: TAMP backup 27 register
-  fields:
-    - name: BKP
-      description: "The application can write or read data to and from these registers. In the default (ERASE) configuration this register is reset on a tamper detection event. It is forced to reset value as long as there is at least one internal or external tamper flag being set. This register is also reset when the readout protection (RDP) is disabled."
-      bit_offset: 0
-      bit_size: 32
-fieldset/BKP28R:
-  description: TAMP backup 28 register
-  fields:
-    - name: BKP
-      description: "The application can write or read data to and from these registers. In the default (ERASE) configuration this register is reset on a tamper detection event. It is forced to reset value as long as there is at least one internal or external tamper flag being set. This register is also reset when the readout protection (RDP) is disabled."
-      bit_offset: 0
-      bit_size: 32
-fieldset/BKP29R:
-  description: TAMP backup 29 register
-  fields:
-    - name: BKP
-      description: "The application can write or read data to and from these registers. In the default (ERASE) configuration this register is reset on a tamper detection event. It is forced to reset value as long as there is at least one internal or external tamper flag being set. This register is also reset when the readout protection (RDP) is disabled."
-      bit_offset: 0
-      bit_size: 32
-fieldset/BKP2R:
-  description: TAMP backup 2 register
-  fields:
-    - name: BKP
-      description: "The application can write or read data to and from these registers. In the default (ERASE) configuration this register is reset on a tamper detection event. It is forced to reset value as long as there is at least one internal or external tamper flag being set. This register is also reset when the readout protection (RDP) is disabled."
-      bit_offset: 0
-      bit_size: 32
-fieldset/BKP30R:
-  description: TAMP backup 30 register
-  fields:
-    - name: BKP
-      description: "The application can write or read data to and from these registers. In the default (ERASE) configuration this register is reset on a tamper detection event. It is forced to reset value as long as there is at least one internal or external tamper flag being set. This register is also reset when the readout protection (RDP) is disabled."
-      bit_offset: 0
-      bit_size: 32
-fieldset/BKP31R:
-  description: TAMP backup 31 register
-  fields:
-    - name: BKP
-      description: "The application can write or read data to and from these registers. In the default (ERASE) configuration this register is reset on a tamper detection event. It is forced to reset value as long as there is at least one internal or external tamper flag being set. This register is also reset when the readout protection (RDP) is disabled."
-      bit_offset: 0
-      bit_size: 32
-fieldset/BKP3R:
-  description: TAMP backup 3 register
-  fields:
-    - name: BKP
-      description: "The application can write or read data to and from these registers. In the default (ERASE) configuration this register is reset on a tamper detection event. It is forced to reset value as long as there is at least one internal or external tamper flag being set. This register is also reset when the readout protection (RDP) is disabled."
-      bit_offset: 0
-      bit_size: 32
-fieldset/BKP4R:
-  description: TAMP backup 4 register
-  fields:
-    - name: BKP
-      description: "The application can write or read data to and from these registers. In the default (ERASE) configuration this register is reset on a tamper detection event. It is forced to reset value as long as there is at least one internal or external tamper flag being set. This register is also reset when the readout protection (RDP) is disabled."
-      bit_offset: 0
-      bit_size: 32
-fieldset/BKP5R:
-  description: TAMP backup 5 register
-  fields:
-    - name: BKP
-      description: "The application can write or read data to and from these registers. In the default (ERASE) configuration this register is reset on a tamper detection event. It is forced to reset value as long as there is at least one internal or external tamper flag being set. This register is also reset when the readout protection (RDP) is disabled."
-      bit_offset: 0
-      bit_size: 32
-fieldset/BKP6R:
-  description: TAMP backup 6 register
-  fields:
-    - name: BKP
-      description: "The application can write or read data to and from these registers. In the default (ERASE) configuration this register is reset on a tamper detection event. It is forced to reset value as long as there is at least one internal or external tamper flag being set. This register is also reset when the readout protection (RDP) is disabled."
-      bit_offset: 0
-      bit_size: 32
-fieldset/BKP7R:
-  description: TAMP backup 7 register
-  fields:
-    - name: BKP
-      description: "The application can write or read data to and from these registers. In the default (ERASE) configuration this register is reset on a tamper detection event. It is forced to reset value as long as there is at least one internal or external tamper flag being set. This register is also reset when the readout protection (RDP) is disabled."
-      bit_offset: 0
-      bit_size: 32
-fieldset/BKP8R:
-  description: TAMP backup 8 register
-  fields:
-    - name: BKP
-      description: "The application can write or read data to and from these registers. In the default (ERASE) configuration this register is reset on a tamper detection event. It is forced to reset value as long as there is at least one internal or external tamper flag being set. This register is also reset when the readout protection (RDP) is disabled."
-      bit_offset: 0
-      bit_size: 32
-fieldset/BKP9R:
-  description: TAMP backup 9 register
+fieldset/BKPR:
+  description: TAMP backup register
   fields:
     - name: BKP
       description: "The application can write or read data to and from these registers. In the default (ERASE) configuration this register is reset on a tamper detection event. It is forced to reset value as long as there is at least one internal or external tamper flag being set. This register is also reset when the readout protection (RDP) is disabled."
       bit_offset: 0
       bit_size: 32
 fieldset/COUNTR:
-  description: "TAMP monotonic counter 1 register "
+  description: "TAMP monotonic counter 1 register"
   fields:
     - name: COUNT
       description: This register is read-only only and is incremented by one when a write access is done to this register. This register cannot roll-over and is frozen when reaching the maximum value.
@@ -578,249 +159,65 @@ fieldset/COUNTR:
 fieldset/CR1:
   description: "TAMP control register 1 "
   fields:
-    - name: TAMP1E
-      description: Tamper detection on IN1 enable
+    - name: TAMPE
+      description: Tamper detection on INx enable
       bit_offset: 0
       bit_size: 1
-    - name: TAMP2E
-      description: Tamper detection on IN2 enable
-      bit_offset: 1
-      bit_size: 1
-    - name: TAMP3E
-      description: Tamper detection on IN3 enable
-      bit_offset: 2
-      bit_size: 1
-    - name: TAMP4E
-      description: Tamper detection on IN4 enable
-      bit_offset: 3
-      bit_size: 1
-    - name: TAMP5E
-      description: Tamper detection on IN5 enable
-      bit_offset: 4
-      bit_size: 1
-    - name: TAMP6E
-      description: Tamper detection on IN6 enable
-      bit_offset: 5
-      bit_size: 1
-    - name: TAMP7E
-      description: Tamper detection on IN7 enable
-      bit_offset: 6
-      bit_size: 1
-    - name: TAMP8E
-      description: Tamper detection on IN8 enable
-      bit_offset: 7
-      bit_size: 1
-    - name: ITAMP1E
-      description: Internal tamper 1 enable
+      array:
+        len: 8
+        stride: 1
+    - name: ITAMPE
+      description: Internal tamper X enable
       bit_offset: 16
       bit_size: 1
-    - name: ITAMP2E
-      description: Internal tamper 2 enable
-      bit_offset: 17
-      bit_size: 1
-    - name: ITAMP3E
-      description: Internal tamper 3 enable
-      bit_offset: 18
-      bit_size: 1
-    - name: ITAMP5E
-      description: Internal tamper 5 enable
-      bit_offset: 20
-      bit_size: 1
-    - name: ITAMP6E
-      description: Internal tamper 6 enable
-      bit_offset: 21
-      bit_size: 1
-    - name: ITAMP7E
-      description: Internal tamper 7 enable
-      bit_offset: 22
-      bit_size: 1
-    - name: ITAMP8E
-      description: Internal tamper 8 enable
-      bit_offset: 23
-      bit_size: 1
-    - name: ITAMP9E
-      description: Internal tamper 9 enable
-      bit_offset: 24
-      bit_size: 1
-    - name: ITAMP11E
-      description: Internal tamper 11 enable
-      bit_offset: 26
-      bit_size: 1
-    - name: ITAMP12E
-      description: Internal tamper 12 enable
-      bit_offset: 27
-      bit_size: 1
-    - name: ITAMP13E
-      description: Internal tamper 13 enable
-      bit_offset: 28
-      bit_size: 1
+      array:
+        len: 13
+        stride: 1
 fieldset/CR2:
-  description: "TAMP control register 2 "
+  description: "TAMP control register 2"
   fields:
-    - name: TAMP1NOER
-      description: Tamper 1 no erase
+    - name: TAMPNOER
+      description: Tamper X no erase
       bit_offset: 0
       bit_size: 1
-      enum: TAMPNOER
-    - name: TAMP2NOER
-      description: Tamper 2 no erase
-      bit_offset: 1
-      bit_size: 1
-      enum: TAMPNOER
-    - name: TAMP3NOER
-      description: Tamper 3 no erase
-      bit_offset: 2
-      bit_size: 1
-      enum: TAMPNOER
-    - name: TAMP4NOER
-      description: Tamper 4 no erase
-      bit_offset: 3
-      bit_size: 1
-      enum: TAMPNOER
-    - name: TAMP5NOER
-      description: Tamper 5 no erase
-      bit_offset: 4
-      bit_size: 1
-      enum: TAMPNOER
-    - name: TAMP6NOER
-      description: Tamper 6 no erase
-      bit_offset: 5
-      bit_size: 1
-      enum: TAMPNOER
-    - name: TAMP7NOER
-      description: Tamper 7 no erase
-      bit_offset: 6
-      bit_size: 1
-      enum: TAMPNOER
-    - name: TAMP8NOER
-      description: Tamper 8 no erase
-      bit_offset: 7
-      bit_size: 1
-      enum: TAMPNOER
-    - name: TAMP1MSK
-      description: Tamper 1 mask. The tamper 1 interrupt must not be enabled when TAMP1MSK is set.
+      array:
+        len: 8
+        stride: 1
+    - name: TAMPMSK
+      description: Tamper X mask. The tamper 1 interrupt must not be enabled when TAMP1MSK is set.
       bit_offset: 16
       bit_size: 1
-      enum: TAMPMSK
-    - name: TAMP2MSK
-      description: "Tamper 2 mask. The tamper 2 interrupt must not be enabled when TAMP2MSK is set."
-      bit_offset: 17
-      bit_size: 1
-      enum: TAMPMSK
-    - name: TAMP3MSK
-      description: "Tamper 3 mask. The tamper 3 interrupt must not be enabled when TAMP3MSK is set."
-      bit_offset: 18
-      bit_size: 1
-      enum: TAMPMSK
+      array:
+        len: 3
+        stride: 1
     - name: BKBLOCK
       description: Backup registers and device secrets access blocked
       bit_offset: 22
       bit_size: 1
-      enum: BKBLOCK
     - name: BKERASE
       description: Backup registers and device secrets erase. Writing '1 to this bit reset the backup registers and device secrets(1). Writing 0 has no effect. This bit is always read as 0.
       bit_offset: 23
       bit_size: 1
-    - name: TAMP1TRG
+    - name: TAMPTRG
       description: Active level for tamper 1 input.
       bit_offset: 24
       bit_size: 1
-      enum: TAMPTRG
-    - name: TAMP2TRG
-      description: "Active level for tamper 2 input. If TAMPFLT = 00 Tamper 2 input rising edge and high level triggers a tamper detection event. If TAMPFLT = 00 Tamper 2 input falling edge and low level triggers a tamper detection event."
-      bit_offset: 25
-      bit_size: 1
-      enum: TAMPTRG
-    - name: TAMP3TRG
-      description: "Active level for tamper 3 input. If TAMPFLT = 00 Tamper 3 input rising edge and high level triggers a tamper detection event. If TAMPFLT = 00 Tamper 3 input falling edge and low level triggers a tamper detection event."
-      bit_offset: 26
-      bit_size: 1
-      enum: TAMPTRG
-    - name: TAMP4TRG
-      description: "Active level for tamper 4 input (active mode disabled). If TAMPFLT = 00 Tamper 4 input rising edge and high level triggers a tamper detection event. If TAMPFLT = 00 Tamper 4 input falling edge and low level triggers a tamper detection event."
-      bit_offset: 27
-      bit_size: 1
-      enum: TAMPTRG
-    - name: TAMP5TRG
-      description: "Active level for tamper 5 input (active mode disabled). If TAMPFLT = 00 Tamper 5 input rising edge and high level triggers a tamper detection event. If TAMPFLT = 00 Tamper 5 input falling edge and low level triggers a tamper detection event."
-      bit_offset: 28
-      bit_size: 1
-      enum: TAMPTRG
-    - name: TAMP6TRG
-      description: "Active level for tamper 6 input (active mode disabled). If TAMPFLT = 00 Tamper 6 input rising edge and high level triggers a tamper detection event. If TAMPFLT = 00 Tamper 6 input falling edge and low level triggers a tamper detection event."
-      bit_offset: 29
-      bit_size: 1
-      enum: TAMPTRG
-    - name: TAMP7TRG
-      description: "Active level for tamper 7 input (active mode disabled). If TAMPFLT = 00 Tamper 7 input rising edge and high level triggers a tamper detection event. If TAMPFLT = 00 Tamper 7 input falling edge and low level triggers a tamper detection event."
-      bit_offset: 30
-      bit_size: 1
-      enum: TAMPTRG
-    - name: TAMP8TRG
-      description: "Active level for tamper 8 input (active mode disabled). If TAMPFLT = 00 Tamper 8 input rising edge and high level triggers a tamper detection event. If TAMPFLT = 00 Tamper 8 input falling edge and low level triggers a tamper detection event."
-      bit_offset: 31
-      bit_size: 1
+      array:
+        len: 8
+        stride: 1
       enum: TAMPTRG
 fieldset/CR3:
-  description: "TAMP control register 3 "
+  description: "TAMP control register 3"
   fields:
-    - name: ITAMP1NOER
-      description: Internal Tamper 1 no erase
+    - name: ITAMPNOER
+      description: Internal Tamper X no erase
       bit_offset: 0
       bit_size: 1
-      enum: ITAMPNOER
-    - name: ITAMP2NOER
-      description: Internal Tamper 2 no erase
-      bit_offset: 1
-      bit_size: 1
-      enum: ITAMPNOER
-    - name: ITAMP3NOER
-      description: Internal Tamper 3 no erase
-      bit_offset: 2
-      bit_size: 1
-      enum: ITAMPNOER
-    - name: ITAMP5NOER
-      description: Internal Tamper 5 no erase
-      bit_offset: 4
-      bit_size: 1
-      enum: ITAMPNOER
-    - name: ITAMP6NOER
-      description: Internal Tamper 6 no erase
-      bit_offset: 5
-      bit_size: 1
-      enum: ITAMPNOER
-    - name: ITAMP7NOER
-      description: Internal Tamper 7 no erase
-      bit_offset: 6
-      bit_size: 1
-      enum: ITAMPNOER
-    - name: ITAMP8NOER
-      description: Internal Tamper 8 no erase
-      bit_offset: 7
-      bit_size: 1
-      enum: ITAMPNOER
-    - name: ITAMP9NOER
-      description: Internal Tamper 9 no erase
-      bit_offset: 8
-      bit_size: 1
-      enum: ITAMPNOER
-    - name: ITAMP11NOER
-      description: Internal Tamper 11 no erase
-      bit_offset: 10
-      bit_size: 1
-      enum: ITAMPNOER
-    - name: ITAMP12NOER
-      description: Internal Tamper 12 no erase
-      bit_offset: 11
-      bit_size: 1
-      enum: ITAMPNOER
-    - name: ITAMP13NOER
-      description: Internal Tamper 13 no erase
-      bit_offset: 12
-      bit_size: 1
-      enum: ITAMPNOER
+      array:
+        len: 13
+        stride: 1
 fieldset/ERCFGR:
-  description: "TAMP erase configuration register "
+  description: "TAMP erase configuration register"
   fields:
     - name: ERCFG0
       description: Configurable device secrets configuration
@@ -828,7 +225,7 @@ fieldset/ERCFGR:
       bit_size: 1
       enum: ERCFG
 fieldset/FLTCR:
-  description: "TAMP filter control register "
+  description: "TAMP filter control register"
   fields:
     - name: TAMPFREQ
       description: "Tamper sampling frequency. Determines the frequency at which each of the INx inputs are sampled."
@@ -850,163 +247,39 @@ fieldset/FLTCR:
       bit_offset: 7
       bit_size: 1
 fieldset/IER:
-  description: "TAMP interrupt enable register "
+  description: "TAMP interrupt enable register"
   fields:
-    - name: TAMP1IE
-      description: Tamper 1 interrupt enable
+    - name: TAMPIE
+      description: Tamper X interrupt enable
       bit_offset: 0
       bit_size: 1
-    - name: TAMP2IE
-      description: Tamper 2 interrupt enable
-      bit_offset: 1
-      bit_size: 1
-    - name: TAMP3IE
-      description: Tamper 3 interrupt enable
-      bit_offset: 2
-      bit_size: 1
-    - name: TAMP4IE
-      description: Tamper 4 interrupt enable
-      bit_offset: 3
-      bit_size: 1
-    - name: TAMP5IE
-      description: Tamper 5 interrupt enable
-      bit_offset: 4
-      bit_size: 1
-    - name: TAMP6IE
-      description: Tamper 6 interrupt enable
-      bit_offset: 5
-      bit_size: 1
-    - name: TAMP7IE
-      description: Tamper 7interrupt enable
-      bit_offset: 6
-      bit_size: 1
-    - name: TAMP8IE
-      description: Tamper 8 interrupt enable
-      bit_offset: 7
-      bit_size: 1
-    - name: ITAMP1IE
-      description: Internal tamper 1 interrupt enable
+      array:
+        len: 8
+        stride: 1
+    - name: ITAMPIE
+      description: Internal tamper X interrupt enable
       bit_offset: 16
       bit_size: 1
-    - name: ITAMP2IE
-      description: Internal tamper 2 interrupt enable
-      bit_offset: 17
-      bit_size: 1
-    - name: ITAMP3IE
-      description: Internal tamper 3 interrupt enable
-      bit_offset: 18
-      bit_size: 1
-    - name: ITAMP5IE
-      description: Internal tamper 5 interrupt enable
-      bit_offset: 20
-      bit_size: 1
-    - name: ITAMP6IE
-      description: Internal tamper 6 interrupt enable
-      bit_offset: 21
-      bit_size: 1
-    - name: ITAMP7IE
-      description: Internal tamper 7 interrupt enable
-      bit_offset: 22
-      bit_size: 1
-    - name: ITAMP8IE
-      description: Internal tamper 8 interrupt enable
-      bit_offset: 23
-      bit_size: 1
-    - name: ITAMP9IE
-      description: Internal tamper 9 interrupt enable
-      bit_offset: 24
-      bit_size: 1
-    - name: ITAMP11IE
-      description: Internal tamper 11 interrupt enable
-      bit_offset: 26
-      bit_size: 1
-    - name: ITAMP12IE
-      description: Internal tamper 12 interrupt enable
-      bit_offset: 27
-      bit_size: 1
-    - name: ITAMP13IE
-      description: Internal tamper 13 interrupt enable
-      bit_offset: 28
-      bit_size: 1
+      array:
+        len: 13
+        stride: 1
 fieldset/MISR:
-  description: "TAMP non-secure masked interrupt status register "
+  description: "TAMP non-secure masked interrupt status register"
   fields:
-    - name: TAMP1MF
-      description: "TAMP1 non-secure interrupt masked flag. This flag is set by hardware when the tamper 1 non-secure interrupt is raised."
+    - name: TAMPMF
+      description: "TAMPx non-secure interrupt masked flag. This flag is set by hardware when the tamper X non-secure interrupt is raised."
       bit_offset: 0
       bit_size: 1
-    - name: TAMP2MF
-      description: "TAMP2 non-secure interrupt masked flag. This flag is set by hardware when the tamper 2 non-secure interrupt is raised."
-      bit_offset: 1
-      bit_size: 1
-    - name: TAMP3MF
-      description: "TAMP3 non-secure interrupt masked flag. This flag is set by hardware when the tamper 3 non-secure interrupt is raised."
-      bit_offset: 2
-      bit_size: 1
-    - name: TAMP4MF
-      description: "TAMP4 non-secure interrupt masked flag. This flag is set by hardware when the tamper 4 non-secure interrupt is raised."
-      bit_offset: 3
-      bit_size: 1
-    - name: TAMP5MF
-      description: "TAMP5 non-secure interrupt masked flag. This flag is set by hardware when the tamper 5 non-secure interrupt is raised."
-      bit_offset: 4
-      bit_size: 1
-    - name: TAMP6MF
-      description: "TAMP6 non-secure interrupt masked flag. This flag is set by hardware when the tamper 6 non-secure interrupt is raised."
-      bit_offset: 5
-      bit_size: 1
-    - name: TAMP7MF
-      description: "TAMP7 non-secure interrupt masked flag. This flag is set by hardware when the tamper 7 non-secure interrupt is raised."
-      bit_offset: 6
-      bit_size: 1
-    - name: TAMP8MF
-      description: "TAMP8 non-secure interrupt masked flag. This flag is set by hardware when the tamper 8 non-secure interrupt is raised."
-      bit_offset: 7
-      bit_size: 1
-    - name: ITAMP1MF
-      description: "Internal tamper 1 non-secure interrupt masked flag. This flag is set by hardware when the internal tamper 1 non-secure interrupt is raised."
+      array:
+        len: 8
+        stride: 1
+    - name: ITAMPMF
+      description: "Internal tamper X non-secure interrupt masked flag. This flag is set by hardware when the internal tamper X non-secure interrupt is raised."
       bit_offset: 16
       bit_size: 1
-    - name: ITAMP2MF
-      description: "Internal tamper 2 non-secure interrupt masked flag. This flag is set by hardware when the internal tamper 2 non-secure interrupt is raised."
-      bit_offset: 17
-      bit_size: 1
-    - name: ITAMP3MF
-      description: "Internal tamper 3 non-secure interrupt masked flag. This flag is set by hardware when the internal tamper 3 non-secure interrupt is raised."
-      bit_offset: 18
-      bit_size: 1
-    - name: ITAMP5MF
-      description: "Internal tamper 5 non-secure interrupt masked flag. This flag is set by hardware when the internal tamper 5 non-secure interrupt is raised."
-      bit_offset: 20
-      bit_size: 1
-    - name: ITAMP6MF
-      description: "Internal tamper 6 non-secure interrupt masked flag. This flag is set by hardware when the internal tamper 6 non-secure interrupt is raised."
-      bit_offset: 21
-      bit_size: 1
-    - name: ITAMP7MF
-      description: "VCORE monitoring tamper non-secure interrupt masked flag. This flag is set by hardware when the internal tamper 7 non-secure interrupt is raised."
-      bit_offset: 22
-      bit_size: 1
-    - name: ITAMP8MF
-      description: "Internal tamper 8 non-secure interrupt masked flag. This flag is set by hardware when the internal tamper 8 non-secure interrupt is raised."
-      bit_offset: 23
-      bit_size: 1
-    - name: ITAMP9MF
-      description: "internal tamper 9 non-secure interrupt masked flag. This flag is set by hardware when the internal tamper 9 non-secure interrupt is raised."
-      bit_offset: 24
-      bit_size: 1
-    - name: ITAMP11MF
-      description: "internal tamper 11 non-secure interrupt masked flag. This flag is set by hardware when the internal tamper 11 non-secure interrupt is raised."
-      bit_offset: 26
-      bit_size: 1
-    - name: ITAMP12MF
-      description: "internal tamper 12 non-secure interrupt masked flag. This flag is set by hardware when the internal tamper 12 non-secure interrupt is raised."
-      bit_offset: 27
-      bit_size: 1
-    - name: ITAMP13MF
-      description: "internal tamper 13 non-secure interrupt masked flag. This flag is set by hardware when the internal tamper 13 non-secure interrupt is raised."
-      bit_offset: 28
-      bit_size: 1
+      array:
+        len: 13
+        stride: 1
 fieldset/PRIVCR:
   description: "TAMP privilege mode control register "
   fields:
@@ -1014,103 +287,41 @@ fieldset/PRIVCR:
       description: Monotonic counter 1 privilege protection
       bit_offset: 15
       bit_size: 1
-      enum: CNTPRIV
+      enum: PRIV
     - name: BKPRWPRIV
       description: Backup registers zone 1 privilege protection
       bit_offset: 29
       bit_size: 1
-      enum: BKPRWPRIV
+      enum: PRIV
     - name: BKPWPRIV
       description: Backup registers zone 2 privilege protection
       bit_offset: 30
       bit_size: 1
-      enum: BKPWPRIV
+      enum: PRIV
     - name: TAMPPRIV
       description: "Tamper privilege protection (excluding backup registers). Note: Refer to for details on the read protection."
       bit_offset: 31
       bit_size: 1
-      enum: TAMPPRIV
+      enum: PRIV
 fieldset/SCR:
-  description: "TAMP status clear register "
+  description: "TAMP status clear register"
   fields:
-    - name: CTAMP1F
-      description: "Clear TAMP1 detection flag. Writing 1 in this bit clears the TAMP1F bit in the SR register."
+    - name: CTAMPF
+      description: "Clear TAMPx detection flag. Writing 1 in this bit clears the TAMPxF bit in the SR register."
       bit_offset: 0
       bit_size: 1
-    - name: CTAMP2F
-      description: "Clear TAMP2 detection flag. Writing 1 in this bit clears the TAMP2F bit in the SR register."
-      bit_offset: 1
-      bit_size: 1
-    - name: CTAMP3F
-      description: "Clear TAMP3 detection flag. Writing 1 in this bit clears the TAMP3F bit in the SR register."
-      bit_offset: 2
-      bit_size: 1
-    - name: CTAMP4F
-      description: "Clear TAMP4 detection flag. Writing 1 in this bit clears the TAMP4F bit in the SR register."
-      bit_offset: 3
-      bit_size: 1
-    - name: CTAMP5F
-      description: "Clear TAMP5 detection flag. Writing 1 in this bit clears the TAMP5F bit in the SR register."
-      bit_offset: 4
-      bit_size: 1
-    - name: CTAMP6F
-      description: "Clear TAMP6 detection flag. Writing 1 in this bit clears the TAMP6F bit in the SR register."
-      bit_offset: 5
-      bit_size: 1
-    - name: CTAMP7F
-      description: "Clear TAMP7 detection flag. Writing 1 in this bit clears the TAMP7F bit in the SR register."
-      bit_offset: 6
-      bit_size: 1
-    - name: CTAMP8F
-      description: "Clear TAMP8 detection flag. Writing 1 in this bit clears the TAMP8F bit in the SR register."
-      bit_offset: 7
-      bit_size: 1
-    - name: CITAMP1F
-      description: "Clear ITAMP1 detection flag. Writing 1 in this bit clears the ITAMP1F bit in the SR register."
+      array:
+        len: 8
+        stride: 1
+    - name: CITAMPF
+      description: "Clear ITAMPx detection flag. Writing 1 in this bit clears the ITAMPxF bit in the SR register."
       bit_offset: 16
       bit_size: 1
-    - name: CITAMP2F
-      description: "Clear ITAMP2 detection flag. Writing 1 in this bit clears the ITAMP2F bit in the SR register."
-      bit_offset: 17
-      bit_size: 1
-    - name: CITAMP3F
-      description: "Clear ITAMP3 detection flag. Writing 1 in this bit clears the ITAMP3F bit in the SR register."
-      bit_offset: 18
-      bit_size: 1
-    - name: CITAMP5F
-      description: "Clear ITAMP5 detection flag. Writing 1 in this bit clears the ITAMP5F bit in the SR register."
-      bit_offset: 20
-      bit_size: 1
-    - name: CITAMP6F
-      description: "Clear ITAMP6 detection flag. Writing 1 in this bit clears the ITAMP6F bit in the SR register."
-      bit_offset: 21
-      bit_size: 1
-    - name: CITAMP7F
-      description: "Clear ITAMP7 detection flag. Writing 1 in this bit clears the ITAMP7F bit in the SR register."
-      bit_offset: 22
-      bit_size: 1
-    - name: CITAMP8F
-      description: "Clear ITAMP8 detection flag. Writing 1 in this bit clears the ITAMP8F bit in the SR register."
-      bit_offset: 23
-      bit_size: 1
-    - name: CITAMP9F
-      description: "Clear ITAMP9 detection flag. Writing 1 in this bit clears the ITAMP9F bit in the SR register."
-      bit_offset: 24
-      bit_size: 1
-    - name: CITAMP11F
-      description: "Clear ITAMP11 detection flag. Writing 1 in this bit clears the ITAMP11F bit in the SR register."
-      bit_offset: 26
-      bit_size: 1
-    - name: CITAMP12F
-      description: "Clear ITAMP12 detection flag. Writing 1 in this bit clears the ITAMP12F bit in the SR register."
-      bit_offset: 27
-      bit_size: 1
-    - name: CITAMP13F
-      description: "Clear ITAMP13 detection flag. Writing 1 in this bit clears the ITAMP13F bit in the SR register."
-      bit_offset: 28
-      bit_size: 1
+      array:
+        len: 13
+        stride: 1
 fieldset/SECCFGR:
-  description: "TAMP secure mode register "
+  description: "TAMP secure mode register"
   fields:
     - name: BKPRWSEC
       description: "Backup registers read/write protection offset. Protection zone 1 is defined for backup registers from BKP0R to BKPxR (x = BKPRWSEC-1, from 0 to 128). if TZEN=1, these backup registers can be read and written only with secure access. If TZEN=0:\tthe protection zone 1 can be read and written with non-secure access. If BKPRWSEC = 0: there is no protection zone 1. If BKPRWPRIV is set, BKPRWSEC[7:0] can be written only in privileged mode."
@@ -1120,7 +331,7 @@ fieldset/SECCFGR:
       description: Monotonic counter 1 secure protection
       bit_offset: 15
       bit_size: 1
-      enum: CNTSEC
+      enum: SEC
     - name: BKPWSEC
       description: "Backup registers write protection offset. Protection zone 2 is defined for backup registers from BKPyR (y = BKPRWSEC, from 0 to 128) to BKPzR (z = BKPWSEC-1, from 0 to 128, BKPWSECBKPRWSEC): if TZEN=1, these backup registers can be written only with secure access. They can be read with secure or non-secure access. Protection zone 3 defined for backup registers from BKPtR (t = BKPWSEC, from 0 to 127). They can be read or written with secure or non-secure access. If TZEN=0:\tthe protection zone 2 can be read and written with non-secure access. If BKPWSEC = 0 or if BKPWSEC BKPRWSEC: there is no protection zone 2. If BKPWPRIV is set, BKPRWSEC[7:0] can be written only in privileged mode."
       bit_offset: 16
@@ -1134,573 +345,155 @@ fieldset/SECCFGR:
       description: "Tamper protection (excluding monotonic counters and backup registers). Note: Refer to for details on the read protection."
       bit_offset: 31
       bit_size: 1
-      enum: TAMPSEC
+      enum: SEC
 fieldset/SMISR:
-  description: "TAMP secure masked interrupt status register "
+  description: "TAMP secure masked interrupt status register"
   fields:
-    - name: TAMP1MF
-      description: "TAMP1 secure interrupt masked flag. This flag is set by hardware when the tamper 1 secure interrupt is raised."
+    - name: TAMPMF
+      description: "TAMPx secure interrupt masked flag. This flag is set by hardware when the tamper X secure interrupt is raised."
       bit_offset: 0
       bit_size: 1
-    - name: TAMP2MF
-      description: "TAMP2 secure interrupt masked flag. This flag is set by hardware when the tamper 2 secure interrupt is raised."
-      bit_offset: 1
-      bit_size: 1
-    - name: TAMP3MF
-      description: "TAMP3 secure interrupt masked flag. This flag is set by hardware when the tamper 3 secure interrupt is raised."
-      bit_offset: 2
-      bit_size: 1
-    - name: TAMP4MF
-      description: "TAMP4 secure interrupt masked flag. This flag is set by hardware when the tamper 4 secure interrupt is raised."
-      bit_offset: 3
-      bit_size: 1
-    - name: TAMP5MF
-      description: "TAMP5 secure interrupt masked flag. This flag is set by hardware when the tamper 5 secure interrupt is raised."
-      bit_offset: 4
-      bit_size: 1
-    - name: TAMP6MF
-      description: "TAMP6 secure interrupt masked flag. This flag is set by hardware when the tamper 6 secure interrupt is raised."
-      bit_offset: 5
-      bit_size: 1
-    - name: TAMP7MF
-      description: "TAMP7 secure interrupt masked flag. This flag is set by hardware when the tamper 7 secure interrupt is raised."
-      bit_offset: 6
-      bit_size: 1
-    - name: TAMP8MF
-      description: "TAMP8 secure interrupt masked flag. This flag is set by hardware when the tamper 8 secure interrupt is raised."
-      bit_offset: 7
-      bit_size: 1
-    - name: ITAMP1MF
-      description: "Internal tamper 1 secure interrupt masked flag. This flag is set by hardware when the internal tamper 1 secure interrupt is raised."
+      array:
+        len: 8
+        stride: 1
+    - name: ITAMPMF
+      description: "Internal tamper X secure interrupt masked flag. This flag is set by hardware when the internal tamper X secure interrupt is raised."
       bit_offset: 16
       bit_size: 1
-    - name: ITAMP2MF
-      description: "Internal tamper 2 secure interrupt masked flag. This flag is set by hardware when the internal tamper 2 secure interrupt is raised."
-      bit_offset: 17
-      bit_size: 1
-    - name: ITAMP3MF
-      description: "Internal tamper 3 secure interrupt masked flag. This flag is set by hardware when the internal tamper 3 secure interrupt is raised."
-      bit_offset: 18
-      bit_size: 1
-    - name: ITAMP5MF
-      description: "Internal tamper 5 secure interrupt masked flag. This flag is set by hardware when the internal tamper 5 secure interrupt is raised."
-      bit_offset: 20
-      bit_size: 1
-    - name: ITAMP6MF
-      description: "Internal tamper 6 secure interrupt masked flag. This flag is set by hardware when the internal tamper 6 secure interrupt is raised."
-      bit_offset: 21
-      bit_size: 1
-    - name: ITAMP7MF
-      description: "VCORE monitoring tamper secure interrupt masked flag. This flag is set by hardware when the internal tamper 7 secure interrupt is raised."
-      bit_offset: 22
-      bit_size: 1
-    - name: ITAMP8MF
-      description: "Internal tamper 8 secure interrupt masked flag. This flag is set by hardware when the internal tamper 8 secure interrupt is raised."
-      bit_offset: 23
-      bit_size: 1
-    - name: ITAMP9MF
-      description: "internal tamper 9 secure interrupt masked flag. This flag is set by hardware when the internal tamper 9 secure interrupt is raised."
-      bit_offset: 24
-      bit_size: 1
-    - name: ITAMP11MF
-      description: "internal tamper 11 secure interrupt masked flag. This flag is set by hardware when the internal tamper 11 secure interrupt is raised."
-      bit_offset: 26
-      bit_size: 1
-    - name: ITAMP12MF
-      description: "internal tamper 12 secure interrupt masked flag. This flag is set by hardware when the internal tamper 12 secure interrupt is raised."
-      bit_offset: 27
-      bit_size: 1
-    - name: ITAMP13MF
-      description: "internal tamper 13 secure interrupt masked flag. This flag is set by hardware when the internal tamper 13 secure interrupt is raised."
-      bit_offset: 28
-      bit_size: 1
+      array:
+        len: 13
+        stride: 1
 fieldset/SR:
-  description: "TAMP status register "
+  description: "TAMP status register"
   fields:
-    - name: TAMP1F
-      description: "TAMP1 detection flag. This flag is set by hardware when a tamper detection event is detected on the TAMP1 input."
+    - name: TAMPF
+      description: "TAMPx detection flag. This flag is set by hardware when a tamper detection event is detected on the TAMPx input."
       bit_offset: 0
       bit_size: 1
-    - name: TAMP2F
-      description: "TAMP2 detection flag. This flag is set by hardware when a tamper detection event is detected on the TAMP2 input."
-      bit_offset: 1
-      bit_size: 1
-    - name: TAMP3F
-      description: "TAMP3 detection flag. This flag is set by hardware when a tamper detection event is detected on the TAMP3 input."
-      bit_offset: 2
-      bit_size: 1
-    - name: TAMP4F
-      description: "TAMP4 detection flag. This flag is set by hardware when a tamper detection event is detected on the TAMP4 input."
-      bit_offset: 3
-      bit_size: 1
-    - name: TAMP5F
-      description: "TAMP5 detection flag. This flag is set by hardware when a tamper detection event is detected on the TAMP5 input."
-      bit_offset: 4
-      bit_size: 1
-    - name: TAMP6F
-      description: "TAMP6 detection flag. This flag is set by hardware when a tamper detection event is detected on the TAMP6 input."
-      bit_offset: 5
-      bit_size: 1
-    - name: TAMP7F
-      description: "TAMP7 detection flag. This flag is set by hardware when a tamper detection event is detected on the TAMP7 input."
-      bit_offset: 6
-      bit_size: 1
-    - name: TAMP8F
-      description: "TAMP8 detection flag. This flag is set by hardware when a tamper detection event is detected on the TAMP8 input"
-      bit_offset: 7
-      bit_size: 1
-    - name: ITAMP1F
-      description: "Internal tamper 1 flag. This flag is set by hardware when a tamper detection event is detected on the internal tamper 1."
+      array:
+        len: 8
+        stride: 1
+    - name: ITAMPF
+      description: "Internal tamper X flag. This flag is set by hardware when a tamper detection event is detected on the internal tamper X."
       bit_offset: 16
       bit_size: 1
-    - name: ITAMP2F
-      description: "Internal tamper 2 flag. This flag is set by hardware when a tamper detection event is detected on the internal tamper 2."
-      bit_offset: 17
-      bit_size: 1
-    - name: ITAMP3F
-      description: "Internal tamper 3 flag. This flag is set by hardware when a tamper detection event is detected on the internal tamper 3."
-      bit_offset: 18
-      bit_size: 1
-    - name: ITAMP5F
-      description: "Internal tamper 5 flag. This flag is set by hardware when a tamper detection event is detected on the internal tamper 5."
-      bit_offset: 20
-      bit_size: 1
-    - name: ITAMP6F
-      description: "Internal tamper 6 flag. This flag is set by hardware when a tamper detection event is detected on the internal tamper 6."
-      bit_offset: 21
-      bit_size: 1
-    - name: ITAMP7F
-      description: "Internal tamper 7 flag. This flag is set by hardware when a tamper detection event is detected on the internal tamper 7."
-      bit_offset: 22
-      bit_size: 1
-    - name: ITAMP8F
-      description: "Internal tamper 8 flag. This flag is set by hardware when a tamper detection event is detected on the internal tamper 8."
-      bit_offset: 23
-      bit_size: 1
-    - name: ITAMP9F
-      description: "Internal tamper 9 flag. This flag is set by hardware when a tamper detection event is detected on the internal tamper 9."
-      bit_offset: 24
-      bit_size: 1
-    - name: ITAMP11F
-      description: "Internal tamper 11 flag. This flag is set by hardware when a tamper detection event is detected on the internal tamper 11."
-      bit_offset: 26
-      bit_size: 1
-    - name: ITAMP12F
-      description: "Internal tamper 12 flag. This flag is set by hardware when a tamper detection event is detected on the internal tamper 12."
-      bit_offset: 27
-      bit_size: 1
-    - name: ITAMP13F
-      description: "Internal tamper 13 flag. This flag is set by hardware when a tamper detection event is detected on the internal tamper 13."
-      bit_offset: 28
-      bit_size: 1
+      array:
+        len: 13
+        stride: 1
 enum/ATCKSEL:
   bit_size: 3
   variants:
-    - name: B_0x0
+    - name: Div1
       description: RTCCLK is selected
       value: 0
-    - name: B_0x1
+    - name: Div2
       description: RTCCLK/2 is selected when (PREDIV_A+1) = 128 (actually selects 1st flip flop output)
       value: 1
-    - name: B_0x2
+    - name: Div4
       description: RTCCLK/4 is selected when (PREDIV_A+1) = 128 (actually selects 2nd flip flop output)
       value: 2
-    - name: B_0x7
+    - name: Div128
       description: RTCCLK/128 is selected when (PREDIV_A+1) = 128 (actually selects 7th flip flop output)
       value: 7
-enum/ATOSEL:
-  bit_size: 3
-  variants:
-    - name: B_0x0
-      description: TAMPOUTSEL6 = OUT1
-      value: 0
-    - name: B_0x1
-      description: TAMPOUTSEL6 = OUT2
-      value: 1
-    - name: B_0x2
-      description: TAMPOUTSEL6 = OUT3
-      value: 2
-    - name: B_0x3
-      description: TAMPOUTSEL6 = OUT4
-      value: 3
-    - name: B_0x4
-      description: TAMPOUTSEL6 = OUT5
-      value: 4
-    - name: B_0x5
-      description: TAMPOUTSEL6 = OUT6
-      value: 5
-    - name: B_0x6
-      description: TAMPOUTSEL6 = OUT7
-      value: 6
-    - name: B_0x7
-      description: TAMPOUTSEL6 = OUT8
-      value: 7
-enum/ATOSHARE:
-  bit_size: 1
-  variants:
-    - name: B_0x0
-      description: Each active tamper input INi is compared with its dedicated output OUTi
-      value: 0
-    - name: B_0x1
-      description: "Each active tamper input INi is compared with TAMPOUTSELx as defined below, with TAMPOUTSELx defined by ATOSELx bits."
-      value: 1
 enum/BHKLOCK:
   bit_size: 1
   variants:
-    - name: B_0x0
+    - name: Unlocked
       description: The Backup registers from BKP0R to BKP7R can be accessed according to the Protection zone they belong to.
       value: 0
-    - name: B_0x1
+    - name: Locked
       description: The backup registers from BKP0R to BKP7R cannot be accessed neither in read nor in write (they are read as 0 and write ignore).
-      value: 1
-enum/BKBLOCK:
-  bit_size: 1
-  variants:
-    - name: B_0x0
-      description: backup registers and device secrets(1) can be accessed if no tamper flag is set
-      value: 0
-    - name: B_0x1
-      description: backup registers and device secrets(1) cannot be accessed
-      value: 1
-enum/BKPRWPRIV:
-  bit_size: 1
-  variants:
-    - name: B_0x0
-      description: Backup registers zone 1 can be read and written with privileged or unprivileged access.
-      value: 0
-    - name: B_0x1
-      description: Backup registers zone 1 can be read and written only with privileged access
-      value: 1
-enum/BKPWPRIV:
-  bit_size: 1
-  variants:
-    - name: B_0x0
-      description: Backup registers zone 2 can be written with privileged or unprivileged access.
-      value: 0
-    - name: B_0x1
-      description: Backup registers zone 2 can be written only with privileged access.
-      value: 1
-enum/CNTPRIV:
-  bit_size: 1
-  variants:
-    - name: B_0x0
-      description: Monotonic counter 1 (COUNTR) can be read and written when the APB access is privileged or non-privileged.
-      value: 0
-    - name: B_0x1
-      description: Monotonic counter 1 (COUNTR) can be read and written only when the APB access is privileged.
-      value: 1
-enum/CNTSEC:
-  bit_size: 1
-  variants:
-    - name: B_0x0
-      description: Monotonic counter 1 (COUNTR) can be read and written when the APB access is secure or non-secure.
-      value: 0
-    - name: B_0x1
-      description: Monotonic counter 1 (COUNTR) can be read and written only when the APB access is secure.
       value: 1
 enum/ERCFG:
   bit_size: 1
   variants:
-    - name: B_0x0
+    - name: Unprotected
       description: Configurable device secrets are not included in the device secrets protected by TAMP peripheral
       value: 0
-    - name: B_0x1
+    - name: Protected
       description: Configurable device secrets are is included in the device secrets protected by TAMP peripheral
-      value: 1
-enum/FLTEN:
-  bit_size: 1
-  variants:
-    - name: B_0x0
-      description: Active tamper filtering disable
-      value: 0
-    - name: B_0x1
-      description: "Active tamper filtering enable: a tamper event is detected when 2 comparison mismatches occur out of 4 consecutive samples."
-      value: 1
-enum/ITAMPNOER:
-  bit_size: 1
-  variants:
-    - name: B_0x0
-      description: Internal Tamper 5 event erases the backup registers and all device secrets(1).
-      value: 0
-    - name: B_0x1
-      description: Internal Tamper 5 event does not erase the backup registers and device secrets(2).
-      value: 1
-enum/TAMPAM:
-  bit_size: 1
-  variants:
-    - name: B_0x0
-      description: Tamper 3 detection mode is passive.
-      value: 0
-    - name: B_0x1
-      description: Tamper 3 detection mode is active.
       value: 1
 enum/TAMPFLT:
   bit_size: 2
   variants:
-    - name: B_0x0
+    - name: NoFilter
       description: Tamper event is activated on edge of INx input transitions to the active level (no internal pull-up on INx input).
       value: 0
-    - name: B_0x1
+    - name: Filter2
       description: Tamper event is activated after 2 consecutive samples at the active level.
       value: 1
-    - name: B_0x2
+    - name: Filter4
       description: Tamper event is activated after 4 consecutive samples at the active level.
       value: 2
-    - name: B_0x3
+    - name: Filter8
       description: Tamper event is activated after 8 consecutive samples at the active level.
       value: 3
 enum/TAMPFREQ:
   bit_size: 3
   variants:
-    - name: B_0x0
+    - name: Hz_1
       description: RTCCLK / 32768 (1 Hz when RTCCLK = 32768 Hz)
       value: 0
-    - name: B_0x1
+    - name: Hz_2
       description: RTCCLK / 16384 (2 Hz when RTCCLK = 32768 Hz)
       value: 1
-    - name: B_0x2
+    - name: Hz_4
       description: RTCCLK / 8192 (4 Hz when RTCCLK = 32768 Hz)
       value: 2
-    - name: B_0x3
+    - name: Hz_8
       description: RTCCLK / 4096 (8 Hz when RTCCLK = 32768 Hz)
       value: 3
-    - name: B_0x4
+    - name: Hz_16
       description: RTCCLK / 2048 (16 Hz when RTCCLK = 32768 Hz)
       value: 4
-    - name: B_0x5
+    - name: Hz_32
       description: RTCCLK / 1024 (32 Hz when RTCCLK = 32768 Hz)
       value: 5
-    - name: B_0x6
+    - name: Hz_64
       description: RTCCLK / 512 (64 Hz when RTCCLK = 32768 Hz)
       value: 6
-    - name: B_0x7
+    - name: Hz_128
       description: RTCCLK / 256 (128 Hz when RTCCLK = 32768 Hz)
       value: 7
-enum/TAMPMSK:
-  bit_size: 1
-  variants:
-    - name: B_0x0
-      description: Tamper 1 event generates a trigger event and TAMP1F must be cleared by software to allow next tamper event detection.
-      value: 0
-    - name: B_0x1
-      description: Tamper 1 event generates a trigger event. TAMP1F is masked and internally cleared by hardware. The backup registers and device secrets are not erased.
-      value: 1
-enum/TAMPNOER:
-  bit_size: 1
-  variants:
-    - name: B_0x0
-      description: Tamper 7 event erases the backup registers and all device secrets(1).
-      value: 0
-    - name: B_0x1
-      description: Tamper 7 event does not erase the backup registers and device secrets(2).
-      value: 1
 enum/TAMPPRCH:
   bit_size: 2
   variants:
-    - name: B_0x0
+    - name: Cycles1
       description: 1 RTCCLK cycle
       value: 0
-    - name: B_0x1
+    - name: Cycles2
       description: 2 RTCCLK cycles
       value: 1
-    - name: B_0x2
+    - name: Cycles4
       description: 4 RTCCLK cycles
       value: 2
-    - name: B_0x3
+    - name: Cycles8
       description: 8 RTCCLK cycles
       value: 3
-enum/TAMPPRIV:
+enum/PRIV:
   bit_size: 1
   variants:
-    - name: B_0x0
-      description: Tamper configuration and interrupt can be written with privileged or unprivileged access.
+    - name: Unprivileged
+      description: Can be read/written with privileged or unprivileged access.
       value: 0
-    - name: B_0x1
-      description: Tamper configuration and interrupt can be written only with privileged access.
+    - name: Privileged
+      description: Can be read/written only with privileged access.
       value: 1
-enum/TAMPSEC:
+enum/SEC:
   bit_size: 1
   variants:
-    - name: B_0x0
-      description: Tamper configuration and interrupt can be written when the APB access is secure or non-secure.
+    - name: NonSecure
+      description: Can be written when the APB access is secure or non-secure.
       value: 0
-    - name: B_0x1
-      description: Tamper configuration and interrupt can be written only when the APB access is secure.
+    - name: Secure
+      description: Can be written only when the APB access is secure.
       value: 1
 enum/TAMPTRG:
   bit_size: 1
   variants:
-    - name: B_0x0
+    - name: FilteredLowOrUnfilteredHigh
       description: "If TAMPFLT 00 Tamper 2 input staying low triggers a tamper detection event. "
       value: 0
-    - name: B_0x1
+    - name: FilteredHighOrUnfilteredLow
       description: "If TAMPFLT 00 Tamper 2 input staying high triggers a tamper detection event. "
       value: 1
-enum/ATCR1_ATOSEL1:
-  bit_size: 2
-  variants:
-    - name: B_0x0
-      description: TAMPOUTSEL1 = OUT1
-      value: 0
-    - name: B_0x1
-      description: TAMPOUTSEL1 = OUT2
-      value: 1
-    - name: B_0x2
-      description: TAMPOUTSEL1 = OUT3
-      value: 2
-    - name: B_0x3
-      description: TAMPOUTSEL1 = OUT4
-      value: 3
-enum/ATCR1_ATOSEL2:
-  bit_size: 2
-  variants:
-    - name: B_0x0
-      description: TAMPOUTSEL2 = OUT1
-      value: 0
-    - name: B_0x1
-      description: TAMPOUTSEL2 = OUT2
-      value: 1
-    - name: B_0x2
-      description: TAMPOUTSEL2 = OUT3
-      value: 2
-    - name: B_0x3
-      description: TAMPOUTSEL2 = OUT4
-      value: 3
-enum/ATCR1_ATOSEL3:
-  bit_size: 2
-  variants:
-    - name: B_0x0
-      description: TAMPOUTSEL3 = OUT1
-      value: 0
-    - name: B_0x1
-      description: TAMPOUTSEL3 = OUT2
-      value: 1
-    - name: B_0x2
-      description: TAMPOUTSEL3 = OUT3
-      value: 2
-    - name: B_0x3
-      description: TAMPOUTSEL3 = OUT4
-      value: 3
-enum/ATCR1_ATOSEL4:
-  bit_size: 2
-  variants:
-    - name: B_0x0
-      description: TAMPOUTSEL4 = OUT1
-      value: 0
-    - name: B_0x1
-      description: TAMPOUTSEL4 = OUT2
-      value: 1
-    - name: B_0x2
-      description: TAMPOUTSEL4 = OUT3
-      value: 2
-    - name: B_0x3
-      description: TAMPOUTSEL4 = OUT4
-      value: 3
-enum/ATCR2_ATOSEL1:
-  bit_size: 3
-  variants:
-    - name: B_0x0
-      description: TAMPOUTSEL1 = OUT1
-      value: 0
-    - name: B_0x1
-      description: TAMPOUTSEL1 = OUT2
-      value: 1
-    - name: B_0x2
-      description: TAMPOUTSEL1 = OUT3
-      value: 2
-    - name: B_0x3
-      description: TAMPOUTSEL1 = OUT4
-      value: 3
-    - name: B_0x4
-      description: TAMPOUTSEL1 = OUT5
-      value: 4
-    - name: B_0x5
-      description: TAMPOUTSEL1 = OUT6
-      value: 5
-    - name: B_0x6
-      description: TAMPOUTSEL1 = OUT7
-      value: 6
-    - name: B_0x7
-      description: TAMPOUTSEL1 = OUT8
-      value: 7
-enum/ATCR2_ATOSEL2:
-  bit_size: 3
-  variants:
-    - name: B_0x0
-      description: TAMPOUTSEL2 = OUT1
-      value: 0
-    - name: B_0x1
-      description: TAMPOUTSEL2 = OUT2
-      value: 1
-    - name: B_0x2
-      description: TAMPOUTSEL2 = OUT3
-      value: 2
-    - name: B_0x3
-      description: TAMPOUTSEL2 = OUT4
-      value: 3
-    - name: B_0x4
-      description: TAMPOUTSEL2 = OUT5
-      value: 4
-    - name: B_0x5
-      description: TAMPOUTSEL2 = OUT6
-      value: 5
-    - name: B_0x6
-      description: TAMPOUTSEL2 = OUT7
-      value: 6
-    - name: B_0x7
-      description: TAMPOUTSEL2 = OUT8
-      value: 7
-enum/ATCR2_ATOSEL3:
-  bit_size: 3
-  variants:
-    - name: B_0x0
-      description: TAMPOUTSEL3 = OUT1
-      value: 0
-    - name: B_0x1
-      description: TAMPOUTSEL3 = OUT2
-      value: 1
-    - name: B_0x2
-      description: TAMPOUTSEL3 = OUT3
-      value: 2
-    - name: B_0x3
-      description: TAMPOUTSEL3 = OUT4
-      value: 3
-    - name: B_0x4
-      description: TAMPOUTSEL3 = OUT5
-      value: 4
-    - name: B_0x5
-      description: TAMPOUTSEL3 = OUT6
-      value: 5
-    - name: B_0x6
-      description: TAMPOUTSEL3 = OUT7
-      value: 6
-    - name: B_0x7
-      description: TAMPOUTSEL3 = OUT8
-      value: 7
-enum/ATCR2_ATOSEL4:
-  bit_size: 3
-  variants:
-    - name: B_0x0
-      description: TAMPOUTSEL4 = OUT1
-      value: 0
-    - name: B_0x1
-      description: TAMPOUTSEL4 = OUT2
-      value: 1
-    - name: B_0x2
-      description: TAMPOUTSEL4 = OUT3
-      value: 2
-    - name: B_0x3
-      description: TAMPOUTSEL4 = OUT4
-      value: 3
-    - name: B_0x4
-      description: TAMPOUTSEL4 = OUT5
-      value: 4
-    - name: B_0x5
-      description: TAMPOUTSEL4 = OUT6
-      value: 5
-    - name: B_0x6
-      description: TAMPOUTSEL4 = OUT7
-      value: 6
-    - name: B_0x7
-      description: TAMPOUTSEL4 = OUT8
-      value: 7

--- a/data/registers/tamp_u5.yaml
+++ b/data/registers/tamp_u5.yaml
@@ -1,0 +1,1706 @@
+block/TAMP:
+  description: Tamper and backup registers
+  items:
+    - name: CR1
+      description: "TAMP control register 1 "
+      byte_offset: 0
+      fieldset: CR1
+    - name: CR2
+      description: "TAMP control register 2 "
+      byte_offset: 4
+      fieldset: CR2
+    - name: CR3
+      description: "TAMP control register 3 "
+      byte_offset: 8
+      fieldset: CR3
+    - name: FLTCR
+      description: "TAMP filter control register "
+      byte_offset: 12
+      fieldset: FLTCR
+    - name: ATCR1
+      description: "TAMP active tamper control register 1 "
+      byte_offset: 16
+      fieldset: ATCR1
+    - name: ATSEEDR
+      description: "TAMP active tamper seed register "
+      byte_offset: 20
+      fieldset: ATSEEDR
+    - name: ATOR
+      description: "TAMP active tamper output register "
+      byte_offset: 24
+      fieldset: ATOR
+    - name: ATCR2
+      description: "TAMP active tamper control register 2 "
+      byte_offset: 28
+      fieldset: ATCR2
+    - name: SECCFGR
+      description: "TAMP secure mode register "
+      byte_offset: 32
+      fieldset: SECCFGR
+    - name: PRIVCR
+      description: "TAMP privilege mode control register "
+      byte_offset: 36
+      fieldset: PRIVCR
+    - name: IER
+      description: "TAMP interrupt enable register "
+      byte_offset: 44
+      fieldset: IER
+    - name: SR
+      description: "TAMP status register "
+      byte_offset: 48
+      fieldset: SR
+    - name: MISR
+      description: "TAMP non-secure masked interrupt status register "
+      byte_offset: 52
+      fieldset: MISR
+    - name: SMISR
+      description: "TAMP secure masked interrupt status register "
+      byte_offset: 56
+      fieldset: SMISR
+    - name: SCR
+      description: "TAMP status clear register "
+      byte_offset: 60
+      fieldset: SCR
+    - name: COUNTR
+      description: "TAMP monotonic counter 1 register "
+      byte_offset: 64
+      fieldset: COUNTR
+    - name: ERCFGR
+      description: "TAMP erase configuration register "
+      byte_offset: 84
+      fieldset: ERCFGR
+    - name: BKP0R
+      description: TAMP backup 0 register
+      byte_offset: 256
+      fieldset: BKP0R
+    - name: BKP1R
+      description: TAMP backup 1 register
+      byte_offset: 260
+      fieldset: BKP1R
+    - name: BKP2R
+      description: TAMP backup 2 register
+      byte_offset: 264
+      fieldset: BKP2R
+    - name: BKP3R
+      description: TAMP backup 3 register
+      byte_offset: 268
+      fieldset: BKP3R
+    - name: BKP4R
+      description: TAMP backup 4 register
+      byte_offset: 272
+      fieldset: BKP4R
+    - name: BKP5R
+      description: TAMP backup 5 register
+      byte_offset: 276
+      fieldset: BKP5R
+    - name: BKP6R
+      description: TAMP backup 6 register
+      byte_offset: 280
+      fieldset: BKP6R
+    - name: BKP7R
+      description: TAMP backup 7 register
+      byte_offset: 284
+      fieldset: BKP7R
+    - name: BKP8R
+      description: TAMP backup 8 register
+      byte_offset: 288
+      fieldset: BKP8R
+    - name: BKP9R
+      description: TAMP backup 9 register
+      byte_offset: 292
+      fieldset: BKP9R
+    - name: BKP10R
+      description: TAMP backup 10 register
+      byte_offset: 296
+      fieldset: BKP10R
+    - name: BKP11R
+      description: TAMP backup 11 register
+      byte_offset: 300
+      fieldset: BKP11R
+    - name: BKP12R
+      description: TAMP backup 12 register
+      byte_offset: 304
+      fieldset: BKP12R
+    - name: BKP13R
+      description: TAMP backup 13 register
+      byte_offset: 308
+      fieldset: BKP13R
+    - name: BKP14R
+      description: TAMP backup 14 register
+      byte_offset: 312
+      fieldset: BKP14R
+    - name: BKP15R
+      description: TAMP backup 15 register
+      byte_offset: 316
+      fieldset: BKP15R
+    - name: BKP16R
+      description: TAMP backup 16 register
+      byte_offset: 320
+      fieldset: BKP16R
+    - name: BKP17R
+      description: TAMP backup 17 register
+      byte_offset: 324
+      fieldset: BKP17R
+    - name: BKP18R
+      description: TAMP backup 18 register
+      byte_offset: 328
+      fieldset: BKP18R
+    - name: BKP19R
+      description: TAMP backup 19 register
+      byte_offset: 332
+      fieldset: BKP19R
+    - name: BKP20R
+      description: TAMP backup 20 register
+      byte_offset: 336
+      fieldset: BKP20R
+    - name: BKP21R
+      description: TAMP backup 21 register
+      byte_offset: 340
+      fieldset: BKP21R
+    - name: BKP22R
+      description: TAMP backup 22 register
+      byte_offset: 344
+      fieldset: BKP22R
+    - name: BKP23R
+      description: TAMP backup 23 register
+      byte_offset: 348
+      fieldset: BKP23R
+    - name: BKP24R
+      description: TAMP backup 24 register
+      byte_offset: 352
+      fieldset: BKP24R
+    - name: BKP25R
+      description: TAMP backup 25 register
+      byte_offset: 356
+      fieldset: BKP25R
+    - name: BKP26R
+      description: TAMP backup 26 register
+      byte_offset: 360
+      fieldset: BKP26R
+    - name: BKP27R
+      description: TAMP backup 27 register
+      byte_offset: 364
+      fieldset: BKP27R
+    - name: BKP28R
+      description: TAMP backup 28 register
+      byte_offset: 368
+      fieldset: BKP28R
+    - name: BKP29R
+      description: TAMP backup 29 register
+      byte_offset: 372
+      fieldset: BKP29R
+    - name: BKP30R
+      description: TAMP backup 30 register
+      byte_offset: 376
+      fieldset: BKP30R
+    - name: BKP31R
+      description: TAMP backup 31 register
+      byte_offset: 380
+      fieldset: BKP31R
+fieldset/ATCR1:
+  description: "TAMP active tamper control register 1 "
+  fields:
+    - name: TAMP1AM
+      description: Tamper 1 active mode
+      bit_offset: 0
+      bit_size: 1
+      enum: TAMPAM
+    - name: TAMP2AM
+      description: Tamper 2 active mode
+      bit_offset: 1
+      bit_size: 1
+      enum: TAMPAM
+    - name: TAMP3AM
+      description: Tamper 3 active mode
+      bit_offset: 2
+      bit_size: 1
+      enum: TAMPAM
+    - name: TAMP4AM
+      description: Tamper 4 active mode
+      bit_offset: 3
+      bit_size: 1
+      enum: TAMPAM
+    - name: TAMP5AM
+      description: Tamper 5 active mode
+      bit_offset: 4
+      bit_size: 1
+      enum: TAMPAM
+    - name: TAMP6AM
+      description: Tamper 6 active mode
+      bit_offset: 5
+      bit_size: 1
+      enum: TAMPAM
+    - name: TAMP7AM
+      description: Tamper 7 active mode
+      bit_offset: 6
+      bit_size: 1
+      enum: TAMPAM
+    - name: TAMP8AM
+      description: Tamper 8 active mode
+      bit_offset: 7
+      bit_size: 1
+      enum: TAMPAM
+    - name: ATOSEL1
+      description: "Active tamper shared output 1 selection. The selected output must be available in the package pinout"
+      bit_offset: 8
+      bit_size: 2
+      enum: ATCR1_ATOSEL1
+    - name: ATOSEL2
+      description: "Active tamper shared output 2 selection. The selected output must be available in the package pinout"
+      bit_offset: 10
+      bit_size: 2
+      enum: ATCR1_ATOSEL2
+    - name: ATOSEL3
+      description: "Active tamper shared output 3 selection. The selected output must be available in the package pinout"
+      bit_offset: 12
+      bit_size: 2
+      enum: ATCR1_ATOSEL3
+    - name: ATOSEL4
+      description: "Active tamper shared output 4 selection. The selected output must be available in the package pinout."
+      bit_offset: 14
+      bit_size: 2
+      enum: ATCR1_ATOSEL4
+    - name: ATCKSEL
+      description: "Active tamper RTC asynchronous prescaler clock selection. These bits selects the RTC asynchronous prescaler stage output.The selected clock is CK_ATPRE.. fCK_ATPRE = fRTCCLK / 2ATCKSEL when (PREDIV_A+1) = 128.. .... These bits can be written only when all active tampers are disabled. The write protection remains for up to 1.5 ck_atpre cycles after all the active tampers are disable."
+      bit_offset: 16
+      bit_size: 3
+      enum: ATCKSEL
+    - name: ATPER
+      description: "Active tamper output change period. The tamper output is changed every CK_ATPER = (2ATPER x CK_ATPRE) cycles. Refer to ."
+      bit_offset: 24
+      bit_size: 3
+    - name: ATOSHARE
+      description: "Active tamper output sharing. IN1 is compared with TAMPOUTSEL1. IN2 is compared with TAMPOUTSEL2. IN3 is compared with TAMPOUTSEL3. IN4 is compared with TAMPOUTSEL4. IN5 is compared with TAMPOUTSEL5. IN6 is compared with TAMPOUTSEL6. IN7 is compared with TAMPOUTSEL7. IN8 is compared with TAMPOUTSEL8"
+      bit_offset: 30
+      bit_size: 1
+      enum: ATOSHARE
+    - name: FLTEN
+      description: Active tamper filter enable
+      bit_offset: 31
+      bit_size: 1
+      enum: FLTEN
+fieldset/ATCR2:
+  description: "TAMP active tamper control register 2 "
+  fields:
+    - name: ATOSEL1
+      description: "Active tamper shared output 1 selection. The selected output must be available in the package pinout. Bits 9:8 are the mirror of ATOSEL1[1:0] in the ATCR1, and so can also be read or. written through ATCR1."
+      bit_offset: 8
+      bit_size: 3
+      enum: ATCR2_ATOSEL1
+    - name: ATOSEL2
+      description: "Active tamper shared output 2 selection. The selected output must be available in the package pinout. Bits 12:11 are the mirror of ATOSEL2[1:0] in the ATCR1, and so can also be read or written through ATCR1."
+      bit_offset: 11
+      bit_size: 3
+      enum: ATCR2_ATOSEL2
+    - name: ATOSEL3
+      description: "Active tamper shared output 3 selection. The selected output must be available in the package pinout. Bits 15:14 are the mirror of ATOSEL3[1:0] in the ATCR1, and so can also be read or written through ATCR1."
+      bit_offset: 14
+      bit_size: 3
+      enum: ATCR2_ATOSEL3
+    - name: ATOSEL4
+      description: "Active tamper shared output 4 selection. The selected output must be available in the package pinout. Bits 18:17 are the mirror of ATOSEL2[1:0] in the ATCR1, and so can also be read or written through ATCR1."
+      bit_offset: 17
+      bit_size: 3
+      enum: ATCR2_ATOSEL4
+    - name: ATOSEL5
+      description: "Active tamper shared output 5 selection. The selected output must be available in the package pinout."
+      bit_offset: 20
+      bit_size: 3
+      enum: ATOSEL
+    - name: ATOSEL6
+      description: "Active tamper shared output 6 selection. The selected output must be available in the package pinout."
+      bit_offset: 23
+      bit_size: 3
+      enum: ATOSEL
+    - name: ATOSEL7
+      description: "Active tamper shared output 7 selection. The selected output must be available in the package pinout."
+      bit_offset: 26
+      bit_size: 3
+      enum: ATOSEL
+    - name: ATOSEL8
+      description: "Active tamper shared output 8 selection. The selected output must be available in the package pinout."
+      bit_offset: 29
+      bit_size: 3
+      enum: ATOSEL
+fieldset/ATOR:
+  description: "TAMP active tamper output register "
+  fields:
+    - name: PRNG
+      description: "Pseudo-random generator value. This field provides the values of the PRNG output. Because of potential inconsistencies due to synchronization delays, PRNG must be read at least twice. The read value is correct if it is equal to previous read value. This field can only be read when the APB is in secure mode."
+      bit_offset: 0
+      bit_size: 8
+    - name: SEEDF
+      description: "Seed running flag. This flag is set by hardware when a new seed is written in the ATSEEDR. It is cleared by hardware when the PRNG has absorbed this new seed, and by system reset. The TAMP APB cock must not be switched off as long as SEEDF is set."
+      bit_offset: 14
+      bit_size: 1
+    - name: INITS
+      description: "Active tamper initialization status. This flag is set by hardware when the PRNG has absorbed the first 128-bit seed, meaning that the enabled active tampers are functional. This flag is cleared when the active tampers are disabled."
+      bit_offset: 15
+      bit_size: 1
+fieldset/ATSEEDR:
+  description: "TAMP active tamper seed register "
+  fields:
+    - name: SEED
+      description: "Pseudo-random generator seed value. This register must be written four times with 32-bit values to provide the 128-bit seed to the PRNG. Writing to this register automatically sends the seed value to the PRNG."
+      bit_offset: 0
+      bit_size: 32
+fieldset/BKP0R:
+  description: TAMP backup 0 register
+  fields:
+    - name: BKP
+      description: "The application can write or read data to and from these registers. In the default (ERASE) configuration this register is reset on a tamper detection event. It is forced to reset value as long as there is at least one internal or external tamper flag being set. This register is also reset when the readout protection (RDP) is disabled."
+      bit_offset: 0
+      bit_size: 32
+fieldset/BKP10R:
+  description: TAMP backup 10 register
+  fields:
+    - name: BKP
+      description: "The application can write or read data to and from these registers. In the default (ERASE) configuration this register is reset on a tamper detection event. It is forced to reset value as long as there is at least one internal or external tamper flag being set. This register is also reset when the readout protection (RDP) is disabled."
+      bit_offset: 0
+      bit_size: 32
+fieldset/BKP11R:
+  description: TAMP backup 11 register
+  fields:
+    - name: BKP
+      description: "The application can write or read data to and from these registers. In the default (ERASE) configuration this register is reset on a tamper detection event. It is forced to reset value as long as there is at least one internal or external tamper flag being set. This register is also reset when the readout protection (RDP) is disabled."
+      bit_offset: 0
+      bit_size: 32
+fieldset/BKP12R:
+  description: TAMP backup 12 register
+  fields:
+    - name: BKP
+      description: "The application can write or read data to and from these registers. In the default (ERASE) configuration this register is reset on a tamper detection event. It is forced to reset value as long as there is at least one internal or external tamper flag being set. This register is also reset when the readout protection (RDP) is disabled."
+      bit_offset: 0
+      bit_size: 32
+fieldset/BKP13R:
+  description: TAMP backup 13 register
+  fields:
+    - name: BKP
+      description: "The application can write or read data to and from these registers. In the default (ERASE) configuration this register is reset on a tamper detection event. It is forced to reset value as long as there is at least one internal or external tamper flag being set. This register is also reset when the readout protection (RDP) is disabled."
+      bit_offset: 0
+      bit_size: 32
+fieldset/BKP14R:
+  description: TAMP backup 14 register
+  fields:
+    - name: BKP
+      description: "The application can write or read data to and from these registers. In the default (ERASE) configuration this register is reset on a tamper detection event. It is forced to reset value as long as there is at least one internal or external tamper flag being set. This register is also reset when the readout protection (RDP) is disabled."
+      bit_offset: 0
+      bit_size: 32
+fieldset/BKP15R:
+  description: TAMP backup 15 register
+  fields:
+    - name: BKP
+      description: "The application can write or read data to and from these registers. In the default (ERASE) configuration this register is reset on a tamper detection event. It is forced to reset value as long as there is at least one internal or external tamper flag being set. This register is also reset when the readout protection (RDP) is disabled."
+      bit_offset: 0
+      bit_size: 32
+fieldset/BKP16R:
+  description: TAMP backup 16 register
+  fields:
+    - name: BKP
+      description: "The application can write or read data to and from these registers. In the default (ERASE) configuration this register is reset on a tamper detection event. It is forced to reset value as long as there is at least one internal or external tamper flag being set. This register is also reset when the readout protection (RDP) is disabled."
+      bit_offset: 0
+      bit_size: 32
+fieldset/BKP17R:
+  description: TAMP backup 17 register
+  fields:
+    - name: BKP
+      description: "The application can write or read data to and from these registers. In the default (ERASE) configuration this register is reset on a tamper detection event. It is forced to reset value as long as there is at least one internal or external tamper flag being set. This register is also reset when the readout protection (RDP) is disabled."
+      bit_offset: 0
+      bit_size: 32
+fieldset/BKP18R:
+  description: TAMP backup 18 register
+  fields:
+    - name: BKP
+      description: "The application can write or read data to and from these registers. In the default (ERASE) configuration this register is reset on a tamper detection event. It is forced to reset value as long as there is at least one internal or external tamper flag being set. This register is also reset when the readout protection (RDP) is disabled."
+      bit_offset: 0
+      bit_size: 32
+fieldset/BKP19R:
+  description: TAMP backup 19 register
+  fields:
+    - name: BKP
+      description: "The application can write or read data to and from these registers. In the default (ERASE) configuration this register is reset on a tamper detection event. It is forced to reset value as long as there is at least one internal or external tamper flag being set. This register is also reset when the readout protection (RDP) is disabled."
+      bit_offset: 0
+      bit_size: 32
+fieldset/BKP1R:
+  description: TAMP backup 1 register
+  fields:
+    - name: BKP
+      description: "The application can write or read data to and from these registers. In the default (ERASE) configuration this register is reset on a tamper detection event. It is forced to reset value as long as there is at least one internal or external tamper flag being set. This register is also reset when the readout protection (RDP) is disabled."
+      bit_offset: 0
+      bit_size: 32
+fieldset/BKP20R:
+  description: TAMP backup 20 register
+  fields:
+    - name: BKP
+      description: "The application can write or read data to and from these registers. In the default (ERASE) configuration this register is reset on a tamper detection event. It is forced to reset value as long as there is at least one internal or external tamper flag being set. This register is also reset when the readout protection (RDP) is disabled."
+      bit_offset: 0
+      bit_size: 32
+fieldset/BKP21R:
+  description: TAMP backup 21 register
+  fields:
+    - name: BKP
+      description: "The application can write or read data to and from these registers. In the default (ERASE) configuration this register is reset on a tamper detection event. It is forced to reset value as long as there is at least one internal or external tamper flag being set. This register is also reset when the readout protection (RDP) is disabled."
+      bit_offset: 0
+      bit_size: 32
+fieldset/BKP22R:
+  description: TAMP backup 22 register
+  fields:
+    - name: BKP
+      description: "The application can write or read data to and from these registers. In the default (ERASE) configuration this register is reset on a tamper detection event. It is forced to reset value as long as there is at least one internal or external tamper flag being set. This register is also reset when the readout protection (RDP) is disabled."
+      bit_offset: 0
+      bit_size: 32
+fieldset/BKP23R:
+  description: TAMP backup 23 register
+  fields:
+    - name: BKP
+      description: "The application can write or read data to and from these registers. In the default (ERASE) configuration this register is reset on a tamper detection event. It is forced to reset value as long as there is at least one internal or external tamper flag being set. This register is also reset when the readout protection (RDP) is disabled."
+      bit_offset: 0
+      bit_size: 32
+fieldset/BKP24R:
+  description: TAMP backup 24 register
+  fields:
+    - name: BKP
+      description: "The application can write or read data to and from these registers. In the default (ERASE) configuration this register is reset on a tamper detection event. It is forced to reset value as long as there is at least one internal or external tamper flag being set. This register is also reset when the readout protection (RDP) is disabled."
+      bit_offset: 0
+      bit_size: 32
+fieldset/BKP25R:
+  description: TAMP backup 25 register
+  fields:
+    - name: BKP
+      description: "The application can write or read data to and from these registers. In the default (ERASE) configuration this register is reset on a tamper detection event. It is forced to reset value as long as there is at least one internal or external tamper flag being set. This register is also reset when the readout protection (RDP) is disabled."
+      bit_offset: 0
+      bit_size: 32
+fieldset/BKP26R:
+  description: TAMP backup 26 register
+  fields:
+    - name: BKP
+      description: "The application can write or read data to and from these registers. In the default (ERASE) configuration this register is reset on a tamper detection event. It is forced to reset value as long as there is at least one internal or external tamper flag being set. This register is also reset when the readout protection (RDP) is disabled."
+      bit_offset: 0
+      bit_size: 32
+fieldset/BKP27R:
+  description: TAMP backup 27 register
+  fields:
+    - name: BKP
+      description: "The application can write or read data to and from these registers. In the default (ERASE) configuration this register is reset on a tamper detection event. It is forced to reset value as long as there is at least one internal or external tamper flag being set. This register is also reset when the readout protection (RDP) is disabled."
+      bit_offset: 0
+      bit_size: 32
+fieldset/BKP28R:
+  description: TAMP backup 28 register
+  fields:
+    - name: BKP
+      description: "The application can write or read data to and from these registers. In the default (ERASE) configuration this register is reset on a tamper detection event. It is forced to reset value as long as there is at least one internal or external tamper flag being set. This register is also reset when the readout protection (RDP) is disabled."
+      bit_offset: 0
+      bit_size: 32
+fieldset/BKP29R:
+  description: TAMP backup 29 register
+  fields:
+    - name: BKP
+      description: "The application can write or read data to and from these registers. In the default (ERASE) configuration this register is reset on a tamper detection event. It is forced to reset value as long as there is at least one internal or external tamper flag being set. This register is also reset when the readout protection (RDP) is disabled."
+      bit_offset: 0
+      bit_size: 32
+fieldset/BKP2R:
+  description: TAMP backup 2 register
+  fields:
+    - name: BKP
+      description: "The application can write or read data to and from these registers. In the default (ERASE) configuration this register is reset on a tamper detection event. It is forced to reset value as long as there is at least one internal or external tamper flag being set. This register is also reset when the readout protection (RDP) is disabled."
+      bit_offset: 0
+      bit_size: 32
+fieldset/BKP30R:
+  description: TAMP backup 30 register
+  fields:
+    - name: BKP
+      description: "The application can write or read data to and from these registers. In the default (ERASE) configuration this register is reset on a tamper detection event. It is forced to reset value as long as there is at least one internal or external tamper flag being set. This register is also reset when the readout protection (RDP) is disabled."
+      bit_offset: 0
+      bit_size: 32
+fieldset/BKP31R:
+  description: TAMP backup 31 register
+  fields:
+    - name: BKP
+      description: "The application can write or read data to and from these registers. In the default (ERASE) configuration this register is reset on a tamper detection event. It is forced to reset value as long as there is at least one internal or external tamper flag being set. This register is also reset when the readout protection (RDP) is disabled."
+      bit_offset: 0
+      bit_size: 32
+fieldset/BKP3R:
+  description: TAMP backup 3 register
+  fields:
+    - name: BKP
+      description: "The application can write or read data to and from these registers. In the default (ERASE) configuration this register is reset on a tamper detection event. It is forced to reset value as long as there is at least one internal or external tamper flag being set. This register is also reset when the readout protection (RDP) is disabled."
+      bit_offset: 0
+      bit_size: 32
+fieldset/BKP4R:
+  description: TAMP backup 4 register
+  fields:
+    - name: BKP
+      description: "The application can write or read data to and from these registers. In the default (ERASE) configuration this register is reset on a tamper detection event. It is forced to reset value as long as there is at least one internal or external tamper flag being set. This register is also reset when the readout protection (RDP) is disabled."
+      bit_offset: 0
+      bit_size: 32
+fieldset/BKP5R:
+  description: TAMP backup 5 register
+  fields:
+    - name: BKP
+      description: "The application can write or read data to and from these registers. In the default (ERASE) configuration this register is reset on a tamper detection event. It is forced to reset value as long as there is at least one internal or external tamper flag being set. This register is also reset when the readout protection (RDP) is disabled."
+      bit_offset: 0
+      bit_size: 32
+fieldset/BKP6R:
+  description: TAMP backup 6 register
+  fields:
+    - name: BKP
+      description: "The application can write or read data to and from these registers. In the default (ERASE) configuration this register is reset on a tamper detection event. It is forced to reset value as long as there is at least one internal or external tamper flag being set. This register is also reset when the readout protection (RDP) is disabled."
+      bit_offset: 0
+      bit_size: 32
+fieldset/BKP7R:
+  description: TAMP backup 7 register
+  fields:
+    - name: BKP
+      description: "The application can write or read data to and from these registers. In the default (ERASE) configuration this register is reset on a tamper detection event. It is forced to reset value as long as there is at least one internal or external tamper flag being set. This register is also reset when the readout protection (RDP) is disabled."
+      bit_offset: 0
+      bit_size: 32
+fieldset/BKP8R:
+  description: TAMP backup 8 register
+  fields:
+    - name: BKP
+      description: "The application can write or read data to and from these registers. In the default (ERASE) configuration this register is reset on a tamper detection event. It is forced to reset value as long as there is at least one internal or external tamper flag being set. This register is also reset when the readout protection (RDP) is disabled."
+      bit_offset: 0
+      bit_size: 32
+fieldset/BKP9R:
+  description: TAMP backup 9 register
+  fields:
+    - name: BKP
+      description: "The application can write or read data to and from these registers. In the default (ERASE) configuration this register is reset on a tamper detection event. It is forced to reset value as long as there is at least one internal or external tamper flag being set. This register is also reset when the readout protection (RDP) is disabled."
+      bit_offset: 0
+      bit_size: 32
+fieldset/COUNTR:
+  description: "TAMP monotonic counter 1 register "
+  fields:
+    - name: COUNT
+      description: This register is read-only only and is incremented by one when a write access is done to this register. This register cannot roll-over and is frozen when reaching the maximum value.
+      bit_offset: 0
+      bit_size: 32
+fieldset/CR1:
+  description: "TAMP control register 1 "
+  fields:
+    - name: TAMP1E
+      description: Tamper detection on IN1 enable
+      bit_offset: 0
+      bit_size: 1
+    - name: TAMP2E
+      description: Tamper detection on IN2 enable
+      bit_offset: 1
+      bit_size: 1
+    - name: TAMP3E
+      description: Tamper detection on IN3 enable
+      bit_offset: 2
+      bit_size: 1
+    - name: TAMP4E
+      description: Tamper detection on IN4 enable
+      bit_offset: 3
+      bit_size: 1
+    - name: TAMP5E
+      description: Tamper detection on IN5 enable
+      bit_offset: 4
+      bit_size: 1
+    - name: TAMP6E
+      description: Tamper detection on IN6 enable
+      bit_offset: 5
+      bit_size: 1
+    - name: TAMP7E
+      description: Tamper detection on IN7 enable
+      bit_offset: 6
+      bit_size: 1
+    - name: TAMP8E
+      description: Tamper detection on IN8 enable
+      bit_offset: 7
+      bit_size: 1
+    - name: ITAMP1E
+      description: Internal tamper 1 enable
+      bit_offset: 16
+      bit_size: 1
+    - name: ITAMP2E
+      description: Internal tamper 2 enable
+      bit_offset: 17
+      bit_size: 1
+    - name: ITAMP3E
+      description: Internal tamper 3 enable
+      bit_offset: 18
+      bit_size: 1
+    - name: ITAMP5E
+      description: Internal tamper 5 enable
+      bit_offset: 20
+      bit_size: 1
+    - name: ITAMP6E
+      description: Internal tamper 6 enable
+      bit_offset: 21
+      bit_size: 1
+    - name: ITAMP7E
+      description: Internal tamper 7 enable
+      bit_offset: 22
+      bit_size: 1
+    - name: ITAMP8E
+      description: Internal tamper 8 enable
+      bit_offset: 23
+      bit_size: 1
+    - name: ITAMP9E
+      description: Internal tamper 9 enable
+      bit_offset: 24
+      bit_size: 1
+    - name: ITAMP11E
+      description: Internal tamper 11 enable
+      bit_offset: 26
+      bit_size: 1
+    - name: ITAMP12E
+      description: Internal tamper 12 enable
+      bit_offset: 27
+      bit_size: 1
+    - name: ITAMP13E
+      description: Internal tamper 13 enable
+      bit_offset: 28
+      bit_size: 1
+fieldset/CR2:
+  description: "TAMP control register 2 "
+  fields:
+    - name: TAMP1NOER
+      description: Tamper 1 no erase
+      bit_offset: 0
+      bit_size: 1
+      enum: TAMPNOER
+    - name: TAMP2NOER
+      description: Tamper 2 no erase
+      bit_offset: 1
+      bit_size: 1
+      enum: TAMPNOER
+    - name: TAMP3NOER
+      description: Tamper 3 no erase
+      bit_offset: 2
+      bit_size: 1
+      enum: TAMPNOER
+    - name: TAMP4NOER
+      description: Tamper 4 no erase
+      bit_offset: 3
+      bit_size: 1
+      enum: TAMPNOER
+    - name: TAMP5NOER
+      description: Tamper 5 no erase
+      bit_offset: 4
+      bit_size: 1
+      enum: TAMPNOER
+    - name: TAMP6NOER
+      description: Tamper 6 no erase
+      bit_offset: 5
+      bit_size: 1
+      enum: TAMPNOER
+    - name: TAMP7NOER
+      description: Tamper 7 no erase
+      bit_offset: 6
+      bit_size: 1
+      enum: TAMPNOER
+    - name: TAMP8NOER
+      description: Tamper 8 no erase
+      bit_offset: 7
+      bit_size: 1
+      enum: TAMPNOER
+    - name: TAMP1MSK
+      description: Tamper 1 mask. The tamper 1 interrupt must not be enabled when TAMP1MSK is set.
+      bit_offset: 16
+      bit_size: 1
+      enum: TAMPMSK
+    - name: TAMP2MSK
+      description: "Tamper 2 mask. The tamper 2 interrupt must not be enabled when TAMP2MSK is set."
+      bit_offset: 17
+      bit_size: 1
+      enum: TAMPMSK
+    - name: TAMP3MSK
+      description: "Tamper 3 mask. The tamper 3 interrupt must not be enabled when TAMP3MSK is set."
+      bit_offset: 18
+      bit_size: 1
+      enum: TAMPMSK
+    - name: BKBLOCK
+      description: Backup registers and device secrets access blocked
+      bit_offset: 22
+      bit_size: 1
+      enum: BKBLOCK
+    - name: BKERASE
+      description: Backup registers and device secrets erase. Writing '1 to this bit reset the backup registers and device secrets(1). Writing 0 has no effect. This bit is always read as 0.
+      bit_offset: 23
+      bit_size: 1
+    - name: TAMP1TRG
+      description: Active level for tamper 1 input.
+      bit_offset: 24
+      bit_size: 1
+      enum: TAMPTRG
+    - name: TAMP2TRG
+      description: "Active level for tamper 2 input. If TAMPFLT = 00 Tamper 2 input rising edge and high level triggers a tamper detection event. If TAMPFLT = 00 Tamper 2 input falling edge and low level triggers a tamper detection event."
+      bit_offset: 25
+      bit_size: 1
+      enum: TAMPTRG
+    - name: TAMP3TRG
+      description: "Active level for tamper 3 input. If TAMPFLT = 00 Tamper 3 input rising edge and high level triggers a tamper detection event. If TAMPFLT = 00 Tamper 3 input falling edge and low level triggers a tamper detection event."
+      bit_offset: 26
+      bit_size: 1
+      enum: TAMPTRG
+    - name: TAMP4TRG
+      description: "Active level for tamper 4 input (active mode disabled). If TAMPFLT = 00 Tamper 4 input rising edge and high level triggers a tamper detection event. If TAMPFLT = 00 Tamper 4 input falling edge and low level triggers a tamper detection event."
+      bit_offset: 27
+      bit_size: 1
+      enum: TAMPTRG
+    - name: TAMP5TRG
+      description: "Active level for tamper 5 input (active mode disabled). If TAMPFLT = 00 Tamper 5 input rising edge and high level triggers a tamper detection event. If TAMPFLT = 00 Tamper 5 input falling edge and low level triggers a tamper detection event."
+      bit_offset: 28
+      bit_size: 1
+      enum: TAMPTRG
+    - name: TAMP6TRG
+      description: "Active level for tamper 6 input (active mode disabled). If TAMPFLT = 00 Tamper 6 input rising edge and high level triggers a tamper detection event. If TAMPFLT = 00 Tamper 6 input falling edge and low level triggers a tamper detection event."
+      bit_offset: 29
+      bit_size: 1
+      enum: TAMPTRG
+    - name: TAMP7TRG
+      description: "Active level for tamper 7 input (active mode disabled). If TAMPFLT = 00 Tamper 7 input rising edge and high level triggers a tamper detection event. If TAMPFLT = 00 Tamper 7 input falling edge and low level triggers a tamper detection event."
+      bit_offset: 30
+      bit_size: 1
+      enum: TAMPTRG
+    - name: TAMP8TRG
+      description: "Active level for tamper 8 input (active mode disabled). If TAMPFLT = 00 Tamper 8 input rising edge and high level triggers a tamper detection event. If TAMPFLT = 00 Tamper 8 input falling edge and low level triggers a tamper detection event."
+      bit_offset: 31
+      bit_size: 1
+      enum: TAMPTRG
+fieldset/CR3:
+  description: "TAMP control register 3 "
+  fields:
+    - name: ITAMP1NOER
+      description: Internal Tamper 1 no erase
+      bit_offset: 0
+      bit_size: 1
+      enum: ITAMPNOER
+    - name: ITAMP2NOER
+      description: Internal Tamper 2 no erase
+      bit_offset: 1
+      bit_size: 1
+      enum: ITAMPNOER
+    - name: ITAMP3NOER
+      description: Internal Tamper 3 no erase
+      bit_offset: 2
+      bit_size: 1
+      enum: ITAMPNOER
+    - name: ITAMP5NOER
+      description: Internal Tamper 5 no erase
+      bit_offset: 4
+      bit_size: 1
+      enum: ITAMPNOER
+    - name: ITAMP6NOER
+      description: Internal Tamper 6 no erase
+      bit_offset: 5
+      bit_size: 1
+      enum: ITAMPNOER
+    - name: ITAMP7NOER
+      description: Internal Tamper 7 no erase
+      bit_offset: 6
+      bit_size: 1
+      enum: ITAMPNOER
+    - name: ITAMP8NOER
+      description: Internal Tamper 8 no erase
+      bit_offset: 7
+      bit_size: 1
+      enum: ITAMPNOER
+    - name: ITAMP9NOER
+      description: Internal Tamper 9 no erase
+      bit_offset: 8
+      bit_size: 1
+      enum: ITAMPNOER
+    - name: ITAMP11NOER
+      description: Internal Tamper 11 no erase
+      bit_offset: 10
+      bit_size: 1
+      enum: ITAMPNOER
+    - name: ITAMP12NOER
+      description: Internal Tamper 12 no erase
+      bit_offset: 11
+      bit_size: 1
+      enum: ITAMPNOER
+    - name: ITAMP13NOER
+      description: Internal Tamper 13 no erase
+      bit_offset: 12
+      bit_size: 1
+      enum: ITAMPNOER
+fieldset/ERCFGR:
+  description: "TAMP erase configuration register "
+  fields:
+    - name: ERCFG0
+      description: Configurable device secrets configuration
+      bit_offset: 0
+      bit_size: 1
+      enum: ERCFG
+fieldset/FLTCR:
+  description: "TAMP filter control register "
+  fields:
+    - name: TAMPFREQ
+      description: "Tamper sampling frequency. Determines the frequency at which each of the INx inputs are sampled."
+      bit_offset: 0
+      bit_size: 3
+      enum: TAMPFREQ
+    - name: TAMPFLT
+      description: "INx filter count. These bits determines the number of consecutive samples at the specified level (TAMP*TRG) needed to activate a tamper event. TAMPFLT is valid for each of the INx inputs."
+      bit_offset: 3
+      bit_size: 2
+      enum: TAMPFLT
+    - name: TAMPPRCH
+      description: "INx precharge duration. These bit determines the duration of time during which the pull-up/is activated before each sample. TAMPPRCH is valid for each of the INx inputs."
+      bit_offset: 5
+      bit_size: 2
+      enum: TAMPPRCH
+    - name: TAMPPUDIS
+      description: "INx pull-up disable. This bit determines if each of the TAMPx pins are precharged before each sample."
+      bit_offset: 7
+      bit_size: 1
+fieldset/IER:
+  description: "TAMP interrupt enable register "
+  fields:
+    - name: TAMP1IE
+      description: Tamper 1 interrupt enable
+      bit_offset: 0
+      bit_size: 1
+    - name: TAMP2IE
+      description: Tamper 2 interrupt enable
+      bit_offset: 1
+      bit_size: 1
+    - name: TAMP3IE
+      description: Tamper 3 interrupt enable
+      bit_offset: 2
+      bit_size: 1
+    - name: TAMP4IE
+      description: Tamper 4 interrupt enable
+      bit_offset: 3
+      bit_size: 1
+    - name: TAMP5IE
+      description: Tamper 5 interrupt enable
+      bit_offset: 4
+      bit_size: 1
+    - name: TAMP6IE
+      description: Tamper 6 interrupt enable
+      bit_offset: 5
+      bit_size: 1
+    - name: TAMP7IE
+      description: Tamper 7interrupt enable
+      bit_offset: 6
+      bit_size: 1
+    - name: TAMP8IE
+      description: Tamper 8 interrupt enable
+      bit_offset: 7
+      bit_size: 1
+    - name: ITAMP1IE
+      description: Internal tamper 1 interrupt enable
+      bit_offset: 16
+      bit_size: 1
+    - name: ITAMP2IE
+      description: Internal tamper 2 interrupt enable
+      bit_offset: 17
+      bit_size: 1
+    - name: ITAMP3IE
+      description: Internal tamper 3 interrupt enable
+      bit_offset: 18
+      bit_size: 1
+    - name: ITAMP5IE
+      description: Internal tamper 5 interrupt enable
+      bit_offset: 20
+      bit_size: 1
+    - name: ITAMP6IE
+      description: Internal tamper 6 interrupt enable
+      bit_offset: 21
+      bit_size: 1
+    - name: ITAMP7IE
+      description: Internal tamper 7 interrupt enable
+      bit_offset: 22
+      bit_size: 1
+    - name: ITAMP8IE
+      description: Internal tamper 8 interrupt enable
+      bit_offset: 23
+      bit_size: 1
+    - name: ITAMP9IE
+      description: Internal tamper 9 interrupt enable
+      bit_offset: 24
+      bit_size: 1
+    - name: ITAMP11IE
+      description: Internal tamper 11 interrupt enable
+      bit_offset: 26
+      bit_size: 1
+    - name: ITAMP12IE
+      description: Internal tamper 12 interrupt enable
+      bit_offset: 27
+      bit_size: 1
+    - name: ITAMP13IE
+      description: Internal tamper 13 interrupt enable
+      bit_offset: 28
+      bit_size: 1
+fieldset/MISR:
+  description: "TAMP non-secure masked interrupt status register "
+  fields:
+    - name: TAMP1MF
+      description: "TAMP1 non-secure interrupt masked flag. This flag is set by hardware when the tamper 1 non-secure interrupt is raised."
+      bit_offset: 0
+      bit_size: 1
+    - name: TAMP2MF
+      description: "TAMP2 non-secure interrupt masked flag. This flag is set by hardware when the tamper 2 non-secure interrupt is raised."
+      bit_offset: 1
+      bit_size: 1
+    - name: TAMP3MF
+      description: "TAMP3 non-secure interrupt masked flag. This flag is set by hardware when the tamper 3 non-secure interrupt is raised."
+      bit_offset: 2
+      bit_size: 1
+    - name: TAMP4MF
+      description: "TAMP4 non-secure interrupt masked flag. This flag is set by hardware when the tamper 4 non-secure interrupt is raised."
+      bit_offset: 3
+      bit_size: 1
+    - name: TAMP5MF
+      description: "TAMP5 non-secure interrupt masked flag. This flag is set by hardware when the tamper 5 non-secure interrupt is raised."
+      bit_offset: 4
+      bit_size: 1
+    - name: TAMP6MF
+      description: "TAMP6 non-secure interrupt masked flag. This flag is set by hardware when the tamper 6 non-secure interrupt is raised."
+      bit_offset: 5
+      bit_size: 1
+    - name: TAMP7MF
+      description: "TAMP7 non-secure interrupt masked flag. This flag is set by hardware when the tamper 7 non-secure interrupt is raised."
+      bit_offset: 6
+      bit_size: 1
+    - name: TAMP8MF
+      description: "TAMP8 non-secure interrupt masked flag. This flag is set by hardware when the tamper 8 non-secure interrupt is raised."
+      bit_offset: 7
+      bit_size: 1
+    - name: ITAMP1MF
+      description: "Internal tamper 1 non-secure interrupt masked flag. This flag is set by hardware when the internal tamper 1 non-secure interrupt is raised."
+      bit_offset: 16
+      bit_size: 1
+    - name: ITAMP2MF
+      description: "Internal tamper 2 non-secure interrupt masked flag. This flag is set by hardware when the internal tamper 2 non-secure interrupt is raised."
+      bit_offset: 17
+      bit_size: 1
+    - name: ITAMP3MF
+      description: "Internal tamper 3 non-secure interrupt masked flag. This flag is set by hardware when the internal tamper 3 non-secure interrupt is raised."
+      bit_offset: 18
+      bit_size: 1
+    - name: ITAMP5MF
+      description: "Internal tamper 5 non-secure interrupt masked flag. This flag is set by hardware when the internal tamper 5 non-secure interrupt is raised."
+      bit_offset: 20
+      bit_size: 1
+    - name: ITAMP6MF
+      description: "Internal tamper 6 non-secure interrupt masked flag. This flag is set by hardware when the internal tamper 6 non-secure interrupt is raised."
+      bit_offset: 21
+      bit_size: 1
+    - name: ITAMP7MF
+      description: "VCORE monitoring tamper non-secure interrupt masked flag. This flag is set by hardware when the internal tamper 7 non-secure interrupt is raised."
+      bit_offset: 22
+      bit_size: 1
+    - name: ITAMP8MF
+      description: "Internal tamper 8 non-secure interrupt masked flag. This flag is set by hardware when the internal tamper 8 non-secure interrupt is raised."
+      bit_offset: 23
+      bit_size: 1
+    - name: ITAMP9MF
+      description: "internal tamper 9 non-secure interrupt masked flag. This flag is set by hardware when the internal tamper 9 non-secure interrupt is raised."
+      bit_offset: 24
+      bit_size: 1
+    - name: ITAMP11MF
+      description: "internal tamper 11 non-secure interrupt masked flag. This flag is set by hardware when the internal tamper 11 non-secure interrupt is raised."
+      bit_offset: 26
+      bit_size: 1
+    - name: ITAMP12MF
+      description: "internal tamper 12 non-secure interrupt masked flag. This flag is set by hardware when the internal tamper 12 non-secure interrupt is raised."
+      bit_offset: 27
+      bit_size: 1
+    - name: ITAMP13MF
+      description: "internal tamper 13 non-secure interrupt masked flag. This flag is set by hardware when the internal tamper 13 non-secure interrupt is raised."
+      bit_offset: 28
+      bit_size: 1
+fieldset/PRIVCR:
+  description: "TAMP privilege mode control register "
+  fields:
+    - name: CNT1PRIV
+      description: Monotonic counter 1 privilege protection
+      bit_offset: 15
+      bit_size: 1
+      enum: CNTPRIV
+    - name: BKPRWPRIV
+      description: Backup registers zone 1 privilege protection
+      bit_offset: 29
+      bit_size: 1
+      enum: BKPRWPRIV
+    - name: BKPWPRIV
+      description: Backup registers zone 2 privilege protection
+      bit_offset: 30
+      bit_size: 1
+      enum: BKPWPRIV
+    - name: TAMPPRIV
+      description: "Tamper privilege protection (excluding backup registers). Note: Refer to for details on the read protection."
+      bit_offset: 31
+      bit_size: 1
+      enum: TAMPPRIV
+fieldset/SCR:
+  description: "TAMP status clear register "
+  fields:
+    - name: CTAMP1F
+      description: "Clear TAMP1 detection flag. Writing 1 in this bit clears the TAMP1F bit in the SR register."
+      bit_offset: 0
+      bit_size: 1
+    - name: CTAMP2F
+      description: "Clear TAMP2 detection flag. Writing 1 in this bit clears the TAMP2F bit in the SR register."
+      bit_offset: 1
+      bit_size: 1
+    - name: CTAMP3F
+      description: "Clear TAMP3 detection flag. Writing 1 in this bit clears the TAMP3F bit in the SR register."
+      bit_offset: 2
+      bit_size: 1
+    - name: CTAMP4F
+      description: "Clear TAMP4 detection flag. Writing 1 in this bit clears the TAMP4F bit in the SR register."
+      bit_offset: 3
+      bit_size: 1
+    - name: CTAMP5F
+      description: "Clear TAMP5 detection flag. Writing 1 in this bit clears the TAMP5F bit in the SR register."
+      bit_offset: 4
+      bit_size: 1
+    - name: CTAMP6F
+      description: "Clear TAMP6 detection flag. Writing 1 in this bit clears the TAMP6F bit in the SR register."
+      bit_offset: 5
+      bit_size: 1
+    - name: CTAMP7F
+      description: "Clear TAMP7 detection flag. Writing 1 in this bit clears the TAMP7F bit in the SR register."
+      bit_offset: 6
+      bit_size: 1
+    - name: CTAMP8F
+      description: "Clear TAMP8 detection flag. Writing 1 in this bit clears the TAMP8F bit in the SR register."
+      bit_offset: 7
+      bit_size: 1
+    - name: CITAMP1F
+      description: "Clear ITAMP1 detection flag. Writing 1 in this bit clears the ITAMP1F bit in the SR register."
+      bit_offset: 16
+      bit_size: 1
+    - name: CITAMP2F
+      description: "Clear ITAMP2 detection flag. Writing 1 in this bit clears the ITAMP2F bit in the SR register."
+      bit_offset: 17
+      bit_size: 1
+    - name: CITAMP3F
+      description: "Clear ITAMP3 detection flag. Writing 1 in this bit clears the ITAMP3F bit in the SR register."
+      bit_offset: 18
+      bit_size: 1
+    - name: CITAMP5F
+      description: "Clear ITAMP5 detection flag. Writing 1 in this bit clears the ITAMP5F bit in the SR register."
+      bit_offset: 20
+      bit_size: 1
+    - name: CITAMP6F
+      description: "Clear ITAMP6 detection flag. Writing 1 in this bit clears the ITAMP6F bit in the SR register."
+      bit_offset: 21
+      bit_size: 1
+    - name: CITAMP7F
+      description: "Clear ITAMP7 detection flag. Writing 1 in this bit clears the ITAMP7F bit in the SR register."
+      bit_offset: 22
+      bit_size: 1
+    - name: CITAMP8F
+      description: "Clear ITAMP8 detection flag. Writing 1 in this bit clears the ITAMP8F bit in the SR register."
+      bit_offset: 23
+      bit_size: 1
+    - name: CITAMP9F
+      description: "Clear ITAMP9 detection flag. Writing 1 in this bit clears the ITAMP9F bit in the SR register."
+      bit_offset: 24
+      bit_size: 1
+    - name: CITAMP11F
+      description: "Clear ITAMP11 detection flag. Writing 1 in this bit clears the ITAMP11F bit in the SR register."
+      bit_offset: 26
+      bit_size: 1
+    - name: CITAMP12F
+      description: "Clear ITAMP12 detection flag. Writing 1 in this bit clears the ITAMP12F bit in the SR register."
+      bit_offset: 27
+      bit_size: 1
+    - name: CITAMP13F
+      description: "Clear ITAMP13 detection flag. Writing 1 in this bit clears the ITAMP13F bit in the SR register."
+      bit_offset: 28
+      bit_size: 1
+fieldset/SECCFGR:
+  description: "TAMP secure mode register "
+  fields:
+    - name: BKPRWSEC
+      description: "Backup registers read/write protection offset. Protection zone 1 is defined for backup registers from BKP0R to BKPxR (x = BKPRWSEC-1, from 0 to 128). if TZEN=1, these backup registers can be read and written only with secure access. If TZEN=0:\tthe protection zone 1 can be read and written with non-secure access. If BKPRWSEC = 0: there is no protection zone 1. If BKPRWPRIV is set, BKPRWSEC[7:0] can be written only in privileged mode."
+      bit_offset: 0
+      bit_size: 8
+    - name: CNT1SEC
+      description: Monotonic counter 1 secure protection
+      bit_offset: 15
+      bit_size: 1
+      enum: CNTSEC
+    - name: BKPWSEC
+      description: "Backup registers write protection offset. Protection zone 2 is defined for backup registers from BKPyR (y = BKPRWSEC, from 0 to 128) to BKPzR (z = BKPWSEC-1, from 0 to 128, BKPWSECBKPRWSEC): if TZEN=1, these backup registers can be written only with secure access. They can be read with secure or non-secure access. Protection zone 3 defined for backup registers from BKPtR (t = BKPWSEC, from 0 to 127). They can be read or written with secure or non-secure access. If TZEN=0:\tthe protection zone 2 can be read and written with non-secure access. If BKPWSEC = 0 or if BKPWSEC BKPRWSEC: there is no protection zone 2. If BKPWPRIV is set, BKPRWSEC[7:0] can be written only in privileged mode."
+      bit_offset: 16
+      bit_size: 8
+    - name: BHKLOCK
+      description: "Boot hardware key lock. This bit can be read and can only be written to 1 by software. It is cleared by hardware together with the backup registers following a tamper detection event or when the readout protection (RDP) is disabled."
+      bit_offset: 30
+      bit_size: 1
+      enum: BHKLOCK
+    - name: TAMPSEC
+      description: "Tamper protection (excluding monotonic counters and backup registers). Note: Refer to for details on the read protection."
+      bit_offset: 31
+      bit_size: 1
+      enum: TAMPSEC
+fieldset/SMISR:
+  description: "TAMP secure masked interrupt status register "
+  fields:
+    - name: TAMP1MF
+      description: "TAMP1 secure interrupt masked flag. This flag is set by hardware when the tamper 1 secure interrupt is raised."
+      bit_offset: 0
+      bit_size: 1
+    - name: TAMP2MF
+      description: "TAMP2 secure interrupt masked flag. This flag is set by hardware when the tamper 2 secure interrupt is raised."
+      bit_offset: 1
+      bit_size: 1
+    - name: TAMP3MF
+      description: "TAMP3 secure interrupt masked flag. This flag is set by hardware when the tamper 3 secure interrupt is raised."
+      bit_offset: 2
+      bit_size: 1
+    - name: TAMP4MF
+      description: "TAMP4 secure interrupt masked flag. This flag is set by hardware when the tamper 4 secure interrupt is raised."
+      bit_offset: 3
+      bit_size: 1
+    - name: TAMP5MF
+      description: "TAMP5 secure interrupt masked flag. This flag is set by hardware when the tamper 5 secure interrupt is raised."
+      bit_offset: 4
+      bit_size: 1
+    - name: TAMP6MF
+      description: "TAMP6 secure interrupt masked flag. This flag is set by hardware when the tamper 6 secure interrupt is raised."
+      bit_offset: 5
+      bit_size: 1
+    - name: TAMP7MF
+      description: "TAMP7 secure interrupt masked flag. This flag is set by hardware when the tamper 7 secure interrupt is raised."
+      bit_offset: 6
+      bit_size: 1
+    - name: TAMP8MF
+      description: "TAMP8 secure interrupt masked flag. This flag is set by hardware when the tamper 8 secure interrupt is raised."
+      bit_offset: 7
+      bit_size: 1
+    - name: ITAMP1MF
+      description: "Internal tamper 1 secure interrupt masked flag. This flag is set by hardware when the internal tamper 1 secure interrupt is raised."
+      bit_offset: 16
+      bit_size: 1
+    - name: ITAMP2MF
+      description: "Internal tamper 2 secure interrupt masked flag. This flag is set by hardware when the internal tamper 2 secure interrupt is raised."
+      bit_offset: 17
+      bit_size: 1
+    - name: ITAMP3MF
+      description: "Internal tamper 3 secure interrupt masked flag. This flag is set by hardware when the internal tamper 3 secure interrupt is raised."
+      bit_offset: 18
+      bit_size: 1
+    - name: ITAMP5MF
+      description: "Internal tamper 5 secure interrupt masked flag. This flag is set by hardware when the internal tamper 5 secure interrupt is raised."
+      bit_offset: 20
+      bit_size: 1
+    - name: ITAMP6MF
+      description: "Internal tamper 6 secure interrupt masked flag. This flag is set by hardware when the internal tamper 6 secure interrupt is raised."
+      bit_offset: 21
+      bit_size: 1
+    - name: ITAMP7MF
+      description: "VCORE monitoring tamper secure interrupt masked flag. This flag is set by hardware when the internal tamper 7 secure interrupt is raised."
+      bit_offset: 22
+      bit_size: 1
+    - name: ITAMP8MF
+      description: "Internal tamper 8 secure interrupt masked flag. This flag is set by hardware when the internal tamper 8 secure interrupt is raised."
+      bit_offset: 23
+      bit_size: 1
+    - name: ITAMP9MF
+      description: "internal tamper 9 secure interrupt masked flag. This flag is set by hardware when the internal tamper 9 secure interrupt is raised."
+      bit_offset: 24
+      bit_size: 1
+    - name: ITAMP11MF
+      description: "internal tamper 11 secure interrupt masked flag. This flag is set by hardware when the internal tamper 11 secure interrupt is raised."
+      bit_offset: 26
+      bit_size: 1
+    - name: ITAMP12MF
+      description: "internal tamper 12 secure interrupt masked flag. This flag is set by hardware when the internal tamper 12 secure interrupt is raised."
+      bit_offset: 27
+      bit_size: 1
+    - name: ITAMP13MF
+      description: "internal tamper 13 secure interrupt masked flag. This flag is set by hardware when the internal tamper 13 secure interrupt is raised."
+      bit_offset: 28
+      bit_size: 1
+fieldset/SR:
+  description: "TAMP status register "
+  fields:
+    - name: TAMP1F
+      description: "TAMP1 detection flag. This flag is set by hardware when a tamper detection event is detected on the TAMP1 input."
+      bit_offset: 0
+      bit_size: 1
+    - name: TAMP2F
+      description: "TAMP2 detection flag. This flag is set by hardware when a tamper detection event is detected on the TAMP2 input."
+      bit_offset: 1
+      bit_size: 1
+    - name: TAMP3F
+      description: "TAMP3 detection flag. This flag is set by hardware when a tamper detection event is detected on the TAMP3 input."
+      bit_offset: 2
+      bit_size: 1
+    - name: TAMP4F
+      description: "TAMP4 detection flag. This flag is set by hardware when a tamper detection event is detected on the TAMP4 input."
+      bit_offset: 3
+      bit_size: 1
+    - name: TAMP5F
+      description: "TAMP5 detection flag. This flag is set by hardware when a tamper detection event is detected on the TAMP5 input."
+      bit_offset: 4
+      bit_size: 1
+    - name: TAMP6F
+      description: "TAMP6 detection flag. This flag is set by hardware when a tamper detection event is detected on the TAMP6 input."
+      bit_offset: 5
+      bit_size: 1
+    - name: TAMP7F
+      description: "TAMP7 detection flag. This flag is set by hardware when a tamper detection event is detected on the TAMP7 input."
+      bit_offset: 6
+      bit_size: 1
+    - name: TAMP8F
+      description: "TAMP8 detection flag. This flag is set by hardware when a tamper detection event is detected on the TAMP8 input"
+      bit_offset: 7
+      bit_size: 1
+    - name: ITAMP1F
+      description: "Internal tamper 1 flag. This flag is set by hardware when a tamper detection event is detected on the internal tamper 1."
+      bit_offset: 16
+      bit_size: 1
+    - name: ITAMP2F
+      description: "Internal tamper 2 flag. This flag is set by hardware when a tamper detection event is detected on the internal tamper 2."
+      bit_offset: 17
+      bit_size: 1
+    - name: ITAMP3F
+      description: "Internal tamper 3 flag. This flag is set by hardware when a tamper detection event is detected on the internal tamper 3."
+      bit_offset: 18
+      bit_size: 1
+    - name: ITAMP5F
+      description: "Internal tamper 5 flag. This flag is set by hardware when a tamper detection event is detected on the internal tamper 5."
+      bit_offset: 20
+      bit_size: 1
+    - name: ITAMP6F
+      description: "Internal tamper 6 flag. This flag is set by hardware when a tamper detection event is detected on the internal tamper 6."
+      bit_offset: 21
+      bit_size: 1
+    - name: ITAMP7F
+      description: "Internal tamper 7 flag. This flag is set by hardware when a tamper detection event is detected on the internal tamper 7."
+      bit_offset: 22
+      bit_size: 1
+    - name: ITAMP8F
+      description: "Internal tamper 8 flag. This flag is set by hardware when a tamper detection event is detected on the internal tamper 8."
+      bit_offset: 23
+      bit_size: 1
+    - name: ITAMP9F
+      description: "Internal tamper 9 flag. This flag is set by hardware when a tamper detection event is detected on the internal tamper 9."
+      bit_offset: 24
+      bit_size: 1
+    - name: ITAMP11F
+      description: "Internal tamper 11 flag. This flag is set by hardware when a tamper detection event is detected on the internal tamper 11."
+      bit_offset: 26
+      bit_size: 1
+    - name: ITAMP12F
+      description: "Internal tamper 12 flag. This flag is set by hardware when a tamper detection event is detected on the internal tamper 12."
+      bit_offset: 27
+      bit_size: 1
+    - name: ITAMP13F
+      description: "Internal tamper 13 flag. This flag is set by hardware when a tamper detection event is detected on the internal tamper 13."
+      bit_offset: 28
+      bit_size: 1
+enum/ATCKSEL:
+  bit_size: 3
+  variants:
+    - name: B_0x0
+      description: RTCCLK is selected
+      value: 0
+    - name: B_0x1
+      description: RTCCLK/2 is selected when (PREDIV_A+1) = 128 (actually selects 1st flip flop output)
+      value: 1
+    - name: B_0x2
+      description: RTCCLK/4 is selected when (PREDIV_A+1) = 128 (actually selects 2nd flip flop output)
+      value: 2
+    - name: B_0x7
+      description: RTCCLK/128 is selected when (PREDIV_A+1) = 128 (actually selects 7th flip flop output)
+      value: 7
+enum/ATOSEL:
+  bit_size: 3
+  variants:
+    - name: B_0x0
+      description: TAMPOUTSEL6 = OUT1
+      value: 0
+    - name: B_0x1
+      description: TAMPOUTSEL6 = OUT2
+      value: 1
+    - name: B_0x2
+      description: TAMPOUTSEL6 = OUT3
+      value: 2
+    - name: B_0x3
+      description: TAMPOUTSEL6 = OUT4
+      value: 3
+    - name: B_0x4
+      description: TAMPOUTSEL6 = OUT5
+      value: 4
+    - name: B_0x5
+      description: TAMPOUTSEL6 = OUT6
+      value: 5
+    - name: B_0x6
+      description: TAMPOUTSEL6 = OUT7
+      value: 6
+    - name: B_0x7
+      description: TAMPOUTSEL6 = OUT8
+      value: 7
+enum/ATOSHARE:
+  bit_size: 1
+  variants:
+    - name: B_0x0
+      description: Each active tamper input INi is compared with its dedicated output OUTi
+      value: 0
+    - name: B_0x1
+      description: "Each active tamper input INi is compared with TAMPOUTSELx as defined below, with TAMPOUTSELx defined by ATOSELx bits."
+      value: 1
+enum/BHKLOCK:
+  bit_size: 1
+  variants:
+    - name: B_0x0
+      description: The Backup registers from BKP0R to BKP7R can be accessed according to the Protection zone they belong to.
+      value: 0
+    - name: B_0x1
+      description: The backup registers from BKP0R to BKP7R cannot be accessed neither in read nor in write (they are read as 0 and write ignore).
+      value: 1
+enum/BKBLOCK:
+  bit_size: 1
+  variants:
+    - name: B_0x0
+      description: backup registers and device secrets(1) can be accessed if no tamper flag is set
+      value: 0
+    - name: B_0x1
+      description: backup registers and device secrets(1) cannot be accessed
+      value: 1
+enum/BKPRWPRIV:
+  bit_size: 1
+  variants:
+    - name: B_0x0
+      description: Backup registers zone 1 can be read and written with privileged or unprivileged access.
+      value: 0
+    - name: B_0x1
+      description: Backup registers zone 1 can be read and written only with privileged access
+      value: 1
+enum/BKPWPRIV:
+  bit_size: 1
+  variants:
+    - name: B_0x0
+      description: Backup registers zone 2 can be written with privileged or unprivileged access.
+      value: 0
+    - name: B_0x1
+      description: Backup registers zone 2 can be written only with privileged access.
+      value: 1
+enum/CNTPRIV:
+  bit_size: 1
+  variants:
+    - name: B_0x0
+      description: Monotonic counter 1 (COUNTR) can be read and written when the APB access is privileged or non-privileged.
+      value: 0
+    - name: B_0x1
+      description: Monotonic counter 1 (COUNTR) can be read and written only when the APB access is privileged.
+      value: 1
+enum/CNTSEC:
+  bit_size: 1
+  variants:
+    - name: B_0x0
+      description: Monotonic counter 1 (COUNTR) can be read and written when the APB access is secure or non-secure.
+      value: 0
+    - name: B_0x1
+      description: Monotonic counter 1 (COUNTR) can be read and written only when the APB access is secure.
+      value: 1
+enum/ERCFG:
+  bit_size: 1
+  variants:
+    - name: B_0x0
+      description: Configurable device secrets are not included in the device secrets protected by TAMP peripheral
+      value: 0
+    - name: B_0x1
+      description: Configurable device secrets are is included in the device secrets protected by TAMP peripheral
+      value: 1
+enum/FLTEN:
+  bit_size: 1
+  variants:
+    - name: B_0x0
+      description: Active tamper filtering disable
+      value: 0
+    - name: B_0x1
+      description: "Active tamper filtering enable: a tamper event is detected when 2 comparison mismatches occur out of 4 consecutive samples."
+      value: 1
+enum/ITAMPNOER:
+  bit_size: 1
+  variants:
+    - name: B_0x0
+      description: Internal Tamper 5 event erases the backup registers and all device secrets(1).
+      value: 0
+    - name: B_0x1
+      description: Internal Tamper 5 event does not erase the backup registers and device secrets(2).
+      value: 1
+enum/TAMPAM:
+  bit_size: 1
+  variants:
+    - name: B_0x0
+      description: Tamper 3 detection mode is passive.
+      value: 0
+    - name: B_0x1
+      description: Tamper 3 detection mode is active.
+      value: 1
+enum/TAMPFLT:
+  bit_size: 2
+  variants:
+    - name: B_0x0
+      description: Tamper event is activated on edge of INx input transitions to the active level (no internal pull-up on INx input).
+      value: 0
+    - name: B_0x1
+      description: Tamper event is activated after 2 consecutive samples at the active level.
+      value: 1
+    - name: B_0x2
+      description: Tamper event is activated after 4 consecutive samples at the active level.
+      value: 2
+    - name: B_0x3
+      description: Tamper event is activated after 8 consecutive samples at the active level.
+      value: 3
+enum/TAMPFREQ:
+  bit_size: 3
+  variants:
+    - name: B_0x0
+      description: RTCCLK / 32768 (1 Hz when RTCCLK = 32768 Hz)
+      value: 0
+    - name: B_0x1
+      description: RTCCLK / 16384 (2 Hz when RTCCLK = 32768 Hz)
+      value: 1
+    - name: B_0x2
+      description: RTCCLK / 8192 (4 Hz when RTCCLK = 32768 Hz)
+      value: 2
+    - name: B_0x3
+      description: RTCCLK / 4096 (8 Hz when RTCCLK = 32768 Hz)
+      value: 3
+    - name: B_0x4
+      description: RTCCLK / 2048 (16 Hz when RTCCLK = 32768 Hz)
+      value: 4
+    - name: B_0x5
+      description: RTCCLK / 1024 (32 Hz when RTCCLK = 32768 Hz)
+      value: 5
+    - name: B_0x6
+      description: RTCCLK / 512 (64 Hz when RTCCLK = 32768 Hz)
+      value: 6
+    - name: B_0x7
+      description: RTCCLK / 256 (128 Hz when RTCCLK = 32768 Hz)
+      value: 7
+enum/TAMPMSK:
+  bit_size: 1
+  variants:
+    - name: B_0x0
+      description: Tamper 1 event generates a trigger event and TAMP1F must be cleared by software to allow next tamper event detection.
+      value: 0
+    - name: B_0x1
+      description: Tamper 1 event generates a trigger event. TAMP1F is masked and internally cleared by hardware. The backup registers and device secrets are not erased.
+      value: 1
+enum/TAMPNOER:
+  bit_size: 1
+  variants:
+    - name: B_0x0
+      description: Tamper 7 event erases the backup registers and all device secrets(1).
+      value: 0
+    - name: B_0x1
+      description: Tamper 7 event does not erase the backup registers and device secrets(2).
+      value: 1
+enum/TAMPPRCH:
+  bit_size: 2
+  variants:
+    - name: B_0x0
+      description: 1 RTCCLK cycle
+      value: 0
+    - name: B_0x1
+      description: 2 RTCCLK cycles
+      value: 1
+    - name: B_0x2
+      description: 4 RTCCLK cycles
+      value: 2
+    - name: B_0x3
+      description: 8 RTCCLK cycles
+      value: 3
+enum/TAMPPRIV:
+  bit_size: 1
+  variants:
+    - name: B_0x0
+      description: Tamper configuration and interrupt can be written with privileged or unprivileged access.
+      value: 0
+    - name: B_0x1
+      description: Tamper configuration and interrupt can be written only with privileged access.
+      value: 1
+enum/TAMPSEC:
+  bit_size: 1
+  variants:
+    - name: B_0x0
+      description: Tamper configuration and interrupt can be written when the APB access is secure or non-secure.
+      value: 0
+    - name: B_0x1
+      description: Tamper configuration and interrupt can be written only when the APB access is secure.
+      value: 1
+enum/TAMPTRG:
+  bit_size: 1
+  variants:
+    - name: B_0x0
+      description: "If TAMPFLT 00 Tamper 2 input staying low triggers a tamper detection event. "
+      value: 0
+    - name: B_0x1
+      description: "If TAMPFLT 00 Tamper 2 input staying high triggers a tamper detection event. "
+      value: 1
+enum/ATCR1_ATOSEL1:
+  bit_size: 2
+  variants:
+    - name: B_0x0
+      description: TAMPOUTSEL1 = OUT1
+      value: 0
+    - name: B_0x1
+      description: TAMPOUTSEL1 = OUT2
+      value: 1
+    - name: B_0x2
+      description: TAMPOUTSEL1 = OUT3
+      value: 2
+    - name: B_0x3
+      description: TAMPOUTSEL1 = OUT4
+      value: 3
+enum/ATCR1_ATOSEL2:
+  bit_size: 2
+  variants:
+    - name: B_0x0
+      description: TAMPOUTSEL2 = OUT1
+      value: 0
+    - name: B_0x1
+      description: TAMPOUTSEL2 = OUT2
+      value: 1
+    - name: B_0x2
+      description: TAMPOUTSEL2 = OUT3
+      value: 2
+    - name: B_0x3
+      description: TAMPOUTSEL2 = OUT4
+      value: 3
+enum/ATCR1_ATOSEL3:
+  bit_size: 2
+  variants:
+    - name: B_0x0
+      description: TAMPOUTSEL3 = OUT1
+      value: 0
+    - name: B_0x1
+      description: TAMPOUTSEL3 = OUT2
+      value: 1
+    - name: B_0x2
+      description: TAMPOUTSEL3 = OUT3
+      value: 2
+    - name: B_0x3
+      description: TAMPOUTSEL3 = OUT4
+      value: 3
+enum/ATCR1_ATOSEL4:
+  bit_size: 2
+  variants:
+    - name: B_0x0
+      description: TAMPOUTSEL4 = OUT1
+      value: 0
+    - name: B_0x1
+      description: TAMPOUTSEL4 = OUT2
+      value: 1
+    - name: B_0x2
+      description: TAMPOUTSEL4 = OUT3
+      value: 2
+    - name: B_0x3
+      description: TAMPOUTSEL4 = OUT4
+      value: 3
+enum/ATCR2_ATOSEL1:
+  bit_size: 3
+  variants:
+    - name: B_0x0
+      description: TAMPOUTSEL1 = OUT1
+      value: 0
+    - name: B_0x1
+      description: TAMPOUTSEL1 = OUT2
+      value: 1
+    - name: B_0x2
+      description: TAMPOUTSEL1 = OUT3
+      value: 2
+    - name: B_0x3
+      description: TAMPOUTSEL1 = OUT4
+      value: 3
+    - name: B_0x4
+      description: TAMPOUTSEL1 = OUT5
+      value: 4
+    - name: B_0x5
+      description: TAMPOUTSEL1 = OUT6
+      value: 5
+    - name: B_0x6
+      description: TAMPOUTSEL1 = OUT7
+      value: 6
+    - name: B_0x7
+      description: TAMPOUTSEL1 = OUT8
+      value: 7
+enum/ATCR2_ATOSEL2:
+  bit_size: 3
+  variants:
+    - name: B_0x0
+      description: TAMPOUTSEL2 = OUT1
+      value: 0
+    - name: B_0x1
+      description: TAMPOUTSEL2 = OUT2
+      value: 1
+    - name: B_0x2
+      description: TAMPOUTSEL2 = OUT3
+      value: 2
+    - name: B_0x3
+      description: TAMPOUTSEL2 = OUT4
+      value: 3
+    - name: B_0x4
+      description: TAMPOUTSEL2 = OUT5
+      value: 4
+    - name: B_0x5
+      description: TAMPOUTSEL2 = OUT6
+      value: 5
+    - name: B_0x6
+      description: TAMPOUTSEL2 = OUT7
+      value: 6
+    - name: B_0x7
+      description: TAMPOUTSEL2 = OUT8
+      value: 7
+enum/ATCR2_ATOSEL3:
+  bit_size: 3
+  variants:
+    - name: B_0x0
+      description: TAMPOUTSEL3 = OUT1
+      value: 0
+    - name: B_0x1
+      description: TAMPOUTSEL3 = OUT2
+      value: 1
+    - name: B_0x2
+      description: TAMPOUTSEL3 = OUT3
+      value: 2
+    - name: B_0x3
+      description: TAMPOUTSEL3 = OUT4
+      value: 3
+    - name: B_0x4
+      description: TAMPOUTSEL3 = OUT5
+      value: 4
+    - name: B_0x5
+      description: TAMPOUTSEL3 = OUT6
+      value: 5
+    - name: B_0x6
+      description: TAMPOUTSEL3 = OUT7
+      value: 6
+    - name: B_0x7
+      description: TAMPOUTSEL3 = OUT8
+      value: 7
+enum/ATCR2_ATOSEL4:
+  bit_size: 3
+  variants:
+    - name: B_0x0
+      description: TAMPOUTSEL4 = OUT1
+      value: 0
+    - name: B_0x1
+      description: TAMPOUTSEL4 = OUT2
+      value: 1
+    - name: B_0x2
+      description: TAMPOUTSEL4 = OUT3
+      value: 2
+    - name: B_0x3
+      description: TAMPOUTSEL4 = OUT4
+      value: 3
+    - name: B_0x4
+      description: TAMPOUTSEL4 = OUT5
+      value: 4
+    - name: B_0x5
+      description: TAMPOUTSEL4 = OUT6
+      value: 5
+    - name: B_0x6
+      description: TAMPOUTSEL4 = OUT7
+      value: 6
+    - name: B_0x7
+      description: TAMPOUTSEL4 = OUT8
+      value: 7

--- a/data/registers/tamp_wl.yaml
+++ b/data/registers/tamp_wl.yaml
@@ -1,0 +1,454 @@
+block/TAMP:
+  description: Tamper and backup registers
+  items:
+    - name: CR1
+      description: control register 1
+      byte_offset: 0
+      fieldset: CR1
+    - name: CR2
+      description: control register 2
+      byte_offset: 4
+      fieldset: CR2
+    - name: CR3
+      description: TAMP control register 3
+      byte_offset: 8
+      fieldset: CR3
+    - name: FLTCR
+      description: TAMP filter control register
+      byte_offset: 12
+      fieldset: FLTCR
+    - name: IER
+      description: TAMP interrupt enable register
+      byte_offset: 44
+      fieldset: IER
+    - name: SR
+      description: TAMP status register
+      byte_offset: 48
+      access: Read
+      fieldset: SR
+    - name: MISR
+      description: TAMP masked interrupt status register
+      byte_offset: 52
+      access: Read
+      fieldset: MISR
+    - name: SCR
+      description: TAMP status clear register
+      byte_offset: 60
+      access: Write
+      fieldset: SCR
+    - name: COUNTR
+      description: monotonic counter register
+      byte_offset: 64
+      access: Read
+      fieldset: COUNTR
+    - name: BKPR
+      description: TAMP backup register
+      array:
+        len: 20
+        stride: 4
+      byte_offset: 256
+      fieldset: BKPR
+fieldset/BKPR:
+  description: TAMP backup register
+  fields:
+    - name: BKP
+      description: BKP
+      bit_offset: 0
+      bit_size: 32
+fieldset/COUNTR:
+  description: monotonic counter register
+  fields:
+    - name: COUNT
+      description: COUNT
+      bit_offset: 0
+      bit_size: 32
+fieldset/CR1:
+  description: control register 1
+  fields:
+    - name: TAMP1E
+      description: Tamper detection on IN1 enable
+      bit_offset: 0
+      bit_size: 1
+    - name: TAMP2E
+      description: Tamper detection on IN2 enable
+      bit_offset: 1
+      bit_size: 1
+    - name: TAMP3E
+      description: Tamper detection on IN3 enable
+      bit_offset: 2
+      bit_size: 1
+    - name: ITAMP3E
+      description: Internal tamper 3 enable
+      bit_offset: 18
+      bit_size: 1
+    - name: ITAMP5E
+      description: Internal tamper 5 enable
+      bit_offset: 20
+      bit_size: 1
+    - name: ITAMP6E
+      description: Internal tamper 6 enable
+      bit_offset: 21
+      bit_size: 1
+    - name: ITAMP8E
+      description: Internal tamper 8 enable
+      bit_offset: 23
+      bit_size: 1
+fieldset/CR2:
+  description: control register 2
+  fields:
+    - name: TAMP1NOER
+      description: Tamper 1 no erase
+      bit_offset: 0
+      bit_size: 1
+      enum: TAMPNOER
+    - name: TAMP2NOER
+      description: Tamper 2 no erase
+      bit_offset: 1
+      bit_size: 1
+      enum: TAMPNOER
+    - name: TAMP3NOER
+      description: Tamper 3 no erase
+      bit_offset: 2
+      bit_size: 1
+      enum: TAMPNOER
+    - name: TAMP1MSK
+      description: Tamper 1 mask. The tamper 1 interrupt must not be enabled when TAMP1MSK is set.
+      bit_offset: 16
+      bit_size: 1
+      enum: TAMPMSK
+    - name: TAMP2MSK
+      description: Tamper 2 mask. The tamper 2 interrupt must not be enabled when TAMP1MSK is set.
+      bit_offset: 17
+      bit_size: 1
+      enum: TAMPMSK
+    - name: TAMP3MSK
+      description: Tamper 3 mask. The tamper 3 interrupt must not be enabled when TAMP1MSK is set.
+      bit_offset: 18
+      bit_size: 1
+      enum: TAMPMSK
+    - name: BKERASE
+      description: Backup registers erase
+      bit_offset: 23
+      bit_size: 1
+      enum: BKERASE
+    - name: TAMP1TRG
+      description: Active level for tamper 1 input.
+      bit_offset: 24
+      bit_size: 1
+      enum: TAMPTRG
+    - name: TAMP2TRG
+      description: Active level for tamper 2 input.
+      bit_offset: 25
+      bit_size: 1
+      enum: TAMPTRG
+    - name: TAMP3TRG
+      description: Active level for tamper 3 input.
+      bit_offset: 26
+      bit_size: 1
+      enum: TAMPTRG
+fieldset/CR3:
+  description: TAMP control register 3
+  fields:
+    - name: ITAMP3NOER
+      description: Internal Tamper 3 no erase
+      bit_offset: 2
+      bit_size: 1
+      enum: ITAMPNOER
+    - name: ITAMP5NOER
+      description: Internal Tamper 5 no erase
+      bit_offset: 4
+      bit_size: 1
+      enum: ITAMPNOER
+    - name: ITAMP6NOER
+      description: Internal Tamper 6 no erase
+      bit_offset: 5
+      bit_size: 1
+      enum: ITAMPNOER
+    - name: ITAMP8NOER
+      description: Internal Tamper 8 no erase
+      bit_offset: 7
+      bit_size: 1
+      enum: ITAMPNOER
+fieldset/FLTCR:
+  description: TAMP filter control register
+  fields:
+    - name: TAMPFREQ
+      description: "Tamper sampling frequency. Determines the frequency at which each of the INx inputs are sampled."
+      bit_offset: 0
+      bit_size: 3
+      enum: TAMPFREQ
+    - name: TAMPFLT
+      description: "INx filter count. These bits determines the number of consecutive samples at the specified level (TAMP*TRG) needed to activate a tamper event. TAMPFLT is valid for each of the INx inputs."
+      bit_offset: 3
+      bit_size: 2
+      enum: TAMPFLT
+    - name: TAMPPRCH
+      description: "INx precharge duration. These bit determines the duration of time during which the pull-up/is activated before each sample. TAMPPRCH is valid for each of the INx inputs."
+      bit_offset: 5
+      bit_size: 2
+      enum: TAMPPRCH
+    - name: TAMPPUDIS
+      description: "INx pull-up disable. This bit determines if each of the TAMPx pins are precharged before each sample."
+      bit_offset: 7
+      bit_size: 1
+fieldset/IER:
+  description: TAMP interrupt enable register
+  fields:
+    - name: TAMP1IE
+      description: Tamper 1 interrupt enable
+      bit_offset: 0
+      bit_size: 1
+    - name: TAMP2IE
+      description: Tamper 2 interrupt enable
+      bit_offset: 1
+      bit_size: 1
+    - name: TAMP3IE
+      description: Tamper 3 interrupt enable
+      bit_offset: 2
+      bit_size: 1
+    - name: ITAMP3IE
+      description: Internal tamper 3 interrupt enable
+      bit_offset: 18
+      bit_size: 1
+    - name: ITAMP5IE
+      description: Internal tamper 5 interrupt enable
+      bit_offset: 20
+      bit_size: 1
+    - name: ITAMP6IE
+      description: Internal tamper 6 interrupt enable
+      bit_offset: 21
+      bit_size: 1
+    - name: ITAMP8IE
+      description: Internal tamper 8 interrupt enable
+      bit_offset: 23
+      bit_size: 1
+fieldset/MISR:
+  description: TAMP masked interrupt status register
+  fields:
+    - name: TAMP1MF
+      description: Tamper 1 interrupt masked flag
+      bit_offset: 0
+      bit_size: 1
+    - name: TAMP2MF
+      description: Tamper 2 interrupt masked flag
+      bit_offset: 1
+      bit_size: 1
+    - name: TAMP3MF
+      description: Tamper 3 interrupt masked flag
+      bit_offset: 2
+      bit_size: 1
+    - name: ITAMP3MF
+      description: Internal tamper 3 interrupt masked flag
+      bit_offset: 18
+      bit_size: 1
+      enum: ITAMPMF
+    - name: ITAMP5MF
+      description: Internal tamper 5 interrupt masked flag
+      bit_offset: 20
+      bit_size: 1
+      enum: ITAMPMF
+    - name: ITAMP6MF
+      description: Internal tamper 6 interrupt masked flag
+      bit_offset: 21
+      bit_size: 1
+      enum: ITAMPMF
+    - name: ITAMP8MF
+      description: Internal tamper 8 interrupt masked flag
+      bit_offset: 23
+      bit_size: 1
+      enum: ITAMPMF
+fieldset/SCR:
+  description: TAMP status clear register
+  fields:
+    - name: CTAMP1F
+      description: Clear tamper 1 detection flag
+      bit_offset: 0
+      bit_size: 1
+    - name: CTAMP2F
+      description: Clear tamper 2 detection flag
+      bit_offset: 1
+      bit_size: 1
+    - name: CTAMP3F
+      description: Clear tamper 3 detection flag
+      bit_offset: 2
+      bit_size: 1
+    - name: CITAMP3F
+      description: Clear internal tamper 3 detection flag
+      bit_offset: 18
+      bit_size: 1
+    - name: CITAMP5F
+      description: Clear internal tamper 5 detection flag
+      bit_offset: 20
+      bit_size: 1
+    - name: CITAMP6F
+      description: Clear internal tamper 6 detection flag
+      bit_offset: 21
+      bit_size: 1
+    - name: CITAMP8F
+      description: Clear internal tamper 8 detection flag
+      bit_offset: 23
+      bit_size: 1
+fieldset/SR:
+  description: TAMP status register
+  fields:
+    - name: TAMP1F
+      description: Tamper 1 detection flag
+      bit_offset: 0
+      bit_size: 1
+      enum: TAMPF
+    - name: TAMP2F
+      description: Tamper 2 detection flag
+      bit_offset: 1
+      bit_size: 1
+      enum: TAMPF
+    - name: TAMP3F
+      description: Tamper 3 detection flag
+      bit_offset: 2
+      bit_size: 1
+      enum: TAMPF
+    - name: ITAMP3F
+      description: Internal tamper 3 detection flag
+      bit_offset: 18
+      bit_size: 1
+      enum: ITAMPF
+    - name: ITAMP5F
+      description: Internal tamper 5 detection flag
+      bit_offset: 20
+      bit_size: 1
+      enum: ITAMPF
+    - name: ITAMP6F
+      description: Internal tamper 6 detection flag
+      bit_offset: 21
+      bit_size: 1
+      enum: ITAMPF
+    - name: ITAMP8F
+      description: Internal tamper 8 detection flag
+      bit_offset: 23
+      bit_size: 1
+      enum: ITAMPF
+enum/BKERASE:
+  bit_size: 1
+  variants:
+    - name: Reset
+      description: Reset backup registers
+      value: 1
+enum/ITAMPF:
+  bit_size: 1
+  variants:
+    - name: Idle
+      description: No tamper detected
+      value: 0
+    - name: Tamper
+      description: Internal tamper detected
+      value: 1
+enum/ITAMPMF:
+  bit_size: 1
+  variants:
+    - name: Idle
+      description: No tamper detected - Masked
+      value: 0
+    - name: Tamper
+      description: Internal tamper detected - Masked
+      value: 1
+enum/ITAMPNOER:
+  bit_size: 1
+  variants:
+    - name: Erase
+      description: Internal tamper x event erases the backup registers
+      value: 0
+    - name: NotErase
+      description: Internal tamper x event does not erase the backup registers
+      value: 1
+enum/TAMPF:
+  bit_size: 1
+  variants:
+    - name: Idle
+      description: No tamper detected
+      value: 0
+    - name: Tamper
+      description: Tamper detected
+      value: 1
+enum/TAMPFLT:
+  bit_size: 2
+  variants:
+    - name: NoFilter
+      description: 'Tamper event is activated on edge of TAMP_INx input transitions to the active level (no internal pull-up on TAMP_INx input)"'
+      value: 0
+    - name: Filter2
+      description: 'Tamper event is activated after 2 consecutive samples at the active level"'
+      value: 1
+    - name: Filter4
+      description: 'Tamper event is activated after 4 consecutive samples at the active level"'
+      value: 2
+    - name: Filter8
+      description: 'Tamper event is activated after 8 consecutive samples at the active level"'
+      value: 3
+enum/TAMPFREQ:
+  bit_size: 3
+  variants:
+    - name: Hz_1
+      description: RTCCLK / 32768 (1 Hz when RTCCLK = 32768 Hz)
+      value: 0
+    - name: Hz_2
+      description: RTCCLK / 16384 (2 Hz when RTCCLK = 32768 Hz)
+      value: 1
+    - name: Hz_4
+      description: RTCCLK / 8192 (4 Hz when RTCCLK = 32768 Hz)
+      value: 2
+    - name: Hz_8
+      description: RTCCLK / 4096 (8 Hz when RTCCLK = 32768 Hz)
+      value: 3
+    - name: Hz_16
+      description: RTCCLK / 2048 (16 Hz when RTCCLK = 32768 Hz)
+      value: 4
+    - name: Hz_32
+      description: RTCCLK / 1024 (32 Hz when RTCCLK = 32768 Hz)
+      value: 5
+    - name: Hz_64
+      description: RTCCLK / 512 (64 Hz when RTCCLK = 32768 Hz)
+      value: 6
+    - name: Hz_128
+      description: RTCCLK / 256 (128 Hz when RTCCLK = 32768 Hz)
+      value: 7
+enum/TAMPMSK:
+  bit_size: 1
+  variants:
+    - name: ResetBySoftware
+      description: Tamper x event generates a trigger event and TAMPxF must be cleared by software to allow next tamper event detection
+      value: 0
+    - name: ResetByHardware
+      description: Tamper x event generates a trigger event. TAMPxF is masked and internally cleared by hardware. The backup registers are not erased. The tamper x interrupt must not be enabled when TAMP3MSK is set
+      value: 1
+enum/TAMPNOER:
+  bit_size: 1
+  variants:
+    - name: Erase
+      description: Tamper x event erases the backup registers
+      value: 0
+    - name: NotErase
+      description: Tamper x event does not erase the backup registers
+      value: 1
+enum/TAMPPRCH:
+  bit_size: 2
+  variants:
+    - name: Cycles1
+      description: 1 RTCCLK cycle
+      value: 0
+    - name: Cycles2
+      description: 2 RTCCLK cycles
+      value: 1
+    - name: Cycles4
+      description: 4 RTCCLK cycles
+      value: 2
+    - name: Cycles8
+      description: 8 RTCCLK cycles
+      value: 3
+enum/TAMPTRG:
+  bit_size: 1
+  variants:
+    - name: FilteredLowOrUnfilteredHigh
+      description: If TAMPFLT != 00 Tamper x input staying low triggers a tamper detection event. If TAMPFLT = 00 Tamper x input rising edge and high level triggers a tamper detection event
+      value: 0
+    - name: FilteredHighOrUnfilteredLow
+      description: If TAMPFLT != 00 Tamper x input staying high triggers a tamper detection event. If TAMPFLT = 00 Tamper x input falling edge and low level triggers a tamper detection event
+      value: 1

--- a/data/registers/tamp_wl.yaml
+++ b/data/registers/tamp_wl.yaml
@@ -65,110 +65,61 @@ fieldset/COUNTR:
 fieldset/CR1:
   description: control register 1
   fields:
-    - name: TAMP1E
-      description: Tamper detection on IN1 enable
+    - name: TAMPE
+      description: Tamper detection on IN X enable
       bit_offset: 0
       bit_size: 1
-    - name: TAMP2E
-      description: Tamper detection on IN2 enable
-      bit_offset: 1
+      array:
+        len: 3
+        stride: 1
+    - name: ITAMPE
+      description: Internal tamper X enable
+      bit_offset: 16
       bit_size: 1
-    - name: TAMP3E
-      description: Tamper detection on IN3 enable
-      bit_offset: 2
-      bit_size: 1
-    - name: ITAMP3E
-      description: Internal tamper 3 enable
-      bit_offset: 18
-      bit_size: 1
-    - name: ITAMP5E
-      description: Internal tamper 5 enable
-      bit_offset: 20
-      bit_size: 1
-    - name: ITAMP6E
-      description: Internal tamper 6 enable
-      bit_offset: 21
-      bit_size: 1
-    - name: ITAMP8E
-      description: Internal tamper 8 enable
-      bit_offset: 23
-      bit_size: 1
+      array:
+        len: 8
+        stride: 1
 fieldset/CR2:
   description: control register 2
   fields:
-    - name: TAMP1NOER
-      description: Tamper 1 no erase
+    - name: TAMPNOER
+      description: Tamper X no erase
       bit_offset: 0
       bit_size: 1
-      enum: TAMPNOER
-    - name: TAMP2NOER
-      description: Tamper 2 no erase
-      bit_offset: 1
-      bit_size: 1
-      enum: TAMPNOER
-    - name: TAMP3NOER
-      description: Tamper 3 no erase
-      bit_offset: 2
-      bit_size: 1
-      enum: TAMPNOER
-    - name: TAMP1MSK
-      description: Tamper 1 mask. The tamper 1 interrupt must not be enabled when TAMP1MSK is set.
+      array:
+        len: 3
+        stride: 1
+    - name: TAMPMSK
+      description: Tamper X mask. The tamper X interrupt must not be enabled when TAMPMSK is set.
       bit_offset: 16
       bit_size: 1
-      enum: TAMPMSK
-    - name: TAMP2MSK
-      description: Tamper 2 mask. The tamper 2 interrupt must not be enabled when TAMP1MSK is set.
-      bit_offset: 17
-      bit_size: 1
-      enum: TAMPMSK
-    - name: TAMP3MSK
-      description: Tamper 3 mask. The tamper 3 interrupt must not be enabled when TAMP1MSK is set.
-      bit_offset: 18
-      bit_size: 1
+      array:
+        len: 3
+        stride: 1
       enum: TAMPMSK
     - name: BKERASE
       description: Backup registers erase
       bit_offset: 23
       bit_size: 1
       enum: BKERASE
-    - name: TAMP1TRG
-      description: Active level for tamper 1 input.
+    - name: TAMPTRG
+      description: Active level for tamper X input
       bit_offset: 24
       bit_size: 1
-      enum: TAMPTRG
-    - name: TAMP2TRG
-      description: Active level for tamper 2 input.
-      bit_offset: 25
-      bit_size: 1
-      enum: TAMPTRG
-    - name: TAMP3TRG
-      description: Active level for tamper 3 input.
-      bit_offset: 26
-      bit_size: 1
+      array:
+        len: 3
+        stride: 1
       enum: TAMPTRG
 fieldset/CR3:
   description: TAMP control register 3
   fields:
-    - name: ITAMP3NOER
-      description: Internal Tamper 3 no erase
-      bit_offset: 2
+    - name: ITAMPNOER
+      description: Internal Tamper X no erase
+      bit_offset: 0
       bit_size: 1
-      enum: ITAMPNOER
-    - name: ITAMP5NOER
-      description: Internal Tamper 5 no erase
-      bit_offset: 4
-      bit_size: 1
-      enum: ITAMPNOER
-    - name: ITAMP6NOER
-      description: Internal Tamper 6 no erase
-      bit_offset: 5
-      bit_size: 1
-      enum: ITAMPNOER
-    - name: ITAMP8NOER
-      description: Internal Tamper 8 no erase
-      bit_offset: 7
-      bit_size: 1
-      enum: ITAMPNOER
+      array:
+        len: 8
+        stride: 1
 fieldset/FLTCR:
   description: TAMP filter control register
   fields:
@@ -194,179 +145,76 @@ fieldset/FLTCR:
 fieldset/IER:
   description: TAMP interrupt enable register
   fields:
-    - name: TAMP1IE
-      description: Tamper 1 interrupt enable
+    - name: TAMPIE
+      description: Tamper X interrupt enable
       bit_offset: 0
       bit_size: 1
-    - name: TAMP2IE
-      description: Tamper 2 interrupt enable
-      bit_offset: 1
+      array:
+        len: 3
+        stride: 1
+    - name: ITAMPIE
+      description: Internal tamper X interrupt enable
+      bit_offset: 16
       bit_size: 1
-    - name: TAMP3IE
-      description: Tamper 3 interrupt enable
-      bit_offset: 2
-      bit_size: 1
-    - name: ITAMP3IE
-      description: Internal tamper 3 interrupt enable
-      bit_offset: 18
-      bit_size: 1
-    - name: ITAMP5IE
-      description: Internal tamper 5 interrupt enable
-      bit_offset: 20
-      bit_size: 1
-    - name: ITAMP6IE
-      description: Internal tamper 6 interrupt enable
-      bit_offset: 21
-      bit_size: 1
-    - name: ITAMP8IE
-      description: Internal tamper 8 interrupt enable
-      bit_offset: 23
-      bit_size: 1
+      array:
+        len: 8
+        stride: 1
 fieldset/MISR:
   description: TAMP masked interrupt status register
   fields:
-    - name: TAMP1MF
-      description: Tamper 1 interrupt masked flag
+    - name: TAMPMF
+      description: Tamper X interrupt masked flag
       bit_offset: 0
       bit_size: 1
-    - name: TAMP2MF
-      description: Tamper 2 interrupt masked flag
-      bit_offset: 1
+      array:
+        len: 3
+        stride: 1
+    - name: ITAMPMF
+      description: Internal tamper X interrupt masked flag
+      bit_offset: 16
       bit_size: 1
-    - name: TAMP3MF
-      description: Tamper 3 interrupt masked flag
-      bit_offset: 2
-      bit_size: 1
-    - name: ITAMP3MF
-      description: Internal tamper 3 interrupt masked flag
-      bit_offset: 18
-      bit_size: 1
-      enum: ITAMPMF
-    - name: ITAMP5MF
-      description: Internal tamper 5 interrupt masked flag
-      bit_offset: 20
-      bit_size: 1
-      enum: ITAMPMF
-    - name: ITAMP6MF
-      description: Internal tamper 6 interrupt masked flag
-      bit_offset: 21
-      bit_size: 1
-      enum: ITAMPMF
-    - name: ITAMP8MF
-      description: Internal tamper 8 interrupt masked flag
-      bit_offset: 23
-      bit_size: 1
-      enum: ITAMPMF
+      array:
+        len: 8
+        stride: 1
 fieldset/SCR:
   description: TAMP status clear register
   fields:
-    - name: CTAMP1F
-      description: Clear tamper 1 detection flag
+    - name: CTAMPF
+      description: Clear tamper X detection flag
       bit_offset: 0
       bit_size: 1
-    - name: CTAMP2F
-      description: Clear tamper 2 detection flag
-      bit_offset: 1
+      array:
+        len: 3
+        stride: 1
+    - name: CITAMPF
+      description: Clear internal tamper X detection flag
+      bit_offset: 16
       bit_size: 1
-    - name: CTAMP3F
-      description: Clear tamper 3 detection flag
-      bit_offset: 2
-      bit_size: 1
-    - name: CITAMP3F
-      description: Clear internal tamper 3 detection flag
-      bit_offset: 18
-      bit_size: 1
-    - name: CITAMP5F
-      description: Clear internal tamper 5 detection flag
-      bit_offset: 20
-      bit_size: 1
-    - name: CITAMP6F
-      description: Clear internal tamper 6 detection flag
-      bit_offset: 21
-      bit_size: 1
-    - name: CITAMP8F
-      description: Clear internal tamper 8 detection flag
-      bit_offset: 23
-      bit_size: 1
+      array:
+        len: 8
+        stride: 1
 fieldset/SR:
   description: TAMP status register
   fields:
-    - name: TAMP1F
-      description: Tamper 1 detection flag
+    - name: TAMPF
+      description: Tamper X detection flag
       bit_offset: 0
       bit_size: 1
-      enum: TAMPF
-    - name: TAMP2F
-      description: Tamper 2 detection flag
-      bit_offset: 1
+      array:
+        len: 3
+        stride: 1
+    - name: ITAMPF
+      description: Internal tamper X detection flag
+      bit_offset: 16
       bit_size: 1
-      enum: TAMPF
-    - name: TAMP3F
-      description: Tamper 3 detection flag
-      bit_offset: 2
-      bit_size: 1
-      enum: TAMPF
-    - name: ITAMP3F
-      description: Internal tamper 3 detection flag
-      bit_offset: 18
-      bit_size: 1
-      enum: ITAMPF
-    - name: ITAMP5F
-      description: Internal tamper 5 detection flag
-      bit_offset: 20
-      bit_size: 1
-      enum: ITAMPF
-    - name: ITAMP6F
-      description: Internal tamper 6 detection flag
-      bit_offset: 21
-      bit_size: 1
-      enum: ITAMPF
-    - name: ITAMP8F
-      description: Internal tamper 8 detection flag
-      bit_offset: 23
-      bit_size: 1
-      enum: ITAMPF
+      array:
+        len: 8
+        stride: 1
 enum/BKERASE:
   bit_size: 1
   variants:
     - name: Reset
       description: Reset backup registers
-      value: 1
-enum/ITAMPF:
-  bit_size: 1
-  variants:
-    - name: Idle
-      description: No tamper detected
-      value: 0
-    - name: Tamper
-      description: Internal tamper detected
-      value: 1
-enum/ITAMPMF:
-  bit_size: 1
-  variants:
-    - name: Idle
-      description: No tamper detected - Masked
-      value: 0
-    - name: Tamper
-      description: Internal tamper detected - Masked
-      value: 1
-enum/ITAMPNOER:
-  bit_size: 1
-  variants:
-    - name: Erase
-      description: Internal tamper x event erases the backup registers
-      value: 0
-    - name: NotErase
-      description: Internal tamper x event does not erase the backup registers
-      value: 1
-enum/TAMPF:
-  bit_size: 1
-  variants:
-    - name: Idle
-      description: No tamper detected
-      value: 0
-    - name: Tamper
-      description: Tamper detected
       value: 1
 enum/TAMPFLT:
   bit_size: 2
@@ -418,15 +266,6 @@ enum/TAMPMSK:
       value: 0
     - name: ResetByHardware
       description: Tamper x event generates a trigger event. TAMPxF is masked and internally cleared by hardware. The backup registers are not erased. The tamper x interrupt must not be enabled when TAMP3MSK is set
-      value: 1
-enum/TAMPNOER:
-  bit_size: 1
-  variants:
-    - name: Erase
-      description: Tamper x event erases the backup registers
-      value: 0
-    - name: NotErase
-      description: Tamper x event does not erase the backup registers
       value: 1
 enum/TAMPPRCH:
   bit_size: 2

--- a/stm32-data-gen/src/chips.rs
+++ b/stm32-data-gen/src/chips.rs
@@ -456,6 +456,11 @@ impl PeriMatcher {
             (".*:LCD:lcdc1_v1.3.*", ("lcd", "v2", "LCD")),
             (".*:UID:.*", ("uid", "v1", "UID")),
             (".*:UCPD:.*", ("ucpd", "v1", "UCPD")),
+            ("STM32G0.*:TAMP:.*", ("tamp", "g0", "TAMP")),
+            ("STM32G4.*:TAMP:.*", ("tamp", "g4", "TAMP")),
+            ("STM32L5.*:TAMP:.*", ("tamp", "l5", "TAMP")),
+            ("STM32U5.*:TAMP:.*", ("tamp", "u5", "TAMP")),
+            ("STM32WL.*:TAMP:.*", ("tamp", "wl", "TAMP")),
         ];
 
         Self {


### PR DESCRIPTION
Adds TAMP register block for the devices where I could understand how it was mapped. Some devices seems to have their TAMP/backup/RTC more intertwined and not as a separate register block. Those are not included.

Also not really sure why only u5 and l5 was mapped automatically while I had to add them manually for g0, g4 and wl through extra/families. I guess some field is missing in one of the sources?

Mainly adding this for gaining access to backup registers. Tested on stm32wle5cc.