### PR TITLE
Add TSC (touch screen controller) peripheral

### DIFF
--- a/data/registers/tsc_v1.yaml
+++ b/data/registers/tsc_v1.yaml
@@ -1,0 +1,601 @@
+block/TSC:
+  description: Touch sensing controller.
+  items:
+  - name: CR
+    description: control register.
+    byte_offset: 0
+    fieldset: CR
+  - name: IER
+    description: interrupt enable register.
+    byte_offset: 4
+    fieldset: IER
+  - name: ICR
+    description: interrupt clear register.
+    byte_offset: 8
+    fieldset: ICR
+  - name: ISR
+    description: interrupt status register.
+    byte_offset: 12
+    fieldset: ISR
+  - name: IOHCR
+    description: I/O hysteresis control register.
+    byte_offset: 16
+    fieldset: IOHCR
+  - name: IOASCR
+    description: I/O analog switch control register.
+    byte_offset: 24
+    fieldset: IOASCR
+  - name: IOSCR
+    description: I/O sampling control register.
+    byte_offset: 32
+    fieldset: IOSCR
+  - name: IOCCR
+    description: I/O channel control register.
+    byte_offset: 40
+    fieldset: IOCCR
+  - name: IOGCSR
+    description: I/O group control status register.
+    byte_offset: 48
+    fieldset: IOGCSR
+  - name: IOGCR
+    description: I/O group x counter register.
+    array:
+      len: 6
+      stride: 4
+    byte_offset: 52
+    access: Read
+    fieldset: IOGCR
+fieldset/CR:
+  description: control register.
+  fields:
+  - name: TSCE
+    description: Touch sensing controller enable.
+    bit_offset: 0
+    bit_size: 1
+  - name: START
+    description: Start a new acquisition.
+    bit_offset: 1
+    bit_size: 1
+  - name: AM
+    description: Acquisition mode.
+    bit_offset: 2
+    bit_size: 1
+  - name: SYNCPOL
+    description: Synchronization pin polarity.
+    bit_offset: 3
+    bit_size: 1
+  - name: IODEF
+    description: I/O Default mode.
+    bit_offset: 4
+    bit_size: 1
+  - name: MCV
+    description: Max count value.
+    bit_offset: 5
+    bit_size: 3
+  - name: PGPSC
+    description: pulse generator prescaler.
+    bit_offset: 12
+    bit_size: 3
+  - name: SSPSC
+    description: Spread spectrum prescaler.
+    bit_offset: 15
+    bit_size: 1
+  - name: SSE
+    description: Spread spectrum enable.
+    bit_offset: 16
+    bit_size: 1
+  - name: SSD
+    description: Spread spectrum deviation.
+    bit_offset: 17
+    bit_size: 7
+  - name: CTPL
+    description: Charge transfer pulse low.
+    bit_offset: 24
+    bit_size: 4
+  - name: CTPH
+    description: Charge transfer pulse high.
+    bit_offset: 28
+    bit_size: 4
+fieldset/ICR:
+  description: interrupt clear register.
+  fields:
+  - name: EOAIC
+    description: End of acquisition interrupt clear.
+    bit_offset: 0
+    bit_size: 1
+  - name: MCEIC
+    description: Max count error interrupt clear.
+    bit_offset: 1
+    bit_size: 1
+fieldset/IER:
+  description: interrupt enable register.
+  fields:
+  - name: EOAIE
+    description: End of acquisition interrupt enable.
+    bit_offset: 0
+    bit_size: 1
+  - name: MCEIE
+    description: Max count error interrupt enable.
+    bit_offset: 1
+    bit_size: 1
+fieldset/IOASCR:
+  description: I/O analog switch control register.
+  fields:
+  - name: G1_IO1
+    description: G1_IO1 analog switch enable.
+    bit_offset: 0
+    bit_size: 1
+  - name: G1_IO2
+    description: G1_IO2 analog switch enable.
+    bit_offset: 1
+    bit_size: 1
+  - name: G1_IO3
+    description: G1_IO3 analog switch enable.
+    bit_offset: 2
+    bit_size: 1
+  - name: G1_IO4
+    description: G1_IO4 analog switch enable.
+    bit_offset: 3
+    bit_size: 1
+  - name: G2_IO1
+    description: G2_IO1 analog switch enable.
+    bit_offset: 4
+    bit_size: 1
+  - name: G2_IO2
+    description: G2_IO2 analog switch enable.
+    bit_offset: 5
+    bit_size: 1
+  - name: G2_IO3
+    description: G2_IO3 analog switch enable.
+    bit_offset: 6
+    bit_size: 1
+  - name: G2_IO4
+    description: G2_IO4 analog switch enable.
+    bit_offset: 7
+    bit_size: 1
+  - name: G3_IO1
+    description: G3_IO1 analog switch enable.
+    bit_offset: 8
+    bit_size: 1
+  - name: G3_IO2
+    description: G3_IO2 analog switch enable.
+    bit_offset: 9
+    bit_size: 1
+  - name: G3_IO3
+    description: G3_IO3 analog switch enable.
+    bit_offset: 10
+    bit_size: 1
+  - name: G3_IO4
+    description: G3_IO4 analog switch enable.
+    bit_offset: 11
+    bit_size: 1
+  - name: G4_IO1
+    description: G4_IO1 analog switch enable.
+    bit_offset: 12
+    bit_size: 1
+  - name: G4_IO2
+    description: G4_IO2 analog switch enable.
+    bit_offset: 13
+    bit_size: 1
+  - name: G4_IO3
+    description: G4_IO3 analog switch enable.
+    bit_offset: 14
+    bit_size: 1
+  - name: G4_IO4
+    description: G4_IO4 analog switch enable.
+    bit_offset: 15
+    bit_size: 1
+  - name: G5_IO1
+    description: G5_IO1 analog switch enable.
+    bit_offset: 16
+    bit_size: 1
+  - name: G5_IO2
+    description: G5_IO2 analog switch enable.
+    bit_offset: 17
+    bit_size: 1
+  - name: G5_IO3
+    description: G5_IO3 analog switch enable.
+    bit_offset: 18
+    bit_size: 1
+  - name: G5_IO4
+    description: G5_IO4 analog switch enable.
+    bit_offset: 19
+    bit_size: 1
+  - name: G6_IO1
+    description: G6_IO1 analog switch enable.
+    bit_offset: 20
+    bit_size: 1
+  - name: G6_IO2
+    description: G6_IO2 analog switch enable.
+    bit_offset: 21
+    bit_size: 1
+  - name: G6_IO3
+    description: G6_IO3 analog switch enable.
+    bit_offset: 22
+    bit_size: 1
+  - name: G6_IO4
+    description: G6_IO4 analog switch enable.
+    bit_offset: 23
+    bit_size: 1
+fieldset/IOCCR:
+  description: I/O channel control register.
+  fields:
+  - name: G1_IO1
+    description: G1_IO1 channel mode.
+    bit_offset: 0
+    bit_size: 1
+  - name: G1_IO2
+    description: G1_IO2 channel mode.
+    bit_offset: 1
+    bit_size: 1
+  - name: G1_IO3
+    description: G1_IO3 channel mode.
+    bit_offset: 2
+    bit_size: 1
+  - name: G1_IO4
+    description: G1_IO4 channel mode.
+    bit_offset: 3
+    bit_size: 1
+  - name: G2_IO1
+    description: G2_IO1 channel mode.
+    bit_offset: 4
+    bit_size: 1
+  - name: G2_IO2
+    description: G2_IO2 channel mode.
+    bit_offset: 5
+    bit_size: 1
+  - name: G2_IO3
+    description: G2_IO3 channel mode.
+    bit_offset: 6
+    bit_size: 1
+  - name: G2_IO4
+    description: G2_IO4 channel mode.
+    bit_offset: 7
+    bit_size: 1
+  - name: G3_IO1
+    description: G3_IO1 channel mode.
+    bit_offset: 8
+    bit_size: 1
+  - name: G3_IO2
+    description: G3_IO2 channel mode.
+    bit_offset: 9
+    bit_size: 1
+  - name: G3_IO3
+    description: G3_IO3 channel mode.
+    bit_offset: 10
+    bit_size: 1
+  - name: G3_IO4
+    description: G3_IO4 channel mode.
+    bit_offset: 11
+    bit_size: 1
+  - name: G4_IO1
+    description: G4_IO1 channel mode.
+    bit_offset: 12
+    bit_size: 1
+  - name: G4_IO2
+    description: G4_IO2 channel mode.
+    bit_offset: 13
+    bit_size: 1
+  - name: G4_IO3
+    description: G4_IO3 channel mode.
+    bit_offset: 14
+    bit_size: 1
+  - name: G4_IO4
+    description: G4_IO4 channel mode.
+    bit_offset: 15
+    bit_size: 1
+  - name: G5_IO1
+    description: G5_IO1 channel mode.
+    bit_offset: 16
+    bit_size: 1
+  - name: G5_IO2
+    description: G5_IO2 channel mode.
+    bit_offset: 17
+    bit_size: 1
+  - name: G5_IO3
+    description: G5_IO3 channel mode.
+    bit_offset: 18
+    bit_size: 1
+  - name: G5_IO4
+    description: G5_IO4 channel mode.
+    bit_offset: 19
+    bit_size: 1
+  - name: G6_IO1
+    description: G6_IO1 channel mode.
+    bit_offset: 20
+    bit_size: 1
+  - name: G6_IO2
+    description: G6_IO2 channel mode.
+    bit_offset: 21
+    bit_size: 1
+  - name: G6_IO3
+    description: G6_IO3 channel mode.
+    bit_offset: 22
+    bit_size: 1
+  - name: G6_IO4
+    description: G6_IO4 channel mode.
+    bit_offset: 23
+    bit_size: 1
+fieldset/IOGCR:
+  description: I/O group x counter register.
+  fields:
+  - name: CNT
+    description: Counter value.
+    bit_offset: 0
+    bit_size: 14
+fieldset/IOGCSR:
+  description: I/O group control status register.
+  fields:
+  - name: G1E
+    description: Analog I/O group x enable.
+    bit_offset: 0
+    bit_size: 1
+  - name: G2E
+    description: Analog I/O group x enable.
+    bit_offset: 1
+    bit_size: 1
+  - name: G3E
+    description: Analog I/O group x enable.
+    bit_offset: 2
+    bit_size: 1
+  - name: G4E
+    description: Analog I/O group x enable.
+    bit_offset: 3
+    bit_size: 1
+  - name: G5E
+    description: Analog I/O group x enable.
+    bit_offset: 4
+    bit_size: 1
+  - name: G6E
+    description: Analog I/O group x enable.
+    bit_offset: 5
+    bit_size: 1
+  - name: G7E
+    description: Analog I/O group x enable.
+    bit_offset: 6
+    bit_size: 1
+  - name: G8E
+    description: Analog I/O group x enable.
+    bit_offset: 7
+    bit_size: 1
+  - name: G1S
+    description: Analog I/O group x status.
+    bit_offset: 16
+    bit_size: 1
+  - name: G2S
+    description: Analog I/O group x status.
+    bit_offset: 17
+    bit_size: 1
+  - name: G3S
+    description: Analog I/O group x status.
+    bit_offset: 18
+    bit_size: 1
+  - name: G4S
+    description: Analog I/O group x status.
+    bit_offset: 19
+    bit_size: 1
+  - name: G5S
+    description: Analog I/O group x status.
+    bit_offset: 20
+    bit_size: 1
+  - name: G6S
+    description: Analog I/O group x status.
+    bit_offset: 21
+    bit_size: 1
+  - name: G7S
+    description: Analog I/O group x status.
+    bit_offset: 22
+    bit_size: 1
+  - name: G8S
+    description: Analog I/O group x status.
+    bit_offset: 23
+    bit_size: 1
+fieldset/IOHCR:
+  description: I/O hysteresis control register.
+  fields:
+  - name: G1_IO1
+    description: G1_IO1 Schmitt trigger hysteresis mode.
+    bit_offset: 0
+    bit_size: 1
+  - name: G1_IO2
+    description: G1_IO2 Schmitt trigger hysteresis mode.
+    bit_offset: 1
+    bit_size: 1
+  - name: G1_IO3
+    description: G1_IO3 Schmitt trigger hysteresis mode.
+    bit_offset: 2
+    bit_size: 1
+  - name: G1_IO4
+    description: G1_IO4 Schmitt trigger hysteresis mode.
+    bit_offset: 3
+    bit_size: 1
+  - name: G2_IO1
+    description: G2_IO1 Schmitt trigger hysteresis mode.
+    bit_offset: 4
+    bit_size: 1
+  - name: G2_IO2
+    description: G2_IO2 Schmitt trigger hysteresis mode.
+    bit_offset: 5
+    bit_size: 1
+  - name: G2_IO3
+    description: G2_IO3 Schmitt trigger hysteresis mode.
+    bit_offset: 6
+    bit_size: 1
+  - name: G2_IO4
+    description: G2_IO4 Schmitt trigger hysteresis mode.
+    bit_offset: 7
+    bit_size: 1
+  - name: G3_IO1
+    description: G3_IO1 Schmitt trigger hysteresis mode.
+    bit_offset: 8
+    bit_size: 1
+  - name: G3_IO2
+    description: G3_IO2 Schmitt trigger hysteresis mode.
+    bit_offset: 9
+    bit_size: 1
+  - name: G3_IO3
+    description: G3_IO3 Schmitt trigger hysteresis mode.
+    bit_offset: 10
+    bit_size: 1
+  - name: G3_IO4
+    description: G3_IO4 Schmitt trigger hysteresis mode.
+    bit_offset: 11
+    bit_size: 1
+  - name: G4_IO1
+    description: G4_IO1 Schmitt trigger hysteresis mode.
+    bit_offset: 12
+    bit_size: 1
+  - name: G4_IO2
+    description: G4_IO2 Schmitt trigger hysteresis mode.
+    bit_offset: 13
+    bit_size: 1
+  - name: G4_IO3
+    description: G4_IO3 Schmitt trigger hysteresis mode.
+    bit_offset: 14
+    bit_size: 1
+  - name: G4_IO4
+    description: G4_IO4 Schmitt trigger hysteresis mode.
+    bit_offset: 15
+    bit_size: 1
+  - name: G5_IO1
+    description: G5_IO1 Schmitt trigger hysteresis mode.
+    bit_offset: 16
+    bit_size: 1
+  - name: G5_IO2
+    description: G5_IO2 Schmitt trigger hysteresis mode.
+    bit_offset: 17
+    bit_size: 1
+  - name: G5_IO3
+    description: G5_IO3 Schmitt trigger hysteresis mode.
+    bit_offset: 18
+    bit_size: 1
+  - name: G5_IO4
+    description: G5_IO4 Schmitt trigger hysteresis mode.
+    bit_offset: 19
+    bit_size: 1
+  - name: G6_IO1
+    description: G6_IO1 Schmitt trigger hysteresis mode.
+    bit_offset: 20
+    bit_size: 1
+  - name: G6_IO2
+    description: G6_IO2 Schmitt trigger hysteresis mode.
+    bit_offset: 21
+    bit_size: 1
+  - name: G6_IO3
+    description: G6_IO3 Schmitt trigger hysteresis mode.
+    bit_offset: 22
+    bit_size: 1
+  - name: G6_IO4
+    description: G6_IO4 Schmitt trigger hysteresis mode.
+    bit_offset: 23
+    bit_size: 1
+fieldset/IOSCR:
+  description: I/O sampling control register.
+  fields:
+  - name: G1_IO1
+    description: G1_IO1 sampling mode.
+    bit_offset: 0
+    bit_size: 1
+  - name: G1_IO2
+    description: G1_IO2 sampling mode.
+    bit_offset: 1
+    bit_size: 1
+  - name: G1_IO3
+    description: G1_IO3 sampling mode.
+    bit_offset: 2
+    bit_size: 1
+  - name: G1_IO4
+    description: G1_IO4 sampling mode.
+    bit_offset: 3
+    bit_size: 1
+  - name: G2_IO1
+    description: G2_IO1 sampling mode.
+    bit_offset: 4
+    bit_size: 1
+  - name: G2_IO2
+    description: G2_IO2 sampling mode.
+    bit_offset: 5
+    bit_size: 1
+  - name: G2_IO3
+    description: G2_IO3 sampling mode.
+    bit_offset: 6
+    bit_size: 1
+  - name: G2_IO4
+    description: G2_IO4 sampling mode.
+    bit_offset: 7
+    bit_size: 1
+  - name: G3_IO1
+    description: G3_IO1 sampling mode.
+    bit_offset: 8
+    bit_size: 1
+  - name: G3_IO2
+    description: G3_IO2 sampling mode.
+    bit_offset: 9
+    bit_size: 1
+  - name: G3_IO3
+    description: G3_IO3 sampling mode.
+    bit_offset: 10
+    bit_size: 1
+  - name: G3_IO4
+    description: G3_IO4 sampling mode.
+    bit_offset: 11
+    bit_size: 1
+  - name: G4_IO1
+    description: G4_IO1 sampling mode.
+    bit_offset: 12
+    bit_size: 1
+  - name: G4_IO2
+    description: G4_IO2 sampling mode.
+    bit_offset: 13
+    bit_size: 1
+  - name: G4_IO3
+    description: G4_IO3 sampling mode.
+    bit_offset: 14
+    bit_size: 1
+  - name: G4_IO4
+    description: G4_IO4 sampling mode.
+    bit_offset: 15
+    bit_size: 1
+  - name: G5_IO1
+    description: G5_IO1 sampling mode.
+    bit_offset: 16
+    bit_size: 1
+  - name: G5_IO2
+    description: G5_IO2 sampling mode.
+    bit_offset: 17
+    bit_size: 1
+  - name: G5_IO3
+    description: G5_IO3 sampling mode.
+    bit_offset: 18
+    bit_size: 1
+  - name: G5_IO4
+    description: G5_IO4 sampling mode.
+    bit_offset: 19
+    bit_size: 1
+  - name: G6_IO1
+    description: G6_IO1 sampling mode.
+    bit_offset: 20
+    bit_size: 1
+  - name: G6_IO2
+    description: G6_IO2 sampling mode.
+    bit_offset: 21
+    bit_size: 1
+  - name: G6_IO3
+    description: G6_IO3 sampling mode.
+    bit_offset: 22
+    bit_size: 1
+  - name: G6_IO4
+    description: G6_IO4 sampling mode.
+    bit_offset: 23
+    bit_size: 1
+fieldset/ISR:
+  description: interrupt status register.
+  fields:
+  - name: EOAF
+    description: End of acquisition flag.
+    bit_offset: 0
+    bit_size: 1
+  - name: MCEF
+    description: Max count error flag.
+    bit_offset: 1
+    bit_size: 1

