### PR TITLE
Update U5 Octospi mapping

### DIFF
--- a/stm32-data-gen/src/chips.rs
+++ b/stm32-data-gen/src/chips.rs
@@ -500,7 +500,11 @@ impl PeriMatcher {
                 ("octospi", "v1", "OCTOSPI"),
             ),
             (
-                "STM32U5.*:OCTOSPI[12]:OCTOSPI:octospi1_v3_0.*",
+                "STM32U5[34].*:OCTOSPI[12]:OCTOSPI:octospi_v1_0L5.*",
+                ("octospi", "v1", "OCTOSPI"),
+            ),
+            (
+                "STM32U5[AFG789].*:OCTOSPI[12]:OCTOSPI:octospi1_v3_0.*",
                 ("octospi", "v1", "OCTOSPI"),
             ),
             (


### PR DESCRIPTION
Update the PERIMAP to correctly associate the U535 and U545 chips with the appropriate version of the octospi implementation. These two sub-families use a different implementation than the rest of the U5 set of chips leading from the fact that only a single octospi peripheral is available on these chips, rather than two with the others.