### PR TITLE
RCC: LSEDRV Register Fixes

### DIFF
--- a/data/registers/rcc_f0.yaml
+++ b/data/registers/rcc_f0.yaml
@@ -806,16 +806,16 @@ enum/LSEDRV:
   bit_size: 2
   variants:
   - name: Low
-    description: Low drive capacity
+    description: Low driving capability
     value: 0
-  - name: MediumHigh
-    description: Medium-high drive capacity
-    value: 1
   - name: MediumLow
-    description: Medium-low drive capacity
+    description: Medium low driving capability
     value: 2
+  - name: MediumHigh
+    description: Medium high driving capability
+    value: 1
   - name: High
-    description: High drive capacity
+    description: High driving capability
     value: 3
 enum/MCO:
   bit_size: 3

--- a/data/registers/rcc_f3.yaml
+++ b/data/registers/rcc_f3.yaml
@@ -957,16 +957,16 @@ enum/LSEDRV:
   bit_size: 2
   variants:
   - name: Low
-    description: Low drive capacity
+    description: Low driving capability
     value: 0
-  - name: MediumHigh
-    description: Medium-high drive capacity
-    value: 1
   - name: MediumLow
-    description: Medium-low drive capacity
+    description: Medium low driving capability
     value: 2
+  - name: MediumHigh
+    description: Medium high driving capability
+    value: 1
   - name: High
-    description: High drive capacity
+    description: High driving capability
     value: 3
 enum/MCO:
   bit_size: 3

--- a/data/registers/rcc_f3_v2.yaml
+++ b/data/registers/rcc_f3_v2.yaml
@@ -933,16 +933,16 @@ enum/LSEDRV:
   bit_size: 2
   variants:
   - name: Low
-    description: Low drive capacity
+    description: Low driving capability
     value: 0
-  - name: MediumHigh
-    description: Medium-high drive capacity
-    value: 1
   - name: MediumLow
-    description: Medium-low drive capacity
+    description: Medium low driving capability
     value: 2
+  - name: MediumHigh
+    description: Medium high driving capability
+    value: 1
   - name: High
-    description: High drive capacity
+    description: High driving capability
     value: 3
 enum/MCO:
   bit_size: 3

--- a/data/registers/rcc_f7.yaml
+++ b/data/registers/rcc_f7.yaml
@@ -1797,16 +1797,16 @@ enum/LSEDRV:
   bit_size: 2
   variants:
   - name: Low
-    description: Low drive capacity
+    description: Low driving capability
     value: 0
-  - name: MediumHigh
-    description: Medium-high drive capacity
-    value: 1
   - name: MediumLow
-    description: Medium-low drive capacity
+    description: Medium low driving capability
     value: 2
+  - name: MediumHigh
+    description: Medium high driving capability
+    value: 1
   - name: High
-    description: High drive capacity
+    description: High driving capability
     value: 3
 enum/MCO1:
   bit_size: 2

--- a/data/registers/rcc_h5.yaml
+++ b/data/registers/rcc_h5.yaml
@@ -2304,17 +2304,17 @@ enum/LSCOSEL:
 enum/LSEDRV:
   bit_size: 2
   variants:
-  - name: Lowest
-    description: Lowest LSE oscillator driving capability
+  - name: Low
+    description: Low driving capability
     value: 0
   - name: MediumLow
-    description: Medium low LSE oscillator driving capability
+    description: Medium low driving capability
     value: 1
   - name: MediumHigh
-    description: Medium high LSE oscillator driving capability
+    description: Medium high driving capability
     value: 2
-  - name: Highest
-    description: Highest LSE oscillator driving capability
+  - name: High
+    description: High driving capability
     value: 3
 enum/LSEEXT:
   bit_size: 1

--- a/data/registers/rcc_h50.yaml
+++ b/data/registers/rcc_h50.yaml
@@ -1496,17 +1496,17 @@ enum/LSCOSEL:
 enum/LSEDRV:
   bit_size: 2
   variants:
-  - name: Lowest
-    description: Lowest LSE oscillator driving capability
+  - name: Low
+    description: Low driving capability
     value: 0
   - name: MediumLow
-    description: Medium low LSE oscillator driving capability
+    description: Medium low driving capability
     value: 1
   - name: MediumHigh
-    description: Medium high LSE oscillator driving capability
+    description: Medium high driving capability
     value: 2
-  - name: Highest
-    description: Highest LSE oscillator driving capability
+  - name: High
+    description: High driving capability
     value: 3
 enum/LSEEXT:
   bit_size: 1

--- a/data/registers/rcc_h7.yaml
+++ b/data/registers/rcc_h7.yaml
@@ -3711,17 +3711,17 @@ enum/LPUARTSEL:
 enum/LSEDRV:
   bit_size: 2
   variants:
-  - name: Lowest
-    description: Lowest LSE oscillator driving capability
+  - name: Low
+    description: Low driving capability
     value: 0
   - name: MediumLow
-    description: Medium low LSE oscillator driving capability
+    description: Medium low driving capability
     value: 1
   - name: MediumHigh
-    description: Medium high LSE oscillator driving capability
+    description: Medium high driving capability
     value: 2
-  - name: Highest
-    description: Highest LSE oscillator driving capability
+  - name: High
+    description: High driving capability
     value: 3
 enum/MCO1:
   bit_size: 3

--- a/data/registers/rcc_h7ab.yaml
+++ b/data/registers/rcc_h7ab.yaml
@@ -2646,17 +2646,17 @@ enum/LPUARTSEL:
 enum/LSEDRV:
   bit_size: 2
   variants:
-  - name: Lowest
-    description: Lowest LSE oscillator driving capability
+  - name: Low
+    description: Low driving capability
     value: 0
   - name: MediumLow
-    description: Medium low LSE oscillator driving capability
+    description: Medium low driving capability
     value: 1
   - name: MediumHigh
-    description: Medium high LSE oscillator driving capability
+    description: Medium high driving capability
     value: 2
-  - name: Highest
-    description: Highest LSE oscillator driving capability
+  - name: High
+    description: High driving capability
     value: 3
 enum/MCO1:
   bit_size: 3

--- a/data/registers/rcc_h7rm0433.yaml
+++ b/data/registers/rcc_h7rm0433.yaml
@@ -3716,10 +3716,10 @@ enum/LSEDRV:
     value: 0
   - name: MediumLow
     description: Medium low LSE oscillator driving capability
-    value: 1
+    value: 2
   - name: MediumHigh
     description: Medium high LSE oscillator driving capability
-    value: 2
+    value: 1
   - name: Highest
     description: Highest LSE oscillator driving capability
     value: 3

--- a/data/registers/rcc_h7rm0433.yaml
+++ b/data/registers/rcc_h7rm0433.yaml
@@ -3711,17 +3711,17 @@ enum/LPUARTSEL:
 enum/LSEDRV:
   bit_size: 2
   variants:
-  - name: Lowest
-    description: Lowest LSE oscillator driving capability
+  - name: Low
+    description: Low driving capability
     value: 0
   - name: MediumLow
-    description: Medium low LSE oscillator driving capability
+    description: Medium low driving capability
     value: 2
   - name: MediumHigh
-    description: Medium high LSE oscillator driving capability
+    description: Medium high driving capability
     value: 1
-  - name: Highest
-    description: Highest LSE oscillator driving capability
+  - name: High
+    description: High driving capability
     value: 3
 enum/MCO1:
   bit_size: 3

