### PR TITLE
adc h5 improving

### DIFF
--- a/data/registers/adc_h5.yaml
+++ b/data/registers/adc_h5.yaml
@@ -135,6 +135,7 @@ fieldset/CFGR:
     description: 'Direct memory access configuration This bit is set and cleared by software to select between two DMA modes of operation and is effective only when DMAEN = 1. For more details, refer to Note: The software is allowed to write this bit only when ADSTART = 0 and JADSTART = 0 (which ensures that no conversion is ongoing).'
     bit_offset: 1
     bit_size: 1
+    enum: DMACFG
   - name: RES
     description: 'Data resolution These bits are written by software to select the resolution of the conversion. Note: The software is allowed to write these bits only when ADSTART = 0 and JADSTART = 0 (which ensures that no conversion is ongoing).'
     bit_offset: 3
@@ -156,10 +157,12 @@ fieldset/CFGR:
     description: 'Overrun mode This bit is set and cleared by software and configure the way data overrun is managed. Note: The software is allowed to write this bit only when ADSTART = 0 (which ensures that no regular conversion is ongoing).'
     bit_offset: 12
     bit_size: 1
+    enum: OVRMOD
   - name: CONT
     description: 'Single / Continuous conversion mode for regular conversions This bit is set and cleared by software. If it is set, regular conversion takes place continuously until it is cleared. Note: It is not possible to have both Discontinuous mode and Continuous mode enabled: it is forbidden to set both DISCEN = 1 and CONT = 1. The software is allowed to write this bit only when ADSTART = 0 (which ensures that no regular conversion is ongoing).'
     bit_offset: 13
     bit_size: 1
+    enum: CONT
   - name: AUTDLY
     description: 'Delayed conversion mode This bit is set and cleared by software to enable/disable the Auto Delayed Conversion mode.. Note: The software is allowed to write this bit only when ADSTART = 0 and JADSTART = 0 (which ensures that no conversion is ongoing).'
     bit_offset: 14
@@ -168,6 +171,7 @@ fieldset/CFGR:
     description: 'Data alignment This bit is set and cleared by software to select right or left alignment. Refer to register, data alignment and offset (ADC_DR, OFFSET, OFFSET_CH, ALIGN). Note: The software is allowed to write this bit only when ADSTART = 0 and JADSTART = 0 (which ensures that no conversion is ongoing).'
     bit_offset: 15
     bit_size: 1
+    enum: ALIGN
   - name: DISCEN
     description: 'Discontinuous mode for regular channels This bit is set and cleared by software to enable/disable Discontinuous mode for regular channels. Note: It is not possible to have both Discontinuous mode and Continuous mode enabled: it is forbidden to set both DISCEN = 1 and CONT = 1. It is not possible to use both auto-injected mode and Discontinuous mode simultaneously: the bits DISCEN and JDISCEN must be kept cleared by software when JAUTO is set. The software is allowed to write this bit only when ADSTART = 0 (which ensures that no regular conversion is ongoing).'
     bit_offset: 16
@@ -184,10 +188,12 @@ fieldset/CFGR:
     description: 'JSQR queue mode This bit is set and cleared by software. It defines how an empty Queue is managed. Refer to for more information. Note: The software is allowed to write this bit only when JADSTART = 0 (which ensures that no injected conversion is ongoing).'
     bit_offset: 21
     bit_size: 1
+    enum: JQM
   - name: AWD1SGL
     description: 'Enable the watchdog 1 on a single channel or on all channels This bit is set and cleared by software to enable the analog watchdog on the channel identified by the AWD1CH[4:0] bits or on all the channels Note: The software is allowed to write these bits only when ADSTART = 0 and JADSTART = 0 (which ensures that no conversion is ongoing).'
     bit_offset: 22
     bit_size: 1
+    enum: AWD1SGL
   - name: AWD1EN
     description: 'Analog watchdog 1 enable on regular channels This bit is set and cleared by software Note: The software is allowed to write this bit only when ADSTART = 0 (which ensures that no regular conversion is ongoing).'
     bit_offset: 23
@@ -232,14 +238,17 @@ fieldset/CFGR2:
     description: 'Triggered Regular Oversampling This bit is set and cleared by software to enable triggered oversampling Note: The software is allowed to write this bit only when ADSTART = 0 (which ensures that no conversion is ongoing).'
     bit_offset: 9
     bit_size: 1
+    enum: TROVS
   - name: ROVSM
     description: 'Regular Oversampling mode This bit is set and cleared by software to select the regular oversampling mode. Note: The software is allowed to write this bit only when ADSTART = 0 (which ensures that no conversion is ongoing).'
     bit_offset: 10
     bit_size: 1