--- a/data/registers/tsc_v2.yaml
+++ b/data/registers/tsc_v2.yaml
@@ -1,0 +1,657 @@
+block/TSC:
+  description: Touch sensing controller.
+  items:
+  - name: CR
+    description: control register.
+    byte_offset: 0
+    fieldset: CR
+  - name: IER
+    description: interrupt enable register.
+    byte_offset: 4
+    fieldset: IER
+  - name: ICR
+    description: interrupt clear register.
+    byte_offset: 8
+    fieldset: ICR
+  - name: ISR
+    description: interrupt status register.
+    byte_offset: 12
+    fieldset: ISR
+  - name: IOHCR
+    description: I/O hysteresis control register.
+    byte_offset: 16
+    fieldset: IOHCR
+  - name: IOASCR
+    description: I/O analog switch control register.
+    byte_offset: 24
+    fieldset: IOASCR
+  - name: IOSCR
+    description: I/O sampling control register.
+    byte_offset: 32
+    fieldset: IOSCR
+  - name: IOCCR
+    description: I/O channel control register.
+    byte_offset: 40
+    fieldset: IOCCR
+  - name: IOGCSR
+    description: I/O group control status register.
+    byte_offset: 48
+    fieldset: IOGCSR
+  - name: IOGCR
+    description: I/O group x counter register.
+    array:
+      len: 7
+      stride: 4
+    byte_offset: 52
+    access: Read
+    fieldset: IOGCR
+fieldset/CR:
+  description: control register.
+  fields:
+  - name: TSCE
+    description: Touch sensing controller enable.
+    bit_offset: 0
+    bit_size: 1
+  - name: START
+    description: Start a new acquisition.
+    bit_offset: 1
+    bit_size: 1
+  - name: AM
+    description: Acquisition mode.
+    bit_offset: 2
+    bit_size: 1
+  - name: SYNCPOL
+    description: Synchronization pin polarity.
+    bit_offset: 3
+    bit_size: 1
+  - name: IODEF
+    description: I/O Default mode.
+    bit_offset: 4
+    bit_size: 1
+  - name: MCV
+    description: Max count value.
+    bit_offset: 5
+    bit_size: 3
+  - name: PGPSC
+    description: pulse generator prescaler.
+    bit_offset: 12
+    bit_size: 3
+  - name: SSPSC
+    description: Spread spectrum prescaler.
+    bit_offset: 15
+    bit_size: 1
+  - name: SSE
+    description: Spread spectrum enable.
+    bit_offset: 16
+    bit_size: 1
+  - name: SSD
+    description: Spread spectrum deviation.
+    bit_offset: 17
+    bit_size: 7
+  - name: CTPL
+    description: Charge transfer pulse low.
+    bit_offset: 24
+    bit_size: 4
+  - name: CTPH
+    description: Charge transfer pulse high.
+    bit_offset: 28
+    bit_size: 4
+fieldset/ICR:
+  description: interrupt clear register.
+  fields:
+  - name: EOAIC
+    description: End of acquisition interrupt clear.
+    bit_offset: 0
+    bit_size: 1
+  - name: MCEIC
+    description: Max count error interrupt clear.
+    bit_offset: 1
+    bit_size: 1
+fieldset/IER:
+  description: interrupt enable register.
+  fields:
+  - name: EOAIE
+    description: End of acquisition interrupt enable.
+    bit_offset: 0
+    bit_size: 1
+  - name: MCEIE
+    description: Max count error interrupt enable.
+    bit_offset: 1
+    bit_size: 1
+fieldset/IOASCR:
+  description: I/O analog switch control register.
+  fields:
+  - name: G1_IO1
+    description: G1_IO1 analog switch enable.
+    bit_offset: 0
+    bit_size: 1
+  - name: G1_IO2
+    description: G1_IO2 analog switch enable.
+    bit_offset: 1
+    bit_size: 1
+  - name: G1_IO3
+    description: G1_IO3 analog switch enable.
+    bit_offset: 2
+    bit_size: 1
+  - name: G1_IO4
+    description: G1_IO4 analog switch enable.
+    bit_offset: 3
+    bit_size: 1
+  - name: G2_IO1
+    description: G2_IO1 analog switch enable.
+    bit_offset: 4
+    bit_size: 1
+  - name: G2_IO2
+    description: G2_IO2 analog switch enable.
+    bit_offset: 5
+    bit_size: 1
+  - name: G2_IO3
+    description: G2_IO3 analog switch enable.
+    bit_offset: 6
+    bit_size: 1
+  - name: G2_IO4
+    description: G2_IO4 analog switch enable.
+    bit_offset: 7
+    bit_size: 1
+  - name: G3_IO1
+    description: G3_IO1 analog switch enable.
+    bit_offset: 8
+    bit_size: 1
+  - name: G3_IO2
+    description: G3_IO2 analog switch enable.
+    bit_offset: 9
+    bit_size: 1
+  - name: G3_IO3
+    description: G3_IO3 analog switch enable.
+    bit_offset: 10
+    bit_size: 1
+  - name: G3_IO4
+    description: G3_IO4 analog switch enable.
+    bit_offset: 11
+    bit_size: 1
+  - name: G4_IO1
+    description: G4_IO1 analog switch enable.
+    bit_offset: 12
+    bit_size: 1
+  - name: G4_IO2
+    description: G4_IO2 analog switch enable.
+    bit_offset: 13
+    bit_size: 1
+  - name: G4_IO3
+    description: G4_IO3 analog switch enable.
+    bit_offset: 14
+    bit_size: 1
+  - name: G4_IO4
+    description: G4_IO4 analog switch enable.
+    bit_offset: 15
+    bit_size: 1
+  - name: G5_IO1
+    description: G5_IO1 analog switch enable.
+    bit_offset: 16
+    bit_size: 1
+  - name: G5_IO2
+    description: G5_IO2 analog switch enable.
+    bit_offset: 17
+    bit_size: 1
+  - name: G5_IO3
+    description: G5_IO3 analog switch enable.
+    bit_offset: 18
+    bit_size: 1
+  - name: G5_IO4
+    description: G5_IO4 analog switch enable.
+    bit_offset: 19
+    bit_size: 1
+  - name: G6_IO1
+    description: G6_IO1 analog switch enable.
+    bit_offset: 20
+    bit_size: 1
+  - name: G6_IO2
+    description: G6_IO2 analog switch enable.
+    bit_offset: 21
+    bit_size: 1
+  - name: G6_IO3
+    description: G6_IO3 analog switch enable.
+    bit_offset: 22
+    bit_size: 1
+  - name: G6_IO4
+    description: G6_IO4 analog switch enable.
+    bit_offset: 23
+    bit_size: 1
+  - name: G7_IO1
+    description: G7_IO1 analog switch enable.
+    bit_offset: 24
+    bit_size: 1
+  - name: G7_IO2
+    description: G7_IO2 analog switch enable.
+    bit_offset: 25
+    bit_size: 1
+  - name: G7_IO3
+    description: G7_IO3 analog switch enable.
+    bit_offset: 26
+    bit_size: 1
+  - name: G7_IO4
+    description: G7_IO4 analog switch enable.
+    bit_offset: 27
+    bit_size: 1
+fieldset/IOCCR:
+  description: I/O channel control register.
+  fields:
+  - name: G1_IO1
+    description: G1_IO1 channel mode.
+    bit_offset: 0
+    bit_size: 1
+  - name: G1_IO2
+    description: G1_IO2 channel mode.
+    bit_offset: 1
+    bit_size: 1
+  - name: G1_IO3
+    description: G1_IO3 channel mode.
+    bit_offset: 2
+    bit_size: 1
+  - name: G1_IO4
+    description: G1_IO4 channel mode.
+    bit_offset: 3
+    bit_size: 1
+  - name: G2_IO1
+    description: G2_IO1 channel mode.
+    bit_offset: 4
+    bit_size: 1
+  - name: G2_IO2
+    description: G2_IO2 channel mode.
+    bit_offset: 5
+    bit_size: 1
+  - name: G2_IO3
+    description: G2_IO3 channel mode.
+    bit_offset: 6
+    bit_size: 1
+  - name: G2_IO4
+    description: G2_IO4 channel mode.
+    bit_offset: 7
+    bit_size: 1
+  - name: G3_IO1
+    description: G3_IO1 channel mode.
+    bit_offset: 8
+    bit_size: 1
+  - name: G3_IO2
+    description: G3_IO2 channel mode.
+    bit_offset: 9
+    bit_size: 1
+  - name: G3_IO3
+    description: G3_IO3 channel mode.
+    bit_offset: 10
+    bit_size: 1
+  - name: G3_IO4
+    description: G3_IO4 channel mode.
+    bit_offset: 11
+    bit_size: 1
+  - name: G4_IO1
+    description: G4_IO1 channel mode.
+    bit_offset: 12
+    bit_size: 1
+  - name: G4_IO2
+    description: G4_IO2 channel mode.
+    bit_offset: 13
+    bit_size: 1
+  - name: G4_IO3
+    description: G4_IO3 channel mode.
+    bit_offset: 14
+    bit_size: 1
+  - name: G4_IO4
+    description: G4_IO4 channel mode.
+    bit_offset: 15
+    bit_size: 1
+  - name: G5_IO1
+    description: G5_IO1 channel mode.
+    bit_offset: 16
+    bit_size: 1
+  - name: G5_IO2
+    description: G5_IO2 channel mode.
+    bit_offset: 17
+    bit_size: 1
+  - name: G5_IO3
+    description: G5_IO3 channel mode.
+    bit_offset: 18
+    bit_size: 1
+  - name: G5_IO4
+    description: G5_IO4 channel mode.
+    bit_offset: 19
+    bit_size: 1
+  - name: G6_IO1
+    description: G6_IO1 channel mode.
+    bit_offset: 20
+    bit_size: 1
+  - name: G6_IO2
+    description: G6_IO2 channel mode.
+    bit_offset: 21
+    bit_size: 1
+  - name: G6_IO3
+    description: G6_IO3 channel mode.
+    bit_offset: 22
+    bit_size: 1
+  - name: G6_IO4
+    description: G6_IO4 channel mode.
+    bit_offset: 23
+    bit_size: 1
+  - name: G7_IO1
+    description: G7_IO1 channel mode.
+    bit_offset: 24
+    bit_size: 1
+  - name: G7_IO2
+    description: G7_IO2 channel mode.
+    bit_offset: 25
+    bit_size: 1
+  - name: G7_IO3
+    description: G7_IO3 channel mode.
+    bit_offset: 26
+    bit_size: 1
+  - name: G7_IO4
+    description: G7_IO4 channel mode.
+    bit_offset: 27
+    bit_size: 1
+fieldset/IOGCR:
+  description: I/O group x counter register.
+  fields:
+  - name: CNT
+    description: Counter value.
+    bit_offset: 0
+    bit_size: 14
+fieldset/IOGCSR:
+  description: I/O group control status register.
+  fields:
+  - name: G1E
+    description: Analog I/O group x enable.
+    bit_offset: 0
+    bit_size: 1
+  - name: G2E
+    description: Analog I/O group x enable.
+    bit_offset: 1
+    bit_size: 1
+  - name: G3E
+    description: Analog I/O group x enable.
+    bit_offset: 2
+    bit_size: 1
+  - name: G4E
+    description: Analog I/O group x enable.
+    bit_offset: 3
+    bit_size: 1
+  - name: G5E
+    description: Analog I/O group x enable.
+    bit_offset: 4
+    bit_size: 1
+  - name: G6E
+    description: Analog I/O group x enable.
+    bit_offset: 5
+    bit_size: 1
+  - name: G7E
+    description: Analog I/O group x enable.
+    bit_offset: 6
+    bit_size: 1
+  - name: G1S
+    description: Analog I/O group x status.
+    bit_offset: 16
+    bit_size: 1
+  - name: G2S
+    description: Analog I/O group x status.
+    bit_offset: 17
+    bit_size: 1
+  - name: G3S
+    description: Analog I/O group x status.
+    bit_offset: 18
+    bit_size: 1
+  - name: G4S
+    description: Analog I/O group x status.
+    bit_offset: 19
+    bit_size: 1
+  - name: G5S
+    description: Analog I/O group x status.
+    bit_offset: 20
+    bit_size: 1
+  - name: G6S
+    description: Analog I/O group x status.
+    bit_offset: 21
+    bit_size: 1
+  - name: G7S
+    description: Analog I/O group x status.
+    bit_offset: 22
+    bit_size: 1
+fieldset/IOHCR:
+  description: I/O hysteresis control register.
+  fields:
+  - name: G1_IO1
+    description: G1_IO1 Schmitt trigger hysteresis mode.
+    bit_offset: 0
+    bit_size: 1
+  - name: G1_IO2
+    description: G1_IO2 Schmitt trigger hysteresis mode.
+    bit_offset: 1
+    bit_size: 1
+  - name: G1_IO3
+    description: G1_IO3 Schmitt trigger hysteresis mode.
+    bit_offset: 2
+    bit_size: 1
+  - name: G1_IO4
+    description: G1_IO4 Schmitt trigger hysteresis mode.
+    bit_offset: 3
+    bit_size: 1
+  - name: G2_IO1
+    description: G2_IO1 Schmitt trigger hysteresis mode.
+    bit_offset: 4
+    bit_size: 1
+  - name: G2_IO2
+    description: G2_IO2 Schmitt trigger hysteresis mode.
+    bit_offset: 5
+    bit_size: 1
+  - name: G2_IO3
+    description: G2_IO3 Schmitt trigger hysteresis mode.
+    bit_offset: 6
+    bit_size: 1
+  - name: G2_IO4
+    description: G2_IO4 Schmitt trigger hysteresis mode.
+    bit_offset: 7
+    bit_size: 1
+  - name: G3_IO1
+    description: G3_IO1 Schmitt trigger hysteresis mode.
+    bit_offset: 8
+    bit_size: 1
+  - name: G3_IO2
+    description: G3_IO2 Schmitt trigger hysteresis mode.
+    bit_offset: 9
+    bit_size: 1
+  - name: G3_IO3
+    description: G3_IO3 Schmitt trigger hysteresis mode.
+    bit_offset: 10
+    bit_size: 1
+  - name: G3_IO4
+    description: G3_IO4 Schmitt trigger hysteresis mode.
+    bit_offset: 11
+    bit_size: 1
+  - name: G4_IO1
+    description: G4_IO1 Schmitt trigger hysteresis mode.
+    bit_offset: 12
+    bit_size: 1
+  - name: G4_IO2
+    description: G4_IO2 Schmitt trigger hysteresis mode.
+    bit_offset: 13
+    bit_size: 1
+  - name: G4_IO3
+    description: G4_IO3 Schmitt trigger hysteresis mode.
+    bit_offset: 14
+    bit_size: 1
+  - name: G4_IO4
+    description: G4_IO4 Schmitt trigger hysteresis mode.
+    bit_offset: 15
+    bit_size: 1
+  - name: G5_IO1
+    description: G5_IO1 Schmitt trigger hysteresis mode.
+    bit_offset: 16
+    bit_size: 1
+  - name: G5_IO2
+    description: G5_IO2 Schmitt trigger hysteresis mode.
+    bit_offset: 17
+    bit_size: 1
+  - name: G5_IO3
+    description: G5_IO3 Schmitt trigger hysteresis mode.
+    bit_offset: 18
+    bit_size: 1
+  - name: G5_IO4
+    description: G5_IO4 Schmitt trigger hysteresis mode.
+    bit_offset: 19
+    bit_size: 1
+  - name: G6_IO1
+    description: G6_IO1 Schmitt trigger hysteresis mode.
+    bit_offset: 20
+    bit_size: 1
+  - name: G6_IO2
+    description: G6_IO2 Schmitt trigger hysteresis mode.
+    bit_offset: 21
+    bit_size: 1
+  - name: G6_IO3
+    description: G6_IO3 Schmitt trigger hysteresis mode.
+    bit_offset: 22
+    bit_size: 1
+  - name: G6_IO4
+    description: G6_IO4 Schmitt trigger hysteresis mode.
+    bit_offset: 23
+    bit_size: 1
+  - name: G7_IO1
+    description: G7_IO1 Schmitt trigger hysteresis mode.
+    bit_offset: 24
+    bit_size: 1
+  - name: G7_IO2
+    description: G7_IO2 Schmitt trigger hysteresis mode.
+    bit_offset: 25
+    bit_size: 1
+  - name: G7_IO3
+    description: G7_IO3 Schmitt trigger hysteresis mode.
+    bit_offset: 26
+    bit_size: 1
+  - name: G7_IO4
+    description: G7_IO4 Schmitt trigger hysteresis mode.
+    bit_offset: 27
+    bit_size: 1
+fieldset/IOSCR:
+  description: I/O sampling control register.
+  fields:
+  - name: G1_IO1
+    description: G1_IO1 sampling mode.
+    bit_offset: 0
+    bit_size: 1
+  - name: G1_IO2
+    description: G1_IO2 sampling mode.
+    bit_offset: 1
+    bit_size: 1
+  - name: G1_IO3
+    description: G1_IO3 sampling mode.
+    bit_offset: 2
+    bit_size: 1
+  - name: G1_IO4
+    description: G1_IO4 sampling mode.
+    bit_offset: 3
+    bit_size: 1
+  - name: G2_IO1
+    description: G2_IO1 sampling mode.
+    bit_offset: 4
+    bit_size: 1
+  - name: G2_IO2
+    description: G2_IO2 sampling mode.
+    bit_offset: 5
+    bit_size: 1
+  - name: G2_IO3
+    description: G2_IO3 sampling mode.
+    bit_offset: 6
+    bit_size: 1
+  - name: G2_IO4
+    description: G2_IO4 sampling mode.
+    bit_offset: 7
+    bit_size: 1
+  - name: G3_IO1
+    description: G3_IO1 sampling mode.
+    bit_offset: 8
+    bit_size: 1
+  - name: G3_IO2
+    description: G3_IO2 sampling mode.
+    bit_offset: 9
+    bit_size: 1
+  - name: G3_IO3
+    description: G3_IO3 sampling mode.
+    bit_offset: 10
+    bit_size: 1
+  - name: G3_IO4
+    description: G3_IO4 sampling mode.
+    bit_offset: 11
+    bit_size: 1
+  - name: G4_IO1
+    description: G4_IO1 sampling mode.
+    bit_offset: 12
+    bit_size: 1
+  - name: G4_IO2
+    description: G4_IO2 sampling mode.
+    bit_offset: 13
+    bit_size: 1
+  - name: G4_IO3
+    description: G4_IO3 sampling mode.
+    bit_offset: 14
+    bit_size: 1
+  - name: G4_IO4
+    description: G4_IO4 sampling mode.
+    bit_offset: 15
+    bit_size: 1
+  - name: G5_IO1
+    description: G5_IO1 sampling mode.
+    bit_offset: 16
+    bit_size: 1
+  - name: G5_IO2
+    description: G5_IO2 sampling mode.
+    bit_offset: 17
+    bit_size: 1
+  - name: G5_IO3
+    description: G5_IO3 sampling mode.
+    bit_offset: 18
+    bit_size: 1
+  - name: G5_IO4
+    description: G5_IO4 sampling mode.
+    bit_offset: 19
+    bit_size: 1
+  - name: G6_IO1
+    description: G6_IO1 sampling mode.
+    bit_offset: 20
+    bit_size: 1
+  - name: G6_IO2
+    description: G6_IO2 sampling mode.
+    bit_offset: 21
+    bit_size: 1
+  - name: G6_IO3
+    description: G6_IO3 sampling mode.
+    bit_offset: 22
+    bit_size: 1
+  - name: G6_IO4
+    description: G6_IO4 sampling mode.
+    bit_offset: 23
+    bit_size: 1
+  - name: G7_IO1
+    description: G7_IO1 sampling mode.
+    bit_offset: 24
+    bit_size: 1
+  - name: G7_IO2
+    description: G7_IO2 sampling mode.
+    bit_offset: 25
+    bit_size: 1
+  - name: G7_IO3
+    description: G7_IO3 sampling mode.
+    bit_offset: 26
+    bit_size: 1
+  - name: G7_IO4
+    description: G7_IO4 sampling mode.
+    bit_offset: 27
+    bit_size: 1
+fieldset/ISR:
+  description: interrupt status register.
+  fields:
+  - name: EOAF
+    description: End of acquisition flag.
+    bit_offset: 0
+    bit_size: 1
+  - name: MCEF
+    description: Max count error flag.
+    bit_offset: 1
+    bit_size: 1