--- a/data/registers/rcc_h7rm0433.yaml
+++ b/data/registers/rcc_h7rm0433.yaml
@@ -1,0 +1,4052 @@
+block/RCC:
+  description: Reset and clock control
+  items:
+  - name: CR
+    description: clock control register
+    byte_offset: 0
+    fieldset: CR
+  - name: HSICFGR
+    description: RCC HSI configuration register
+    byte_offset: 4
+    fieldset: HSICFGR
+  - name: CRRCR
+    description: RCC Clock Recovery RC Register
+    byte_offset: 8
+    access: Read
+    fieldset: CRRCR
+  - name: CSICFGR
+    description: RCC CSI configuration register
+    byte_offset: 12
+    fieldset: CSICFGR
+  - name: CFGR
+    description: RCC Clock Configuration Register
+    byte_offset: 16
+    fieldset: CFGR
+  - name: D1CFGR
+    description: RCC Domain 1 Clock Configuration Register
+    byte_offset: 24
+    fieldset: D1CFGR
+  - name: D2CFGR
+    description: RCC Domain 2 Clock Configuration Register
+    byte_offset: 28
+    fieldset: D2CFGR
+  - name: D3CFGR
+    description: RCC Domain 3 Clock Configuration Register
+    byte_offset: 32
+    fieldset: D3CFGR
+  - name: PLLCKSELR
+    description: RCC PLLs Clock Source Selection Register
+    byte_offset: 40
+    fieldset: PLLCKSELR
+  - name: PLLCFGR
+    description: RCC PLLs Configuration Register
+    byte_offset: 44
+    fieldset: PLLCFGR
+  - name: PLLDIVR
+    description: RCC PLL1 Dividers Configuration Register
+    array:
+      len: 3
+      stride: 8
+    byte_offset: 48
+    fieldset: PLLDIVR
+  - name: PLLFRACR
+    description: RCC PLL1 Fractional Divider Register
+    array:
+      len: 3
+      stride: 8
+    byte_offset: 52
+    fieldset: PLLFRACR
+  - name: D1CCIPR
+    description: RCC Domain 1 Kernel Clock Configuration Register
+    byte_offset: 76
+    fieldset: D1CCIPR
+  - name: D2CCIP1R
+    description: RCC Domain 2 Kernel Clock Configuration Register
+    byte_offset: 80
+    fieldset: D2CCIP1R
+  - name: D2CCIP2R
+    description: RCC Domain 2 Kernel Clock Configuration Register
+    byte_offset: 84
+    fieldset: D2CCIP2R
+  - name: D3CCIPR
+    description: RCC Domain 3 Kernel Clock Configuration Register
+    byte_offset: 88
+    fieldset: D3CCIPR
+  - name: CIER
+    description: RCC Clock Source Interrupt Enable Register
+    byte_offset: 96
+    fieldset: CIER
+  - name: CIFR
+    description: RCC Clock Source Interrupt Flag Register
+    byte_offset: 100
+    access: Read
+    fieldset: CIFR
+  - name: CICR
+    description: RCC Clock Source Interrupt Clear Register
+    byte_offset: 104
+    fieldset: CICR
+  - name: BDCR
+    description: RCC Backup Domain Control Register
+    byte_offset: 112
+    fieldset: BDCR
+  - name: CSR
+    description: RCC Clock Control and Status Register
+    byte_offset: 116
+    fieldset: CSR
+  - name: AHB3RSTR
+    description: RCC AHB3 Reset Register
+    byte_offset: 124
+    fieldset: AHB3RSTR
+  - name: AHB1RSTR
+    description: RCC AHB1 Peripheral Reset Register
+    byte_offset: 128
+    fieldset: AHB1RSTR
+  - name: AHB2RSTR
+    description: RCC AHB2 Peripheral Reset Register
+    byte_offset: 132
+    fieldset: AHB2RSTR
+  - name: AHB4RSTR
+    description: RCC AHB4 Peripheral Reset Register
+    byte_offset: 136
+    fieldset: AHB4RSTR
+  - name: APB3RSTR
+    description: RCC APB3 Peripheral Reset Register
+    byte_offset: 140
+    fieldset: APB3RSTR
+  - name: APB1LRSTR
+    description: RCC APB1 Peripheral Reset Register
+    byte_offset: 144
+    fieldset: APB1LRSTR
+  - name: APB1HRSTR
+    description: RCC APB1 Peripheral Reset Register
+    byte_offset: 148
+    fieldset: APB1HRSTR
+  - name: APB2RSTR
+    description: RCC APB2 Peripheral Reset Register
+    byte_offset: 152
+    fieldset: APB2RSTR
+  - name: APB4RSTR
+    description: RCC APB4 Peripheral Reset Register
+    byte_offset: 156
+    fieldset: APB4RSTR
+  - name: GCR
+    description: Global Control Register
+    byte_offset: 160
+    fieldset: GCR
+  - name: D3AMR
+    description: RCC D3 Autonomous mode Register
+    byte_offset: 168
+    fieldset: D3AMR
+  - name: RSR
+    description: RCC Reset Status Register
+    byte_offset: 208
+    fieldset: RSR
+  - name: AHB3ENR
+    description: RCC AHB3 Clock Register
+    byte_offset: 212
+    fieldset: AHB3ENR
+  - name: AHB1ENR
+    description: RCC AHB1 Clock Register
+    byte_offset: 216
+    fieldset: AHB1ENR
+  - name: AHB2ENR
+    description: RCC AHB2 Clock Register
+    byte_offset: 220
+    fieldset: AHB2ENR
+  - name: AHB4ENR
+    description: RCC AHB4 Clock Register
+    byte_offset: 224
+    fieldset: AHB4ENR
+  - name: APB3ENR
+    description: RCC APB3 Clock Register
+    byte_offset: 228
+    fieldset: APB3ENR
+  - name: APB1LENR
+    description: RCC APB1 Clock Register
+    byte_offset: 232
+    fieldset: APB1LENR
+  - name: APB1HENR
+    description: RCC APB1 Clock Register
+    byte_offset: 236
+    fieldset: APB1HENR
+  - name: APB2ENR
+    description: RCC APB2 Clock Register
+    byte_offset: 240
+    fieldset: APB2ENR
+  - name: APB4ENR
+    description: RCC APB4 Clock Register
+    byte_offset: 244
+    fieldset: APB4ENR
+  - name: AHB3LPENR
+    description: RCC AHB3 Sleep Clock Register
+    byte_offset: 252
+    fieldset: AHB3LPENR
+  - name: AHB1LPENR
+    description: RCC AHB1 Sleep Clock Register
+    byte_offset: 256
+    fieldset: AHB1LPENR
+  - name: AHB2LPENR
+    description: RCC AHB2 Sleep Clock Register
+    byte_offset: 260
+    fieldset: AHB2LPENR
+  - name: AHB4LPENR
+    description: RCC AHB4 Sleep Clock Register
+    byte_offset: 264
+    fieldset: AHB4LPENR
+  - name: APB3LPENR
+    description: RCC APB3 Sleep Clock Register
+    byte_offset: 268
+    fieldset: APB3LPENR
+  - name: APB1LLPENR
+    description: RCC APB1 Low Sleep Clock Register
+    byte_offset: 272
+    fieldset: APB1LLPENR
+  - name: APB1HLPENR
+    description: RCC APB1 High Sleep Clock Register
+    byte_offset: 276
+    fieldset: APB1HLPENR
+  - name: APB2LPENR
+    description: RCC APB2 Sleep Clock Register
+    byte_offset: 280
+    fieldset: APB2LPENR
+  - name: APB4LPENR
+    description: RCC APB4 Sleep Clock Register
+    byte_offset: 284
+    fieldset: APB4LPENR
+  - name: C1_RSR
+    description: RCC Reset Status Register
+    byte_offset: 304
+    fieldset: C1_RSR
+  - name: C1_AHB3ENR
+    description: RCC AHB3 Clock Register
+    byte_offset: 308
+    fieldset: C1_AHB3ENR
+  - name: C1_AHB1ENR
+    description: RCC AHB1 Clock Register
+    byte_offset: 312
+    fieldset: C1_AHB1ENR
+  - name: C1_AHB2ENR
+    description: RCC AHB2 Clock Register
+    byte_offset: 316
+    fieldset: C1_AHB2ENR
+  - name: C1_AHB4ENR
+    description: RCC AHB4 Clock Register
+    byte_offset: 320
+    fieldset: C1_AHB4ENR
+  - name: C1_APB3ENR
+    description: RCC APB3 Clock Register
+    byte_offset: 324
+    fieldset: C1_APB3ENR
+  - name: C1_APB1LENR
+    description: RCC APB1 Clock Register
+    byte_offset: 328
+    fieldset: C1_APB1LENR
+  - name: C1_APB1HENR
+    description: RCC APB1 Clock Register
+    byte_offset: 332
+    fieldset: C1_APB1HENR
+  - name: C1_APB2ENR
+    description: RCC APB2 Clock Register
+    byte_offset: 336
+    fieldset: C1_APB2ENR
+  - name: C1_APB4ENR
+    description: RCC APB4 Clock Register
+    byte_offset: 340
+    fieldset: C1_APB4ENR
+  - name: C1_AHB3LPENR
+    description: RCC AHB3 Sleep Clock Register
+    byte_offset: 348
+    fieldset: C1_AHB3LPENR
+  - name: C1_AHB1LPENR
+    description: RCC AHB1 Sleep Clock Register
+    byte_offset: 352
+    fieldset: C1_AHB1LPENR
+  - name: C1_AHB2LPENR
+    description: RCC AHB2 Sleep Clock Register
+    byte_offset: 356
+    fieldset: C1_AHB2LPENR
+  - name: C1_AHB4LPENR
+    description: RCC AHB4 Sleep Clock Register
+    byte_offset: 360
+    fieldset: C1_AHB4LPENR
+  - name: C1_APB3LPENR
+    description: RCC APB3 Sleep Clock Register
+    byte_offset: 364
+    fieldset: C1_APB3LPENR
+  - name: C1_APB1LLPENR
+    description: RCC APB1 Low Sleep Clock Register
+    byte_offset: 368
+    fieldset: C1_APB1LLPENR
+  - name: C1_APB1HLPENR
+    description: RCC APB1 High Sleep Clock Register
+    byte_offset: 372
+    fieldset: C1_APB1HLPENR
+  - name: C1_APB2LPENR
+    description: RCC APB2 Sleep Clock Register
+    byte_offset: 376
+    fieldset: C1_APB2LPENR
+  - name: C1_APB4LPENR
+    description: RCC APB4 Sleep Clock Register
+    byte_offset: 380
+    fieldset: C1_APB4LPENR
+fieldset/AHB1ENR:
+  description: RCC AHB1 Clock Register
+  fields:
+  - name: DMA1EN
+    description: DMA1 Clock Enable
+    bit_offset: 0
+    bit_size: 1
+  - name: DMA2EN
+    description: DMA2 Clock Enable
+    bit_offset: 1
+    bit_size: 1
+  - name: ADC12EN
+    description: ADC1/2 Peripheral Clocks Enable
+    bit_offset: 5
+    bit_size: 1
+  - name: ARTEN
+    description: ART Clock Enable
+    bit_offset: 14
+    bit_size: 1
+  - name: ETH1MACEN
+    description: Ethernet MAC bus interface Clock Enable
+    bit_offset: 15
+    bit_size: 1
+  - name: ETH1TXEN
+    description: Ethernet Transmission Clock Enable
+    bit_offset: 16
+    bit_size: 1
+  - name: ETH1RXEN
+    description: Ethernet Reception Clock Enable
+    bit_offset: 17
+    bit_size: 1
+  - name: USB_OTG_HSEN
+    description: USB_OTG_HS Peripheral Clocks Enable
+    bit_offset: 25
+    bit_size: 1
+  - name: USB_OTG_HS_ULPIEN
+    description: USB_OTG_HS ULPI clock enable
+    bit_offset: 26
+    bit_size: 1
+  - name: USB_OTG_FSEN
+    description: USB_OTG_FS Peripheral Clocks Enable
+    bit_offset: 27
+    bit_size: 1
+  - name: USB_OTG_FS_ULPIEN
+    description: USB_OTG_FS ULPI clock enable
+    bit_offset: 28
+    bit_size: 1
+fieldset/AHB1LPENR:
+  description: RCC AHB1 Sleep Clock Register
+  fields:
+  - name: DMA1LPEN
+    description: DMA1 Clock Enable During CSleep Mode
+    bit_offset: 0
+    bit_size: 1
+  - name: DMA2LPEN
+    description: DMA2 Clock Enable During CSleep Mode
+    bit_offset: 1
+    bit_size: 1
+  - name: ADC12LPEN
+    description: ADC1/2 Peripheral Clocks Enable During CSleep Mode
+    bit_offset: 5
+    bit_size: 1
+  - name: ARTLPEN
+    description: ART Clock Enable During CSleep Mode
+    bit_offset: 14
+    bit_size: 1
+  - name: ETH1MACLPEN
+    description: Ethernet MAC bus interface Clock Enable During CSleep Mode
+    bit_offset: 15
+    bit_size: 1
+  - name: ETH1TXLPEN
+    description: Ethernet Transmission Clock Enable During CSleep Mode
+    bit_offset: 16
+    bit_size: 1
+  - name: ETH1RXLPEN
+    description: Ethernet Reception Clock Enable During CSleep Mode
+    bit_offset: 17
+    bit_size: 1
+  - name: USB_OTG_HSLPEN
+    description: USB_OTG_HS peripheral clock enable during CSleep mode
+    bit_offset: 25
+    bit_size: 1
+  - name: USB_OTG_HS_ULPILPEN
+    description: USB_PHY1 clock enable during CSleep mode
+    bit_offset: 26
+    bit_size: 1
+  - name: USB_OTG_FSLPEN
+    description: USB_OTG_FS peripheral clock enable during CSleep mode
+    bit_offset: 27
+    bit_size: 1
+  - name: USB_OTG_FS_ULPILPEN
+    description: USB_PHY2 clocks enable during CSleep mode
+    bit_offset: 28
+    bit_size: 1
+fieldset/AHB1RSTR:
+  description: RCC AHB1 Peripheral Reset Register
+  fields:
+  - name: DMA1RST
+    description: DMA1 block reset
+    bit_offset: 0
+    bit_size: 1
+  - name: DMA2RST
+    description: DMA2 block reset
+    bit_offset: 1
+    bit_size: 1
+  - name: ADC12RST
+    description: ADC1&2 block reset
+    bit_offset: 5
+    bit_size: 1
+  - name: ARTRST
+    description: ART block reset
+    bit_offset: 14
+    bit_size: 1
+  - name: ETH1MACRST
+    description: ETH1MAC block reset
+    bit_offset: 15
+    bit_size: 1
+  - name: USB_OTG_HSRST
+    description: USB_OTG_HS block reset
+    bit_offset: 25
+    bit_size: 1
+  - name: USB_OTG_FSRST
+    description: USB_OTG_FS block reset
+    bit_offset: 27
+    bit_size: 1
+fieldset/AHB2ENR:
+  description: RCC AHB2 Clock Register
+  fields:
+  - name: DCMIEN
+    description: DCMI peripheral clock
+    bit_offset: 0
+    bit_size: 1
+  - name: CRYPTEN
+    description: CRYPT peripheral clock enable
+    bit_offset: 4
+    bit_size: 1
+  - name: HASHEN
+    description: HASH peripheral clock enable
+    bit_offset: 5
+    bit_size: 1
+  - name: RNGEN
+    description: RNG peripheral clocks enable
+    bit_offset: 6
+    bit_size: 1
+  - name: SDMMC2EN
+    description: SDMMC2 and SDMMC2 delay clock enable
+    bit_offset: 9
+    bit_size: 1
+  - name: FMACEN
+    description: FMAC enable
+    bit_offset: 16
+    bit_size: 1
+  - name: CORDICEN
+    description: CORDIC enable
+    bit_offset: 17
+    bit_size: 1
+  - name: SRAM1EN
+    description: SRAM1 block enable
+    bit_offset: 29
+    bit_size: 1
+  - name: SRAM2EN
+    description: SRAM2 block enable
+    bit_offset: 30
+    bit_size: 1
+  - name: SRAM3EN
+    description: SRAM3 block enable
+    bit_offset: 31
+    bit_size: 1
+fieldset/AHB2LPENR:
+  description: RCC AHB2 Sleep Clock Register
+  fields:
+  - name: DCMILPEN
+    description: DCMI peripheral clock enable during csleep mode
+    bit_offset: 0
+    bit_size: 1
+  - name: CRYPTLPEN
+    description: CRYPT peripheral clock enable during CSleep mode
+    bit_offset: 4
+    bit_size: 1
+  - name: HASHLPEN
+    description: HASH peripheral clock enable during CSleep mode
+    bit_offset: 5
+    bit_size: 1
+  - name: RNGLPEN
+    description: RNG peripheral clock enable during CSleep mode
+    bit_offset: 6
+    bit_size: 1
+  - name: SDMMC2LPEN
+    description: SDMMC2 and SDMMC2 Delay Clock Enable During CSleep Mode
+    bit_offset: 9
+    bit_size: 1
+  - name: FMACLPEN
+    description: FMAC enable during CSleep Mode
+    bit_offset: 16
+    bit_size: 1
+  - name: CORDICLPEN
+    description: CORDIC enable during CSleep Mode
+    bit_offset: 17
+    bit_size: 1
+  - name: SRAM1LPEN
+    description: SRAM1 Clock Enable During CSleep Mode
+    bit_offset: 29
+    bit_size: 1
+  - name: SRAM2LPEN
+    description: SRAM2 Clock Enable During CSleep Mode
+    bit_offset: 30
+    bit_size: 1
+  - name: SRAM3LPEN
+    description: SRAM3 Clock Enable During CSleep Mode
+    bit_offset: 31
+    bit_size: 1
+fieldset/AHB2RSTR:
+  description: RCC AHB2 Peripheral Reset Register
+  fields:
+  - name: DCMIRST
+    description: DCMI block reset
+    bit_offset: 0
+    bit_size: 1
+  - name: CRYPTRST
+    description: Cryptography block reset
+    bit_offset: 4
+    bit_size: 1
+  - name: HASHRST
+    description: Hash block reset
+    bit_offset: 5
+    bit_size: 1
+  - name: RNGRST
+    description: Random Number Generator block reset
+    bit_offset: 6
+    bit_size: 1
+  - name: SDMMC2RST
+    description: SDMMC2 and SDMMC2 Delay block reset
+    bit_offset: 9
+    bit_size: 1
+  - name: FMACRST
+    description: FMAC reset
+    bit_offset: 16
+    bit_size: 1
+  - name: CORDICRST
+    description: CORDIC reset
+    bit_offset: 17
+    bit_size: 1
+fieldset/AHB3ENR:
+  description: RCC AHB3 Clock Register
+  fields:
+  - name: MDMAEN
+    description: MDMA Peripheral Clock Enable
+    bit_offset: 0
+    bit_size: 1
+  - name: DMA2DEN
+    description: DMA2D Peripheral Clock Enable
+    bit_offset: 4
+    bit_size: 1
+  - name: JPGDECEN
+    description: JPGDEC Peripheral Clock Enable
+    bit_offset: 5
+    bit_size: 1
+  - name: FMCEN
+    description: FMC Peripheral Clocks Enable
+    bit_offset: 12
+    bit_size: 1
+  - name: QUADSPIEN
+    description: QUADSPI and QUADSPI Delay Clock Enable
+    bit_offset: 14
+    bit_size: 1
+  - name: SDMMC1EN
+    description: SDMMC1 and SDMMC1 Delay Clock Enable
+    bit_offset: 16
+    bit_size: 1
+  - name: OCTOSPI2EN
+    description: OCTOSPI2 and OCTOSPI2 delay block enable
+    bit_offset: 19
+    bit_size: 1
+  - name: IOMNGREN
+    description: OCTOSPI IO manager enable
+    bit_offset: 21
+    bit_size: 1
+  - name: OTFD1EN
+    description: OTFDEC1 enable
+    bit_offset: 22
+    bit_size: 1
+  - name: OTFD2EN
+    description: OTFDEC2 enable
+    bit_offset: 23
+    bit_size: 1
+  - name: DTCM1EN
+    description: D1 DTCM1 block enable
+    bit_offset: 28
+    bit_size: 1
+  - name: DTCM2EN
+    description: D1 DTCM2 block enable
+    bit_offset: 29
+    bit_size: 1
+  - name: ITCM1EN
+    description: D1 ITCM block enable
+    bit_offset: 30
+    bit_size: 1
+  - name: AXISRAMEN
+    description: AXISRAM block enable
+    bit_offset: 31
+    bit_size: 1
+fieldset/AHB3LPENR:
+  description: RCC AHB3 Sleep Clock Register
+  fields:
+  - name: MDMALPEN
+    description: MDMA Clock Enable During CSleep Mode
+    bit_offset: 0
+    bit_size: 1
+  - name: DMA2DLPEN
+    description: DMA2D Clock Enable During CSleep Mode
+    bit_offset: 4
+    bit_size: 1
+  - name: JPGDECLPEN
+    description: JPGDEC Clock Enable During CSleep Mode
+    bit_offset: 5
+    bit_size: 1
+  - name: FLASHLPEN
+    description: FLASH Clock Enable During CSleep Mode
+    bit_offset: 8
+    bit_size: 1
+  - name: FMCLPEN
+    description: FMC Peripheral Clocks Enable During CSleep Mode
+    bit_offset: 12
+    bit_size: 1
+  - name: QSPILPEN
+    description: QUADSPI and QUADSPI Delay Clock Enable During CSleep Mode
+    bit_offset: 14
+    bit_size: 1
+  - name: SDMMC1LPEN
+    description: SDMMC1 and SDMMC1 Delay Clock Enable During CSleep Mode
+    bit_offset: 16
+    bit_size: 1
+  - name: OCTOSPI2LPEN
+    description: OCTOSPI2 and OCTOSPI2 delay block enable during CSleep Mode
+    bit_offset: 19
+    bit_size: 1
+  - name: IOMNGRLPEN
+    description: OCTOSPI IO manager enable during CSleep Mode
+    bit_offset: 21
+    bit_size: 1
+  - name: OTFD1LPEN
+    description: OTFDEC1 enable during CSleep Mode
+    bit_offset: 22
+    bit_size: 1
+  - name: OTFD2LPEN
+    description: OTFDEC2 enable during CSleep Mode
+    bit_offset: 23
+    bit_size: 1
+  - name: D1DTCM1LPEN
+    description: D1DTCM1 Block Clock Enable During CSleep mode
+    bit_offset: 28
+    bit_size: 1
+  - name: DTCM2LPEN
+    description: D1 DTCM2 Block Clock Enable During CSleep mode
+    bit_offset: 29
+    bit_size: 1
+  - name: ITCMLPEN
+    description: D1ITCM Block Clock Enable During CSleep mode
+    bit_offset: 30
+    bit_size: 1
+  - name: AXISRAMLPEN
+    description: AXISRAM Block Clock Enable During CSleep mode
+    bit_offset: 31
+    bit_size: 1
+fieldset/AHB3RSTR:
+  description: RCC AHB3 Reset Register
+  fields:
+  - name: MDMARST
+    description: MDMA block reset
+    bit_offset: 0
+    bit_size: 1
+  - name: DMA2DRST
+    description: DMA2D block reset
+    bit_offset: 4
+    bit_size: 1
+  - name: JPGDECRST
+    description: JPGDEC block reset
+    bit_offset: 5
+    bit_size: 1
+  - name: FMCRST
+    description: FMC block reset
+    bit_offset: 12
+    bit_size: 1
+  - name: QSPIRST
+    description: QUADSPI and QUADSPI delay block reset
+    bit_offset: 14
+    bit_size: 1
+  - name: SDMMC1RST
+    description: SDMMC1 and SDMMC1 delay block reset
+    bit_offset: 16
+    bit_size: 1
+  - name: OCTOSPI2RST
+    description: OCTOSPI2 and OCTOSPI2 delay block reset
+    bit_offset: 19
+    bit_size: 1
+  - name: IOMNGRRST
+    description: OCTOSPI IO manager reset
+    bit_offset: 21
+    bit_size: 1
+  - name: OTFD1RST
+    description: OTFDEC1 reset
+    bit_offset: 22
+    bit_size: 1
+  - name: OTFD2RST
+    description: OTFDEC2 reset
+    bit_offset: 23
+    bit_size: 1
+  - name: CPURST
+    description: CPU reset
+    bit_offset: 31
+    bit_size: 1
+fieldset/AHB4ENR:
+  description: RCC AHB4 Clock Register
+  fields:
+  - name: GPIOAEN
+    description: 0GPIO peripheral clock enable
+    bit_offset: 0
+    bit_size: 1
+  - name: GPIOBEN
+    description: 0GPIO peripheral clock enable
+    bit_offset: 1
+    bit_size: 1
+  - name: GPIOCEN
+    description: 0GPIO peripheral clock enable
+    bit_offset: 2
+    bit_size: 1
+  - name: GPIODEN
+    description: 0GPIO peripheral clock enable
+    bit_offset: 3
+    bit_size: 1
+  - name: GPIOEEN
+    description: 0GPIO peripheral clock enable
+    bit_offset: 4
+    bit_size: 1
+  - name: GPIOFEN
+    description: 0GPIO peripheral clock enable
+    bit_offset: 5
+    bit_size: 1
+  - name: GPIOGEN
+    description: 0GPIO peripheral clock enable
+    bit_offset: 6
+    bit_size: 1
+  - name: GPIOHEN
+    description: 0GPIO peripheral clock enable
+    bit_offset: 7
+    bit_size: 1
+  - name: GPIOIEN
+    description: 0GPIO peripheral clock enable
+    bit_offset: 8
+    bit_size: 1
+  - name: GPIOJEN
+    description: 0GPIO peripheral clock enable
+    bit_offset: 9
+    bit_size: 1
+  - name: GPIOKEN
+    description: 0GPIO peripheral clock enable
+    bit_offset: 10
+    bit_size: 1
+  - name: CRCEN
+    description: CRC peripheral clock enable
+    bit_offset: 19
+    bit_size: 1
+  - name: BDMAEN
+    description: BDMA and DMAMUX2 Clock Enable
+    bit_offset: 21
+    bit_size: 1
+  - name: ADC3EN
+    description: ADC3 Peripheral Clocks Enable
+    bit_offset: 24
+    bit_size: 1
+  - name: HSEMEN
+    description: HSEM peripheral clock enable
+    bit_offset: 25
+    bit_size: 1
+  - name: BKPSRAMEN
+    description: Backup RAM Clock Enable
+    bit_offset: 28
+    bit_size: 1
+fieldset/AHB4LPENR:
+  description: RCC AHB4 Sleep Clock Register
+  fields:
+  - name: GPIOALPEN
+    description: GPIO peripheral clock enable during CSleep mode
+    bit_offset: 0
+    bit_size: 1
+  - name: GPIOBLPEN
+    description: GPIO peripheral clock enable during CSleep mode
+    bit_offset: 1
+    bit_size: 1
+  - name: GPIOCLPEN
+    description: GPIO peripheral clock enable during CSleep mode
+    bit_offset: 2
+    bit_size: 1
+  - name: GPIODLPEN
+    description: GPIO peripheral clock enable during CSleep mode
+    bit_offset: 3
+    bit_size: 1
+  - name: GPIOELPEN
+    description: GPIO peripheral clock enable during CSleep mode
+    bit_offset: 4
+    bit_size: 1
+  - name: GPIOFLPEN
+    description: GPIO peripheral clock enable during CSleep mode
+    bit_offset: 5
+    bit_size: 1
+  - name: GPIOGLPEN
+    description: GPIO peripheral clock enable during CSleep mode
+    bit_offset: 6
+    bit_size: 1
+  - name: GPIOHLPEN
+    description: GPIO peripheral clock enable during CSleep mode
+    bit_offset: 7
+    bit_size: 1
+  - name: GPIOILPEN
+    description: GPIO peripheral clock enable during CSleep mode
+    bit_offset: 8
+    bit_size: 1
+  - name: GPIOJLPEN
+    description: GPIO peripheral clock enable during CSleep mode
+    bit_offset: 9
+    bit_size: 1
+  - name: GPIOKLPEN
+    description: GPIO peripheral clock enable during CSleep mode
+    bit_offset: 10
+    bit_size: 1
+  - name: CRCLPEN
+    description: CRC peripheral clock enable during CSleep mode
+    bit_offset: 19
+    bit_size: 1
+  - name: BDMALPEN
+    description: BDMA Clock Enable During CSleep Mode
+    bit_offset: 21
+    bit_size: 1
+  - name: ADC3LPEN
+    description: ADC3 Peripheral Clocks Enable During CSleep Mode
+    bit_offset: 24
+    bit_size: 1
+  - name: BKPSRAMLPEN
+    description: Backup RAM Clock Enable During CSleep Mode
+    bit_offset: 28
+    bit_size: 1
+  - name: SRAM4LPEN
+    description: SRAM4 Clock Enable During CSleep Mode
+    bit_offset: 29
+    bit_size: 1
+fieldset/AHB4RSTR:
+  description: RCC AHB4 Peripheral Reset Register
+  fields:
+  - name: GPIOARST
+    description: GPIO block reset
+    bit_offset: 0
+    bit_size: 1
+  - name: GPIOBRST
+    description: GPIO block reset
+    bit_offset: 1
+    bit_size: 1
+  - name: GPIOCRST
+    description: GPIO block reset
+    bit_offset: 2
+    bit_size: 1
+  - name: GPIODRST
+    description: GPIO block reset
+    bit_offset: 3
+    bit_size: 1
+  - name: GPIOERST
+    description: GPIO block reset
+    bit_offset: 4
+    bit_size: 1
+  - name: GPIOFRST
+    description: GPIO block reset
+    bit_offset: 5
+    bit_size: 1
+  - name: GPIOGRST
+    description: GPIO block reset
+    bit_offset: 6
+    bit_size: 1
+  - name: GPIOHRST
+    description: GPIO block reset
+    bit_offset: 7
+    bit_size: 1
+  - name: GPIOIRST
+    description: GPIO block reset
+    bit_offset: 8
+    bit_size: 1
+  - name: GPIOJRST
+    description: GPIO block reset
+    bit_offset: 9
+    bit_size: 1
+  - name: GPIOKRST
+    description: GPIO block reset
+    bit_offset: 10
+    bit_size: 1
+  - name: CRCRST
+    description: CRC block reset
+    bit_offset: 19
+    bit_size: 1
+  - name: BDMARST
+    description: BDMA block reset
+    bit_offset: 21
+    bit_size: 1
+  - name: ADC3RST
+    description: ADC3 block reset
+    bit_offset: 24
+    bit_size: 1
+  - name: HSEMRST
+    description: HSEM block reset
+    bit_offset: 25
+    bit_size: 1
+fieldset/APB1HENR:
+  description: RCC APB1 Clock Register
+  fields:
+  - name: CRSEN
+    description: Clock Recovery System peripheral clock enable
+    bit_offset: 1
+    bit_size: 1
+  - name: SWPEN
+    description: SWPMI Peripheral Clocks Enable
+    bit_offset: 2
+    bit_size: 1
+  - name: OPAMPEN
+    description: OPAMP peripheral clock enable
+    bit_offset: 4
+    bit_size: 1
+  - name: MDIOSEN
+    description: MDIOS peripheral clock enable
+    bit_offset: 5
+    bit_size: 1
+  - name: FDCANEN
+    description: FDCAN Peripheral Clocks Enable
+    bit_offset: 8
+    bit_size: 1
+  - name: TIM23EN
+    description: TIM23 block enable
+    bit_offset: 24
+    bit_size: 1
+  - name: TIM24EN
+    description: TIM24 block enable
+    bit_offset: 25
+    bit_size: 1
+fieldset/APB1HLPENR:
+  description: RCC APB1 High Sleep Clock Register
+  fields:
+  - name: CRSLPEN
+    description: Clock Recovery System peripheral clock enable during CSleep mode
+    bit_offset: 1
+    bit_size: 1
+  - name: SWPLPEN
+    description: SWPMI Peripheral Clocks Enable During CSleep Mode
+    bit_offset: 2
+    bit_size: 1
+  - name: OPAMPLPEN
+    description: OPAMP peripheral clock enable during CSleep mode
+    bit_offset: 4
+    bit_size: 1
+  - name: MDIOSLPEN
+    description: MDIOS peripheral clock enable during CSleep mode
+    bit_offset: 5
+    bit_size: 1
+  - name: FDCANLPEN
+    description: FDCAN Peripheral Clocks Enable During CSleep Mode
+    bit_offset: 8
+    bit_size: 1
+  - name: TIM23LPEN
+    description: TIM23 block enable during CSleep Mode
+    bit_offset: 24
+    bit_size: 1
+  - name: TIM24LPEN
+    description: TIM24 block enable during CSleep Mode
+    bit_offset: 25
+    bit_size: 1
+fieldset/APB1HRSTR:
+  description: RCC APB1 Peripheral Reset Register
+  fields:
+  - name: CRSRST
+    description: Clock Recovery System reset
+    bit_offset: 1
+    bit_size: 1
+  - name: SWPRST
+    description: SWPMI block reset
+    bit_offset: 2
+    bit_size: 1
+  - name: OPAMPRST
+    description: OPAMP block reset
+    bit_offset: 4
+    bit_size: 1
+  - name: MDIOSRST
+    description: MDIOS block reset
+    bit_offset: 5
+    bit_size: 1
+  - name: FDCANRST
+    description: FDCAN block reset
+    bit_offset: 8
+    bit_size: 1
+  - name: TIM23RST
+    description: TIM23 block reset
+    bit_offset: 24
+    bit_size: 1
+  - name: TIM24RST
+    description: TIM24 block reset
+    bit_offset: 25
+    bit_size: 1
+fieldset/APB1LENR:
+  description: RCC APB1 Clock Register
+  fields:
+  - name: TIM2EN
+    description: TIM peripheral clock enable
+    bit_offset: 0
+    bit_size: 1
+  - name: TIM3EN
+    description: TIM peripheral clock enable
+    bit_offset: 1
+    bit_size: 1
+  - name: TIM4EN
+    description: TIM peripheral clock enable
+    bit_offset: 2
+    bit_size: 1
+  - name: TIM5EN
+    description: TIM peripheral clock enable
+    bit_offset: 3
+    bit_size: 1
+  - name: TIM6EN
+    description: TIM peripheral clock enable
+    bit_offset: 4
+    bit_size: 1
+  - name: TIM7EN
+    description: TIM peripheral clock enable
+    bit_offset: 5
+    bit_size: 1
+  - name: TIM12EN
+    description: TIM peripheral clock enable
+    bit_offset: 6
+    bit_size: 1
+  - name: TIM13EN
+    description: TIM peripheral clock enable
+    bit_offset: 7
+    bit_size: 1
+  - name: TIM14EN
+    description: TIM peripheral clock enable
+    bit_offset: 8
+    bit_size: 1
+  - name: LPTIM1EN
+    description: LPTIM1 Peripheral Clocks Enable
+    bit_offset: 9
+    bit_size: 1
+  - name: WWDG2EN
+    description: WWDG2 peripheral clock enable
+    bit_offset: 11
+    bit_size: 1
+  - name: SPI2EN
+    description: SPI2 Peripheral Clocks Enable
+    bit_offset: 14
+    bit_size: 1
+  - name: SPI3EN
+    description: SPI3 Peripheral Clocks Enable
+    bit_offset: 15
+    bit_size: 1
+  - name: SPDIFRXEN
+    description: SPDIFRX Peripheral Clocks Enable
+    bit_offset: 16
+    bit_size: 1
+  - name: USART2EN
+    description: USART2 Peripheral Clocks Enable
+    bit_offset: 17
+    bit_size: 1
+  - name: USART3EN
+    description: USART3 Peripheral Clocks Enable
+    bit_offset: 18
+    bit_size: 1
+  - name: UART4EN
+    description: UART4 Peripheral Clocks Enable
+    bit_offset: 19
+    bit_size: 1
+  - name: UART5EN
+    description: UART5 Peripheral Clocks Enable
+    bit_offset: 20
+    bit_size: 1
+  - name: I2C1EN
+    description: I2C1 Peripheral Clocks Enable
+    bit_offset: 21
+    bit_size: 1
+  - name: I2C2EN
+    description: I2C2 Peripheral Clocks Enable
+    bit_offset: 22
+    bit_size: 1
+  - name: I2C3EN
+    description: I2C3 Peripheral Clocks Enable
+    bit_offset: 23
+    bit_size: 1
+  - name: I2C5EN
+    description: "I2C5 Peripheral Clocks\r Enable"
+    bit_offset: 25
+    bit_size: 1
+  - name: CECEN
+    description: HDMI-CEC peripheral clock enable
+    bit_offset: 27
+    bit_size: 1
+  - name: DAC12EN
+    description: DAC1&2 peripheral clock enable
+    bit_offset: 29
+    bit_size: 1
+  - name: UART7EN
+    description: UART7 Peripheral Clocks Enable
+    bit_offset: 30
+    bit_size: 1
+  - name: UART8EN
+    description: UART8 Peripheral Clocks Enable
+    bit_offset: 31
+    bit_size: 1
+fieldset/APB1LLPENR:
+  description: RCC APB1 Low Sleep Clock Register
+  fields:
+  - name: TIM2LPEN
+    description: TIM2 peripheral clock enable during CSleep mode
+    bit_offset: 0
+    bit_size: 1
+  - name: TIM3LPEN
+    description: TIM3 peripheral clock enable during CSleep mode
+    bit_offset: 1
+    bit_size: 1
+  - name: TIM4LPEN
+    description: TIM4 peripheral clock enable during CSleep mode
+    bit_offset: 2
+    bit_size: 1
+  - name: TIM5LPEN
+    description: TIM5 peripheral clock enable during CSleep mode
+    bit_offset: 3
+    bit_size: 1
+  - name: TIM6LPEN
+    description: TIM6 peripheral clock enable during CSleep mode
+    bit_offset: 4
+    bit_size: 1
+  - name: TIM7LPEN
+    description: TIM7 peripheral clock enable during CSleep mode
+    bit_offset: 5
+    bit_size: 1
+  - name: TIM12LPEN
+    description: TIM12 peripheral clock enable during CSleep mode
+    bit_offset: 6
+    bit_size: 1
+  - name: TIM13LPEN
+    description: TIM13 peripheral clock enable during CSleep mode
+    bit_offset: 7
+    bit_size: 1
+  - name: TIM14LPEN
+    description: TIM14 peripheral clock enable during CSleep mode
+    bit_offset: 8
+    bit_size: 1
+  - name: LPTIM1LPEN
+    description: LPTIM1 Peripheral Clocks Enable During CSleep Mode
+    bit_offset: 9
+    bit_size: 1
+  - name: WWDG2LPEN
+    description: WWDG2 peripheral Clocks Enable During CSleep Mode
+    bit_offset: 11
+    bit_size: 1
+  - name: SPI2LPEN
+    description: SPI2 Peripheral Clocks Enable During CSleep Mode
+    bit_offset: 14
+    bit_size: 1
+  - name: SPI3LPEN
+    description: SPI3 Peripheral Clocks Enable During CSleep Mode
+    bit_offset: 15
+    bit_size: 1
+  - name: SPDIFRXLPEN
+    description: SPDIFRX Peripheral Clocks Enable During CSleep Mode
+    bit_offset: 16
+    bit_size: 1
+  - name: USART2LPEN
+    description: USART2 Peripheral Clocks Enable During CSleep Mode
+    bit_offset: 17
+    bit_size: 1
+  - name: USART3LPEN
+    description: USART3 Peripheral Clocks Enable During CSleep Mode
+    bit_offset: 18
+    bit_size: 1
+  - name: UART4LPEN
+    description: UART4 Peripheral Clocks Enable During CSleep Mode
+    bit_offset: 19
+    bit_size: 1
+  - name: UART5LPEN
+    description: UART5 Peripheral Clocks Enable During CSleep Mode
+    bit_offset: 20
+    bit_size: 1
+  - name: I2C1LPEN
+    description: I2C1 Peripheral Clocks Enable During CSleep Mode
+    bit_offset: 21
+    bit_size: 1
+  - name: I2C2LPEN
+    description: I2C2 Peripheral Clocks Enable During CSleep Mode
+    bit_offset: 22
+    bit_size: 1
+  - name: I2C3LPEN
+    description: I2C3 Peripheral Clocks Enable During CSleep Mode
+    bit_offset: 23
+    bit_size: 1
+  - name: I2C5LPEN
+    description: I2C5 block enable during CSleep Mode
+    bit_offset: 25
+    bit_size: 1
+  - name: CECLPEN
+    description: HDMI-CEC Peripheral Clocks Enable During CSleep Mode
+    bit_offset: 27
+    bit_size: 1
+  - name: DAC12LPEN
+    description: DAC1/2 peripheral clock enable during CSleep mode
+    bit_offset: 29
+    bit_size: 1
+  - name: UART7LPEN
+    description: UART7 Peripheral Clocks Enable During CSleep Mode
+    bit_offset: 30
+    bit_size: 1
+  - name: UART8LPEN
+    description: UART8 Peripheral Clocks Enable During CSleep Mode
+    bit_offset: 31
+    bit_size: 1
+fieldset/APB1LRSTR:
+  description: RCC APB1 Peripheral Reset Register
+  fields:
+  - name: TIM2RST
+    description: TIM block reset
+    bit_offset: 0
+    bit_size: 1
+  - name: TIM3RST
+    description: TIM block reset
+    bit_offset: 1
+    bit_size: 1
+  - name: TIM4RST
+    description: TIM block reset
+    bit_offset: 2
+    bit_size: 1
+  - name: TIM5RST
+    description: TIM block reset
+    bit_offset: 3
+    bit_size: 1
+  - name: TIM6RST
+    description: TIM block reset
+    bit_offset: 4
+    bit_size: 1
+  - name: TIM7RST
+    description: TIM block reset
+    bit_offset: 5
+    bit_size: 1
+  - name: TIM12RST
+    description: TIM block reset
+    bit_offset: 6
+    bit_size: 1
+  - name: TIM13RST
+    description: TIM block reset
+    bit_offset: 7
+    bit_size: 1
+  - name: TIM14RST
+    description: TIM block reset
+    bit_offset: 8
+    bit_size: 1
+  - name: LPTIM1RST
+    description: TIM block reset
+    bit_offset: 9
+    bit_size: 1
+  - name: SPI2RST
+    description: SPI2 block reset
+    bit_offset: 14
+    bit_size: 1
+  - name: SPI3RST
+    description: SPI3 block reset
+    bit_offset: 15
+    bit_size: 1
+  - name: SPDIFRXRST
+    description: SPDIFRX block reset
+    bit_offset: 16
+    bit_size: 1
+  - name: USART2RST
+    description: USART2 block reset
+    bit_offset: 17
+    bit_size: 1
+  - name: USART3RST
+    description: USART3 block reset
+    bit_offset: 18
+    bit_size: 1
+  - name: UART4RST
+    description: UART4 block reset
+    bit_offset: 19
+    bit_size: 1
+  - name: UART5RST
+    description: UART5 block reset
+    bit_offset: 20
+    bit_size: 1
+  - name: I2C1RST
+    description: I2C1 block reset
+    bit_offset: 21
+    bit_size: 1
+  - name: I2C2RST
+    description: I2C2 block reset
+    bit_offset: 22
+    bit_size: 1
+  - name: I2C3RST
+    description: I2C3 block reset
+    bit_offset: 23
+    bit_size: 1
+  - name: I2C5RST
+    description: I2C5 block reset
+    bit_offset: 25
+    bit_size: 1
+  - name: CECRST
+    description: HDMI-CEC block reset
+    bit_offset: 27
+    bit_size: 1
+  - name: DAC12RST
+    description: DAC1 and 2 Blocks Reset
+    bit_offset: 29
+    bit_size: 1
+  - name: UART7RST
+    description: UART7 block reset
+    bit_offset: 30
+    bit_size: 1
+  - name: UART8RST
+    description: UART8 block reset
+    bit_offset: 31
+    bit_size: 1
+fieldset/APB2ENR:
+  description: RCC APB2 Clock Register
+  fields:
+  - name: TIM1EN
+    description: TIM1 peripheral clock enable
+    bit_offset: 0
+    bit_size: 1
+  - name: TIM8EN
+    description: TIM8 peripheral clock enable
+    bit_offset: 1
+    bit_size: 1
+  - name: USART1EN
+    description: USART1 Peripheral Clocks Enable
+    bit_offset: 4
+    bit_size: 1
+  - name: USART6EN
+    description: USART6 Peripheral Clocks Enable
+    bit_offset: 5
+    bit_size: 1
+  - name: UART9EN
+    description: "UART9 Peripheral Clocks\r Enable"
+    bit_offset: 6
+    bit_size: 1
+  - name: USART10EN
+    description: "USART10 Peripheral Clocks\r Enable"
+    bit_offset: 7
+    bit_size: 1
+  - name: SPI1EN
+    description: SPI1 Peripheral Clocks Enable
+    bit_offset: 12
+    bit_size: 1
+  - name: SPI4EN
+    description: SPI4 Peripheral Clocks Enable
+    bit_offset: 13
+    bit_size: 1
+  - name: TIM15EN
+    description: TIM15 peripheral clock enable
+    bit_offset: 16
+    bit_size: 1
+  - name: TIM16EN
+    description: TIM16 peripheral clock enable
+    bit_offset: 17
+    bit_size: 1
+  - name: TIM17EN
+    description: TIM17 peripheral clock enable
+    bit_offset: 18
+    bit_size: 1
+  - name: SPI5EN
+    description: SPI5 Peripheral Clocks Enable
+    bit_offset: 20
+    bit_size: 1
+  - name: SAI1EN
+    description: SAI1 Peripheral Clocks Enable
+    bit_offset: 22
+    bit_size: 1
+  - name: SAI2EN
+    description: SAI2 Peripheral Clocks Enable
+    bit_offset: 23
+    bit_size: 1
+  - name: SAI3EN
+    description: SAI3 Peripheral Clocks Enable
+    bit_offset: 24
+    bit_size: 1
+  - name: DFSDM1EN
+    description: DFSDM1 Peripheral Clocks Enable
+    bit_offset: 28
+    bit_size: 1
+  - name: HRTIMEN
+    description: HRTIM peripheral clock enable
+    bit_offset: 29
+    bit_size: 1
+fieldset/APB2LPENR:
+  description: RCC APB2 Sleep Clock Register
+  fields:
+  - name: TIM1LPEN
+    description: TIM1 peripheral clock enable during CSleep mode
+    bit_offset: 0
+    bit_size: 1
+  - name: TIM8LPEN
+    description: TIM8 peripheral clock enable during CSleep mode
+    bit_offset: 1
+    bit_size: 1
+  - name: USART1LPEN
+    description: USART1 Peripheral Clocks Enable During CSleep Mode
+    bit_offset: 4
+    bit_size: 1
+  - name: USART6LPEN
+    description: USART6 Peripheral Clocks Enable During CSleep Mode
+    bit_offset: 5
+    bit_size: 1
+  - name: SPI1LPEN
+    description: SPI1 Peripheral Clocks Enable During CSleep Mode
+    bit_offset: 12
+    bit_size: 1
+  - name: SPI4LPEN
+    description: SPI4 Peripheral Clocks Enable During CSleep Mode
+    bit_offset: 13
+    bit_size: 1
+  - name: TIM15LPEN
+    description: TIM15 peripheral clock enable during CSleep mode
+    bit_offset: 16
+    bit_size: 1
+  - name: TIM16LPEN
+    description: TIM16 peripheral clock enable during CSleep mode
+    bit_offset: 17
+    bit_size: 1
+  - name: TIM17LPEN
+    description: TIM17 peripheral clock enable during CSleep mode
+    bit_offset: 18
+    bit_size: 1
+  - name: SPI5LPEN
+    description: SPI5 Peripheral Clocks Enable During CSleep Mode
+    bit_offset: 20
+    bit_size: 1
+  - name: SAI1LPEN
+    description: SAI1 Peripheral Clocks Enable During CSleep Mode
+    bit_offset: 22
+    bit_size: 1
+  - name: SAI2LPEN
+    description: SAI2 Peripheral Clocks Enable During CSleep Mode
+    bit_offset: 23
+    bit_size: 1
+  - name: SAI3LPEN
+    description: SAI3 Peripheral Clocks Enable During CSleep Mode
+    bit_offset: 24
+    bit_size: 1
+  - name: DFSDM1LPEN
+    description: DFSDM1 Peripheral Clocks Enable During CSleep Mode
+    bit_offset: 28
+    bit_size: 1
+  - name: HRTIMLPEN
+    description: HRTIM peripheral clock enable during CSleep mode
+    bit_offset: 29
+    bit_size: 1
+fieldset/APB2RSTR:
+  description: RCC APB2 Peripheral Reset Register
+  fields:
+  - name: TIM1RST
+    description: TIM1 block reset
+    bit_offset: 0
+    bit_size: 1
+  - name: TIM8RST
+    description: TIM8 block reset
+    bit_offset: 1
+    bit_size: 1
+  - name: USART1RST
+    description: USART1 block reset
+    bit_offset: 4
+    bit_size: 1
+  - name: USART6RST
+    description: USART6 block reset
+    bit_offset: 5
+    bit_size: 1
+  - name: UART9RST
+    description: UART9 block reset
+    bit_offset: 6
+    bit_size: 1
+  - name: USART10RST
+    description: USART10 block reset
+    bit_offset: 7
+    bit_size: 1
+  - name: SPI1RST
+    description: SPI1 block reset
+    bit_offset: 12
+    bit_size: 1
+  - name: SPI4RST
+    description: SPI4 block reset
+    bit_offset: 13
+    bit_size: 1
+  - name: TIM15RST
+    description: TIM15 block reset
+    bit_offset: 16
+    bit_size: 1
+  - name: TIM16RST
+    description: TIM16 block reset
+    bit_offset: 17
+    bit_size: 1
+  - name: TIM17RST
+    description: TIM17 block reset
+    bit_offset: 18
+    bit_size: 1
+  - name: SPI5RST
+    description: SPI5 block reset
+    bit_offset: 20
+    bit_size: 1
+  - name: SAI1RST
+    description: SAI1 block reset
+    bit_offset: 22
+    bit_size: 1
+  - name: SAI2RST
+    description: SAI2 block reset
+    bit_offset: 23
+    bit_size: 1
+  - name: SAI3RST
+    description: SAI3 block reset
+    bit_offset: 24
+    bit_size: 1
+  - name: DFSDM1RST
+    description: DFSDM1 block reset
+    bit_offset: 28
+    bit_size: 1
+  - name: HRTIMRST
+    description: HRTIM block reset
+    bit_offset: 29
+    bit_size: 1
+fieldset/APB3ENR:
+  description: RCC APB3 Clock Register
+  fields:
+  - name: LTDCEN
+    description: LTDC peripheral clock enable
+    bit_offset: 3
+    bit_size: 1
+  - name: DSIEN
+    description: DSI Peripheral clocks enable
+    bit_offset: 4
+    bit_size: 1
+  - name: WWDG1EN
+    description: WWDG1 Clock Enable
+    bit_offset: 6
+    bit_size: 1
+fieldset/APB3LPENR:
+  description: RCC APB3 Sleep Clock Register
+  fields:
+  - name: LTDCLPEN
+    description: LTDC peripheral clock enable during CSleep mode
+    bit_offset: 3
+    bit_size: 1
+  - name: DSILPEN
+    description: DSI Peripheral Clock Enable During CSleep Mode
+    bit_offset: 4
+    bit_size: 1
+  - name: WWDG1LPEN
+    description: WWDG1 Clock Enable During CSleep Mode
+    bit_offset: 6
+    bit_size: 1
+fieldset/APB3RSTR:
+  description: RCC APB3 Peripheral Reset Register
+  fields:
+  - name: LTDCRST
+    description: LTDC block reset
+    bit_offset: 3
+    bit_size: 1
+  - name: DSIRST
+    description: DSI block reset
+    bit_offset: 4
+    bit_size: 1
+fieldset/APB4ENR:
+  description: RCC APB4 Clock Register
+  fields:
+  - name: SYSCFGEN
+    description: SYSCFG peripheral clock enable
+    bit_offset: 1
+    bit_size: 1
+  - name: LPUART1EN
+    description: LPUART1 Peripheral Clocks Enable
+    bit_offset: 3
+    bit_size: 1
+  - name: SPI6EN
+    description: SPI6 Peripheral Clocks Enable
+    bit_offset: 5
+    bit_size: 1
+  - name: I2C4EN
+    description: I2C4 Peripheral Clocks Enable
+    bit_offset: 7
+    bit_size: 1
+  - name: LPTIM2EN
+    description: LPTIM2 Peripheral Clocks Enable
+    bit_offset: 9
+    bit_size: 1
+  - name: LPTIM3EN
+    description: LPTIM3 Peripheral Clocks Enable
+    bit_offset: 10
+    bit_size: 1
+  - name: LPTIM4EN
+    description: LPTIM4 Peripheral Clocks Enable
+    bit_offset: 11
+    bit_size: 1
+  - name: LPTIM5EN
+    description: LPTIM5 Peripheral Clocks Enable
+    bit_offset: 12
+    bit_size: 1
+  - name: DAC2EN
+    description: DAC2 (containing one converter) peripheral clock enable
+    bit_offset: 13
+    bit_size: 1
+  - name: COMP12EN
+    description: COMP1/2 peripheral clock enable
+    bit_offset: 14
+    bit_size: 1
+  - name: VREFEN
+    description: VREF peripheral clock enable
+    bit_offset: 15
+    bit_size: 1
+  - name: RTCAPBEN
+    description: RTC APB Clock Enable
+    bit_offset: 16
+    bit_size: 1
+  - name: SAI4EN
+    description: SAI4 Peripheral Clocks Enable
+    bit_offset: 21
+    bit_size: 1
+  - name: DTSEN
+    description: Digital temperature sensor block enable
+    bit_offset: 26
+    bit_size: 1
+fieldset/APB4LPENR:
+  description: RCC APB4 Sleep Clock Register
+  fields:
+  - name: SYSCFGLPEN
+    description: SYSCFG peripheral clock enable during CSleep mode
+    bit_offset: 1
+    bit_size: 1
+  - name: LPUART1LPEN
+    description: LPUART1 Peripheral Clocks Enable During CSleep Mode
+    bit_offset: 3
+    bit_size: 1
+  - name: SPI6LPEN
+    description: SPI6 Peripheral Clocks Enable During CSleep Mode
+    bit_offset: 5
+    bit_size: 1
+  - name: I2C4LPEN
+    description: I2C4 Peripheral Clocks Enable During CSleep Mode
+    bit_offset: 7
+    bit_size: 1
+  - name: LPTIM2LPEN
+    description: LPTIM2 Peripheral Clocks Enable During CSleep Mode
+    bit_offset: 9
+    bit_size: 1
+  - name: LPTIM3LPEN
+    description: LPTIM3 Peripheral Clocks Enable During CSleep Mode
+    bit_offset: 10
+    bit_size: 1
+  - name: LPTIM4LPEN
+    description: LPTIM4 Peripheral Clocks Enable During CSleep Mode
+    bit_offset: 11
+    bit_size: 1
+  - name: LPTIM5LPEN
+    description: LPTIM5 Peripheral Clocks Enable During CSleep Mode
+    bit_offset: 12
+    bit_size: 1
+  - name: DAC2LPEN
+    description: DAC2 (containing one converter) peripheral clock enable during CSleep mode
+    bit_offset: 13
+    bit_size: 1
+  - name: COMP12LPEN
+    description: COMP1/2 peripheral clock enable during CSleep mode
+    bit_offset: 14
+    bit_size: 1
+  - name: VREFLPEN
+    description: VREF peripheral clock enable during CSleep mode
+    bit_offset: 15
+    bit_size: 1
+  - name: RTCAPBLPEN
+    description: RTC APB Clock Enable During CSleep Mode
+    bit_offset: 16
+    bit_size: 1
+  - name: SAI4LPEN
+    description: SAI4 Peripheral Clocks Enable During CSleep Mode
+    bit_offset: 21
+    bit_size: 1
+  - name: DTSLPEN
+    description: Digital temperature sensor block enable during CSleep Mode
+    bit_offset: 26
+    bit_size: 1
+fieldset/APB4RSTR:
+  description: RCC APB4 Peripheral Reset Register
+  fields:
+  - name: SYSCFGRST
+    description: SYSCFG block reset
+    bit_offset: 1
+    bit_size: 1
+  - name: LPUART1RST
+    description: LPUART1 block reset
+    bit_offset: 3
+    bit_size: 1
+  - name: SPI6RST
+    description: SPI6 block reset
+    bit_offset: 5
+    bit_size: 1
+  - name: I2C4RST
+    description: I2C4 block reset
+    bit_offset: 7
+    bit_size: 1
+  - name: LPTIM2RST
+    description: LPTIM2 block reset
+    bit_offset: 9
+    bit_size: 1
+  - name: LPTIM3RST
+    description: LPTIM3 block reset
+    bit_offset: 10
+    bit_size: 1
+  - name: LPTIM4RST
+    description: LPTIM4 block reset
+    bit_offset: 11
+    bit_size: 1
+  - name: LPTIM5RST
+    description: LPTIM5 block reset
+    bit_offset: 12
+    bit_size: 1
+  - name: DAC2RST
+    description: DAC2 (containing one converter) reset
+    bit_offset: 13
+    bit_size: 1
+  - name: COMP12RST
+    description: COMP12 Blocks Reset
+    bit_offset: 14
+    bit_size: 1
+  - name: VREFRST
+    description: VREF block reset
+    bit_offset: 15
+    bit_size: 1
+  - name: SAI4RST
+    description: SAI4 block reset
+    bit_offset: 21
+    bit_size: 1
+  - name: DTSRST
+    description: Digital temperature sensor block reset
+    bit_offset: 26
+    bit_size: 1
+fieldset/BDCR:
+  description: RCC Backup Domain Control Register
+  fields:
+  - name: LSEON
+    description: LSE oscillator enabled
+    bit_offset: 0
+    bit_size: 1
+  - name: LSERDY
+    description: LSE oscillator ready
+    bit_offset: 1
+    bit_size: 1
+  - name: LSEBYP
+    description: LSE oscillator bypass
+    bit_offset: 2
+    bit_size: 1
+  - name: LSEDRV
+    description: LSE oscillator driving capability
+    bit_offset: 3
+    bit_size: 2
+    enum: LSEDRV
+  - name: LSECSSON
+    description: LSE clock security system enable
+    bit_offset: 5
+    bit_size: 1
+  - name: LSECSSD
+    description: LSE clock security system failure detection
+    bit_offset: 6
+    bit_size: 1
+  - name: RTCSEL
+    description: RTC clock source selection
+    bit_offset: 8
+    bit_size: 2
+    enum: RTCSEL
+  - name: RTCEN
+    description: RTC clock enable
+    bit_offset: 15
+    bit_size: 1
+  - name: BDRST
+    description: VSwitch domain software reset
+    bit_offset: 16
+    bit_size: 1
+fieldset/C1_AHB1ENR:
+  description: RCC AHB1 Clock Register
+  fields:
+  - name: DMA1EN
+    description: DMA1 Clock Enable
+    bit_offset: 0
+    bit_size: 1
+  - name: DMA2EN
+    description: DMA2 Clock Enable
+    bit_offset: 1
+    bit_size: 1
+  - name: ADC12EN
+    description: ADC1/2 Peripheral Clocks Enable
+    bit_offset: 5
+    bit_size: 1
+  - name: ARTEN
+    description: ART Clock Enable
+    bit_offset: 14
+    bit_size: 1
+  - name: ETH1MACEN
+    description: Ethernet MAC bus interface Clock Enable
+    bit_offset: 15
+    bit_size: 1
+  - name: ETH1TXEN
+    description: Ethernet Transmission Clock Enable
+    bit_offset: 16
+    bit_size: 1
+  - name: ETH1RXEN
+    description: Ethernet Reception Clock Enable
+    bit_offset: 17
+    bit_size: 1
+  - name: USB_OTG_HSEN
+    description: USB_OTG_HS Peripheral Clocks Enable
+    bit_offset: 25
+    bit_size: 1
+  - name: USB_OTG_HS_ULPIEN
+    description: USB_PHY1 Clocks Enable
+    bit_offset: 26
+    bit_size: 1
+  - name: USB_OTG_FSEN
+    description: USB_OTG_FS Peripheral Clocks Enable
+    bit_offset: 27
+    bit_size: 1
+  - name: USB_OTG_FS_ULPIEN
+    description: USB_PHY2 Clocks Enable
+    bit_offset: 28
+    bit_size: 1
+fieldset/C1_AHB1LPENR:
+  description: RCC AHB1 Sleep Clock Register
+  fields:
+  - name: DMA1LPEN
+    description: DMA1 Clock Enable During CSleep Mode
+    bit_offset: 0
+    bit_size: 1
+  - name: DMA2LPEN
+    description: DMA2 Clock Enable During CSleep Mode
+    bit_offset: 1
+    bit_size: 1
+  - name: ADC12LPEN
+    description: ADC1/2 Peripheral Clocks Enable During CSleep Mode
+    bit_offset: 5
+    bit_size: 1
+  - name: ARTLPEN
+    description: ART Clock Enable During CSleep Mode
+    bit_offset: 14
+    bit_size: 1
+  - name: ETH1MACLPEN
+    description: Ethernet MAC bus interface Clock Enable During CSleep Mode
+    bit_offset: 15
+    bit_size: 1
+  - name: ETH1TXLPEN
+    description: Ethernet Transmission Clock Enable During CSleep Mode
+    bit_offset: 16
+    bit_size: 1
+  - name: ETH1RXLPEN
+    description: Ethernet Reception Clock Enable During CSleep Mode
+    bit_offset: 17
+    bit_size: 1
+  - name: USB_OTG_HSLPEN
+    description: USB_OTG_HS peripheral clock enable during CSleep mode
+    bit_offset: 25
+    bit_size: 1
+  - name: USB_OTG_HS_ULPILPEN
+    description: USB_PHY1 clock enable during CSleep mode
+    bit_offset: 26
+    bit_size: 1
+  - name: USB_OTG_FSLPEN
+    description: USB_OTG_FS peripheral clock enable during CSleep mode
+    bit_offset: 27
+    bit_size: 1
+  - name: USB_OTG_FS_ULPILPEN
+    description: USB_PHY2 clocks enable during CSleep mode
+    bit_offset: 28
+    bit_size: 1
+fieldset/C1_AHB2ENR:
+  description: RCC AHB2 Clock Register
+  fields:
+  - name: DCMIEN
+    description: DCMI peripheral clock
+    bit_offset: 0
+    bit_size: 1
+  - name: CRYPTEN
+    description: CRYPT peripheral clock enable
+    bit_offset: 4
+    bit_size: 1
+  - name: HASHEN
+    description: HASH peripheral clock enable
+    bit_offset: 5
+    bit_size: 1
+  - name: RNGEN
+    description: RNG peripheral clocks enable
+    bit_offset: 6
+    bit_size: 1
+  - name: SDMMC2EN
+    description: SDMMC2 and SDMMC2 delay clock enable
+    bit_offset: 9
+    bit_size: 1
+  - name: SRAM1EN
+    description: SRAM1 block enable
+    bit_offset: 29
+    bit_size: 1
+  - name: SRAM2EN
+    description: SRAM2 block enable
+    bit_offset: 30
+    bit_size: 1
+  - name: SRAM3EN
+    description: SRAM3 block enable
+    bit_offset: 31
+    bit_size: 1
+fieldset/C1_AHB2LPENR:
+  description: RCC AHB2 Sleep Clock Register
+  fields:
+  - name: DCMILPEN
+    description: DCMI peripheral clock enable during csleep mode
+    bit_offset: 0
+    bit_size: 1
+  - name: CRYPTLPEN
+    description: CRYPT peripheral clock enable during CSleep mode
+    bit_offset: 4
+    bit_size: 1
+  - name: HASHLPEN
+    description: HASH peripheral clock enable during CSleep mode
+    bit_offset: 5
+    bit_size: 1
+  - name: RNGLPEN
+    description: RNG peripheral clock enable during CSleep mode
+    bit_offset: 6
+    bit_size: 1
+  - name: SDMMC2LPEN
+    description: SDMMC2 and SDMMC2 Delay Clock Enable During CSleep Mode
+    bit_offset: 9
+    bit_size: 1
+  - name: FMACLPEN
+    description: FMAC enable during CSleep Mode
+    bit_offset: 16
+    bit_size: 1
+  - name: CORDICLPEN
+    description: CORDIC enable during CSleep Mode
+    bit_offset: 17
+    bit_size: 1
+  - name: SRAM1LPEN
+    description: SRAM1 Clock Enable During CSleep Mode
+    bit_offset: 29
+    bit_size: 1
+  - name: SRAM2LPEN
+    description: SRAM2 Clock Enable During CSleep Mode
+    bit_offset: 30
+    bit_size: 1
+  - name: SRAM3LPEN
+    description: SRAM3 Clock Enable During CSleep Mode
+    bit_offset: 31
+    bit_size: 1
+fieldset/C1_AHB3ENR:
+  description: RCC AHB3 Clock Register
+  fields:
+  - name: MDMAEN
+    description: MDMA Peripheral Clock Enable
+    bit_offset: 0
+    bit_size: 1
+  - name: DMA2DEN
+    description: DMA2D Peripheral Clock Enable
+    bit_offset: 4
+    bit_size: 1
+  - name: JPGDECEN
+    description: JPGDEC Peripheral Clock Enable
+    bit_offset: 5
+    bit_size: 1
+  - name: FMCEN
+    description: FMC Peripheral Clocks Enable
+    bit_offset: 12
+    bit_size: 1
+  - name: QUADSPIEN
+    description: QUADSPI and QUADSPI Delay Clock Enable
+    bit_offset: 14
+    bit_size: 1
+  - name: SDMMC1EN
+    description: SDMMC1 and SDMMC1 Delay Clock Enable
+    bit_offset: 16
+    bit_size: 1
+fieldset/C1_AHB3LPENR:
+  description: RCC AHB3 Sleep Clock Register
+  fields:
+  - name: MDMALPEN
+    description: MDMA Clock Enable During CSleep Mode
+    bit_offset: 0
+    bit_size: 1
+  - name: DMA2DLPEN
+    description: DMA2D Clock Enable During CSleep Mode
+    bit_offset: 4
+    bit_size: 1
+  - name: JPGDECLPEN
+    description: JPGDEC Clock Enable During CSleep Mode
+    bit_offset: 5
+    bit_size: 1
+  - name: FLASHPREN
+    description: Flash interface clock enable during csleep mode
+    bit_offset: 8
+    bit_size: 1
+  - name: FMCLPEN
+    description: FMC Peripheral Clocks Enable During CSleep Mode
+    bit_offset: 12
+    bit_size: 1
+  - name: QSPILPEN
+    description: QUADSPI and QUADSPI Delay Clock Enable During CSleep Mode
+    bit_offset: 14
+    bit_size: 1
+  - name: SDMMC1LPEN
+    description: SDMMC1 and SDMMC1 Delay Clock Enable During CSleep Mode
+    bit_offset: 16
+    bit_size: 1
+  - name: OCTOSPI2LPEN
+    description: OCTOSPI2 and OCTOSPI2 delay block enable during CSleep Mode
+    bit_offset: 19
+    bit_size: 1
+  - name: IOMNGRLPEN
+    description: OCTOSPI IO manager enable during CSleep Mode
+    bit_offset: 21
+    bit_size: 1
+  - name: OTFD1LPEN
+    description: OTFDEC1 enable during CSleep Mode
+    bit_offset: 22
+    bit_size: 1
+  - name: OTFD2LPEN
+    description: OTFDEC2 enable during CSleep Mode
+    bit_offset: 23
+    bit_size: 1
+  - name: D1DTCM1LPEN
+    description: D1DTCM1 Block Clock Enable During CSleep mode
+    bit_offset: 28
+    bit_size: 1
+  - name: DTCM2LPEN
+    description: D1 DTCM2 Block Clock Enable During CSleep mode
+    bit_offset: 29
+    bit_size: 1
+  - name: ITCMLPEN
+    description: D1ITCM Block Clock Enable During CSleep mode
+    bit_offset: 30
+    bit_size: 1
+  - name: AXISRAMLPEN
+    description: AXISRAM Block Clock Enable During CSleep mode
+    bit_offset: 31
+    bit_size: 1
+fieldset/C1_AHB4ENR:
+  description: RCC AHB4 Clock Register
+  fields:
+  - name: GPIOAEN
+    description: 0GPIO peripheral clock enable
+    bit_offset: 0
+    bit_size: 1
+  - name: GPIOBEN
+    description: 0GPIO peripheral clock enable
+    bit_offset: 1
+    bit_size: 1
+  - name: GPIOCEN
+    description: 0GPIO peripheral clock enable
+    bit_offset: 2
+    bit_size: 1
+  - name: GPIODEN
+    description: 0GPIO peripheral clock enable
+    bit_offset: 3
+    bit_size: 1
+  - name: GPIOEEN
+    description: 0GPIO peripheral clock enable
+    bit_offset: 4
+    bit_size: 1
+  - name: GPIOFEN
+    description: 0GPIO peripheral clock enable
+    bit_offset: 5
+    bit_size: 1
+  - name: GPIOGEN
+    description: 0GPIO peripheral clock enable
+    bit_offset: 6
+    bit_size: 1
+  - name: GPIOHEN
+    description: 0GPIO peripheral clock enable
+    bit_offset: 7
+    bit_size: 1
+  - name: GPIOIEN
+    description: 0GPIO peripheral clock enable
+    bit_offset: 8
+    bit_size: 1
+  - name: GPIOJEN
+    description: 0GPIO peripheral clock enable
+    bit_offset: 9
+    bit_size: 1
+  - name: GPIOKEN
+    description: 0GPIO peripheral clock enable
+    bit_offset: 10
+    bit_size: 1
+  - name: CRCEN
+    description: CRC peripheral clock enable
+    bit_offset: 19
+    bit_size: 1
+  - name: BDMAEN
+    description: BDMA and DMAMUX2 Clock Enable
+    bit_offset: 21
+    bit_size: 1
+  - name: ADC3EN
+    description: ADC3 Peripheral Clocks Enable
+    bit_offset: 24
+    bit_size: 1
+  - name: HSEMEN
+    description: HSEM peripheral clock enable
+    bit_offset: 25
+    bit_size: 1
+  - name: BKPSRAMEN
+    description: Backup RAM Clock Enable
+    bit_offset: 28
+    bit_size: 1
+fieldset/C1_AHB4LPENR:
+  description: RCC AHB4 Sleep Clock Register
+  fields:
+  - name: GPIOALPEN
+    description: GPIO peripheral clock enable during CSleep mode
+    bit_offset: 0
+    bit_size: 1
+  - name: GPIOBLPEN
+    description: GPIO peripheral clock enable during CSleep mode
+    bit_offset: 1
+    bit_size: 1
+  - name: GPIOCLPEN
+    description: GPIO peripheral clock enable during CSleep mode
+    bit_offset: 2
+    bit_size: 1
+  - name: GPIODLPEN
+    description: GPIO peripheral clock enable during CSleep mode
+    bit_offset: 3
+    bit_size: 1
+  - name: GPIOELPEN
+    description: GPIO peripheral clock enable during CSleep mode
+    bit_offset: 4
+    bit_size: 1
+  - name: GPIOFLPEN
+    description: GPIO peripheral clock enable during CSleep mode
+    bit_offset: 5
+    bit_size: 1
+  - name: GPIOGLPEN
+    description: GPIO peripheral clock enable during CSleep mode
+    bit_offset: 6
+    bit_size: 1
+  - name: GPIOHLPEN
+    description: GPIO peripheral clock enable during CSleep mode
+    bit_offset: 7
+    bit_size: 1
+  - name: GPIOILPEN
+    description: GPIO peripheral clock enable during CSleep mode
+    bit_offset: 8
+    bit_size: 1
+  - name: GPIOJLPEN
+    description: GPIO peripheral clock enable during CSleep mode
+    bit_offset: 9
+    bit_size: 1
+  - name: GPIOKLPEN
+    description: GPIO peripheral clock enable during CSleep mode
+    bit_offset: 10
+    bit_size: 1
+  - name: CRCLPEN
+    description: CRC peripheral clock enable during CSleep mode
+    bit_offset: 19
+    bit_size: 1
+  - name: BDMALPEN
+    description: BDMA Clock Enable During CSleep Mode
+    bit_offset: 21
+    bit_size: 1
+  - name: ADC3LPEN
+    description: ADC3 Peripheral Clocks Enable During CSleep Mode
+    bit_offset: 24
+    bit_size: 1
+  - name: BKPSRAMLPEN
+    description: Backup RAM Clock Enable During CSleep Mode
+    bit_offset: 28
+    bit_size: 1
+  - name: SRAM4LPEN
+    description: SRAM4 Clock Enable During CSleep Mode
+    bit_offset: 29
+    bit_size: 1
+fieldset/C1_APB1HENR:
+  description: RCC APB1 Clock Register
+  fields:
+  - name: CRSEN
+    description: Clock Recovery System peripheral clock enable
+    bit_offset: 1
+    bit_size: 1
+  - name: SWPEN
+    description: SWPMI Peripheral Clocks Enable
+    bit_offset: 2
+    bit_size: 1
+  - name: OPAMPEN
+    description: OPAMP peripheral clock enable
+    bit_offset: 4
+    bit_size: 1
+  - name: MDIOSEN
+    description: MDIOS peripheral clock enable
+    bit_offset: 5
+    bit_size: 1
+  - name: FDCANEN
+    description: FDCAN Peripheral Clocks Enable
+    bit_offset: 8
+    bit_size: 1
+fieldset/C1_APB1HLPENR:
+  description: RCC APB1 High Sleep Clock Register
+  fields:
+  - name: CRSLPEN
+    description: Clock Recovery System peripheral clock enable during CSleep mode
+    bit_offset: 1
+    bit_size: 1
+  - name: SWPLPEN
+    description: SWPMI Peripheral Clocks Enable During CSleep Mode
+    bit_offset: 2
+    bit_size: 1
+  - name: OPAMPLPEN
+    description: OPAMP peripheral clock enable during CSleep mode
+    bit_offset: 4
+    bit_size: 1
+  - name: MDIOSLPEN
+    description: MDIOS peripheral clock enable during CSleep mode
+    bit_offset: 5
+    bit_size: 1
+  - name: FDCANLPEN
+    description: FDCAN Peripheral Clocks Enable During CSleep Mode
+    bit_offset: 8
+    bit_size: 1
+  - name: TIM23LPEN
+    description: TIM23 block enable during CSleep Mode
+    bit_offset: 24
+    bit_size: 1
+  - name: TIM24LPEN
+    description: TIM24 block enable during CSleep Mode
+    bit_offset: 25
+    bit_size: 1
+fieldset/C1_APB1LENR:
+  description: RCC APB1 Clock Register
+  fields:
+  - name: TIM2EN
+    description: TIM peripheral clock enable
+    bit_offset: 0
+    bit_size: 1
+  - name: TIM3EN
+    description: TIM peripheral clock enable
+    bit_offset: 1
+    bit_size: 1
+  - name: TIM4EN
+    description: TIM peripheral clock enable
+    bit_offset: 2
+    bit_size: 1
+  - name: TIM5EN
+    description: TIM peripheral clock enable
+    bit_offset: 3
+    bit_size: 1
+  - name: TIM6EN
+    description: TIM peripheral clock enable
+    bit_offset: 4
+    bit_size: 1
+  - name: TIM7EN
+    description: TIM peripheral clock enable
+    bit_offset: 5
+    bit_size: 1
+  - name: TIM12EN
+    description: TIM peripheral clock enable
+    bit_offset: 6
+    bit_size: 1
+  - name: TIM13EN
+    description: TIM peripheral clock enable
+    bit_offset: 7
+    bit_size: 1
+  - name: TIM14EN
+    description: TIM peripheral clock enable
+    bit_offset: 8
+    bit_size: 1
+  - name: LPTIM1EN
+    description: LPTIM1 Peripheral Clocks Enable
+    bit_offset: 9
+    bit_size: 1
+  - name: WWDG2EN
+    description: WWDG2 peripheral clock enable
+    bit_offset: 11
+    bit_size: 1
+  - name: SPI2EN
+    description: SPI2 Peripheral Clocks Enable
+    bit_offset: 14
+    bit_size: 1
+  - name: SPI3EN
+    description: SPI3 Peripheral Clocks Enable
+    bit_offset: 15
+    bit_size: 1
+  - name: SPDIFRXEN
+    description: SPDIFRX Peripheral Clocks Enable
+    bit_offset: 16
+    bit_size: 1
+  - name: USART2EN
+    description: USART2 Peripheral Clocks Enable
+    bit_offset: 17
+    bit_size: 1
+  - name: USART3EN
+    description: USART3 Peripheral Clocks Enable
+    bit_offset: 18
+    bit_size: 1
+  - name: UART4EN
+    description: UART4 Peripheral Clocks Enable
+    bit_offset: 19
+    bit_size: 1
+  - name: UART5EN
+    description: UART5 Peripheral Clocks Enable
+    bit_offset: 20
+    bit_size: 1
+  - name: I2C1EN
+    description: I2C1 Peripheral Clocks Enable
+    bit_offset: 21
+    bit_size: 1
+  - name: I2C2EN
+    description: I2C2 Peripheral Clocks Enable
+    bit_offset: 22
+    bit_size: 1
+  - name: I2C3EN
+    description: I2C3 Peripheral Clocks Enable
+    bit_offset: 23
+    bit_size: 1
+  - name: I2C5EN
+    description: "I2C5 Peripheral Clocks\r Enable"
+    bit_offset: 25
+    bit_size: 1
+  - name: CECEN
+    description: HDMI-CEC peripheral clock enable
+    bit_offset: 27
+    bit_size: 1
+  - name: DAC12EN
+    description: DAC1&2 peripheral clock enable
+    bit_offset: 29
+    bit_size: 1
+  - name: UART7EN
+    description: UART7 Peripheral Clocks Enable
+    bit_offset: 30
+    bit_size: 1
+  - name: UART8EN
+    description: UART8 Peripheral Clocks Enable
+    bit_offset: 31
+    bit_size: 1
+fieldset/C1_APB1LLPENR:
+  description: RCC APB1 Low Sleep Clock Register
+  fields:
+  - name: TIM2LPEN
+    description: TIM2 peripheral clock enable during CSleep mode
+    bit_offset: 0
+    bit_size: 1
+  - name: TIM3LPEN
+    description: TIM3 peripheral clock enable during CSleep mode
+    bit_offset: 1
+    bit_size: 1
+  - name: TIM4LPEN
+    description: TIM4 peripheral clock enable during CSleep mode
+    bit_offset: 2
+    bit_size: 1
+  - name: TIM5LPEN
+    description: TIM5 peripheral clock enable during CSleep mode
+    bit_offset: 3
+    bit_size: 1
+  - name: TIM6LPEN
+    description: TIM6 peripheral clock enable during CSleep mode
+    bit_offset: 4
+    bit_size: 1
+  - name: TIM7LPEN
+    description: TIM7 peripheral clock enable during CSleep mode
+    bit_offset: 5
+    bit_size: 1
+  - name: TIM12LPEN
+    description: TIM12 peripheral clock enable during CSleep mode
+    bit_offset: 6
+    bit_size: 1
+  - name: TIM13LPEN
+    description: TIM13 peripheral clock enable during CSleep mode
+    bit_offset: 7
+    bit_size: 1
+  - name: TIM14LPEN
+    description: TIM14 peripheral clock enable during CSleep mode
+    bit_offset: 8
+    bit_size: 1
+  - name: LPTIM1LPEN
+    description: LPTIM1 Peripheral Clocks Enable During CSleep Mode
+    bit_offset: 9
+    bit_size: 1
+  - name: WWDG2LPEN
+    description: WWDG2 peripheral Clocks Enable During CSleep Mode
+    bit_offset: 11
+    bit_size: 1
+  - name: SPI2LPEN
+    description: SPI2 Peripheral Clocks Enable During CSleep Mode
+    bit_offset: 14
+    bit_size: 1
+  - name: SPI3LPEN
+    description: SPI3 Peripheral Clocks Enable During CSleep Mode
+    bit_offset: 15
+    bit_size: 1
+  - name: SPDIFRXLPEN
+    description: SPDIFRX Peripheral Clocks Enable During CSleep Mode
+    bit_offset: 16
+    bit_size: 1
+  - name: USART2LPEN
+    description: USART2 Peripheral Clocks Enable During CSleep Mode
+    bit_offset: 17
+    bit_size: 1
+  - name: USART3LPEN
+    description: USART3 Peripheral Clocks Enable During CSleep Mode
+    bit_offset: 18
+    bit_size: 1
+  - name: UART4LPEN
+    description: UART4 Peripheral Clocks Enable During CSleep Mode
+    bit_offset: 19
+    bit_size: 1
+  - name: UART5LPEN
+    description: UART5 Peripheral Clocks Enable During CSleep Mode
+    bit_offset: 20
+    bit_size: 1
+  - name: I2C1LPEN
+    description: I2C1 Peripheral Clocks Enable During CSleep Mode
+    bit_offset: 21
+    bit_size: 1
+  - name: I2C2LPEN
+    description: I2C2 Peripheral Clocks Enable During CSleep Mode
+    bit_offset: 22
+    bit_size: 1
+  - name: I2C3LPEN
+    description: I2C3 Peripheral Clocks Enable During CSleep Mode
+    bit_offset: 23
+    bit_size: 1
+  - name: I2C5LPEN
+    description: I2C5 block enable during CSleep Mode
+    bit_offset: 25
+    bit_size: 1
+  - name: CECLPEN
+    description: HDMI-CEC Peripheral Clocks Enable During CSleep Mode
+    bit_offset: 27
+    bit_size: 1
+  - name: DAC12LPEN
+    description: DAC1/2 peripheral clock enable during CSleep mode
+    bit_offset: 29
+    bit_size: 1
+  - name: UART7LPEN
+    description: UART7 Peripheral Clocks Enable During CSleep Mode
+    bit_offset: 30
+    bit_size: 1
+  - name: UART8LPEN
+    description: UART8 Peripheral Clocks Enable During CSleep Mode
+    bit_offset: 31
+    bit_size: 1
+fieldset/C1_APB2ENR:
+  description: RCC APB2 Clock Register
+  fields:
+  - name: TIM1EN
+    description: TIM1 peripheral clock enable
+    bit_offset: 0
+    bit_size: 1
+  - name: TIM8EN
+    description: TIM8 peripheral clock enable
+    bit_offset: 1
+    bit_size: 1
+  - name: USART1EN
+    description: USART1 Peripheral Clocks Enable
+    bit_offset: 4
+    bit_size: 1
+  - name: USART6EN
+    description: USART6 Peripheral Clocks Enable
+    bit_offset: 5
+    bit_size: 1
+  - name: UART9EN
+    description: "UART9 Peripheral Clocks\r Enable"
+    bit_offset: 6
+    bit_size: 1
+  - name: USART10EN
+    description: "USART10 Peripheral Clocks\r Enable"
+    bit_offset: 7
+    bit_size: 1
+  - name: SPI1EN
+    description: SPI1 Peripheral Clocks Enable
+    bit_offset: 12
+    bit_size: 1
+  - name: SPI4EN
+    description: SPI4 Peripheral Clocks Enable
+    bit_offset: 13
+    bit_size: 1
+  - name: TIM15EN
+    description: TIM15 peripheral clock enable
+    bit_offset: 16
+    bit_size: 1
+  - name: TIM16EN
+    description: TIM16 peripheral clock enable
+    bit_offset: 17
+    bit_size: 1
+  - name: TIM17EN
+    description: TIM17 peripheral clock enable
+    bit_offset: 18
+    bit_size: 1
+  - name: SPI5EN
+    description: SPI5 Peripheral Clocks Enable
+    bit_offset: 20
+    bit_size: 1
+  - name: SAI1EN
+    description: SAI1 Peripheral Clocks Enable
+    bit_offset: 22
+    bit_size: 1
+  - name: SAI2EN
+    description: SAI2 Peripheral Clocks Enable
+    bit_offset: 23
+    bit_size: 1
+  - name: SAI3EN
+    description: SAI3 Peripheral Clocks Enable
+    bit_offset: 24
+    bit_size: 1
+  - name: DFSDM1EN
+    description: DFSDM1 Peripheral Clocks Enable
+    bit_offset: 28
+    bit_size: 1
+  - name: HRTIMEN
+    description: HRTIM peripheral clock enable
+    bit_offset: 29
+    bit_size: 1
+fieldset/C1_APB2LPENR:
+  description: RCC APB2 Sleep Clock Register
+  fields:
+  - name: TIM1LPEN
+    description: TIM1 peripheral clock enable during CSleep mode
+    bit_offset: 0
+    bit_size: 1
+  - name: TIM8LPEN
+    description: TIM8 peripheral clock enable during CSleep mode
+    bit_offset: 1
+    bit_size: 1
+  - name: USART1LPEN
+    description: USART1 Peripheral Clocks Enable During CSleep Mode
+    bit_offset: 4
+    bit_size: 1
+  - name: USART6LPEN
+    description: USART6 Peripheral Clocks Enable During CSleep Mode
+    bit_offset: 5
+    bit_size: 1
+  - name: SPI1LPEN
+    description: SPI1 Peripheral Clocks Enable During CSleep Mode
+    bit_offset: 12
+    bit_size: 1
+  - name: SPI4LPEN
+    description: SPI4 Peripheral Clocks Enable During CSleep Mode
+    bit_offset: 13
+    bit_size: 1
+  - name: TIM15LPEN
+    description: TIM15 peripheral clock enable during CSleep mode
+    bit_offset: 16
+    bit_size: 1
+  - name: TIM16LPEN
+    description: TIM16 peripheral clock enable during CSleep mode
+    bit_offset: 17
+    bit_size: 1
+  - name: TIM17LPEN
+    description: TIM17 peripheral clock enable during CSleep mode
+    bit_offset: 18
+    bit_size: 1
+  - name: SPI5LPEN
+    description: SPI5 Peripheral Clocks Enable During CSleep Mode
+    bit_offset: 20
+    bit_size: 1
+  - name: SAI1LPEN
+    description: SAI1 Peripheral Clocks Enable During CSleep Mode
+    bit_offset: 22
+    bit_size: 1
+  - name: SAI2LPEN
+    description: SAI2 Peripheral Clocks Enable During CSleep Mode
+    bit_offset: 23
+    bit_size: 1
+  - name: SAI3LPEN
+    description: SAI3 Peripheral Clocks Enable During CSleep Mode
+    bit_offset: 24
+    bit_size: 1
+  - name: DFSDM1LPEN
+    description: DFSDM1 Peripheral Clocks Enable During CSleep Mode
+    bit_offset: 28
+    bit_size: 1
+  - name: HRTIMLPEN
+    description: HRTIM peripheral clock enable during CSleep mode
+    bit_offset: 29
+    bit_size: 1
+fieldset/C1_APB3ENR:
+  description: RCC APB3 Clock Register
+  fields:
+  - name: LTDCEN
+    description: LTDC peripheral clock enable
+    bit_offset: 3
+    bit_size: 1
+  - name: DSIEN
+    description: DSI Peripheral clocks enable
+    bit_offset: 4
+    bit_size: 1
+  - name: WWDG1EN
+    description: WWDG1 Clock Enable
+    bit_offset: 6
+    bit_size: 1
+fieldset/C1_APB3LPENR:
+  description: RCC APB3 Sleep Clock Register
+  fields:
+  - name: LTDCLPEN
+    description: LTDC peripheral clock enable during CSleep mode
+    bit_offset: 3
+    bit_size: 1
+  - name: DSILPEN
+    description: DSI Peripheral Clock Enable During CSleep Mode
+    bit_offset: 4
+    bit_size: 1
+  - name: WWDG1LPEN
+    description: WWDG1 Clock Enable During CSleep Mode
+    bit_offset: 6
+    bit_size: 1
+fieldset/C1_APB4ENR:
+  description: RCC APB4 Clock Register
+  fields:
+  - name: SYSCFGEN
+    description: SYSCFG peripheral clock enable
+    bit_offset: 1
+    bit_size: 1
+  - name: LPUART1EN
+    description: LPUART1 Peripheral Clocks Enable
+    bit_offset: 3
+    bit_size: 1
+  - name: SPI6EN
+    description: SPI6 Peripheral Clocks Enable
+    bit_offset: 5
+    bit_size: 1
+  - name: I2C4EN
+    description: I2C4 Peripheral Clocks Enable
+    bit_offset: 7
+    bit_size: 1
+  - name: LPTIM2EN
+    description: LPTIM2 Peripheral Clocks Enable
+    bit_offset: 9
+    bit_size: 1
+  - name: LPTIM3EN
+    description: LPTIM3 Peripheral Clocks Enable
+    bit_offset: 10
+    bit_size: 1
+  - name: LPTIM4EN
+    description: LPTIM4 Peripheral Clocks Enable
+    bit_offset: 11
+    bit_size: 1
+  - name: LPTIM5EN
+    description: LPTIM5 Peripheral Clocks Enable
+    bit_offset: 12
+    bit_size: 1
+  - name: COMP12EN
+    description: COMP1/2 peripheral clock enable
+    bit_offset: 14
+    bit_size: 1
+  - name: VREFEN
+    description: VREF peripheral clock enable
+    bit_offset: 15
+    bit_size: 1
+  - name: RTCAPBEN
+    description: RTC APB Clock Enable
+    bit_offset: 16
+    bit_size: 1
+  - name: SAI4EN
+    description: SAI4 Peripheral Clocks Enable
+    bit_offset: 21
+    bit_size: 1
+fieldset/C1_APB4LPENR:
+  description: RCC APB4 Sleep Clock Register
+  fields:
+  - name: SYSCFGLPEN
+    description: SYSCFG peripheral clock enable during CSleep mode
+    bit_offset: 1
+    bit_size: 1
+  - name: LPUART1LPEN
+    description: LPUART1 Peripheral Clocks Enable During CSleep Mode
+    bit_offset: 3
+    bit_size: 1
+  - name: SPI6LPEN
+    description: SPI6 Peripheral Clocks Enable During CSleep Mode
+    bit_offset: 5
+    bit_size: 1
+  - name: I2C4LPEN
+    description: I2C4 Peripheral Clocks Enable During CSleep Mode
+    bit_offset: 7
+    bit_size: 1
+  - name: LPTIM2LPEN
+    description: LPTIM2 Peripheral Clocks Enable During CSleep Mode
+    bit_offset: 9
+    bit_size: 1
+  - name: LPTIM3LPEN
+    description: LPTIM3 Peripheral Clocks Enable During CSleep Mode
+    bit_offset: 10
+    bit_size: 1
+  - name: LPTIM4LPEN
+    description: LPTIM4 Peripheral Clocks Enable During CSleep Mode
+    bit_offset: 11
+    bit_size: 1
+  - name: LPTIM5LPEN
+    description: LPTIM5 Peripheral Clocks Enable During CSleep Mode
+    bit_offset: 12
+    bit_size: 1
+  - name: COMP12LPEN
+    description: COMP1/2 peripheral clock enable during CSleep mode
+    bit_offset: 14
+    bit_size: 1
+  - name: VREFLPEN
+    description: VREF peripheral clock enable during CSleep mode
+    bit_offset: 15
+    bit_size: 1
+  - name: RTCAPBLPEN
+    description: RTC APB Clock Enable During CSleep Mode
+    bit_offset: 16
+    bit_size: 1
+  - name: SAI4LPEN
+    description: SAI4 Peripheral Clocks Enable During CSleep Mode
+    bit_offset: 21
+    bit_size: 1
+  - name: DTSLPEN
+    description: Digital temperature sensor block enable during CSleep Mode
+    bit_offset: 26
+    bit_size: 1
+fieldset/C1_RSR:
+  description: RCC Reset Status Register
+  fields:
+  - name: RMVF
+    description: Remove reset flag
+    bit_offset: 16
+    bit_size: 1
+  - name: CPURSTF
+    description: CPU reset flag
+    bit_offset: 17
+    bit_size: 1
+  - name: D1RSTF
+    description: D1 domain power switch reset flag
+    bit_offset: 19
+    bit_size: 1
+  - name: D2RSTF
+    description: D2 domain power switch reset flag
+    bit_offset: 20
+    bit_size: 1
+  - name: BORRSTF
+    description: BOR reset flag
+    bit_offset: 21
+    bit_size: 1
+  - name: PINRSTF
+    description: Pin reset flag (NRST)
+    bit_offset: 22
+    bit_size: 1
+  - name: PORRSTF
+    description: POR/PDR reset flag
+    bit_offset: 23
+    bit_size: 1
+  - name: SFTRSTF
+    description: System reset from CPU reset flag
+    bit_offset: 24
+    bit_size: 1
+  - name: IWDG1RSTF
+    description: Independent Watchdog reset flag
+    bit_offset: 26
+    bit_size: 1
+  - name: WWDG1RSTF
+    description: Window Watchdog reset flag
+    bit_offset: 28
+    bit_size: 1
+  - name: LPWRRSTF
+    description: Reset due to illegal D1 DStandby or CPU CStop flag
+    bit_offset: 30
+    bit_size: 1
+fieldset/CFGR:
+  description: RCC Clock Configuration Register
+  fields:
+  - name: SW
+    description: System clock switch
+    bit_offset: 0
+    bit_size: 3
+    enum: SW
+  - name: SWS
+    description: System clock switch status
+    bit_offset: 3
+    bit_size: 3
+    enum: SW
+  - name: STOPWUCK
+    description: System clock selection after a wake up from system Stop
+    bit_offset: 6
+    bit_size: 1
+    enum: STOPWUCK
+  - name: STOPKERWUCK
+    description: Kernel clock selection after a wake up from system Stop
+    bit_offset: 7
+    bit_size: 1
+    enum: STOPWUCK
+  - name: RTCPRE
+    description: HSE division factor for RTC clock
+    bit_offset: 8
+    bit_size: 6
+  - name: HRTIMSEL
+    description: High Resolution Timer clock prescaler selection
+    bit_offset: 14
+    bit_size: 1
+    enum: HRTIMSEL
+  - name: TIMPRE
+    description: Timers clocks prescaler selection
+    bit_offset: 15
+    bit_size: 1
+    enum: TIMPRE
+  - name: MCO1PRE
+    description: MCO1 prescaler
+    bit_offset: 18
+    bit_size: 4
+  - name: MCO1
+    description: Micro-controller clock output 1
+    bit_offset: 22
+    bit_size: 3
+    enum: MCO1
+  - name: MCO2PRE
+    description: MCO2 prescaler
+    bit_offset: 25
+    bit_size: 4
+  - name: MCO2
+    description: Micro-controller clock output 2
+    bit_offset: 29
+    bit_size: 3
+    enum: MCO2
+fieldset/CICR:
+  description: RCC Clock Source Interrupt Clear Register
+  fields:
+  - name: LSIRDYC
+    description: LSI ready Interrupt Clear
+    bit_offset: 0
+    bit_size: 1
+  - name: LSERDYC
+    description: LSE ready Interrupt Clear
+    bit_offset: 1
+    bit_size: 1
+  - name: HSIRDYC
+    description: HSI ready Interrupt Clear
+    bit_offset: 2
+    bit_size: 1
+  - name: HSERDYC
+    description: HSE ready Interrupt Clear
+    bit_offset: 3
+    bit_size: 1
+  - name: HSE_ready_Interrupt_Clear
+    description: CSI ready Interrupt Clear
+    bit_offset: 4
+    bit_size: 1
+  - name: HSI48RDYC
+    description: RC48 ready Interrupt Clear
+    bit_offset: 5
+    bit_size: 1
+  - name: PLLRDYC
+    description: PLL1 ready Interrupt Clear
+    bit_offset: 6
+    bit_size: 1
+    array:
+      len: 3
+      stride: 1
+  - name: LSECSSC
+    description: LSE clock security system Interrupt Clear
+    bit_offset: 9
+    bit_size: 1
+  - name: HSECSSC
+    description: HSE clock security system Interrupt Clear
+    bit_offset: 10
+    bit_size: 1
+fieldset/CIER:
+  description: RCC Clock Source Interrupt Enable Register
+  fields:
+  - name: LSIRDYIE
+    description: LSI ready Interrupt Enable
+    bit_offset: 0
+    bit_size: 1
+  - name: LSERDYIE
+    description: LSE ready Interrupt Enable
+    bit_offset: 1
+    bit_size: 1
+  - name: HSIRDYIE
+    description: HSI ready Interrupt Enable
+    bit_offset: 2
+    bit_size: 1
+  - name: HSERDYIE
+    description: HSE ready Interrupt Enable
+    bit_offset: 3
+    bit_size: 1
+  - name: CSIRDYIE
+    description: CSI ready Interrupt Enable
+    bit_offset: 4
+    bit_size: 1
+  - name: HSI48RDYIE
+    description: RC48 ready Interrupt Enable
+    bit_offset: 5
+    bit_size: 1
+  - name: PLLRDYIE
+    description: PLL1 ready Interrupt Enable
+    bit_offset: 6
+    bit_size: 1
+    array:
+      len: 3
+      stride: 1
+  - name: LSECSSIE
+    description: LSE clock security system Interrupt Enable
+    bit_offset: 9
+    bit_size: 1
+fieldset/CIFR:
+  description: RCC Clock Source Interrupt Flag Register
+  fields:
+  - name: LSIRDYF
+    description: LSI ready Interrupt Flag
+    bit_offset: 0
+    bit_size: 1
+  - name: LSERDYF
+    description: LSE ready Interrupt Flag
+    bit_offset: 1
+    bit_size: 1
+  - name: HSIRDYF
+    description: HSI ready Interrupt Flag
+    bit_offset: 2
+    bit_size: 1
+  - name: HSERDYF
+    description: HSE ready Interrupt Flag
+    bit_offset: 3
+    bit_size: 1
+  - name: CSIRDY
+    description: CSI ready Interrupt Flag
+    bit_offset: 4
+    bit_size: 1
+  - name: HSI48RDYF
+    description: RC48 ready Interrupt Flag
+    bit_offset: 5
+    bit_size: 1
+  - name: PLLRDYF
+    description: PLL1 ready Interrupt Flag
+    bit_offset: 6
+    bit_size: 1
+    array:
+      len: 3
+      stride: 1
+  - name: LSECSSF
+    description: LSE clock security system Interrupt Flag
+    bit_offset: 9
+    bit_size: 1
+  - name: HSECSSF
+    description: HSE clock security system Interrupt Flag
+    bit_offset: 10
+    bit_size: 1
+fieldset/CR:
+  description: clock control register
+  fields:
+  - name: HSION
+    description: Internal high-speed clock enable
+    bit_offset: 0
+    bit_size: 1
+  - name: HSIKERON
+    description: High Speed Internal clock enable in Stop mode
+    bit_offset: 1
+    bit_size: 1
+  - name: HSIRDY
+    description: HSI clock ready flag
+    bit_offset: 2
+    bit_size: 1
+  - name: HSIDIV
+    description: HSI clock divider
+    bit_offset: 3
+    bit_size: 2
+    enum: HSIDIV
+  - name: HSIDIVF
+    description: HSI divider flag
+    bit_offset: 5
+    bit_size: 1
+  - name: CSION
+    description: CSI clock enable
+    bit_offset: 7
+    bit_size: 1
+  - name: CSIRDY
+    description: CSI clock ready flag
+    bit_offset: 8
+    bit_size: 1
+  - name: CSIKERON
+    description: CSI clock enable in Stop mode
+    bit_offset: 9
+    bit_size: 1
+  - name: HSI48ON
+    description: RC48 clock enable
+    bit_offset: 12
+    bit_size: 1
+  - name: HSI48RDY
+    description: RC48 clock ready flag
+    bit_offset: 13
+    bit_size: 1
+  - name: D1CKRDY
+    description: D1 domain clocks ready flag
+    bit_offset: 14
+    bit_size: 1
+  - name: D2CKRDY
+    description: D2 domain clocks ready flag
+    bit_offset: 15
+    bit_size: 1
+  - name: HSEON
+    description: HSE clock enable
+    bit_offset: 16
+    bit_size: 1
+  - name: HSERDY
+    description: HSE clock ready flag
+    bit_offset: 17
+    bit_size: 1
+  - name: HSEBYP
+    description: HSE clock bypass
+    bit_offset: 18
+    bit_size: 1
+  - name: HSECSSON
+    description: HSE Clock Security System enable
+    bit_offset: 19
+    bit_size: 1
+  - name: PLLON
+    description: PLL1 enable
+    bit_offset: 24
+    bit_size: 1
+    array:
+      len: 3
+      stride: 2
+  - name: PLLRDY
+    description: PLL1 clock ready flag
+    bit_offset: 25
+    bit_size: 1
+    array:
+      len: 3
+      stride: 2
+fieldset/CRRCR:
+  description: RCC Clock Recovery RC Register
+  fields:
+  - name: HSI48CAL
+    description: Internal RC 48 MHz clock calibration
+    bit_offset: 0
+    bit_size: 10
+fieldset/CSICFGR:
+  description: RCC CSI configuration register
+  fields:
+  - name: CSICAL
+    description: CSI clock calibration
+    bit_offset: 0
+    bit_size: 9
+  - name: CSITRIM
+    description: CSI clock trimming
+    bit_offset: 24
+    bit_size: 6
+fieldset/CSR:
+  description: RCC Clock Control and Status Register
+  fields:
+  - name: LSION
+    description: LSI oscillator enable
+    bit_offset: 0
+    bit_size: 1
+  - name: LSIRDY
+    description: LSI oscillator ready
+    bit_offset: 1
+    bit_size: 1
+fieldset/D1CCIPR:
+  description: RCC Domain 1 Kernel Clock Configuration Register
+  fields:
+  - name: FMCSEL
+    description: FMC kernel clock source selection
+    bit_offset: 0
+    bit_size: 2
+    enum: FMCSEL
+  - name: QSPISEL
+    description: QUADSPI kernel clock source selection
+    bit_offset: 4
+    bit_size: 2
+    enum: FMCSEL
+  - name: DSISEL
+    description: kernel clock source selection
+    bit_offset: 8
+    bit_size: 1
+  - name: SDMMCSEL
+    description: SDMMC kernel clock source selection
+    bit_offset: 16
+    bit_size: 1
+    enum: SDMMCSEL
+  - name: CKPERSEL
+    description: per_ck clock source selection
+    bit_offset: 28
+    bit_size: 2
+    enum: CKPERSEL
+fieldset/D1CFGR:
+  description: RCC Domain 1 Clock Configuration Register
+  fields:
+  - name: HPRE
+    description: D1 domain AHB prescaler
+    bit_offset: 0
+    bit_size: 4
+    enum: HPRE
+  - name: D1PPRE
+    description: D1 domain APB3 prescaler
+    bit_offset: 4
+    bit_size: 3
+    enum: PPRE
+  - name: D1CPRE
+    description: D1 domain Core prescaler
+    bit_offset: 8
+    bit_size: 4
+    enum: HPRE
+fieldset/D2CCIP1R:
+  description: RCC Domain 2 Kernel Clock Configuration Register
+  fields:
+  - name: SAI1SEL
+    description: SAI1 and DFSDM1 kernel Aclk clock source selection
+    bit_offset: 0
+    bit_size: 3
+    enum: SAISEL
+  - name: SAI23SEL
+    description: SAI2 and SAI3 kernel clock source selection
+    bit_offset: 6
+    bit_size: 3
+    enum: SAISEL
+  - name: SPI123SEL
+    description: SPI/I2S1,2 and 3 kernel clock source selection
+    bit_offset: 12
+    bit_size: 3
+    enum: SAISEL
+  - name: SPI45SEL
+    description: SPI4 and 5 kernel clock source selection
+    bit_offset: 16
+    bit_size: 3
+    enum: SPI45SEL
+  - name: SPDIFRXSEL
+    description: SPDIFRX kernel clock source selection
+    bit_offset: 20
+    bit_size: 2
+    enum: SPDIFRXSEL
+  - name: DFSDM1SEL
+    description: DFSDM1 kernel Clk clock source selection
+    bit_offset: 24
+    bit_size: 1
+    enum: DFSDMSEL
+  - name: FDCANSEL
+    description: FDCAN kernel clock source selection
+    bit_offset: 28
+    bit_size: 2
+    enum: FDCANSEL
+  - name: SWPSEL
+    description: SWPMI kernel clock source selection
+    bit_offset: 31
+    bit_size: 1
+    enum: SWPSEL
+fieldset/D2CCIP2R:
+  description: RCC Domain 2 Kernel Clock Configuration Register
+  fields:
+  - name: USART234578SEL
+    description: USART2/3, UART4,5, 7/8 (APB1) kernel clock source selection
+    bit_offset: 0
+    bit_size: 3
+    enum: USART234578SEL
+  - name: USART16910SEL
+    description: USART1, 6, 9 and 10 kernel clock source selection
+    bit_offset: 3
+    bit_size: 3
+    enum: USART16910SEL
+  - name: RNGSEL
+    description: RNG kernel clock source selection
+    bit_offset: 8
+    bit_size: 2
+    enum: RNGSEL
+  - name: I2C1235SEL
+    description: I2C1,2,3 kernel clock source selection
+    bit_offset: 12
+    bit_size: 2
+    enum: I2C1235SEL
+  - name: USBSEL
+    description: USBOTG 1 and 2 kernel clock source selection
+    bit_offset: 20
+    bit_size: 2
+    enum: USBSEL
+  - name: CECSEL
+    description: HDMI-CEC kernel clock source selection
+    bit_offset: 22
+    bit_size: 2
+    enum: CECSEL
+  - name: LPTIM1SEL
+    description: LPTIM1 kernel clock source selection
+    bit_offset: 28
+    bit_size: 3
+    enum: LPTIM1SEL
+fieldset/D2CFGR:
+  description: RCC Domain 2 Clock Configuration Register
+  fields:
+  - name: D2PPRE1
+    description: D2 domain APB1 prescaler
+    bit_offset: 4
+    bit_size: 3
+    enum: PPRE
+  - name: D2PPRE2
+    description: D2 domain APB2 prescaler
+    bit_offset: 8
+    bit_size: 3
+    enum: PPRE
+fieldset/D3AMR:
+  description: RCC D3 Autonomous mode Register
+  fields:
+  - name: BDMAAMEN
+    description: BDMA and DMAMUX Autonomous mode enable
+    bit_offset: 0
+    bit_size: 1
+  - name: LPUART1AMEN
+    description: LPUART1 Autonomous mode enable
+    bit_offset: 3
+    bit_size: 1
+  - name: SPI6AMEN
+    description: SPI6 Autonomous mode enable
+    bit_offset: 5
+    bit_size: 1
+  - name: I2C4AMEN
+    description: I2C4 Autonomous mode enable
+    bit_offset: 7
+    bit_size: 1
+  - name: LPTIM2AMEN
+    description: LPTIM2 Autonomous mode enable
+    bit_offset: 9
+    bit_size: 1
+  - name: LPTIM3AMEN
+    description: LPTIM3 Autonomous mode enable
+    bit_offset: 10
+    bit_size: 1
+  - name: LPTIM4AMEN
+    description: LPTIM4 Autonomous mode enable
+    bit_offset: 11
+    bit_size: 1
+  - name: LPTIM5AMEN
+    description: LPTIM5 Autonomous mode enable
+    bit_offset: 12
+    bit_size: 1
+  - name: DAC2AMEN
+    description: DAC2 (containing one converter) Autonomous mode enable
+    bit_offset: 13
+    bit_size: 1
+  - name: COMP12AMEN
+    description: COMP12 Autonomous mode enable
+    bit_offset: 14
+    bit_size: 1
+  - name: VREFAMEN
+    description: VREF Autonomous mode enable
+    bit_offset: 15
+    bit_size: 1
+  - name: RTCAMEN
+    description: RTC Autonomous mode enable
+    bit_offset: 16
+    bit_size: 1
+  - name: CRCAMEN
+    description: CRC Autonomous mode enable
+    bit_offset: 19
+    bit_size: 1
+  - name: SAI4AMEN
+    description: SAI4 Autonomous mode enable
+    bit_offset: 21
+    bit_size: 1
+  - name: ADC3AMEN
+    description: ADC3 Autonomous mode enable
+    bit_offset: 24
+    bit_size: 1
+  - name: DTSAMEN
+    description: Digital temperature sensor Autonomous mode enable
+    bit_offset: 26
+    bit_size: 1
+  - name: BKPSRAMAMEN
+    description: Backup RAM Autonomous mode enable
+    bit_offset: 28
+    bit_size: 1
+  - name: SRAM4AMEN
+    description: SRAM4 Autonomous mode enable
+    bit_offset: 29
+    bit_size: 1
+fieldset/D3CCIPR:
+  description: RCC Domain 3 Kernel Clock Configuration Register
+  fields:
+  - name: LPUART1SEL
+    description: LPUART1 kernel clock source selection
+    bit_offset: 0
+    bit_size: 3
+    enum: LPUARTSEL
+  - name: I2C4SEL
+    description: I2C4 kernel clock source selection
+    bit_offset: 8
+    bit_size: 2
+    enum: I2C4SEL
+  - name: LPTIM2SEL
+    description: LPTIM2 kernel clock source selection
+    bit_offset: 10
+    bit_size: 3
+    enum: LPTIM2SEL
+  - name: LPTIM345SEL
+    description: LPTIM3,4,5 kernel clock source selection
+    bit_offset: 13
+    bit_size: 3
+    enum: LPTIM2SEL
+  - name: ADCSEL
+    description: SAR ADC kernel clock source selection
+    bit_offset: 16
+    bit_size: 2
+    enum: ADCSEL
+  - name: SAI4ASEL
+    description: Sub-Block A of SAI4 kernel clock source selection
+    bit_offset: 21
+    bit_size: 3
+    enum: SAIASEL
+  - name: SAI4BSEL
+    description: Sub-Block B of SAI4 kernel clock source selection
+    bit_offset: 24
+    bit_size: 3
+    enum: SAIASEL
+  - name: DFSDM2SEL
+    description: DFSDM2 kernel clock source selection
+    bit_offset: 27
+    bit_size: 1
+  - name: SPI6SEL
+    description: SPI6 kernel clock source selection
+    bit_offset: 28
+    bit_size: 3
+    enum: SPI6SEL
+fieldset/D3CFGR:
+  description: RCC Domain 3 Clock Configuration Register
+  fields:
+  - name: D3PPRE
+    description: D3 domain APB4 prescaler
+    bit_offset: 4
+    bit_size: 3
+    enum: PPRE
+fieldset/GCR:
+  description: Global Control Register
+  fields:
+  - name: WW1RSC
+    description: WWDG1 reset scope control
+    bit_offset: 0
+    bit_size: 1
+  - name: WW2RSC
+    description: WWDG2 reset scope control
+    bit_offset: 1
+    bit_size: 1
+  - name: BOOT_C1
+    description: Force allow CPU1 to boot
+    bit_offset: 2
+    bit_size: 1
+  - name: BOOT_C2
+    description: Force allow CPU2 to boot
+    bit_offset: 3
+    bit_size: 1
+fieldset/HSICFGR:
+  description: RCC HSI configuration register
+  fields:
+  - name: HSICAL
+    description: HSI clock calibration
+    bit_offset: 0
+    bit_size: 12
+  - name: HSITRIM
+    description: HSI clock trimming
+    bit_offset: 24
+    bit_size: 7
+fieldset/ICSCR:
+  description: RCC Internal Clock Source Calibration Register
+  fields:
+  - name: HSICAL
+    description: HSI clock calibration
+    bit_offset: 0
+    bit_size: 12
+  - name: HSITRIM
+    description: HSI clock trimming
+    bit_offset: 12
+    bit_size: 6
+  - name: CSICAL
+    description: CSI clock calibration
+    bit_offset: 18
+    bit_size: 8
+  - name: CSITRIM
+    description: CSI clock trimming
+    bit_offset: 26
+    bit_size: 5
+fieldset/PLLCFGR:
+  description: RCC PLLs Configuration Register
+  fields:
+  - name: PLLFRACEN
+    description: PLL1 fractional latch enable
+    bit_offset: 0
+    bit_size: 1
+    array:
+      len: 3
+      stride: 4
+  - name: PLLVCOSEL
+    description: PLL1 VCO selection
+    bit_offset: 1
+    bit_size: 1
+    array:
+      len: 3
+      stride: 4
+    enum: PLLVCOSEL
+  - name: PLLRGE
+    description: PLL1 input frequency range
+    bit_offset: 2
+    bit_size: 2
+    array:
+      len: 3
+      stride: 4
+    enum: PLLRGE
+  - name: DIVPEN
+    description: PLL1 DIVP divider output enable
+    bit_offset: 16
+    bit_size: 1
+    array:
+      len: 3
+      stride: 3
+  - name: DIVQEN
+    description: PLL1 DIVQ divider output enable
+    bit_offset: 17
+    bit_size: 1
+    array:
+      len: 3
+      stride: 3
+  - name: DIVREN
+    description: PLL1 DIVR divider output enable
+    bit_offset: 18
+    bit_size: 1
+    array:
+      len: 3
+      stride: 3
+fieldset/PLLCKSELR:
+  description: RCC PLLs Clock Source Selection Register
+  fields:
+  - name: PLLSRC
+    description: DIVMx and PLLs clock source selection
+    bit_offset: 0
+    bit_size: 2
+    enum: PLLSRC
+  - name: DIVM
+    description: Prescaler for PLL1
+    bit_offset: 4
+    bit_size: 6
+    array:
+      len: 3
+      stride: 8
+fieldset/PLLDIVR:
+  description: RCC PLL1 Dividers Configuration Register
+  fields:
+  - name: PLLN
+    description: Multiplication factor for PLL1 VCO
+    bit_offset: 0
+    bit_size: 9
+  - name: PLLP
+    description: PLL DIVP division factor
+    bit_offset: 9
+    bit_size: 7
+  - name: PLLQ
+    description: PLL DIVQ division factor
+    bit_offset: 16
+    bit_size: 7
+  - name: PLLR
+    description: PLL DIVR division factor
+    bit_offset: 24
+    bit_size: 7
+fieldset/PLLFRACR:
+  description: RCC PLL Fractional Divider Register
+  fields:
+  - name: FRACN
+    description: Fractional part of the multiplication factor for PLL VCO
+    bit_offset: 3
+    bit_size: 13
+fieldset/RSR:
+  description: RCC Reset Status Register
+  fields:
+  - name: RMVF
+    description: Remove reset flag
+    bit_offset: 16
+    bit_size: 1
+  - name: CPURSTF
+    description: CPU reset flag
+    bit_offset: 17
+    bit_size: 1
+  - name: D1RSTF
+    description: D1 domain power switch reset flag
+    bit_offset: 19
+    bit_size: 1
+  - name: D2RSTF
+    description: D2 domain power switch reset flag
+    bit_offset: 20
+    bit_size: 1
+  - name: BORRSTF
+    description: BOR reset flag
+    bit_offset: 21
+    bit_size: 1
+  - name: PINRSTF
+    description: Pin reset flag (NRST)
+    bit_offset: 22
+    bit_size: 1
+  - name: PORRSTF
+    description: POR/PDR reset flag
+    bit_offset: 23
+    bit_size: 1
+  - name: SFTRSTF
+    description: System reset from CPU reset flag
+    bit_offset: 24
+    bit_size: 1
+  - name: IWDG1RSTF
+    description: Independent Watchdog reset flag
+    bit_offset: 26
+    bit_size: 1
+  - name: WWDG1RSTF
+    description: Window Watchdog reset flag
+    bit_offset: 28
+    bit_size: 1
+  - name: LPWRRSTF
+    description: Reset due to illegal D1 DStandby or CPU CStop flag
+    bit_offset: 30
+    bit_size: 1
+enum/ADCSEL:
+  bit_size: 2
+  variants:
+  - name: PLL2_P
+    description: pll2_p selected as peripheral clock
+    value: 0
+  - name: PLL3_R
+    description: pll3_r selected as peripheral clock
+    value: 1
+  - name: PER
+    description: PER selected as peripheral clock
+    value: 2
+enum/CECSEL:
+  bit_size: 2
+  variants:
+  - name: LSE
+    description: LSE selected as peripheral clock
+    value: 0
+  - name: LSI
+    description: LSI selected as peripheral clock
+    value: 1
+  - name: CSI_KER
+    description: csi_ker selected as peripheral clock
+    value: 2
+enum/CKPERSEL:
+  bit_size: 2
+  variants:
+  - name: HSI
+    description: HSI selected as peripheral clock
+    value: 0
+  - name: CSI
+    description: CSI selected as peripheral clock
+    value: 1
+  - name: HSE
+    description: HSE selected as peripheral clock
+    value: 2
+enum/DFSDMSEL:
+  bit_size: 1
+  variants:
+  - name: RCC_PCLK2
+    description: rcc_pclk2 selected as peripheral clock
+    value: 0
+  - name: SYS
+    description: System clock selected as peripheral clock
+    value: 1
+enum/FDCANSEL:
+  bit_size: 2
+  variants:
+  - name: HSE
+    description: HSE selected as peripheral clock
+    value: 0
+  - name: PLL1_Q
+    description: pll1_q selected as peripheral clock
+    value: 1
+  - name: PLL2_Q
+    description: pll2_q selected as peripheral clock
+    value: 2
+enum/FMCSEL:
+  bit_size: 2
+  variants:
+  - name: RCC_HCLK3
+    description: rcc_hclk3 selected as peripheral clock
+    value: 0
+  - name: PLL1_Q
+    description: pll1_q selected as peripheral clock
+    value: 1
+  - name: PLL2_R
+    description: pll2_r selected as peripheral clock
+    value: 2
+  - name: PER
+    description: PER selected as peripheral clock
+    value: 3
+enum/HPRE:
+  bit_size: 4
+  variants:
+  - name: Div1
+    description: sys_ck not divided
+    value: 0
+  - name: Div2
+    description: sys_ck divided by 2
+    value: 8
+  - name: Div4
+    description: sys_ck divided by 4
+    value: 9
+  - name: Div8
+    description: sys_ck divided by 8
+    value: 10
+  - name: Div16
+    description: sys_ck divided by 16
+    value: 11
+  - name: Div64
+    description: sys_ck divided by 64
+    value: 12
+  - name: Div128
+    description: sys_ck divided by 128
+    value: 13
+  - name: Div256
+    description: sys_ck divided by 256
+    value: 14
+  - name: Div512
+    description: sys_ck divided by 512
+    value: 15
+enum/HRTIMSEL:
+  bit_size: 1
+  variants:
+  - name: TIMY_KER
+    description: The HRTIM prescaler clock source is the same as other timers (rcc_timy_ker_ck)
+    value: 0
+  - name: C_CK
+    description: The HRTIM prescaler clock source is the CPU clock (c_ck)
+    value: 1
+enum/HSIDIV:
+  bit_size: 2
+  variants:
+  - name: Div1
+    description: No division
+    value: 0
+  - name: Div2
+    description: Division by 2
+    value: 1
+  - name: Div4
+    description: Division by 4
+    value: 2
+  - name: Div8
+    description: Division by 8
+    value: 3
+enum/I2C1235SEL:
+  bit_size: 2
+  variants:
+  - name: RCC_PCLK1
+    description: rcc_pclk1 selected as peripheral clock
+    value: 0
+  - name: PLL3_R
+    description: pll3_r selected as peripheral clock
+    value: 1
+  - name: HSI_KER
+    description: hsi_ker selected as peripheral clock
+    value: 2
+  - name: CSI_KER
+    description: csi_ker selected as peripheral clock
+    value: 3
+enum/I2C4SEL:
+  bit_size: 2
+  variants:
+  - name: RCC_PCLK4
+    description: rcc_pclk4 selected as peripheral clock
+    value: 0
+  - name: PLL3_R
+    description: pll3_r selected as peripheral clock
+    value: 1
+  - name: HSI_KER
+    description: hsi_ker selected as peripheral clock
+    value: 2
+  - name: CSI_KER
+    description: csi_ker selected as peripheral clock
+    value: 3
+enum/LPTIM1SEL:
+  bit_size: 3
+  variants:
+  - name: RCC_PCLK1
+    description: rcc_pclk1 selected as peripheral clock
+    value: 0
+  - name: PLL2_P
+    description: pll2_p selected as peripheral clock
+    value: 1
+  - name: PLL3_R
+    description: pll3_r selected as peripheral clock
+    value: 2
+  - name: LSE
+    description: LSE selected as peripheral clock
+    value: 3
+  - name: LSI
+    description: LSI selected as peripheral clock
+    value: 4
+  - name: PER
+    description: PER selected as peripheral clock
+    value: 5
+enum/LPTIM2SEL:
+  bit_size: 3
+  variants:
+  - name: RCC_PCLK4
+    description: rcc_pclk4 selected as peripheral clock
+    value: 0
+  - name: PLL2_P
+    description: pll2_p selected as peripheral clock
+    value: 1
+  - name: PLL3_R
+    description: pll3_r selected as peripheral clock
+    value: 2
+  - name: LSE
+    description: LSE selected as peripheral clock
+    value: 3
+  - name: LSI
+    description: LSI selected as peripheral clock
+    value: 4
+  - name: PER
+    description: PER selected as peripheral clock
+    value: 5
+enum/LPUARTSEL:
+  bit_size: 3
+  variants:
+  - name: RCC_PCLK_D3
+    description: rcc_pclk_d3 selected as peripheral clock
+    value: 0
+  - name: PLL2_Q
+    description: pll2_q selected as peripheral clock
+    value: 1
+  - name: PLL3_Q
+    description: pll3_q selected as peripheral clock
+    value: 2
+  - name: HSI_KER
+    description: hsi_ker selected as peripheral clock
+    value: 3
+  - name: CSI_KER
+    description: csi_ker selected as peripheral clock
+    value: 4
+  - name: LSE
+    description: LSE selected as peripheral clock
+    value: 5
+enum/LSEDRV:
+  bit_size: 2
+  variants:
+  - name: Lowest
+    description: Lowest LSE oscillator driving capability
+    value: 0
+  - name: MediumLow
+    description: Medium low LSE oscillator driving capability
+    value: 1
+  - name: MediumHigh
+    description: Medium high LSE oscillator driving capability
+    value: 2
+  - name: Highest
+    description: Highest LSE oscillator driving capability
+    value: 3
+enum/MCO1:
+  bit_size: 3
+  variants:
+  - name: HSI
+    description: HSI selected for micro-controller clock output
+    value: 0
+  - name: LSE
+    description: LSE selected for micro-controller clock output
+    value: 1
+  - name: HSE
+    description: HSE selected for micro-controller clock output
+    value: 2
+  - name: PLL1_Q
+    description: pll1_q selected for micro-controller clock output
+    value: 3
+  - name: HSI48
+    description: HSI48 selected for micro-controller clock output
+    value: 4
+enum/MCO2:
+  bit_size: 3
+  variants:
+  - name: SYSCLK
+    description: System clock selected for micro-controller clock output
+    value: 0
+  - name: PLL2_P
+    description: pll2_p selected for micro-controller clock output
+    value: 1
+  - name: HSE
+    description: HSE selected for micro-controller clock output
+    value: 2
+  - name: PLL1_P
+    description: pll1_p selected for micro-controller clock output
+    value: 3
+  - name: CSI
+    description: CSI selected for micro-controller clock output
+    value: 4
+  - name: LSI
+    description: LSI selected for micro-controller clock output
+    value: 5
+enum/PLLRGE:
+  bit_size: 2
+  variants:
+  - name: Range1
+    description: Frequency is between 1 and 2 MHz
+    value: 0
+  - name: Range2
+    description: Frequency is between 2 and 4 MHz
+    value: 1
+  - name: Range4
+    description: Frequency is between 4 and 8 MHz
+    value: 2
+  - name: Range8
+    description: Frequency is between 8 and 16 MHz
+    value: 3
+enum/PLLSRC:
+  bit_size: 2
+  variants:
+  - name: HSI
+    description: HSI selected as PLL clock
+    value: 0
+  - name: CSI
+    description: CSI selected as PLL clock
+    value: 1
+  - name: HSE
+    description: HSE selected as PLL clock
+    value: 2
+  - name: None
+    description: No clock sent to DIVMx dividers and PLLs
+    value: 3
+enum/PLLVCOSEL:
+  bit_size: 1
+  variants:
+  - name: WideVCO
+    description: VCO frequency range 192 to 836 MHz
+    value: 0
+  - name: MediumVCO
+    description: VCO frequency range 150 to 420 MHz
+    value: 1
+enum/PPRE:
+  bit_size: 3
+  variants:
+  - name: Div1
+    description: rcc_hclk not divided
+    value: 0
+  - name: Div2
+    description: rcc_hclk divided by 2
+    value: 4
+  - name: Div4
+    description: rcc_hclk divided by 4
+    value: 5
+  - name: Div8
+    description: rcc_hclk divided by 8
+    value: 6
+  - name: Div16
+    description: rcc_hclk divided by 16
+    value: 7
+enum/RNGSEL:
+  bit_size: 2
+  variants:
+  - name: HSI48
+    description: HSI48 selected as peripheral clock
+    value: 0
+  - name: PLL1_Q
+    description: pll1_q selected as peripheral clock
+    value: 1
+  - name: LSE
+    description: LSE selected as peripheral clock
+    value: 2
+  - name: LSI
+    description: LSI selected as peripheral clock
+    value: 3
+enum/RTCSEL:
+  bit_size: 2
+  variants:
+  - name: NoClock
+    description: No clock
+    value: 0
+  - name: LSE
+    description: LSE oscillator clock used as RTC clock
+    value: 1
+  - name: LSI
+    description: LSI oscillator clock used as RTC clock
+    value: 2
+  - name: HSE
+    description: HSE oscillator clock divided by a prescaler used as RTC clock
+    value: 3
+enum/SAIASEL:
+  bit_size: 3
+  variants:
+  - name: PLL1_Q
+    description: pll1_q selected as peripheral clock
+    value: 0
+  - name: PLL2_P
+    description: pll2_p selected as peripheral clock
+    value: 1
+  - name: PLL3_P
+    description: pll3_p selected as peripheral clock
+    value: 2
+  - name: I2S_CKIN
+    description: i2s_ckin selected as peripheral clock
+    value: 3
+  - name: PER
+    description: PER selected as peripheral clock
+    value: 4
+enum/SAISEL:
+  bit_size: 3
+  variants:
+  - name: PLL1_Q
+    description: pll1_q selected as peripheral clock
+    value: 0
+  - name: PLL2_P
+    description: pll2_p selected as peripheral clock
+    value: 1
+  - name: PLL3_P
+    description: pll3_p selected as peripheral clock
+    value: 2
+  - name: I2S_CKIN
+    description: I2S_CKIN selected as peripheral clock
+    value: 3
+  - name: PER
+    description: PER selected as peripheral clock
+    value: 4
+enum/SDMMCSEL:
+  bit_size: 1
+  variants:
+  - name: PLL1_Q
+    description: pll1_q selected as peripheral clock
+    value: 0
+  - name: PLL2_R
+    description: pll2_r selected as peripheral clock
+    value: 1
+enum/SPDIFRXSEL:
+  bit_size: 2
+  variants:
+  - name: PLL1_Q
+    description: pll1_q selected as peripheral clock
+    value: 0
+  - name: PLL2_R
+    description: pll2_r selected as peripheral clock
+    value: 1
+  - name: PLL3_R
+    description: pll3_r selected as peripheral clock
+    value: 2
+  - name: HSI_KER
+    description: hsi_ker selected as peripheral clock
+    value: 3
+enum/SPI45SEL:
+  bit_size: 3
+  variants:
+  - name: APB
+    description: APB clock selected as peripheral clock
+    value: 0
+  - name: PLL2_Q
+    description: pll2_q selected as peripheral clock
+    value: 1
+  - name: PLL3_Q
+    description: pll3_q selected as peripheral clock
+    value: 2
+  - name: HSI_KER
+    description: hsi_ker selected as peripheral clock
+    value: 3
+  - name: CSI_KER
+    description: csi_ker selected as peripheral clock
+    value: 4
+  - name: HSE
+    description: HSE selected as peripheral clock
+    value: 5
+enum/SPI6SEL:
+  bit_size: 3
+  variants:
+  - name: RCC_PCLK4
+    description: rcc_pclk4 selected as peripheral clock
+    value: 0
+  - name: PLL2_Q
+    description: pll2_q selected as peripheral clock
+    value: 1
+  - name: PLL3_Q
+    description: pll3_q selected as peripheral clock
+    value: 2
+  - name: HSI_KER
+    description: hsi_ker selected as peripheral clock
+    value: 3
+  - name: CSI_KER
+    description: csi_ker selected as peripheral clock
+    value: 4
+  - name: HSE
+    description: HSE selected as peripheral clock
+    value: 5
+enum/STOPWUCK:
+  bit_size: 1
+  variants:
+  - name: HSI
+    description: HSI selected as wake up clock from system Stop
+    value: 0
+  - name: CSI
+    description: CSI selected as wake up clock from system Stop
+    value: 1
+enum/SW:
+  bit_size: 3
+  variants:
+  - name: HSI
+    description: HSI selected as system clock
+    value: 0
+  - name: CSI
+    description: CSI selected as system clock
+    value: 1
+  - name: HSE
+    description: HSE selected as system clock
+    value: 2
+  - name: PLL1
+    description: PLL1 selected as system clock
+    value: 3
+enum/SWPSEL:
+  bit_size: 1
+  variants:
+  - name: PCLK
+    description: pclk selected as peripheral clock
+    value: 0
+  - name: HSI_KER
+    description: hsi_ker selected as peripheral clock
+    value: 1
+enum/TIMPRE:
+  bit_size: 1
+  variants:
+  - name: DefaultX2
+    description: Timer kernel clock equal to 2x pclk by default
+    value: 0
+  - name: DefaultX4
+    description: Timer kernel clock equal to 4x pclk by default
+    value: 1
+enum/USART16910SEL:
+  bit_size: 3
+  variants:
+  - name: RCC_PCLK2
+    description: rcc_pclk2 selected as peripheral clock
+    value: 0
+  - name: PLL2_Q
+    description: pll2_q selected as peripheral clock
+    value: 1
+  - name: PLL3_Q
+    description: pll3_q selected as peripheral clock
+    value: 2
+  - name: HSI_KER
+    description: hsi_ker selected as peripheral clock
+    value: 3
+  - name: CSI_KER
+    description: csi_ker selected as peripheral clock
+    value: 4
+  - name: LSE
+    description: LSE selected as peripheral clock
+    value: 5
+enum/USART234578SEL:
+  bit_size: 3
+  variants:
+  - name: RCC_PCLK1
+    description: rcc_pclk1 selected as peripheral clock
+    value: 0
+  - name: PLL2_Q
+    description: pll2_q selected as peripheral clock
+    value: 1
+  - name: PLL3_Q
+    description: pll3_q selected as peripheral clock
+    value: 2
+  - name: HSI_KER
+    description: hsi_ker selected as peripheral clock
+    value: 3
+  - name: CSI_KER
+    description: csi_ker selected as peripheral clock
+    value: 4
+  - name: LSE
+    description: LSE selected as peripheral clock
+    value: 5
+enum/USBSEL:
+  bit_size: 2
+  variants:
+  - name: DISABLE
+    description: Disable the kernel clock
+    value: 0
+  - name: PLL1_Q
+    description: pll1_q selected as peripheral clock
+    value: 1
+  - name: PLL3_Q
+    description: pll3_q selected as peripheral clock
+    value: 2
+  - name: HSI48
+    description: HSI48 selected as peripheral clock
+    value: 3

