### PR TITLE
ADC: remove EXTSEL and JEXTSEL enum as they can be inconsistent between chips

### DIFF
--- a/data/registers/adc_f1.yaml
+++ b/data/registers/adc_f1.yaml
@@ -152,7 +152,6 @@ fieldset/CR2:
     description: External event select for injected group
     bit_offset: 12
     bit_size: 3
-    enum: EXTSEL
   - name: JEXTTRIG
     description: External trigger conversion mode for injected channels
     bit_offset: 15
@@ -161,7 +160,6 @@ fieldset/CR2:
     description: External event select for regular group
     bit_offset: 17
     bit_size: 3
-    enum: EXTSEL
   - name: EXTTRIG
     description: External trigger conversion mode for regular channels
     bit_offset: 20
@@ -343,33 +341,6 @@ enum/DUALMOD:
   - name: AlternateTrigger
     description: Alternate trigger mode only
     value: 9
-enum/EXTSEL:
-  bit_size: 3
-  variants:
-  - name: TIM1TRGO
-    description: Timer 1 TRGO event
-    value: 0
-  - name: TIM1CC4
-    description: Timer 1 CC4 event
-    value: 1
-  - name: TIM2TRGO
-    description: Timer 2 TRGO event
-    value: 2
-  - name: TIM2CC1
-    description: Timer 2 CC1 event
-    value: 3
-  - name: TIM3CC4
-    description: Timer 3 CC4 event
-    value: 4
-  - name: TIM4TRGO
-    description: Timer 4 TRGO event
-    value: 5
-  - name: TIM8CC4
-    description: EXTI line 15/Timer 8 CC4 event
-    value: 6
-  - name: SWSTART
-    description: SWSTART
-    value: 7
 enum/SAMPLE_TIME:
   bit_size: 3
   variants:

--- a/data/registers/adc_f3.yaml
+++ b/data/registers/adc_f3.yaml
@@ -138,7 +138,6 @@ fieldset/CFGR:
     description: External trigger selection for regular group
     bit_offset: 6
     bit_size: 4
-    enum: EXTSEL
   - name: EXTEN
     description: External trigger enable and polarity selection for regular channels
     bit_offset: 10
@@ -436,7 +435,6 @@ fieldset/JSQR:
     description: External Trigger Selection for injected group
     bit_offset: 2
     bit_size: 4
-    enum: JEXTSEL
   - name: JEXTEN
     description: External Trigger Enable and Polarity Selection for injected channels
     bit_offset: 6
@@ -617,51 +615,6 @@ enum/EXTEN:
   - name: BothEdges
     description: Trigger detection on both the rising and falling edges
     value: 3
-enum/EXTSEL:
-  bit_size: 4
-  variants:
-  - name: TIM1_CC1
-    description: Timer 1 CC1 event
-    value: 0
-  - name: TIM1_CC2
-    description: Timer 1 CC2 event
-    value: 1
-  - name: TIM1_CC3
-    description: Timer 1 CC3 event
-    value: 2
-  - name: TIM2_CC2
-    description: Timer 2 CC2 event
-    value: 3
-  - name: TIM3_TRGO
-    description: Timer 3 TRGO event
-    value: 4
-  - name: EXTI11
-    description: EXTI line 11
-    value: 6
-  - name: HRTIM_ADCTRG1
-    description: HRTIM_ADCTRG1 event
-    value: 7
-  - name: HRTIM_ADCTRG3
-    description: HRTIM_ADCTRG3 event
-    value: 8
-  - name: TIM1_TRGO
-    description: Timer 1 TRGO event
-    value: 9
-  - name: TIM1_TRGO2
-    description: Timer 1 TRGO2 event
-    value: 10
-  - name: TIM2_TRGO
-    description: Timer 2 TRGO event
-    value: 11
-  - name: TIM6_TRGO
-    description: Timer 6 TRGO event
-    value: 13
-  - name: TIM15_TRGO
-    description: Timer 15 TRGO event
-    value: 14
-  - name: TIM3_CC4
-    description: Timer 3 CC4 event
-    value: 15
 enum/JEXTEN:
   bit_size: 2
   variants:
@@ -677,51 +630,6 @@ enum/JEXTEN:
   - name: BothEdges
     description: Trigger detection on both the rising and falling edges
     value: 3
