### PR TITLE
Fix register address mapping

### DIFF
--- a/stm32-data-gen/src/header.rs
+++ b/stm32-data-gen/src/header.rs
@@ -162,6 +162,14 @@ impl Defines {
             ("DBGMCU", &["DBGMCU_BASE", "DBG_BASE"]),
             ("QUADSPI", &["QUADSPI_BASE", "QSPI_R", "QSPI_R_BASE", "QSPI_REG_BASE"]),
             ("QUADSPI1", &["QUADSPI1_BASE", "QSPI_R", "QSPI_R_BASE", "QSPI_REG_BASE"]),
+            (
+                "OCTOSPI",
+                &["OSPI_R", "OCTOSPI_R_BASE", "OCTOSPI_R_BASE_NS", "OCTOSPI_REG_BASE"],
+            ),
+            (
+                "OCTOSPI1",
+                &["OSPI_R", "OCTOSPI1_R_BASE", "OCTOSPI1_R_BASE_NS", "OCTOSPI1_REG_BASE"],
+            ),
             ("FLASH", &["FLASH_R_BASE", "FLASH_REG_BASE"]),
             (
                 "ADC_COMMON",


### PR DESCRIPTION
Octospi peripheral register address is getting set to the memory-mapped region for the U5 family. This alternate mapping for the peripheral corrects the register address that is generated.