+    enum: ROVSM
   - name: SWTRIG
     description: 'Software trigger bit for sampling time control trigger mode This bit is set and cleared by software to enable the bulb sampling mode. Note: The software is allowed to write this bit only when ADSTART = 0 (which ensures that no conversion is ongoing).'
     bit_offset: 25
     bit_size: 1
+    enum: SWTRIG
   - name: BULB
     description: 'Bulb sampling mode This bit is set and cleared by software to enable the bulb sampling mode. SAMPTRIG bit must not be set when the BULB bit is set. The very first ADC conversion is performed with the sampling time specified in SMPx bits. Note: The software is allowed to write this bit only when ADSTART = 0 (which ensures that no conversion is ongoing).'
     bit_offset: 26
@@ -287,6 +296,7 @@ fieldset/CR:
     description: 'Differential mode for calibration This bit is set and cleared by software to configure the Single-ended or Differential inputs mode for the calibration. Note: The software is allowed to write this bit only when the ADC is disabled and is not calibrating (ADCAL = 0, JADSTART = 0, JADSTP = 0, ADSTART = 0, ADSTP = 0, ADDIS = 0 and ADEN = 0).'
     bit_offset: 30
     bit_size: 1
+    enum: ADCALDIF
   - name: ADCAL
     description: 'ADC calibration This bit is set by software to start the calibration of the ADC. Program first the bit ADCALDIF to determine if this calibration applies for Single-ended or Differential inputs mode. It is cleared by hardware after calibration is complete. Note: The software is allowed to launch a calibration by setting ADCAL only when ADEN = 0. The software is allowed to update the calibration factor by writing ADC_CALFACT only when ADEN = 1 and ADSTART = 0 and JADSTART = 0 (ADC enabled and no conversion is ongoing).'
     bit_offset: 31
@@ -411,6 +421,7 @@ fieldset/JSQR:
     description: 'External trigger enable and polarity selection for injected channels These bits are set and cleared by software to select the external trigger polarity and enable the trigger of an injected group. Note: The software is allowed to write these bits only when JADSTART = 0 (which ensures that no injected conversion is ongoing). If JQM = 1 and if the Queue of Context becomes empty, the software and hardware triggers of the injected sequence are both internally disabled (refer to Queue of context for injected conversions).'
     bit_offset: 7
     bit_size: 2
+    enum: EXTEN
   - name: JSQ
     description: '1st-4th conversions in the injected sequence These bits are written by software with the channel number (0 to 19) assigned as the 1st-4th in the injected conversion sequence. Note: The software is allowed to write these bits only when JADSTART = 0 (which ensures that no injected conversion is ongoing).'
     bit_offset: 9
@@ -429,6 +440,7 @@ fieldset/OFR:
     description: 'Positive offset This bit is set and cleared by software to enable the positive offset. Note: The software is allowed to write these bits only when ADSTART = 0 and JADSTART = 0 (which ensures that no conversion is ongoing).'
     bit_offset: 24
     bit_size: 1
+    enum: OFFSETPOS
   - name: SATEN
     description: 'Saturation enable This bit is set and cleared by software to enable the saturation at 0x000 and 0xFFF for the offset function. Note: The software is allowed to write these bits only when ADSTART = 0 and JADSTART = 0 (which ensures that no conversion is ongoing).'
     bit_offset: 25
@@ -467,6 +479,7 @@ fieldset/SMPR1:
     description: Addition of one clock cycle to the sampling time. To make sure no conversion is ongoing, the software is allowed to write this bit only when ADSTART = 0 and JADSTART = 0
     bit_offset: 31
     bit_size: 1
+    enum: SMPPLUS
 fieldset/SMPR2:
   description: sample time register 2
   fields:
@@ -559,6 +572,51 @@ fieldset/TR3:
     description: 'Analog watchdog 3 higher threshold These bits are written by software to define the higher threshold for the analog watchdog 3. Refer to AWD2CH, AWD3CH, AWD_HTx, AWD_LTx, AWDx) Note: The software is allowed to write these bits only when ADSTART = 0 and JADSTART = 0 (which ensures that no conversion is ongoing).'
     bit_offset: 16
     bit_size: 8