--- a/data/registers/tsc_v3.yaml
+++ b/data/registers/tsc_v3.yaml
@@ -1,0 +1,729 @@
+block/TSC:
+  description: Touch sensing controller.
+  items:
+  - name: CR
+    description: control register.
+    byte_offset: 0
+    fieldset: CR
+  - name: IER
+    description: interrupt enable register.
+    byte_offset: 4
+    fieldset: IER
+  - name: ICR
+    description: interrupt clear register.
+    byte_offset: 8
+    fieldset: ICR
+  - name: ISR
+    description: interrupt status register.
+    byte_offset: 12
+    fieldset: ISR
+  - name: IOHCR
+    description: I/O hysteresis control register.
+    byte_offset: 16
+    fieldset: IOHCR
+  - name: IOASCR
+    description: I/O analog switch control register.
+    byte_offset: 24
+    fieldset: IOASCR
+  - name: IOSCR
+    description: I/O sampling control register.
+    byte_offset: 32
+    fieldset: IOSCR
+  - name: IOCCR
+    description: I/O channel control register.
+    byte_offset: 40
+    fieldset: IOCCR
+  - name: IOGCSR
+    description: I/O group control status register.
+    byte_offset: 48
+    fieldset: IOGCSR
+  - name: IOGCR
+    description: I/O group x counter register.
+    array:
+      len: 8
+      stride: 4
+    byte_offset: 52
+    access: Read
+    fieldset: IOGCR
+fieldset/CR:
+  description: control register.
+  fields:
+  - name: TSCE
+    description: Touch sensing controller enable.
+    bit_offset: 0
+    bit_size: 1
+  - name: START
+    description: Start a new acquisition.
+    bit_offset: 1
+    bit_size: 1
+  - name: AM
+    description: Acquisition mode.
+    bit_offset: 2
+    bit_size: 1
+  - name: SYNCPOL
+    description: Synchronization pin polarity.
+    bit_offset: 3
+    bit_size: 1
+  - name: IODEF
+    description: I/O Default mode.
+    bit_offset: 4
+    bit_size: 1
+  - name: MCV
+    description: Max count value.
+    bit_offset: 5
+    bit_size: 3
+  - name: PGPSC
+    description: pulse generator prescaler.
+    bit_offset: 12
+    bit_size: 3
+  - name: SSPSC
+    description: Spread spectrum prescaler.
+    bit_offset: 15
+    bit_size: 1
+  - name: SSE
+    description: Spread spectrum enable.
+    bit_offset: 16
+    bit_size: 1
+  - name: SSD
+    description: Spread spectrum deviation.
+    bit_offset: 17
+    bit_size: 7
+  - name: CTPL
+    description: Charge transfer pulse low.
+    bit_offset: 24
+    bit_size: 4
+  - name: CTPH
+    description: Charge transfer pulse high.
+    bit_offset: 28
+    bit_size: 4
+fieldset/ICR:
+  description: interrupt clear register.
+  fields:
+  - name: EOAIC
+    description: End of acquisition interrupt clear.
+    bit_offset: 0
+    bit_size: 1
+  - name: MCEIC
+    description: Max count error interrupt clear.
+    bit_offset: 1
+    bit_size: 1
+fieldset/IER:
+  description: interrupt enable register.
+  fields:
+  - name: EOAIE
+    description: End of acquisition interrupt enable.
+    bit_offset: 0
+    bit_size: 1
+  - name: MCEIE
+    description: Max count error interrupt enable.
+    bit_offset: 1
+    bit_size: 1
+fieldset/IOASCR:
+  description: I/O analog switch control register.
+  fields:
+  - name: G1_IO1
+    description: G1_IO1 analog switch enable.
+    bit_offset: 0
+    bit_size: 1
+  - name: G1_IO2
+    description: G1_IO2 analog switch enable.
+    bit_offset: 1
+    bit_size: 1
+  - name: G1_IO3
+    description: G1_IO3 analog switch enable.
+    bit_offset: 2
+    bit_size: 1
+  - name: G1_IO4
+    description: G1_IO4 analog switch enable.
+    bit_offset: 3
+    bit_size: 1
+  - name: G2_IO1
+    description: G2_IO1 analog switch enable.
+    bit_offset: 4
+    bit_size: 1
+  - name: G2_IO2
+    description: G2_IO2 analog switch enable.
+    bit_offset: 5
+    bit_size: 1
+  - name: G2_IO3
+    description: G2_IO3 analog switch enable.
+    bit_offset: 6
+    bit_size: 1
+  - name: G2_IO4
+    description: G2_IO4 analog switch enable.
+    bit_offset: 7
+    bit_size: 1
+  - name: G3_IO1
+    description: G3_IO1 analog switch enable.
+    bit_offset: 8
+    bit_size: 1
+  - name: G3_IO2
+    description: G3_IO2 analog switch enable.
+    bit_offset: 9
+    bit_size: 1
+  - name: G3_IO3
+    description: G3_IO3 analog switch enable.
+    bit_offset: 10
+    bit_size: 1
+  - name: G3_IO4
+    description: G3_IO4 analog switch enable.
+    bit_offset: 11
+    bit_size: 1
+  - name: G4_IO1
+    description: G4_IO1 analog switch enable.
+    bit_offset: 12
+    bit_size: 1
+  - name: G4_IO2
+    description: G4_IO2 analog switch enable.
+    bit_offset: 13
+    bit_size: 1
+  - name: G4_IO3
+    description: G4_IO3 analog switch enable.
+    bit_offset: 14
+    bit_size: 1
+  - name: G4_IO4
+    description: G4_IO4 analog switch enable.
+    bit_offset: 15
+    bit_size: 1
+  - name: G5_IO1
+    description: G5_IO1 analog switch enable.
+    bit_offset: 16
+    bit_size: 1
+  - name: G5_IO2
+    description: G5_IO2 analog switch enable.
+    bit_offset: 17
+    bit_size: 1
+  - name: G5_IO3
+    description: G5_IO3 analog switch enable.
+    bit_offset: 18
+    bit_size: 1
+  - name: G5_IO4
+    description: G5_IO4 analog switch enable.
+    bit_offset: 19
+    bit_size: 1
+  - name: G6_IO1
+    description: G6_IO1 analog switch enable.
+    bit_offset: 20
+    bit_size: 1
+  - name: G6_IO2
+    description: G6_IO2 analog switch enable.
+    bit_offset: 21
+    bit_size: 1
+  - name: G6_IO3
+    description: G6_IO3 analog switch enable.
+    bit_offset: 22
+    bit_size: 1
+  - name: G6_IO4
+    description: G6_IO4 analog switch enable.
+    bit_offset: 23
+    bit_size: 1
+  - name: G7_IO1
+    description: G7_IO1 analog switch enable.
+    bit_offset: 24
+    bit_size: 1
+  - name: G7_IO2
+    description: G7_IO2 analog switch enable.
+    bit_offset: 25
+    bit_size: 1
+  - name: G7_IO3
+    description: G7_IO3 analog switch enable.
+    bit_offset: 26
+    bit_size: 1
+  - name: G7_IO4
+    description: G7_IO4 analog switch enable.
+    bit_offset: 27
+    bit_size: 1
+  - name: G8_IO1
+    description: G8_IO1 analog switch enable.
+    bit_offset: 28
+    bit_size: 1
+  - name: G8_IO2
+    description: G8_IO2 analog switch enable.
+    bit_offset: 29
+    bit_size: 1
+  - name: G8_IO3
+    description: G8_IO3 analog switch enable.
+    bit_offset: 30
+    bit_size: 1
+  - name: G8_IO4
+    description: G8_IO4 analog switch enable.
+    bit_offset: 31
+    bit_size: 1
+fieldset/IOCCR:
+  description: I/O channel control register.
+  fields:
+  - name: G1_IO1
+    description: G1_IO1 channel mode.
+    bit_offset: 0
+    bit_size: 1
+  - name: G1_IO2
+    description: G1_IO2 channel mode.
+    bit_offset: 1
+    bit_size: 1
+  - name: G1_IO3
+    description: G1_IO3 channel mode.
+    bit_offset: 2
+    bit_size: 1
+  - name: G1_IO4
+    description: G1_IO4 channel mode.
+    bit_offset: 3
+    bit_size: 1
+  - name: G2_IO1
+    description: G2_IO1 channel mode.
+    bit_offset: 4
+    bit_size: 1
+  - name: G2_IO2
+    description: G2_IO2 channel mode.
+    bit_offset: 5
+    bit_size: 1
+  - name: G2_IO3
+    description: G2_IO3 channel mode.
+    bit_offset: 6
+    bit_size: 1
+  - name: G2_IO4
+    description: G2_IO4 channel mode.
+    bit_offset: 7
+    bit_size: 1
+  - name: G3_IO1
+    description: G3_IO1 channel mode.
+    bit_offset: 8
+    bit_size: 1
+  - name: G3_IO2
+    description: G3_IO2 channel mode.
+    bit_offset: 9
+    bit_size: 1
+  - name: G3_IO3
+    description: G3_IO3 channel mode.
+    bit_offset: 10
+    bit_size: 1
+  - name: G3_IO4
+    description: G3_IO4 channel mode.
+    bit_offset: 11
+    bit_size: 1
+  - name: G4_IO1
+    description: G4_IO1 channel mode.
+    bit_offset: 12
+    bit_size: 1
+  - name: G4_IO2
+    description: G4_IO2 channel mode.
+    bit_offset: 13
+    bit_size: 1
+  - name: G4_IO3
+    description: G4_IO3 channel mode.
+    bit_offset: 14
+    bit_size: 1
+  - name: G4_IO4
+    description: G4_IO4 channel mode.
+    bit_offset: 15
+    bit_size: 1
+  - name: G5_IO1
+    description: G5_IO1 channel mode.
+    bit_offset: 16
+    bit_size: 1
+  - name: G5_IO2
+    description: G5_IO2 channel mode.
+    bit_offset: 17
+    bit_size: 1
+  - name: G5_IO3
+    description: G5_IO3 channel mode.
+    bit_offset: 18
+    bit_size: 1
+  - name: G5_IO4
+    description: G5_IO4 channel mode.
+    bit_offset: 19
+    bit_size: 1
+  - name: G6_IO1
+    description: G6_IO1 channel mode.
+    bit_offset: 20
+    bit_size: 1
+  - name: G6_IO2
+    description: G6_IO2 channel mode.
+    bit_offset: 21
+    bit_size: 1
+  - name: G6_IO3
+    description: G6_IO3 channel mode.
+    bit_offset: 22
+    bit_size: 1
+  - name: G6_IO4
+    description: G6_IO4 channel mode.
+    bit_offset: 23
+    bit_size: 1
+  - name: G7_IO1
+    description: G7_IO1 channel mode.
+    bit_offset: 24
+    bit_size: 1
+  - name: G7_IO2
+    description: G7_IO2 channel mode.
+    bit_offset: 25
+    bit_size: 1
+  - name: G7_IO3
+    description: G7_IO3 channel mode.
+    bit_offset: 26
+    bit_size: 1
+  - name: G7_IO4
+    description: G7_IO4 channel mode.
+    bit_offset: 27
+    bit_size: 1
+  - name: G8_IO1
+    description: G8_IO1 channel mode.
+    bit_offset: 28
+    bit_size: 1
+  - name: G8_IO2
+    description: G8_IO2 channel mode.
+    bit_offset: 29
+    bit_size: 1
+  - name: G8_IO3
+    description: G8_IO3 channel mode.
+    bit_offset: 30
+    bit_size: 1
+  - name: G8_IO4
+    description: G8_IO4 channel mode.
+    bit_offset: 31
+    bit_size: 1
+fieldset/IOGCR:
+  description: I/O group x counter register.
+  fields:
+  - name: CNT
+    description: Counter value.
+    bit_offset: 0
+    bit_size: 14
+fieldset/IOGCSR:
+  description: I/O group control status register.
+  fields:
+  - name: G1E
+    description: Analog I/O group x enable.
+    bit_offset: 0
+    bit_size: 1
+  - name: G2E
+    description: Analog I/O group x enable.
+    bit_offset: 1
+    bit_size: 1
+  - name: G3E
+    description: Analog I/O group x enable.
+    bit_offset: 2
+    bit_size: 1
+  - name: G4E
+    description: Analog I/O group x enable.
+    bit_offset: 3
+    bit_size: 1
+  - name: G5E
+    description: Analog I/O group x enable.
+    bit_offset: 4
+    bit_size: 1
+  - name: G6E
+    description: Analog I/O group x enable.
+    bit_offset: 5
+    bit_size: 1
+  - name: G7E
+    description: Analog I/O group x enable.
+    bit_offset: 6
+    bit_size: 1
+  - name: G8E
+    description: Analog I/O group x enable.
+    bit_offset: 7
+    bit_size: 1
+  - name: G1S
+    description: Analog I/O group x status.
+    bit_offset: 16
+    bit_size: 1
+  - name: G2S
+    description: Analog I/O group x status.
+    bit_offset: 17
+    bit_size: 1
+  - name: G3S
+    description: Analog I/O group x status.
+    bit_offset: 18
+    bit_size: 1
+  - name: G4S
+    description: Analog I/O group x status.
+    bit_offset: 19
+    bit_size: 1
+  - name: G5S
+    description: Analog I/O group x status.
+    bit_offset: 20
+    bit_size: 1
+  - name: G6S
+    description: Analog I/O group x status.
+    bit_offset: 21
+    bit_size: 1
+  - name: G7S
+    description: Analog I/O group x status.
+    bit_offset: 22
+    bit_size: 1
+  - name: G8S
+    description: Analog I/O group x status.
+    bit_offset: 23
+    bit_size: 1
+fieldset/IOHCR:
+  description: I/O hysteresis control register.
+  fields:
+  - name: G1_IO1
+    description: G1_IO1 Schmitt trigger hysteresis mode.
+    bit_offset: 0
+    bit_size: 1
+  - name: G1_IO2
+    description: G1_IO2 Schmitt trigger hysteresis mode.
+    bit_offset: 1
+    bit_size: 1
+  - name: G1_IO3
+    description: G1_IO3 Schmitt trigger hysteresis mode.
+    bit_offset: 2
+    bit_size: 1
+  - name: G1_IO4
+    description: G1_IO4 Schmitt trigger hysteresis mode.
+    bit_offset: 3
+    bit_size: 1
+  - name: G2_IO1
+    description: G2_IO1 Schmitt trigger hysteresis mode.
+    bit_offset: 4
+    bit_size: 1
+  - name: G2_IO2
+    description: G2_IO2 Schmitt trigger hysteresis mode.
+    bit_offset: 5
+    bit_size: 1
+  - name: G2_IO3
+    description: G2_IO3 Schmitt trigger hysteresis mode.
+    bit_offset: 6
+    bit_size: 1
+  - name: G2_IO4
+    description: G2_IO4 Schmitt trigger hysteresis mode.
+    bit_offset: 7
+    bit_size: 1
+  - name: G3_IO1
+    description: G3_IO1 Schmitt trigger hysteresis mode.
+    bit_offset: 8
+    bit_size: 1
+  - name: G3_IO2
+    description: G3_IO2 Schmitt trigger hysteresis mode.
+    bit_offset: 9
+    bit_size: 1
+  - name: G3_IO3
+    description: G3_IO3 Schmitt trigger hysteresis mode.
+    bit_offset: 10
+    bit_size: 1
+  - name: G3_IO4
+    description: G3_IO4 Schmitt trigger hysteresis mode.
+    bit_offset: 11
+    bit_size: 1
+  - name: G4_IO1
+    description: G4_IO1 Schmitt trigger hysteresis mode.
+    bit_offset: 12
+    bit_size: 1
+  - name: G4_IO2
+    description: G4_IO2 Schmitt trigger hysteresis mode.
+    bit_offset: 13
+    bit_size: 1
+  - name: G4_IO3
+    description: G4_IO3 Schmitt trigger hysteresis mode.
+    bit_offset: 14
+    bit_size: 1
+  - name: G4_IO4
+    description: G4_IO4 Schmitt trigger hysteresis mode.
+    bit_offset: 15
+    bit_size: 1
+  - name: G5_IO1
+    description: G5_IO1 Schmitt trigger hysteresis mode.
+    bit_offset: 16
+    bit_size: 1
+  - name: G5_IO2
+    description: G5_IO2 Schmitt trigger hysteresis mode.
+    bit_offset: 17
+    bit_size: 1
+  - name: G5_IO3
+    description: G5_IO3 Schmitt trigger hysteresis mode.
+    bit_offset: 18
+    bit_size: 1
+  - name: G5_IO4
+    description: G5_IO4 Schmitt trigger hysteresis mode.
+    bit_offset: 19
+    bit_size: 1
+  - name: G6_IO1
+    description: G6_IO1 Schmitt trigger hysteresis mode.
+    bit_offset: 20
+    bit_size: 1
+  - name: G6_IO2
+    description: G6_IO2 Schmitt trigger hysteresis mode.
+    bit_offset: 21
+    bit_size: 1
+  - name: G6_IO3
+    description: G6_IO3 Schmitt trigger hysteresis mode.
+    bit_offset: 22
+    bit_size: 1
+  - name: G6_IO4
+    description: G6_IO4 Schmitt trigger hysteresis mode.
+    bit_offset: 23
+    bit_size: 1
+  - name: G7_IO1
+    description: G7_IO1 Schmitt trigger hysteresis mode.
+    bit_offset: 24
+    bit_size: 1
+  - name: G7_IO2
+    description: G7_IO2 Schmitt trigger hysteresis mode.
+    bit_offset: 25
+    bit_size: 1
+  - name: G7_IO3
+    description: G7_IO3 Schmitt trigger hysteresis mode.
+    bit_offset: 26
+    bit_size: 1
+  - name: G7_IO4
+    description: G7_IO4 Schmitt trigger hysteresis mode.
+    bit_offset: 27
+    bit_size: 1
+  - name: G8_IO1
+    description: G8_IO1 Schmitt trigger hysteresis mode.
+    bit_offset: 28
+    bit_size: 1
+  - name: G8_IO2
+    description: G8_IO2 Schmitt trigger hysteresis mode.
+    bit_offset: 29
+    bit_size: 1
+  - name: G8_IO3
+    description: G8_IO3 Schmitt trigger hysteresis mode.
+    bit_offset: 30
+    bit_size: 1
+  - name: G8_IO4
+    description: G8_IO4 Schmitt trigger hysteresis mode.
+    bit_offset: 31
+    bit_size: 1
+fieldset/IOSCR:
+  description: I/O sampling control register.
+  fields:
+  - name: G1_IO1
+    description: G1_IO1 sampling mode.
+    bit_offset: 0
+    bit_size: 1
+  - name: G1_IO2
+    description: G1_IO2 sampling mode.
+    bit_offset: 1
+    bit_size: 1
+  - name: G1_IO3
+    description: G1_IO3 sampling mode.
+    bit_offset: 2
+    bit_size: 1
+  - name: G1_IO4
+    description: G1_IO4 sampling mode.
+    bit_offset: 3
+    bit_size: 1
+  - name: G2_IO1
+    description: G2_IO1 sampling mode.
+    bit_offset: 4
+    bit_size: 1
+  - name: G2_IO2
+    description: G2_IO2 sampling mode.
+    bit_offset: 5
+    bit_size: 1
+  - name: G2_IO3
+    description: G2_IO3 sampling mode.
+    bit_offset: 6
+    bit_size: 1
+  - name: G2_IO4
+    description: G2_IO4 sampling mode.
+    bit_offset: 7
+    bit_size: 1
+  - name: G3_IO1
+    description: G3_IO1 sampling mode.
+    bit_offset: 8
+    bit_size: 1
+  - name: G3_IO2
+    description: G3_IO2 sampling mode.
+    bit_offset: 9
+    bit_size: 1
+  - name: G3_IO3
+    description: G3_IO3 sampling mode.
+    bit_offset: 10
+    bit_size: 1
+  - name: G3_IO4
+    description: G3_IO4 sampling mode.
+    bit_offset: 11
+    bit_size: 1
+  - name: G4_IO1
+    description: G4_IO1 sampling mode.
+    bit_offset: 12
+    bit_size: 1
+  - name: G4_IO2
+    description: G4_IO2 sampling mode.
+    bit_offset: 13
+    bit_size: 1
+  - name: G4_IO3
+    description: G4_IO3 sampling mode.
+    bit_offset: 14
+    bit_size: 1
+  - name: G4_IO4
+    description: G4_IO4 sampling mode.
+    bit_offset: 15
+    bit_size: 1
+  - name: G5_IO1
+    description: G5_IO1 sampling mode.
+    bit_offset: 16
+    bit_size: 1
+  - name: G5_IO2
+    description: G5_IO2 sampling mode.
+    bit_offset: 17
+    bit_size: 1
+  - name: G5_IO3
+    description: G5_IO3 sampling mode.
+    bit_offset: 18
+    bit_size: 1
+  - name: G5_IO4
+    description: G5_IO4 sampling mode.
+    bit_offset: 19
+    bit_size: 1
+  - name: G6_IO1
+    description: G6_IO1 sampling mode.
+    bit_offset: 20
+    bit_size: 1
+  - name: G6_IO2
+    description: G6_IO2 sampling mode.
+    bit_offset: 21
+    bit_size: 1
+  - name: G6_IO3
+    description: G6_IO3 sampling mode.
+    bit_offset: 22
+    bit_size: 1
+  - name: G6_IO4
+    description: G6_IO4 sampling mode.
+    bit_offset: 23
+    bit_size: 1
+  - name: G7_IO1
+    description: G7_IO1 sampling mode.
+    bit_offset: 24
+    bit_size: 1
+  - name: G7_IO2
+    description: G7_IO2 sampling mode.
+    bit_offset: 25
+    bit_size: 1
+  - name: G7_IO3
+    description: G7_IO3 sampling mode.
+    bit_offset: 26
+    bit_size: 1
+  - name: G7_IO4
+    description: G7_IO4 sampling mode.
+    bit_offset: 27
+    bit_size: 1
+  - name: G8_IO1
+    description: G8_IO1 sampling mode.
+    bit_offset: 28
+    bit_size: 1
+  - name: G8_IO2
+    description: G8_IO2 sampling mode.
+    bit_offset: 29
+    bit_size: 1
+  - name: G8_IO3
+    description: G8_IO3 sampling mode.
+    bit_offset: 30
+    bit_size: 1
+  - name: G8_IO4
+    description: G8_IO4 sampling mode.
+    bit_offset: 31
+    bit_size: 1
+fieldset/ISR:
+  description: interrupt status register.
+  fields:
+  - name: EOAF
+    description: End of acquisition flag.
+    bit_offset: 0
+    bit_size: 1
+  - name: MCEF
+    description: Max count error flag.
+    bit_offset: 1
+    bit_size: 1

