### PR TITLE
add irq name exception for "TIM6_DAC"

### DIFF
--- a/stm32-data-gen/src/interrupts.rs
+++ b/stm32-data-gen/src/interrupts.rs
@@ -151,6 +151,7 @@ impl ChipInterrupts {
                 ("HASH_RNG", &["RNG"]),
                 ("USB_HP_CAN_TX", &["CAN_TX"]),
                 ("USB_LP_CAN_RX0", &["CAN_RX0"]),
+                ("TIM6_DAC", &["TIM6", "DAC"]),
             ];
             let mut header_name = name.clone();
             if !exists_irq.contains(&name) {


### PR DESCRIPTION
stm32-data-gen trace:

before:

```
 TRACE stm32_data_gen::interrupts > parsing interrupts for chip STM32L051R8 core cm0p
 ...
 TRACE stm32_data_gen::interrupts >   irq="TIM6_DAC_IRQn:Y,2V:TIM6,DAC:TIM6,DAC:"
 TRACE stm32_data_gen::interrupts >     name=TIM6_DAC
 TRACE stm32_data_gen::interrupts >     irq missing in C header, ignoring
 ...
```

after:

```
 TRACE stm32_data_gen::interrupts > parsing interrupts for chip STM32L051R8 core cm0p
 ...
 TRACE stm32_data_gen::interrupts >   irq="TIM6_DAC_IRQn:Y,2V:TIM6,DAC:TIM6,DAC:"
 TRACE stm32_data_gen::interrupts >     name=TIM6_DAC
 TRACE stm32_data_gen::interrupts >     peri_names: ["TIM6", "DAC"]
 TRACE stm32_data_gen::interrupts >     part=TIM6
 TRACE stm32_data_gen::interrupts >     part=TIM6, pp=["TIM6"]
 TRACE stm32_data_gen::interrupts >     part=DAC
 TRACE stm32_data_gen::interrupts >     part=DAC, pp=["DAC"]
 TRACE stm32_data_gen::interrupts >     signal: DAC GLOBAL
 TRACE stm32_data_gen::interrupts >     signal: TIM6 BRK
 TRACE stm32_data_gen::interrupts >     signal: TIM6 UP
 TRACE stm32_data_gen::interrupts >     signal: TIM6 TRG
 TRACE stm32_data_gen::interrupts >     signal: TIM6 COM
 TRACE stm32_data_gen::interrupts >     signal: TIM6 CC
 ...
```