-enum/JEXTSEL:
-  bit_size: 4
-  variants:
-  - name: TIM1_TRGO
-    description: Timer 1 TRGO event
-    value: 0
-  - name: TIM1_CC4
-    description: Timer 1 CC4 event
-    value: 1
-  - name: TIM2_TRGO
-    description: Timer 2 TRGO event
-    value: 2
-  - name: TIM2_CC1
-    description: Timer 2 CC1 event
-    value: 3
-  - name: TIM3_CC4
-    description: Timer 3 CC4 event
-    value: 4
-  - name: EXTI15
-    description: EXTI line 15
-    value: 6
-  - name: TIM1_TRGO2
-    description: Timer 1 TRGO2 event
-    value: 8
-  - name: HRTIM_ADCTRG2
-    description: HRTIM_ADCTRG2 event
-    value: 9
-  - name: HRTIM_ADCTRG4
-    description: HRTIM_ADCTRG4 event
-    value: 10
-  - name: TIM3_CC3
-    description: Timer 3 CC3 event
-    value: 11
-  - name: TIM3_TRGO
-    description: Timer 3 TRGO event
-    value: 12
-  - name: TIM3_CC1
-    description: Timer 3 CC1 event
-    value: 13
-  - name: TIM6_TRGO
-    description: Timer 6 TRGO event
-    value: 14
-  - name: TIM15_TRGO
-    description: Timer 15 TRGO event
-    value: 15
 enum/JQM:
   bit_size: 1
   variants:

--- a/data/registers/adc_f3_v2.yaml
+++ b/data/registers/adc_f3_v2.yaml
@@ -169,7 +169,6 @@ fieldset/CR2:
     description: external event select for injected group
     bit_offset: 12
     bit_size: 3
-    enum: JEXTSEL
   - name: JEXTTRIG
     description: external trigger conversion mode for injected channels
     bit_offset: 15
@@ -178,7 +177,6 @@ fieldset/CR2:
     description: external event select for regular group
     bit_offset: 17
     bit_size: 3
-    enum: EXTSEL
   - name: EXTTRIG
     description: external trigger conversion mode for regular channels
     bit_offset: 20
@@ -526,60 +524,6 @@ enum/DISCNUM:
     value: 6
   - name: DISCNUM_8
     description: 8 conversions are discontinued and the conversions are carried out on 8 channels
-    value: 7
-enum/EXTSEL:
-  bit_size: 3
-  variants:
-  - name: TIM19_TRGO
-    description: Timer 19 TRGO event
-    value: 0
-  - name: TIM19_CC3
-    description: Timer 19 CC3 event
-    value: 1
-  - name: TIM19_CC4
-    description: Timer 19 CC4 event
-    value: 2
-  - name: TIM2_CC2
-    description: Timer 2 CC2 event
-    value: 3
-  - name: TIM3_TRGO
-    description: Timer 3 TRGO event
-    value: 4
-  - name: TIM4_CC4
-    description: Timer 4 CC4 event
-    value: 5
-  - name: EXTI_LINE11
-    description: External interrupt line 11
-    value: 6
-  - name: SWSTART
-    description: SWSTART bit
-    value: 7
-enum/JEXTSEL:
-  bit_size: 3
-  variants:
-  - name: TIM19_CC1
-    description: Timer 19 CC1 event
-    value: 0
-  - name: TIM19_CC2
-    description: Timer 19 CC2 event
-    value: 1
-  - name: TIM2_TRGO
-    description: Timer 2 TRGO event
-    value: 2
-  - name: TIM2_CC1
-    description: Timer 2 CC1 event
-    value: 3
-  - name: TIM3_CC4
-    description: Timer 3 CC4 event
-    value: 4
-  - name: TIM4_TRGO
-    description: Timer 4 TRGO event
-    value: 5
-  - name: EXTI_LINE15
-    description: External interrupt line 15
-    value: 6
-  - name: JSWSTART
-    description: JSWSTART bit
     value: 7
 enum/SAMPLE_TIME:
   bit_size: 3

--- a/data/registers/adc_v1.yaml
+++ b/data/registers/adc_v1.yaml
@@ -88,7 +88,6 @@ fieldset/CFGR1:
     description: External trigger selection
     bit_offset: 6
     bit_size: 3
-    enum: EXTSEL
   - name: EXTEN
     description: External trigger enable and polarity selection
     bit_offset: 10
@@ -303,24 +302,6 @@ enum/EXTEN:
   - name: BothEdges
     description: Trigger detection on both the rising and falling edges
     value: 3
