### PR TITLE
Corrected hash STR register to RW

### DIFF
--- a/data/registers/hash_v1.yaml
+++ b/data/registers/hash_v1.yaml
@@ -1,113 +1,112 @@
 block/HASH:
   description: Hash processor.
   items:
-  - name: CR
-    description: control register.
-    byte_offset: 0
-    fieldset: CR
-  - name: DIN
-    description: data input register.
-    byte_offset: 4
-    access: Write
-  - name: STR
-    description: start register.
-    byte_offset: 8
-    access: Write
-    fieldset: STR
-  - name: HR
-    description: digest registers.
-    array:
-      len: 5
-      stride: 4
-    byte_offset: 12
-    access: Read
-  - name: IMR
-    description: interrupt enable register.
-    byte_offset: 32
-    fieldset: IMR
-  - name: SR
-    description: status register.
-    byte_offset: 36
-    fieldset: SR
-  - name: CSR
-    description: context swap registers.
-    array:
-      len: 51
-      stride: 4
-    byte_offset: 248
+    - name: CR
+      description: control register.
+      byte_offset: 0
+      fieldset: CR
+    - name: DIN
+      description: data input register.
+      byte_offset: 4
+      access: Write
+    - name: STR
+      description: start register.
+      byte_offset: 8
+      fieldset: STR
+    - name: HR
+      description: digest registers.
+      array:
+        len: 5
+        stride: 4
+      byte_offset: 12
+      access: Read
+    - name: IMR
+      description: interrupt enable register.
+      byte_offset: 32
+      fieldset: IMR
+    - name: SR
+      description: status register.
+      byte_offset: 36
+      fieldset: SR
+    - name: CSR
+      description: context swap registers.
+      array:
+        len: 51
+        stride: 4
+      byte_offset: 248
 fieldset/CR:
   description: control register.
   fields:
-  - name: INIT
-    description: Initialize message digest calculation.
-    bit_offset: 2
-    bit_size: 1
-  - name: DMAE
-    description: DMA enable.
-    bit_offset: 3
-    bit_size: 1
-  - name: DATATYPE
-    description: Data type selection.
-    bit_offset: 4
-    bit_size: 2
-  - name: MODE
-    description: Mode selection.
-    bit_offset: 6
-    bit_size: 1
-  - name: ALGO
-    description: Algorithm selection.
-    bit_offset: 7
-    bit_size: 1
-  - name: NBW
-    description: Number of words already pushed.
-    bit_offset: 8
-    bit_size: 4
-  - name: DINNE
-    description: DIN not empty.
-    bit_offset: 12
-    bit_size: 1
-  - name: LKEY
-    description: Long key selection.
-    bit_offset: 16
-    bit_size: 1
+    - name: INIT
+      description: Initialize message digest calculation.
+      bit_offset: 2
+      bit_size: 1
+    - name: DMAE
+      description: DMA enable.
+      bit_offset: 3
+      bit_size: 1
+    - name: DATATYPE
+      description: Data type selection.
+      bit_offset: 4
+      bit_size: 2
+    - name: MODE
+      description: Mode selection.
+      bit_offset: 6
+      bit_size: 1
+    - name: ALGO
+      description: Algorithm selection.
+      bit_offset: 7
+      bit_size: 1
+    - name: NBW
+      description: Number of words already pushed.
+      bit_offset: 8
+      bit_size: 4
+    - name: DINNE
+      description: DIN not empty.
+      bit_offset: 12
+      bit_size: 1
+    - name: LKEY
+      description: Long key selection.
+      bit_offset: 16
+      bit_size: 1
 fieldset/IMR:
   description: interrupt enable register.
   fields:
-  - name: DINIE
-    description: Data input interrupt enable.
-    bit_offset: 0
-    bit_size: 1
-  - name: DCIE
-    description: Digest calculation completion interrupt enable.
-    bit_offset: 1
-    bit_size: 1
+    - name: DINIE
+      description: Data input interrupt enable.
+      bit_offset: 0
+      bit_size: 1
+    - name: DCIE
+      description: Digest calculation completion interrupt enable.
+      bit_offset: 1
+      bit_size: 1
 fieldset/SR:
   description: status register.
   fields:
-  - name: DINIS
-    description: Data input interrupt status.
-    bit_offset: 0
-    bit_size: 1
-  - name: DCIS
-    description: Digest calculation completion interrupt status.
-    bit_offset: 1
-    bit_size: 1
-  - name: DMAS
-    description: DMA Status.
-    bit_offset: 2
-    bit_size: 1
-  - name: BUSY
-    description: Busy bit.
-    bit_offset: 3
-    bit_size: 1
+    - name: DINIS
+      description: Data input interrupt status.
+      bit_offset: 0
+      bit_size: 1
+    - name: DCIS
+      description: Digest calculation completion interrupt status.
+      bit_offset: 1
+      bit_size: 1
+    - name: DMAS
+      description: DMA Status.
+      bit_offset: 2
+      bit_size: 1
+    - name: BUSY
+      description: Busy bit.
+      bit_offset: 3
+      bit_size: 1
 fieldset/STR:
   description: start register.
   fields:
-  - name: NBLW
-    description: Number of valid bits in the last word of the message.
-    bit_offset: 0
-    bit_size: 5
-  - name: DCAL
-    description: Digest calculation.
-    bit_offset: 8
-    bit_size: 1
+    - name: NBLW
+      description: Number of valid bits in the last word of the message.
+      bit_offset: 0
+      bit_size: 5
+    - name: DCAL
+      description: Digest calculation.
+      bit_offset: 8
+      bit_size: 1


### PR DESCRIPTION
The hash STR register is typically write-only, but for context-restoring use it is necessary to be able to read this register. This PR marks the STR register in the v1 config as read/write, matching the other configs.