### PR TITLE
Add HASH v4

### DIFF
--- a/data/registers/hash_v4.yaml
+++ b/data/registers/hash_v4.yaml
@@ -1,0 +1,134 @@
+block/HASH:
+  description: Hash processor.
+  items:
+  - name: CR
+    description: control register.
+    byte_offset: 0
+    fieldset: CR
+  - name: DIN
+    description: data input register.
+    byte_offset: 4
+    access: Write
+  - name: STR
+    description: start register.
+    byte_offset: 8
+    fieldset: STR
+  - name: HRA
+    description: digest registers.
+    array:
+      len: 5
+      stride: 4
+    byte_offset: 12
+  - name: IMR
+    description: interrupt enable register.
+    byte_offset: 32
+    fieldset: IMR
+  - name: SR
+    description: status register.
+    byte_offset: 36
+    fieldset: SR
+  - name: CSR
+    description: context swap registers.
+    array:
+      len: 54
+      stride: 4
+    byte_offset: 248
+  - name: HR
+    description: HASH digest register.
+    array:
+      len: 8
+      stride: 4
+    byte_offset: 784
+    access: Read
+fieldset/CR:
+  description: control register.
+  fields:
+  - name: INIT
+    description: Initialize message digest calculation.
+    bit_offset: 2
+    bit_size: 1
+  - name: DMAE
+    description: DMA enable.
+    bit_offset: 3
+    bit_size: 1
+  - name: DATATYPE
+    description: Data type selection.
+    bit_offset: 4
+    bit_size: 2
+  - name: MODE
+    description: Mode selection.
+    bit_offset: 6
+    bit_size: 1
+  - name: NBW
+    description: Number of words already pushed.
+    bit_offset: 8
+    bit_size: 4
+  - name: DINNE
+    description: DIN not empty.
+    bit_offset: 12
+    bit_size: 1
+  - name: MDMAT
+    description: Multiple DMA Transfers.
+    bit_offset: 13
+    bit_size: 1
+  - name: LKEY
+    description: Long key selection.
+    bit_offset: 16
+    bit_size: 1
+  - name: ALGO
+    description: Algorithm selection.
+    bit_offset: 17
+    bit_size: 2
+fieldset/IMR:
+  description: interrupt enable register.
+  fields:
+  - name: DINIE
+    description: Data input interrupt enable.
+    bit_offset: 0
+    bit_size: 1
+  - name: DCIE
+    description: Digest calculation completion interrupt enable.
+    bit_offset: 1
+    bit_size: 1
+fieldset/SR:
+  description: status register.
+  fields:
+  - name: DINIS
+    description: Data input interrupt status.
+    bit_offset: 0
+    bit_size: 1
+  - name: DCIS
+    description: Digest calculation completion interrupt status.
+    bit_offset: 1
+    bit_size: 1
+  - name: DMAS
+    description: DMA Status.
+    bit_offset: 2
+    bit_size: 1
+  - name: BUSY
+    description: Busy bit.
+    bit_offset: 3
+    bit_size: 1
+  - name: NBWP
+    description: Number of words already pushed.
+    bit_offset: 9
+    bit_size: 5
+  - name: DINNE
+    description: DIN not empty.
+    bit_offset: 15
+    bit_size: 1
+  - name: NBWE
+    description: Number of words expected.
+    bit_offset: 16
+    bit_size: 5
+fieldset/STR:
+  description: start register.
+  fields:
+  - name: NBLW
+    description: Number of valid bits in the last word of the message.
+    bit_offset: 0
+    bit_size: 5
+  - name: DCAL
+    description: Digest calculation.
+    bit_offset: 8
+    bit_size: 1

--- a/stm32-data-gen/src/chips.rs
+++ b/stm32-data-gen/src/chips.rs
@@ -530,6 +530,8 @@ impl PeriMatcher {
             ("STM32U5.*:ADF[12]:.*", ("adf", "v1", "ADF")),
             (".*:HASH:hash1_v1_0", ("hash", "v1", "HASH")),
             (".*:HASH:hash1_v2_0", ("hash", "v2", "HASH")),
+            ("STM32U5.*:HASH:.*", ("hash", "v4", "HASH")),
+            ("STM32WBA.*:HASH:.*", ("hash", "v4", "HASH")),
             (".*:HASH:hash1_v2_2", ("hash", "v2", "HASH")),
             (".*:HASH:hash1_v4_0", ("hash", "v3", "HASH")),
         ];


### PR DESCRIPTION
This change applies to the STM32U5 and STM32WBA series. Despite having the same ST IP version, these series have a minor change to the mapping of ALGO bits compared to v2. They also add the read-only field NBWP. 