-enum/EXTSEL:
-  bit_size: 3
-  variants:
-  - name: TIM1_TRGO
-    description: Timer 1 TRGO Event
-    value: 0
-  - name: TIM1_CC4
-    description: Timer 1 CC4 event
-    value: 1
-  - name: TIM2_TRGO
-    description: Timer 2 TRGO event
-    value: 2
-  - name: TIM3_TRGO
-    description: Timer 3 TRGO event
-    value: 3
-  - name: TIM15_TRGO
-    description: Timer 15 TRGO event
-    value: 4
 enum/OVRMOD:
   bit_size: 1
   variants:

--- a/data/registers/adc_v2.yaml
+++ b/data/registers/adc_v2.yaml
@@ -161,7 +161,6 @@ fieldset/CR2:
     description: External event select for injected group
     bit_offset: 16
     bit_size: 4
-    enum: JEXTSEL
   - name: JEXTEN
     description: External trigger enable for injected channels
     bit_offset: 20
@@ -175,7 +174,6 @@ fieldset/CR2:
     description: External event select for regular group
     bit_offset: 24
     bit_size: 4
-    enum: EXTSEL
   - name: EXTEN
     description: External trigger enable for regular channels
     bit_offset: 28
@@ -411,30 +409,6 @@ enum/EXTEN:
   - name: BothEdges
     description: Trigger detection on both the rising and falling edges
     value: 3
-enum/EXTSEL:
-  bit_size: 4
-  variants:
-  - name: TIM1CC1
-    description: Timer 1 CC1 event
-    value: 0
-  - name: TIM1CC2
-    description: Timer 1 CC2 event
-    value: 1
-  - name: TIM1CC3
-    description: Timer 1 CC3 event
-    value: 2
-  - name: TIM2CC2
-    description: Timer 2 CC2 event
-    value: 3
-  - name: TIM2CC3
-    description: Timer 2 CC3 event
-    value: 4
-  - name: TIM2CC4
-    description: Timer 2 CC4 event
-    value: 5
-  - name: TIM2TRGO
-    description: Timer 2 TRGO event
-    value: 6
 enum/JEOC:
   bit_size: 1
   variants:
@@ -459,51 +433,6 @@ enum/JEXTEN:
   - name: BothEdges
     description: Trigger detection on both the rising and falling edges
     value: 3
-enum/JEXTSEL:
-  bit_size: 4
-  variants:
-  - name: TIM1TRGO
-    description: Timer 1 TRGO event
-    value: 0
-  - name: TIM1CC4
-    description: Timer 1 CC4 event
-    value: 1
-  - name: TIM2TRGO
-    description: Timer 2 TRGO event
-    value: 2
-  - name: TIM2CC1
-    description: Timer 2 CC1 event
-    value: 3
-  - name: TIM3CC4
-    description: Timer 3 CC4 event
-    value: 4
-  - name: TIM4TRGO
-    description: Timer 4 TRGO event
-    value: 5
-  - name: TIM8CC4
-    description: Timer 8 CC4 event
-    value: 7
-  - name: TIM1TRGO2
-    description: Timer 1 TRGO(2) event
-    value: 8
-  - name: TIM8TRGO
-    description: Timer 8 TRGO event
-    value: 9
-  - name: TIM8TRGO2
-    description: Timer 8 TRGO(2) event
-    value: 10
-  - name: TIM3CC3
-    description: Timer 3 CC3 event
-    value: 11
-  - name: TIM5TRGO
-    description: Timer 5 TRGO event
-    value: 12
-  - name: TIM3CC1
-    description: Timer 3 CC1 event
-    value: 13
-  - name: TIM6TRGO
-    description: Timer 6 TRGO event
-    value: 14
 enum/JSTRT:
   bit_size: 1
   variants:

--- a/data/registers/adc_v4.yaml
+++ b/data/registers/adc_v4.yaml
@@ -171,7 +171,6 @@ fieldset/CFGR:
     description: group regular external trigger source
     bit_offset: 5
     bit_size: 5
-    enum: EXTSEL
   - name: EXTEN
     description: group regular external trigger polarity
     bit_offset: 10
@@ -515,7 +514,6 @@ fieldset/JSQR:
     description: group injected external trigger source
     bit_offset: 2
     bit_size: 5
-    enum: JEXTSEL
   - name: JEXTEN
     description: group injected external trigger polarity
     bit_offset: 7
@@ -708,72 +706,6 @@ enum/EXTEN:
   - name: BothEdges
     description: Trigger detection on both the rising and falling edges
     value: 3