--- a/data/registers/rcc_l0.yaml
+++ b/data/registers/rcc_l0.yaml
@@ -1037,16 +1037,16 @@ enum/LSEDRV:
   bit_size: 2
   variants:
   - name: Low
-    description: Lowest drive
+    description: Low driving capability
     value: 0
   - name: MediumLow
-    description: Medium low drive
+    description: Medium low driving capability
     value: 1
   - name: MediumHigh
-    description: Medium high drive
+    description: Medium high driving capability
     value: 2
   - name: High
-    description: Highest drive
+    description: High driving capability
     value: 3
 enum/MCOPRE:
   bit_size: 3

--- a/data/registers/rcc_l4.yaml
+++ b/data/registers/rcc_l4.yaml
@@ -1737,16 +1737,16 @@ enum/LSEDRV:
   bit_size: 2
   variants:
   - name: Low
-    description: Lowest drive
+    description: Low driving capability
     value: 0
   - name: MediumLow
-    description: Medium low drive
+    description: Medium low driving capability
     value: 1
   - name: MediumHigh
-    description: Medium high drive
+    description: Medium high driving capability
     value: 2
   - name: High
-    description: Highest drive
+    description: High driving capability
     value: 3
 enum/MCOPRE:
   bit_size: 3

--- a/data/registers/rcc_l5.yaml
+++ b/data/registers/rcc_l5.yaml
@@ -2028,17 +2028,17 @@ enum/LSCOSEL:
 enum/LSEDRV:
   bit_size: 2
   variants:
-  - name: Lower
-    description: '''Xtal mode'' lower driving capability'
+  - name: Low
+    description: Low driving capability
     value: 0
   - name: MediumLow
-    description: '''Xtal mode'' medium low driving capability'
+    description: Medium low driving capability
     value: 1
   - name: MediumHigh
-    description: '''Xtal mode'' medium high driving capability'
+    description: Medium high driving capability
     value: 2
-  - name: Higher
-    description: '''Xtal mode'' higher driving capability'
+  - name: High
+    description: High driving capability
     value: 3
 enum/MCOPRE:
   bit_size: 3

--- a/data/registers/rcc_u5.yaml
+++ b/data/registers/rcc_u5.yaml
@@ -2727,17 +2727,17 @@ enum/LSCOSEL:
 enum/LSEDRV:
   bit_size: 2
   variants:
-  - name: LOW
-    description: '''Xtal mode lower driving capability'
+  - name: Low
+    description: Low driving capability
     value: 0
-  - name: MEDIUM_LOW
-    description: '''Xtal mode medium-low driving capability'
+  - name: MediumLow
+    description: Medium low driving capability
     value: 1
-  - name: MEDIUM_HIGH
-    description: '''Xtal mode medium-high driving capability'
+  - name: MediumHigh
+    description: Medium high driving capability
     value: 2
-  - name: HIGH
-    description: '''Xtal mode higher driving capability'
+  - name: High
+    description: High driving capability
     value: 3
 enum/LSIPREDIV:
   bit_size: 1

