### PR TITLE
Corrected hash v3 register arrays

### DIFF
--- a/data/registers/hash_v3.yaml
+++ b/data/registers/hash_v3.yaml
@@ -31,13 +31,13 @@ block/HASH:
   - name: CSR
     description: context swap registers.
     array:
-      len: 54
+      len: 103
       stride: 4
     byte_offset: 248
   - name: HR
     description: HASH digest register.
     array:
-      len: 8
+      len: 16
       stride: 4
     byte_offset: 784
     access: Read


### PR DESCRIPTION
The lengths for CSR and HR register arrays are incorrect in the v3 hash implementation.