+enum/ADCALDIF:
+  bit_size: 1
+  variants:
+  - name: SingleEnded
+    description: Calibration for single-ended mode
+    value: 0
+  - name: Differential
+    description: Calibration for differential mode
+    value: 1
+enum/ALIGN:
+  bit_size: 1
+  variants:
+  - name: Right
+    description: Right alignment
+    value: 0
+  - name: Left
+    description: Left alignment
+    value: 1
+enum/AWD1SGL:
+  bit_size: 1
+  variants:
+  - name: All
+    description: Analog watchdog 1 enabled on all channels
+    value: 0
+  - name: Single
+    description: Analog watchdog 1 enabled on single channel selected in AWD1CH
+    value: 1
+enum/CONT:
+  bit_size: 1
+  variants:
+  - name: Single
+    description: Single conversion mode
+    value: 0
+  - name: Continuous
+    description: Continuous conversion mode
+    value: 1
+enum/DMACFG:
+  bit_size: 1
+  variants:
+  - name: OneShot
+    description: DMA One Shot mode selected
+    value: 0
+  - name: Circular
+    description: DMA Circular mode selected
+    value: 1
 enum/EXTEN:
   bit_size: 2
   variants:
@@ -574,72 +632,127 @@ enum/EXTEN:
   - name: BothEdges
     description: Hardware trigger detection on both the rising and falling edge
     value: 3
+enum/JQM:
+  bit_size: 1
+  variants:
+  - name: Mode0
+    description: 'JSQR Mode 0: Queue maintains the last written configuration into JSQR'
+    value: 0
+  - name: Mode1
+    description: 'JSQR Mode 1: An empty queue disables software and hardware triggers of the injected sequence'
+    value: 1
+enum/OFFSETPOS:
+  bit_size: 1
+  variants:
+  - name: Negative
+    description: Negative offset
+    value: 0
+  - name: Positive
+    description: Positive offset
+    value: 1
+enum/OVRMOD:
+  bit_size: 1
+  variants:
+  - name: Preserve
+    description: Preserve DR register when an overrun is detected
+    value: 0
+  - name: Overwrite
+    description: Overwrite DR register when an overrun is detected
+    value: 1
 enum/OVSR:
   bit_size: 3
   variants:
   - name: x2
-    description: x2
     value: 0
   - name: x4
-    description: x4
     value: 1
   - name: x8
-    description: x8
     value: 2
   - name: x16
-    description: x16
     value: 3
   - name: x32
-    description: x32
     value: 4
   - name: x64
-    description: x64
     value: 5
   - name: x128
-    description: x128
     value: 6
   - name: x256
-    description: x256
     value: 7
 enum/RES:
   bit_size: 2
   variants:
-  - name: TwelveBit
+  - name: Bits12
     description: 12-bit resolution
     value: 0
-  - name: TenBit
+  - name: Bits10
     description: 10-bit resolution
     value: 1
-  - name: EightBit
+  - name: Bits8
     description: 8-bit resolution
     value: 2
-  - name: SixBit
+  - name: Bits6
     description: 6-bit resolution
     value: 3
+enum/ROVSM:
+  bit_size: 1
+  variants:
+  - name: Continued
+    description: Oversampling is temporary stopped and continued after injection sequence
+    value: 0
+  - name: Resumed
+    description: Oversampling is aborted and resumed from start after injection sequence
+    value: 1
 enum/SAMPLE_TIME:
   bit_size: 3
   variants:
   - name: Cycles2_5
-    description: 2.5 ADC cycles
+    description: 2.5 ADC clock cycles
     value: 0
   - name: Cycles6_5
-    description: 6.5 ADC cycles
+    description: 6.5 ADC clock cycles
     value: 1
   - name: Cycles12_5
-    description: 12.5 ADC cycles
+    description: 12.5 ADC clock cycles
     value: 2
   - name: Cycles24_5
-    description: 24.5 ADC cycles
+    description: 24.5 ADC clock cycles
     value: 3
   - name: Cycles47_5
-    description: 47.5 ADC cycles
+    description: 47.5 ADC clock cycles
     value: 4
   - name: Cycles92_5
-    description: 92.5 ADC cycles
+    description: 92.5 ADC clock cycles
     value: 5
   - name: Cycles247_5
-    description: 247.5 ADC cycles
+    description: 247.5 ADC clock cycles
     value: 6
   - name: Cycles640_5
-    description: 640.5 ADC cycles
+    description: 640.5 ADC clock cycles
     value: 7
+enum/SMPPLUS:
+  bit_size: 1
+  variants:
+  - name: Cycles2_5
+    description: The sampling time remains set to 2.5 ADC clock cycles remains
+    value: 0
+  - name: Cycles3_5
+    description: 2.5 ADC clock cycle sampling time becomes 3.5 ADC clock cycles for the ADC_SMPR1 and ADC_SMPR2 registers.
+    value: 1
+enum/SWTRIG:
+  bit_size: 1
+  variants:
+  - name: Conversion
+    description: Software trigger starts the conversion for sampling time control trigger mode
+    value: 0
+  - name: Sampling
+    description: Software trigger starts the sampling for sampling time control trigger mode
+    value: 1
+enum/TROVS:
+  bit_size: 1
+  variants:
+  - name: Automatic
+    description: All oversampled conversions for a channel are run following a trigger
+    value: 0
+  - name: Triggered
+    description: Each oversampled conversion for a channel needs a new trigger
+    value: 1