--- a/data/registers/rcc_wb.yaml
+++ b/data/registers/rcc_wb.yaml
@@ -723,6 +723,7 @@ fieldset/BDCR:
     description: SE oscillator drive capability
     bit_offset: 3
     bit_size: 2
+    enum: LSEDRV
   - name: LSECSSON
     description: LSECSSON
     bit_offset: 5
@@ -1716,4 +1717,19 @@ enum/RTCSEL:
     value: 2
   - name: HSE
     description: HSE oscillator clock divided by 32 selected
+    value: 3
+enum/LSEDRV:
+  bit_size: 2
+  variants:
+  - name: Low
+    description: Low driving capability
+    value: 0
+  - name: MediumLow
+    description: Medium low driving capability
+    value: 1
+  - name: MediumHigh
+    description: Medium high driving capability
+    value: 2
+  - name: High
+    description: High driving capability
     value: 3

--- a/data/registers/rcc_wba.yaml
+++ b/data/registers/rcc_wba.yaml
@@ -1324,17 +1324,17 @@ enum/LSCOSEL:
 enum/LSEDRV:
   bit_size: 2
   variants:
-  - name: LOW
-    description: '''Xtal mode lower driving capability'
+  - name: Low
+    description: Low driving capability
     value: 0
-  - name: MEDIUM_LOW
-    description: '''Xtal mode medium-low driving capability'
+  - name: MediumLow
+    description: Medium low driving capability
     value: 1
