### PR TITLE
Fixed generation for quadspi v4 for STM32g474 family

### DIFF
--- a/data/registers/quadspi_v4.yaml
+++ b/data/registers/quadspi_v4.yaml
@@ -1,0 +1,291 @@
+block/QUADSPI:
+  description: QuadSPI interface
+  items:
+  - name: CR
+    description: control register
+    byte_offset: 0
+    fieldset: CR
+  - name: DCR
+    description: device configuration register
+    byte_offset: 4
+    fieldset: DCR
+  - name: SR
+    description: status register
+    byte_offset: 8
+    access: Read
+    fieldset: SR
+  - name: FCR
+    description: flag clear register
+    byte_offset: 12
+    fieldset: FCR
+  - name: DLR
+    description: data length register
+    byte_offset: 16
+    fieldset: DLR
+  - name: CCR
+    description: communication configuration register
+    byte_offset: 20
+    fieldset: CCR
+  - name: AR
+    description: address register
+    byte_offset: 24
+    fieldset: AR
+  - name: ABR
+    description: ABR
+    byte_offset: 28
+    fieldset: ABR
+  - name: DR
+    description: data register
+    byte_offset: 32
+    fieldset: DR
+  - name: PSMKR
+    description: polling status mask register
+    byte_offset: 36
+    fieldset: PSMKR
+  - name: PSMAR
+    description: polling status match register
+    byte_offset: 40
+    fieldset: PSMAR
+  - name: PIR
+    description: polling interval register
+    byte_offset: 44
+    fieldset: PIR
+  - name: LPTR
+    description: low-power timeout register
+    byte_offset: 48
+    fieldset: LPTR
+fieldset/ABR:
+  description: ABR
+  fields:
+  - name: ALTERNATE
+    description: ALTERNATE
+    bit_offset: 0
+    bit_size: 32
+fieldset/AR:
+  description: address register
+  fields:
+  - name: ADDRESS
+    description: Address
+    bit_offset: 0
+    bit_size: 32
+fieldset/CCR:
+  description: communication configuration register
+  fields:
+  - name: INSTRUCTION
+    description: Instruction
+    bit_offset: 0
+    bit_size: 8
+  - name: IMODE
+    description: Instruction mode
+    bit_offset: 8
+    bit_size: 2
+  - name: ADMODE
+    description: Address mode
+    bit_offset: 10
+    bit_size: 2
+  - name: ADSIZE
+    description: Address size
+    bit_offset: 12
+    bit_size: 2
+  - name: ABMODE
+    description: Alternate bytes mode
+    bit_offset: 14
+    bit_size: 2
+  - name: ABSIZE
+    description: Alternate bytes size
+    bit_offset: 16
+    bit_size: 2
+  - name: DCYC
+    description: Number of dummy cycles
+    bit_offset: 18
+    bit_size: 5
+  - name: DMODE
+    description: Data mode
+    bit_offset: 24
+    bit_size: 2
+  - name: FMODE
+    description: Functional mode
+    bit_offset: 26
+    bit_size: 2
+  - name: SIOO
+    description: Send instruction only once mode
+    bit_offset: 28
+    bit_size: 1
+  - name: DDRM
+    description: Double data rate mode
+    bit_offset: 31
+    bit_size: 1
+fieldset/CR:
+  description: control register
+  fields:
+  - name: EN
+    description: Enable
+    bit_offset: 0
+    bit_size: 1
+  - name: ABORT
+    description: Abort request
+    bit_offset: 1
+    bit_size: 1
+  - name: DMAEN
+    description: DMA enable
+    bit_offset: 2
+    bit_size: 1
+  - name: TCEN
+    description: Timeout counter enable
+    bit_offset: 3
+    bit_size: 1
+  - name: SSHIFT
+    description: Sample shift
+    bit_offset: 4
+    bit_size: 1
+  - name: DFM
+    description: DFM
+    bit_offset: 6
+    bit_size: 1
+  - name: FSEL
+    description: FSEL
+    bit_offset: 7
+    bit_size: 1
+  - name: FTHRES
+    description: IFO threshold level
+    bit_offset: 8
+    bit_size: 5
+  - name: TEIE
+    description: Transfer error interrupt enable
+    bit_offset: 16
+    bit_size: 1
+  - name: TCIE
+    description: Transfer complete interrupt enable
+    bit_offset: 17
+    bit_size: 1
+  - name: FTIE
+    description: FIFO threshold interrupt enable
+    bit_offset: 18
+    bit_size: 1
+  - name: SMIE
+    description: Status match interrupt enable
+    bit_offset: 19
+    bit_size: 1
+  - name: TOIE
+    description: TimeOut interrupt enable
+    bit_offset: 20
+    bit_size: 1
+  - name: APMS
+    description: Automatic poll mode stop
+    bit_offset: 22
+    bit_size: 1
+  - name: PMM
+    description: Polling match mode
+    bit_offset: 23
+    bit_size: 1
+  - name: PRESCALER
+    description: Clock prescaler
+    bit_offset: 24
+    bit_size: 8
+fieldset/DCR:
+  description: device configuration register
+  fields:
+  - name: CKMODE
+    description: Mode 0 / mode 3
+    bit_offset: 0
+    bit_size: 1
+  - name: CSHT
+    description: Chip select high time
+    bit_offset: 8
+    bit_size: 3
+  - name: FSIZE
+    description: FLASH memory size
+    bit_offset: 16
+    bit_size: 5
+fieldset/DLR:
+  description: data length register
+  fields:
+  - name: DL
+    description: Data length
+    bit_offset: 0
+    bit_size: 32
+fieldset/DR:
+  description: data register
+  fields:
+  - name: DATA
+    description: Data
+    bit_offset: 0
+    bit_size: 32
+fieldset/FCR:
+  description: flag clear register
+  fields:
+  - name: CTEF
+    description: Clear transfer error flag
+    bit_offset: 0
+    bit_size: 1
+  - name: CTCF
+    description: Clear transfer complete flag
+    bit_offset: 1
+    bit_size: 1
+  - name: CSMF
+    description: Clear status match flag
+    bit_offset: 3
+    bit_size: 1
+  - name: CTOF
+    description: Clear timeout flag
+    bit_offset: 4
+    bit_size: 1
+fieldset/LPTR:
+  description: low-power timeout register
+  fields:
+  - name: TIMEOUT
+    description: Timeout period
+    bit_offset: 0
+    bit_size: 16
+fieldset/PIR:
+  description: polling interval register
+  fields:
+  - name: INTERVAL
+    description: Polling interval
+    bit_offset: 0
+    bit_size: 16
+fieldset/PSMAR:
+  description: polling status match register
+  fields:
+  - name: MATCH
+    description: Status match
+    bit_offset: 0
+    bit_size: 32
+fieldset/PSMKR:
+  description: polling status mask register
+  fields:
+  - name: MASK
+    description: Status mask
+    bit_offset: 0
+    bit_size: 32
+fieldset/SR:
+  description: status register
+  fields:
+  - name: TEF
+    description: Transfer error flag
+    bit_offset: 0
+    bit_size: 1
+  - name: TCF
+    description: Transfer complete flag
+    bit_offset: 1
+    bit_size: 1
+  - name: FTF
+    description: FIFO threshold flag
+    bit_offset: 2
+    bit_size: 1
+  - name: SMF
+    description: Status match flag
+    bit_offset: 3
+    bit_size: 1
+  - name: TOF
+    description: Timeout flag
+    bit_offset: 4
+    bit_size: 1
+  - name: BUSY
+    description: Busy
+    bit_offset: 5
+    bit_size: 1
+  - name: FLEVEL
+    description: FIFO level
+    bit_offset: 8
+    bit_size: 5