--- a/data/registers/adc_h5.yaml
+++ b/data/registers/adc_h5.yaml
@@ -78,7 +78,6 @@ block/ADC:
       len: 4
       stride: 4
     byte_offset: 128
-    # access: Read
     fieldset: JDR
   - name: AWD2CR
     description: Analog Watchdog 2 Configuration Register
@@ -460,10 +459,10 @@ fieldset/SMPR1:
     description: 'Channel 0-9 sampling time selection These bits are written by software to select the sampling time individually for each channel. During sample cycles, the channel selection bits must remain unchanged. Note: The software is allowed to write these bits only when ADSTART = 0 and JADSTART = 0 (which ensures that no conversion is ongoing). Some channels are not connected physically. Keep the corresponding SMPx[2:0] setting to the reset value.'
     bit_offset: 0
     bit_size: 3
-    enum: SAMPLE_TIME
     array:
       len: 10
       stride: 3
+    enum: SAMPLE_TIME
   - name: SMPPLUS
     description: Addition of one clock cycle to the sampling time. To make sure no conversion is ongoing, the software is allowed to write this bit only when ADSTART = 0 and JADSTART = 0
     bit_offset: 31
@@ -475,10 +474,10 @@ fieldset/SMPR2:
     description: 'Channel 10-19 sampling time selection These bits are written by software to select the sampling time individually for each channel. During sample cycles, the channel selection bits must remain unchanged. Note: The software is allowed to write these bits only when ADSTART = 0 and JADSTART = 0 (which ensures that no conversion is ongoing). Some channels are not connected physically. Keep the corresponding SMPx[2:0] setting to the reset value.'
     bit_offset: 0
     bit_size: 3
-    enum: SAMPLE_TIME
     array:
       len: 10
       stride: 3
+    enum: SAMPLE_TIME
 fieldset/SQR1:
   description: regular sequence register 1
   fields:
@@ -560,21 +559,6 @@ fieldset/TR3:
     description: 'Analog watchdog 3 higher threshold These bits are written by software to define the higher threshold for the analog watchdog 3. Refer to AWD2CH, AWD3CH, AWD_HTx, AWD_LTx, AWDx) Note: The software is allowed to write these bits only when ADSTART = 0 and JADSTART = 0 (which ensures that no conversion is ongoing).'
     bit_offset: 16
     bit_size: 8
-enum/RES:
-  bit_size: 2
-  variants:
-  - name: TwelveBit
-    description: 12-bit resolution
-    value: 0
-  - name: TenBit
-    description: 10-bit resolution
-    value: 1
-  - name: EightBit
-    description: 8-bit resolution
-    value: 2
-  - name: SixBit
-    description: 6-bit resolution
-    value: 3
 enum/EXTEN:
   bit_size: 2
   variants:
@@ -617,6 +601,21 @@ enum/OVSR:
   - name: x256
     description: x256
     value: 7
+enum/RES:
+  bit_size: 2
+  variants:
+  - name: TwelveBit
+    description: 12-bit resolution
+    value: 0
+  - name: TenBit
+    description: 10-bit resolution
+    value: 1
+  - name: EightBit
+    description: 8-bit resolution
+    value: 2
+  - name: SixBit
+    description: 6-bit resolution
+    value: 3
 enum/SAMPLE_TIME:
   bit_size: 3
   variants:

--- a/data/registers/adccommon_h5.yaml
+++ b/data/registers/adccommon_h5.yaml
@@ -29,6 +29,40 @@ block/ADC_COMMON:
     description: size identification register
     byte_offset: 252
     fieldset: SIDR