--- a/stm32-data-gen/src/chips.rs
+++ b/stm32-data-gen/src/chips.rs
@@ -493,6 +493,11 @@ impl PeriMatcher {
             ),
             ("STM32L4.*:GFXMMU:.*", ("gfxmmu", "v1", "GFXMMU")),
             ("STM32U5.*:GFXMMU:.*", ("gfxmmu", "v2", "GFXMMU")),
+            ("STM32F0x[128].*:TSC:.*", ("tsc", "v1", "TSC")),
+            ("STM32F3[07][123].*:TSC:.*", ("tsc", "v1", "TSC")),
+            ("STM32WB55.*:TSC:.*", ("tsc", "v2", "TSC")),
+            ("STM32L[045].*:TSC:.*", ("tsc", "v3", "TSC")),
+            ("STM32U5.*:TSC:.*", ("tsc", "v3", "TSC")),
         ];
 
         Self {

--- a/transforms/TSC.yaml
+++ b/transforms/TSC.yaml
@@ -1,0 +1,8 @@
+transforms:
+  - !MergeFieldsets
+    from: (IOG)\d+(CR)
+    to: $1$2
+  - !MakeRegisterArray
+    blocks: .*
+    from: (IOG)\d+(CR)
+    to: $1$2


### PR DESCRIPTION
Note: Some field sets have potential to be collapsed to two dimensional arrays, but `chiptool` doesn't support this.