-  - name: MEDIUM_HIGH
-    description: '''Xtal mode medium-high driving capability'
+  - name: MediumHigh
+    description: Medium high driving capability
     value: 2
-  - name: HIGH
-    description: '''Xtal mode higher driving capability'
+  - name: High
+    description: High driving capability
     value: 3
 enum/LSETRIM:
   bit_size: 2

--- a/data/registers/rcc_wl5.yaml
+++ b/data/registers/rcc_wl5.yaml
@@ -669,6 +669,7 @@ fieldset/BDCR:
     description: LSE oscillator drive capability
     bit_offset: 3
     bit_size: 2
+    enum: LSEDRV
   - name: LSECSSON
     description: CSS on LSE enable
     bit_offset: 5
@@ -1568,4 +1569,19 @@ enum/RTCSEL:
     value: 2
   - name: HSE
     description: HSE oscillator clock divided by 32 selected
+    value: 3
+enum/LSEDRV:
+  bit_size: 2
+  variants:
+  - name: Low
+    description: Low driving capability
+    value: 0
+  - name: MediumLow
+    description: Medium low driving capability
+    value: 1
+  - name: MediumHigh
+    description: Medium high driving capability
+    value: 2
+  - name: High
+    description: High driving capability
     value: 3

--- a/data/registers/rcc_wle.yaml
+++ b/data/registers/rcc_wle.yaml
@@ -605,6 +605,7 @@ fieldset/BDCR:
     description: LSE oscillator drive capability
     bit_offset: 3
     bit_size: 2