+fieldset/CCR:
+  description: common control register
+  fields:
+  - name: CKMODE
+    description: 'ADC clock mode These bits are set and cleared by software to define the ADC clock scheme (which is common to both master and slave ADCs): In all synchronous clock modes, there is no jitter in the delay from a timer trigger to the start of a conversion. Note: The software is allowed to write these bits only when the ADCs are disabled (ADCAL = 0, JADSTART = 0, ADSTART = 0, ADSTP = 0, ADDIS = 0 and ADEN = 0).'
+    bit_offset: 16
+    bit_size: 2
+  - name: PRESC
+    description: 'ADC prescaler These bits are set and cleared by software to select the frequency of the clock to the ADC. The clock is common for all the ADCs. other: reserved Note: The software is allowed to write these bits only when the ADC is disabled (ADCAL = 0, JADSTART = 0, ADSTART = 0, ADSTP = 0, ADDIS = 0 and ADEN = 0). The ADC prescaler value is applied only when CKMODE[1:0] = 0b00.'
+    bit_offset: 18
+    bit_size: 4
+  - name: VREFEN
+    description: VREFINT enable This bit is set and cleared by software to enable/disable the VREFINT channel
+    bit_offset: 22
+    bit_size: 1
+  - name: TSEN
+    description: VSENSE enable This bit is set and cleared by software to control VSENSE
+    bit_offset: 23
+    bit_size: 1
+  - name: VBATEN
+    description: VBAT enable This bit is set and cleared by software to control
+    bit_offset: 24
+    bit_size: 1
+fieldset/CDR:
+  description: common regular data register for dual mode
+  fields:
+  - name: RDATA_MST
+    description: Regular data of the master ADC. In dual mode, these bits contain the regular data of the master ADC. Refer to . The data alignment is applied as described in offset (ADC_DR, OFFSET, OFFSET_CH, ALIGN)) In MDMA = 0b11 mode, bits 15:8 contains SLV_ADC_DR[7:0], bits 7:0 contains MST_ADC_DR[7:0].
+    bit_offset: 0
+    bit_size: 16
+  - name: RDATA_SLV
+    description: Regular data of the slave ADC In dual mode, these bits contain the regular data of the slave ADC. Refer to Dual ADC modes. The data alignment is applied as described in offset (ADC_DR, OFFSET, OFFSET_CH, ALIGN)).
+    bit_offset: 16
+    bit_size: 16
 fieldset/CSR:
   description: common status register
   fields:
@@ -120,40 +154,6 @@ fieldset/CSR:
     description: Injected Context Queue Overflow flag of the slave ADC This bit is a copy of the JQOVF bit in the corresponding ADC_ISR register.
     bit_offset: 26
     bit_size: 1
-fieldset/CCR:
-  description: common control register
-  fields:
-  - name: CKMODE
-    description: 'ADC clock mode These bits are set and cleared by software to define the ADC clock scheme (which is common to both master and slave ADCs): In all synchronous clock modes, there is no jitter in the delay from a timer trigger to the start of a conversion. Note: The software is allowed to write these bits only when the ADCs are disabled (ADCAL = 0, JADSTART = 0, ADSTART = 0, ADSTP = 0, ADDIS = 0 and ADEN = 0).'
-    bit_offset: 16
-    bit_size: 2
-  - name: PRESC
-    description: 'ADC prescaler These bits are set and cleared by software to select the frequency of the clock to the ADC. The clock is common for all the ADCs. other: reserved Note: The software is allowed to write these bits only when the ADC is disabled (ADCAL = 0, JADSTART = 0, ADSTART = 0, ADSTP = 0, ADDIS = 0 and ADEN = 0). The ADC prescaler value is applied only when CKMODE[1:0] = 0b00.'
-    bit_offset: 18
-    bit_size: 4
-  - name: VREFEN
-    description: VREFINT enable This bit is set and cleared by software to enable/disable the VREFINT channel
-    bit_offset: 22
-    bit_size: 1
-  - name: TSEN
-    description: VSENSE enable This bit is set and cleared by software to control VSENSE
-    bit_offset: 23
-    bit_size: 1
-  - name: VBATEN
-    description: VBAT enable This bit is set and cleared by software to control
-    bit_offset: 24
-    bit_size: 1
-fieldset/CDR:
-  description: common regular data register for dual mode
-  fields:
-  - name: RDATA_MST
-    description: Regular data of the master ADC. In dual mode, these bits contain the regular data of the master ADC. Refer to . The data alignment is applied as described in offset (ADC_DR, OFFSET, OFFSET_CH, ALIGN)) In MDMA = 0b11 mode, bits 15:8 contains SLV_ADC_DR[7:0], bits 7:0 contains MST_ADC_DR[7:0].
-    bit_offset: 0
-    bit_size: 16
-  - name: RDATA_SLV
-    description: Regular data of the slave ADC In dual mode, these bits contain the regular data of the slave ADC. Refer to Dual ADC modes. The data alignment is applied as described in offset (ADC_DR, OFFSET, OFFSET_CH, ALIGN)).
-    bit_offset: 16
-    bit_size: 16
 fieldset/HWCFGR0:
   description: hardware configuration register
   fields:
@@ -173,17 +173,6 @@ fieldset/HWCFGR0:
     description: Idle value for non-selected channels
     bit_offset: 12
     bit_size: 4
