### PR TITLE
Add SYSCFG_UR18 register

### DIFF
--- a/data/registers/syscfg_h7.yaml
+++ b/data/registers/syscfg_h7.yaml
@@ -112,6 +112,11 @@ block/SYSCFG:
     byte_offset: 836
     access: Read
     fieldset: UR17
+  - name: UR18
+    description: SYSCFG user register 18
+    byte_offset: 840
+    access: Read
+    fieldset: UR18
 fieldset/CCCR:
   description: SYSCFG compensation cell code register
   fields:
@@ -314,6 +319,13 @@ fieldset/UR17:
   fields:
   - name: IO_HSLV
     description: I/O high speed / low voltage
+    bit_offset: 0
+    bit_size: 1
+fieldset/UR18:
+  description: SYSCFG user register 18
+  fields:
+  - name: CPU_FREQ_BOOST
+    description: CPU maximum frequency boost enable
     bit_offset: 0
     bit_size: 1
 fieldset/UR2:


### PR DESCRIPTION
Not sure if this is read-only or read-write, I couldn't find any info in the reference manual. I just marked it as read-only as that's what the other syscfg register was marked as.

Fixes #385 