### PR TITLE
Fix octospi base register address mapping

### DIFF
--- a/stm32-data-gen/src/header.rs
+++ b/stm32-data-gen/src/header.rs
@@ -162,6 +162,14 @@ impl Defines {
             ("DBGMCU", &["DBGMCU_BASE", "DBG_BASE"]),
             ("QUADSPI", &["QUADSPI_BASE", "QSPI_R", "QSPI_R_BASE", "QSPI_REG_BASE"]),
             ("QUADSPI1", &["QUADSPI1_BASE", "QSPI_R", "QSPI_R_BASE", "QSPI_REG_BASE"]),
+            (
+                "OCTOSPI",
+                &["OSPI_R", "OCTOSPI_R_BASE", "OCTOSPI_R_BASE_NS", "OCTOSPI_REG_BASE"],
+            ),
+            (
+                "OCTOSPI1",
+                &["OSPI_R", "OCTOSPI1_R_BASE", "OCTOSPI1_R_BASE_NS", "OCTOSPI1_REG_BASE"],
+            ),
             ("FLASH", &["FLASH_R_BASE", "FLASH_REG_BASE"]),
             (
                 "ADC_COMMON",


### PR DESCRIPTION
The generated octospi register block is being mapped to the memory mapped section (specifically for the U5 chips, need additional validation for other families). The correct register address for the peripheral requires an addition to the alternate peripheral mappings.