-fieldset/VERR:
-  description: version register
-  fields:
-  - name: MINREV
-    description: 'Minor revision These bits returns the ADC IP minor revision 0002: Major revision = X.2.'
-    bit_offset: 0
-    bit_size: 4
-  - name: MAJREV
-    description: Major revision These bits returns the ADC IP major revision
-    bit_offset: 4
-    bit_size: 4
 fieldset/IPDR:
   description: identification register
   fields:
@@ -198,3 +187,14 @@ fieldset/SIDR:
     description: 'Size Identification SID[31:8]: fixed code that characterizes the ADC_SIDR register. This field is always read at 0xA3C5DD. SID[7:0]: read-only numeric field that returns the address offset (in Kbytes) of the identification registers from the IP base address:.'
     bit_offset: 0
     bit_size: 32
+fieldset/VERR:
+  description: version register
+  fields:
+  - name: MINREV
+    description: 'Minor revision These bits returns the ADC IP minor revision 0002: Major revision = X.2.'
+    bit_offset: 0
+    bit_size: 4
+  - name: MAJREV
+    description: Major revision These bits returns the ADC IP major revision
+    bit_offset: 4
+    bit_size: 4

--- a/data/registers/adccommon_h5.yaml
+++ b/data/registers/adccommon_h5.yaml
@@ -24,22 +24,41 @@ block/ADC_COMMON:
   - name: IPDR
     description: identification register
     byte_offset: 248
-    fieldset: IPDR
   - name: SIDR
     description: size identification register
     byte_offset: 252
-    fieldset: SIDR
 fieldset/CCR:
   description: common control register
   fields:
+  - name: DUAL
+    description: 'Dual ADC mode selection These bits are written by software to select the operating mode. 0 value means Independent Mode. Values 00001 to 01001 means Dual mode, master and slave ADCs are working together. All other combinations are reserved and must not be programmed Note: The software is allowed to write these bits only when the ADCs are disabled (ADCAL = 0, JADSTART = 0, ADSTART = 0, ADSTP = 0, ADDIS = 0 and ADEN = 0).'
+    bit_offset: 0
+    bit_size: 5
+    enum: DUAL
+  - name: DELAY
+    description: 'Delay between 2 sampling phases These bits are set and cleared by software. These bits are used in dual interleaved modes. Refer to for the value of ADC resolution versus DELAY bits values. Note: The software is allowed to write these bits only when the ADCs are disabled (ADCAL = 0, JADSTART = 0, ADSTART = 0, ADSTP = 0, ADDIS = 0 and ADEN = 0).'
+    bit_offset: 8
+    bit_size: 4
+  - name: DMACFG
+    description: 'DMA configuration (for dual ADC mode) This bit is set and cleared by software to select between two DMA modes of operation and is effective only when DMAEN = 1. For more details, refer to Note: The software is allowed to write these bits only when ADSTART = 0 (which ensures that no regular conversion is ongoing).'
+    bit_offset: 13
+    bit_size: 1
+    enum: DMACFG
+  - name: MDMA
+    description: 'Direct memory access mode for dual ADC mode This bitfield is set and cleared by software. Refer to the DMA controller section for more details. Note: The software is allowed to write these bits only when ADSTART = 0 (which ensures that no regular conversion is ongoing).'
+    bit_offset: 14
+    bit_size: 2
+    enum: MDMA
   - name: CKMODE
     description: 'ADC clock mode These bits are set and cleared by software to define the ADC clock scheme (which is common to both master and slave ADCs): In all synchronous clock modes, there is no jitter in the delay from a timer trigger to the start of a conversion. Note: The software is allowed to write these bits only when the ADCs are disabled (ADCAL = 0, JADSTART = 0, ADSTART = 0, ADSTP = 0, ADDIS = 0 and ADEN = 0).'
     bit_offset: 16
     bit_size: 2
+    enum: CKMODE
   - name: PRESC
     description: 'ADC prescaler These bits are set and cleared by software to select the frequency of the clock to the ADC. The clock is common for all the ADCs. other: reserved Note: The software is allowed to write these bits only when the ADC is disabled (ADCAL = 0, JADSTART = 0, ADSTART = 0, ADSTP = 0, ADDIS = 0 and ADEN = 0). The ADC prescaler value is applied only when CKMODE[1:0] = 0b00.'
     bit_offset: 18
     bit_size: 4
+    enum: PRESC
   - name: VREFEN
     description: VREFINT enable This bit is set and cleared by software to enable/disable the VREFINT channel
     bit_offset: 22