-enum/EXTSEL:
-  bit_size: 5
-  variants:
-  - name: TIM1_CC1
-    description: Timer 1 CC1 event
-    value: 0
-  - name: TIM1_CC2
-    description: Timer 1 CC2 event
-    value: 1
-  - name: TIM1_CC3
-    description: Timer 1 CC3 event
-    value: 2
-  - name: TIM2_CC2
-    description: Timer 2 CC2 event
-    value: 3
-  - name: TIM3_TRGO
-    description: Timer 3 TRGO event
-    value: 4
-  - name: TIM4_CC4
-    description: Timer 4 CC4 event
-    value: 5
-  - name: EXTI11
-    description: EXTI line 11
-    value: 6
-  - name: TIM8_TRGO
-    description: Timer 8 TRGO event
-    value: 7
-  - name: TIM8_TRGO2
-    description: Timer 8 TRGO2 event
-    value: 8
-  - name: TIM1_TRGO
-    description: Timer 1 TRGO event
-    value: 9
-  - name: TIM1_TRGO2
-    description: Timer 1 TRGO2 event
-    value: 10
-  - name: TIM2_TRGO
-    description: Timer 2 TRGO event
-    value: 11
-  - name: TIM4_TRGO
-    description: Timer 4 TRGO event
-    value: 12
-  - name: TIM6_TRGO
-    description: Timer 6 TRGO event
-    value: 13
-  - name: TIM15_TRGO
-    description: Timer 15 TRGO event
-    value: 14
-  - name: TIM3_CC4
-    description: Timer 3 CC4 event
-    value: 15
-  - name: HRTIM1_ADCTRG1
-    description: HRTIM1_ADCTRG1 event
-    value: 16
-  - name: HRTIM1_ADCTRG3
-    description: HRTIM1_ADCTRG3 event
-    value: 17
-  - name: LPTIM1_OUT
-    description: LPTIM1_OUT event
-    value: 18
-  - name: LPTIM2_OUT
-    description: LPTIM2_OUT event
-    value: 19
-  - name: LPTIM3_OUT
-    description: LPTIM3_OUT event
-    value: 20
 enum/JEXTEN:
   bit_size: 2
   variants:
@@ -789,72 +721,6 @@ enum/JEXTEN:
   - name: BothEdges
     description: Trigger detection on both the rising and falling edges
     value: 3
-enum/JEXTSEL:
-  bit_size: 5
-  variants:
-  - name: TIM1_TRGO
-    description: Timer 1 TRGO event
-    value: 0
-  - name: TIM1_CC4
-    description: Timer 1 CC4 event
-    value: 1
-  - name: TIM2_TRGO
-    description: Timer 2 TRGO event
-    value: 2
-  - name: TIM2_CC1
-    description: Timer 2 CC1 event
-    value: 3
-  - name: TIM3_CC4
-    description: Timer 3 CC4 event
-    value: 4
-  - name: TIM4_TRGO
-    description: Timer 4 TRGO event
-    value: 5
-  - name: EXTI15
-    description: EXTI line 15
-    value: 6
-  - name: TIM8_CC4
-    description: Timer 8 CC4 event
-    value: 7
-  - name: TIM1_TRGO2
-    description: Timer 1 TRGO2 event
-    value: 8
-  - name: TIM8_TRGO
-    description: Timer 8 TRGO event
-    value: 9
-  - name: TIM8_TRGO2
-    description: Timer 8 TRGO2 event
-    value: 10
-  - name: TIM3_CC3
-    description: Timer 3 CC3 event
-    value: 11
-  - name: TIM3_TRGO
-    description: Timer 3 TRGO event
-    value: 12
-  - name: TIM3_CC1
-    description: Timer 3 CC1 event
-    value: 13
-  - name: TIM6_TRGO
-    description: Timer 6 TRGO event
-    value: 14
-  - name: TIM15_TRGO
-    description: Timer 15 TRGO event
-    value: 15
-  - name: HRTIM1_ADCTRG2
-    description: HRTIM1_ADCTRG2 event
-    value: 16
-  - name: HRTIM1_ADCTRG4
-    description: HRTIM1_ADCTRG4 event
-    value: 17
-  - name: LPTIM1_OUT
-    description: LPTIM1_OUT event
-    value: 18
-  - name: LPTIM2_OUT
-    description: LPTIM2_OUT event
-    value: 19
-  - name: LPTIM3_OUT
-    description: LPTIM3_OUT event
-    value: 20
 enum/JQM:
   bit_size: 1
   variants:


### PR DESCRIPTION
See #310 for more discussion about the subject.