### PR TITLE
add man impl. pin signals

### DIFF
--- a/data/extra/family/STM32F3.yaml
+++ b/data/extra/family/STM32F3.yaml
@@ -6,3 +6,15 @@ peripherals:
       kind: vrefintcal
       version: v1
       block: VREFINTCAL
+  - name: OPAMP2
+    pins:
+      - pin: PA5
+        signal: VM1
+      - pin: PC5
+        signal: VM0
+      - pin: PA7
+        signal: VP0
+      - pin: PD14
+        signal: VP1
+      - pin: PB0
+        signal: VP2

--- a/stm32-data-gen/src/chips.rs
+++ b/stm32-data-gen/src/chips.rs
@@ -1065,9 +1065,9 @@ fn process_core(
         }
     }
 
+    let have_peris: HashSet<_> = peripherals.keys().cloned().collect();
     let mut peripherals: Vec<_> = peripherals.into_values().collect();
     peripherals.sort_by_key(|x| x.name.clone());
-    let have_peris: HashSet<_> = peripherals.iter_mut().map(|p| p.name.clone()).collect();
     // Collect DMA versions in the chip
     let mut chip_dmas: Vec<_> = group
         .ips

--- a/stm32-data-serde/src/lib.rs
+++ b/stm32-data-serde/src/lib.rs
@@ -84,6 +84,7 @@ pub mod chip {
         #[derive(Clone, Debug, Eq, PartialEq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
         pub struct Peripheral {
             pub name: String,
+            #[serde(default)]
             pub address: u32,
             #[serde(skip_serializing_if = "Option::is_none")]
             pub registers: Option<peripheral::Registers>,


### PR DESCRIPTION
this will allow implementation of generated op-amp and comparator pins, where the selector is not specified in the xml files