@@ -94,18 +113,13 @@ fieldset/CSR:
     description: End of injected sequence flag of the master ADC This bit is a copy of the JEOS bit in the corresponding ADC_ISR register.
     bit_offset: 6
     bit_size: 1
-  - name: AWD1_MST
+  - name: AWD_MST
     description: Analog watchdog 1 flag of the master ADC This bit is a copy of the AWD1 bit in the corresponding ADC_ISR register.
     bit_offset: 7
     bit_size: 1
-  - name: AWD2_MST
-    description: Analog watchdog 2 flag of the master ADC This bit is a copy of the AWD2 bit in the corresponding ADC_ISR register.
-    bit_offset: 8
-    bit_size: 1
-  - name: AWD3_MST
-    description: Analog watchdog 3 flag of the master ADC This bit is a copy of the AWD3 bit in the corresponding ADC_ISR register.
-    bit_offset: 9
-    bit_size: 1
+    array:
+      len: 3
+      stride: 1
   - name: JQOVF_MST
     description: Injected Context Queue Overflow flag of the master ADC This bit is a copy of the JQOVF bit in the corresponding ADC_ISR register.
     bit_offset: 10
@@ -138,18 +152,13 @@ fieldset/CSR:
     description: End of injected sequence flag of the slave ADC This bit is a copy of the JEOS bit in the corresponding ADC_ISR register.
     bit_offset: 22
     bit_size: 1
-  - name: AWD1_SLV
+  - name: AWD_SLV
     description: Analog watchdog 1 flag of the slave ADC This bit is a copy of the AWD1 bit in the corresponding ADC_ISR register.
     bit_offset: 23
     bit_size: 1
-  - name: AWD2_SLV
-    description: Analog watchdog 2 flag of the slave ADC This bit is a copy of the AWD2 bit in the corresponding ADC_ISR register.
-    bit_offset: 24
-    bit_size: 1
-  - name: AWD3_SLV
-    description: Analog watchdog 3 flag of the slave ADC This bit is a copy of the AWD3 bit in the corresponding ADC_ISR register.
-    bit_offset: 25
-    bit_size: 1
+    array:
+      len: 3
+      stride: 1
   - name: JQOVF_SLV
     description: Injected Context Queue Overflow flag of the slave ADC This bit is a copy of the JQOVF bit in the corresponding ADC_ISR register.
     bit_offset: 26
@@ -173,20 +182,7 @@ fieldset/HWCFGR0:
     description: Idle value for non-selected channels
     bit_offset: 12
     bit_size: 4
-fieldset/IPDR:
-  description: identification register
-  fields:
-  - name: ID
-    description: 'Peripheral identifier These bits returns the ADC identifier. ID[31:0] = 0x0011 0006: c7amba_aditf5_90_v1.'
-    bit_offset: 0
-    bit_size: 32
-fieldset/SIDR:
-  description: size identification register
-  fields:
-  - name: SID
-    description: 'Size Identification SID[31:8]: fixed code that characterizes the ADC_SIDR register. This field is always read at 0xA3C5DD. SID[7:0]: read-only numeric field that returns the address offset (in Kbytes) of the identification registers from the IP base address:.'
-    bit_offset: 0
-    bit_size: 32
+    enum: IDLEVALUE
 fieldset/VERR:
   description: version register
   fields:
@@ -198,3 +194,114 @@ fieldset/VERR:
     description: Major revision These bits returns the ADC IP major revision
     bit_offset: 4
     bit_size: 4