+    enum: LSEDRV
   - name: LSECSSON
     description: CSS on LSE enable
     bit_offset: 5
@@ -1190,4 +1191,19 @@ enum/RTCSEL:
     value: 2
   - name: HSE
     description: HSE oscillator clock divided by 32 selected
+    value: 3
+enum/LSEDRV:
+  bit_size: 2
+  variants:
+  - name: Low
+    description: Low driving capability
+    value: 0
+  - name: MediumLow
+    description: Medium low driving capability
+    value: 1
+  - name: MediumHigh
+    description: Medium high driving capability
+    value: 2
+  - name: High
+    description: High driving capability
     value: 3

--- a/stm32-data-gen/src/chips.rs
+++ b/stm32-data-gen/src/chips.rs
@@ -297,6 +297,7 @@ impl PeriMatcher {
             ("STM32G0.*:RCC:.*", ("rcc", "g0", "RCC")),
             ("STM32G4.*:RCC:.*", ("rcc", "g4", "RCC")),
             ("STM32H7[AB].*:RCC:.*", ("rcc", "h7ab", "RCC")),
+            ("STM32H7(42|43|53|50).*:RCC:.*", ("rcc", "h7rm0433", "RCC")),
             ("STM32H7.*:RCC:.*", ("rcc", "h7", "RCC")),
             ("STM32L0.*:RCC:.*", ("rcc", "l0", "RCC")),
             ("STM32L1.*:RCC:.*", ("rcc", "l1", "RCC")),


### PR DESCRIPTION
Three changes:

1. The H7 parts from RM0433 have swapped bits for MediumLow and MediumHigh, and for this family they decided to just note it in the errata rather than change the reference manual. The F0, F3v2, F3, and F7 also have swapped bits according to their reference manuals. I created a separate rcc_h7rm0433.yaml just for this change.
2. Some of the reference manuals use slightly different names for the LSEDRV variants: Low, Lower, Lowest, LOW, etc. I unified these all to make it easier for the HAL.
3. The WB and WL families have LSEDRV registers but were missing the associated enums. Verified in the latest RMs.