### PR TITLE
Fix UART definitions present in STM32F1 series

### DIFF
--- a/stm32-data-gen/src/chips.rs
+++ b/stm32-data-gen/src/chips.rs
@@ -122,6 +122,7 @@ impl PeriMatcher {
             (".*:USART:sci3_v1_2", ("usart", "v4", "USART")),
             (".*:USART:sci3_v2_0", ("usart", "v4", "USART")),
             (".*:USART:sci3_v2_1", ("usart", "v4", "USART")),
+            (".*:UART:sci2_v1_1", ("usart", "v1", "USART")),
             (".*:UART:sci2_v1_2_F4", ("usart", "v2", "USART")),
             (".*:UART:sci2_v2_1", ("usart", "v3", "USART")),
             (".*:UART:sci2_v3_0", ("usart", "v4", "USART")),


### PR DESCRIPTION
perimap was missing for {UART, sci2_v1_1} target.

For instance, for STM32F103RC, taking the [STM32F103RC.json](https://github.com/embassy-rs/stm32-data-generated/blob/5f9a4a68c94a629409c5039c20ca1a7961347bed/data/chips/STM32F103RC.json#L2246);

Before:
```
{
    "name": "UART4",
    "address": 1073761280,
    "rcc": {
    [...]
```
After:
```
  {
      "name": "UART4",
      "address": 1073761280,
      "registers": {
          "kind": "usart",
          "version": "v1",
          "block": "USART"
      },
      "rcc": {
      [...]
```          