+enum/CKMODE:
+  bit_size: 2
+  variants:
+  - name: Asynchronous
+    description: Use Kernel Clock adc_ker_ck_input divided by PRESC. Asynchronous to AHB clock
+    value: 0
+  - name: SyncDiv1
+    description: Use AHB clock rcc_hclk3. In this case rcc_hclk must equal sys_d1cpre_ck
+    value: 1
+  - name: SyncDiv2
+    description: Use AHB clock rcc_hclk3 divided by 2
+    value: 2
+  - name: SyncDiv4
+    description: Use AHB clock rcc_hclk3 divided by 4
+    value: 3
+enum/DMACFG:
+  bit_size: 1
+  variants:
+  - name: OneShot
+    description: DMA One Shot mode selected
+    value: 0
+  - name: Circular
+    description: DMA Circular mode selected
+    value: 1
+enum/DUAL:
+  bit_size: 5
+  variants:
+  - name: Independent
+    description: Independent mode
+    value: 0
+  - name: DualRJ
+    description: Dual, combined regular simultaneous + injected simultaneous mode
+    value: 1
+  - name: DualRA
+    description: Dual, combined regular simultaneous + alternate trigger mode
+    value: 2
+  - name: DualIJ
+    description: Dual, combined interleaved mode + injected simultaneous mode
+    value: 3
+  - name: DualJ
+    description: Dual, injected simultaneous mode only
+    value: 5
+  - name: DualR
+    description: Dual, regular simultaneous mode only
+    value: 6
+  - name: DualI
+    description: Dual, interleaved mode only
+    value: 7
+  - name: DualA
+    description: Dual, alternate trigger mode only
+    value: 9
+enum/IDLEVALUE:
+  bit_size: 4
+  variants:
+  - name: H13
+    description: Dummy channel selection is 0x13
+    value: 0
+  - name: H1F
+    description: Dummy channel selection is 0x1F
+    value: 1
+enum/MDMA:
+  bit_size: 2
+  variants:
+  - name: NoPack
+    description: Without data packing, CDR/CDR2 not used
+    value: 0
+  - name: Format32to10
+    description: CDR formatted for 32-bit down to 10-bit resolution
+    value: 2
+  - name: Format8
+    description: CDR formatted for 8-bit resolution
+    value: 3
+enum/PRESC:
+  bit_size: 4
+  variants:
+  - name: Div1
+    description: adc_ker_ck_input not divided
+    value: 0
+  - name: Div2
+    description: adc_ker_ck_input divided by 2
+    value: 1
+  - name: Div4
+    description: adc_ker_ck_input divided by 4
+    value: 2
+  - name: Div6
+    description: adc_ker_ck_input divided by 6
+    value: 3
+  - name: Div8
+    description: adc_ker_ck_input divided by 8
+    value: 4
+  - name: Div10
+    description: adc_ker_ck_input divided by 10
+    value: 5
+  - name: Div12
+    description: adc_ker_ck_input divided by 12
+    value: 6
+  - name: Div16
+    description: adc_ker_ck_input divided by 16
+    value: 7
+  - name: Div32
+    description: adc_ker_ck_input divided by 32
+    value: 8
+  - name: Div64
+    description: adc_ker_ck_input divided by 64
+    value: 9
+  - name: Div128
+    description: adc_ker_ck_input divided by 128
+    value: 10
+  - name: Div256
+    description: adc_ker_ck_input divided by 256
+    value: 11

--- a/transforms/ADC.yaml
+++ b/transforms/ADC.yaml
@@ -1,13 +1,50 @@
 transforms:
+  - !Rename
+    from: ^ADC1$
+    to: ADC
+
   - !DeleteEnums
     from: ^(AWD1?|J?EOC|JEOS|J?STRT|OVR|ADRDY|EOS(MP)?|JQOVF|ENDED)(_MST)?$
 
   - !MakeFieldArray
-    fieldsets: CSR
-    from: AWD[1-3]_MST
-    to: AWD_MST
+    fieldsets: ^(IER|ISR)$
+    from: AWD\d(IE)?
+    to: AWD$1
 
   - !MakeFieldArray
-    fieldsets: CSR
-    from: AWD[1-3]_SLV
-    to: AWD_SLV
+    fieldsets: ^(CFGR)$
+    from: EXTSEL\d
+    to: EXTSEL
+
+  - !MakeFieldArray
+    fieldsets: SMPR\d
+    from: SMP\d+
+    to: SMP
+
+  - !MakeFieldArray
+    fieldsets: JSQR
+    from: JSQ\d
+    to: JSQ
+
+  - !MergeFieldsets
+    from: OFR\d
+    to: OFR
+
+  - !MakeRegisterArray
+    blocks: ADC
+    from: OFR\d
+    to: OFR
+
+  - !MergeFieldsets
+    from: JDR\d
+    to: JDR
+
+  - !MakeRegisterArray
+    blocks: ADC
+    from: JDR\d
+    to: JDR
+
+  - !MakeFieldArray
+    fieldsets: ^SQR\d$
+    from: SQ\d+
+    to: SQ

--- a/transforms/ADCCOMMON.yaml
+++ b/transforms/ADCCOMMON.yaml
@@ -1,0 +1,13 @@
+transforms:
+  - !ModifyByteOffset
+    blocks: ADC_COMMON
+    exclude_items: ^CDR$
+    add_offset: -768 # 0x300
+
+  - !MakeFieldArray
+    fieldsets: CSR
+    from: AWD\d_(MST|SLV)
+    to: AWD_$1
+
+  - !DeleteFieldsets
+    from: ^(IPDR|SIDR)$


### PR DESCRIPTION
do a format, add a few enums and fields, recreate transform yaml files.

by the way, I use a feature from embassy-rs/chiptool#26 to offset registers' byte_offsets of `ADC_COMMON` block.
Please consider merge that first before merge this PR, thanks!