### PR TITLE
Add OCTOSPI1 register bits

### DIFF
--- a/data/registers/rcc_h7.yaml
+++ b/data/registers/rcc_h7.yaml
@@ -558,6 +558,10 @@ fieldset/AHB3ENR:
     description: QUADSPI and QUADSPI Delay Clock Enable
     bit_offset: 14
     bit_size: 1
+  - name: OCTOSPI1EN
+    description: OCTOSPI2 and OCTOSPI2 delay block enable
+    bit_offset: 14
+    bit_size: 1
   - name: SDMMC1EN
     description: SDMMC1 and SDMMC1 Delay Clock Enable
     bit_offset: 16
@@ -621,6 +625,10 @@ fieldset/AHB3LPENR:
     description: QUADSPI and QUADSPI Delay Clock Enable During CSleep Mode
     bit_offset: 14
     bit_size: 1
+  - name: OCTOSPI1LPEN
+    description: OCTOSPI1 and OCTOSPI1 delay block enable during CSleep Mode
+    bit_offset: 14
+    bit_size: 1
   - name: SDMMC1LPEN
     description: SDMMC1 and SDMMC1 Delay Clock Enable During CSleep Mode
     bit_offset: 16
@@ -678,6 +686,10 @@ fieldset/AHB3RSTR:
     bit_size: 1
   - name: QUADSPIRST
     description: QUADSPI and QUADSPI delay block reset
+    bit_offset: 14
+    bit_size: 1
+  - name: OCTOSPI1RST
+    description: OCTOSPI1 and OCTOSPI1 delay block reset
     bit_offset: 14
     bit_size: 1
   - name: SDMMC1RST
@@ -3052,6 +3064,11 @@ fieldset/D1CCIPR:
     enum: FMCSEL
   - name: QUADSPISEL
     description: QUADSPI kernel clock source selection
+    bit_offset: 4
+    bit_size: 2
+    enum: FMCSEL
+  - name: OCTOSPISEL
+    description: OCTOSPI kernel clock source selection
     bit_offset: 4
     bit_size: 2
     enum: FMCSEL


### PR DESCRIPTION
Those were previously only called QUADSPI, which is needed on some chips like the STM32H745, but those bits are used as OCTOSPI1 bits on other chips like the STM32H723.

Should fix #384 