--- a/stm32-data-gen/src/chips.rs
+++ b/stm32-data-gen/src/chips.rs
@@ -937,7 +937,7 @@ fn process_core(
         } else if chip_name.starts_with("STM32H7") && pname == "HRTIM" {
             defines.get_peri_addr("HRTIM1")
         } else if pname.starts_with("QUADSPI") && chip_name.starts_with("STM32G474") {
-            defines.get_peri_addr("QSPI")
+            defines.get_peri_addr("QSPI_R")
         } else {
             defines.get_peri_addr(&pname)
         };

--- a/stm32-data-gen/src/chips.rs
+++ b/stm32-data-gen/src/chips.rs
@@ -251,6 +251,7 @@ impl PeriMatcher {
             (".*:LTDC:lcdtft1_v1_1", ("ltdc", "v1", "LTDC")),
             (".*:MDIOS:mdios1_v1_0", ("mdios", "v1", "MDIOS")),
             (".*:QUADSPI:quadspi1_v1_0", ("quadspi", "v1", "QUADSPI")),
+            (".*:QUADSPI:quadspi1_v4_1", ("quadspi", "v4", "QUADSPI")),
             ("STM32F1.*:BKP.*", ("bkp", "v1", "BKP")),
             (".*:RTC:rtc1_v1_1", ("rtc", "v1", "RTC")),
             ("STM32F0.*:RTC:rtc2_.*", ("rtc", "v2f0", "RTC")),
@@ -935,6 +936,8 @@ fn process_core(
             defines.get_peri_addr("ADC1")
         } else if chip_name.starts_with("STM32H7") && pname == "HRTIM" {
             defines.get_peri_addr("HRTIM1")
+        } else if pname.starts_with("QUADSPI") && chip_name.starts_with("STM32G474") {
+            defines.get_peri_addr("QSPI")
         } else {
             defines.get_peri_addr(&pname)
         };


### PR DESCRIPTION
The main cause of issue #293 was that in addition to a new version of the QUADSPI peripheral, it had a different name inside the C header that defined its base address, leading to it never being generated. 