### PR TITLE
Add enum/ADCSET to rcc_l5.yaml

### DIFF
--- a/data/registers/rcc_l5.yaml
+++ b/data/registers/rcc_l5.yaml
@@ -1931,7 +1931,7 @@ enum/ADCSEL:
   - name: DISABLE
     description: No clock selected
     value: 0
-  - name: PLL1_Q
+  - name: PLLSAI1_R
     description: PLLADC1CLK clock selected
     value: 1
   - name: SYS

--- a/data/registers/rcc_l5.yaml
+++ b/data/registers/rcc_l5.yaml
@@ -1383,6 +1383,7 @@ fieldset/CCIPR1:
     description: ADCs clock source selection
     bit_offset: 28
     bit_size: 2
+    enum: ADCSEL
 fieldset/CCIPR2:
   description: Peripherals independent clock configuration register
   fields:
@@ -1924,6 +1925,18 @@ fieldset/SECSR:
     description: RMVFSECF
     bit_offset: 12
     bit_size: 1
+enum/ADCSEL:
+  bit_size: 2
+  variants:
+  - name: DISABLE
+    description: No clock selected
+    value: 0
+  - name: PLL1_Q
+    description: PLLADC1CLK clock selected
+    value: 1
+  - name: SYS
+    description: SYSCLK clock selected
+    value: 3
 enum/CLK48SEL:
   bit_size: 2
   variants:


### PR DESCRIPTION
enum/ADCSET was omitted on the STM32L5 processor family.

Change per discussion with dirbaio on Matrix channel