### PR TITLE
fix enum name collision, correct bit size and value

### DIFF
--- a/data/registers/syscfg_f3.yaml
+++ b/data/registers/syscfg_f3.yaml
@@ -60,7 +60,7 @@ fieldset/CFGR1:
     description: ADC24 DMA remapping bit
     bit_offset: 8
     bit_size: 1
-    enum: ADC2_DMA_RMP
+    enum: ADC2_DMA_RMP_CFGR1
   - name: TIM16_DMA_RMP
     description: TIM16 DMA request remapping bit
     bit_offset: 11
@@ -217,7 +217,7 @@ fieldset/CFGR3:
     description: ADC2 DMA remapping bit
     bit_offset: 8
     bit_size: 2
-    enum: ADC2_DMA_RMP
+    enum: ADC2_DMA_RMP_CFGR3
   - name: DAC1_TRIG3_RMP
     description: DAC1_CH1 / DAC1_CH2 Trigger remap
     bit_offset: 16
@@ -393,12 +393,18 @@ enum/ADC12_JEXT6_RMP:
   - name: Tim20
     description: Trigger source is TIM20_TRGO2
     value: 1
-enum/ADC2_DMA_RMP:
+enum/ADC2_DMA_RMP_CFGR1:
   bit_size: 1
   variants:
-  - name: MapDma2
-    description: ADC2 mapped on DMA2
-    value: 0
+  - name: NotRemapped
+    description: ADC24 DMA requests mapped on DMA2 channels 1 and 2
+    value: 2
+  - name: Remapped
+    description: ADC24 DMA requests mapped on DMA2 channels 3 and 4
+    value: 3
+enum/ADC2_DMA_RMP_CFGR3:
+  bit_size: 2
+  variants:
   - name: MapDma1Ch2
     description: ADC2 mapped on DMA1 channel 2
     value: 2


### PR DESCRIPTION
the collision happens inside RM0316, and among RM0364, RM0365 and RM0316.