### PR TITLE
H7 RCC CRYP Register Naming

### DIFF
--- a/data/registers/rcc_h7.yaml
+++ b/data/registers/rcc_h7.yaml
@@ -425,8 +425,8 @@ fieldset/AHB2ENR:
     description: DCMI peripheral clock
     bit_offset: 0
     bit_size: 1
-  - name: CRYPTEN
-    description: CRYPT peripheral clock enable
+  - name: CRYPEN
+    description: CRYP peripheral clock enable
     bit_offset: 4
     bit_size: 1
   - name: HASHEN
@@ -468,8 +468,8 @@ fieldset/AHB2LPENR:
     description: DCMI peripheral clock enable during csleep mode
     bit_offset: 0
     bit_size: 1
-  - name: CRYPTLPEN
-    description: CRYPT peripheral clock enable during CSleep mode
+  - name: CRYPLPEN
+    description: CRYP peripheral clock enable during CSleep mode
     bit_offset: 4
     bit_size: 1
   - name: HASHLPEN
@@ -511,8 +511,8 @@ fieldset/AHB2RSTR:
     description: DCMI block reset
     bit_offset: 0
     bit_size: 1
-  - name: CRYPTRST
-    description: Cryptography block reset
+  - name: CRYPRST
+    description: CRYPography block reset
     bit_offset: 4
     bit_size: 1
   - name: HASHRST
@@ -1884,8 +1884,8 @@ fieldset/C1_AHB2ENR:
     description: DCMI peripheral clock
     bit_offset: 0
     bit_size: 1
-  - name: CRYPTEN
-    description: CRYPT peripheral clock enable
+  - name: CRYPEN
+    description: CRYP peripheral clock enable
     bit_offset: 4
     bit_size: 1
   - name: HASHEN
@@ -1919,8 +1919,8 @@ fieldset/C1_AHB2LPENR:
     description: DCMI peripheral clock enable during csleep mode
     bit_offset: 0
     bit_size: 1
-  - name: CRYPTLPEN
-    description: CRYPT peripheral clock enable during CSleep mode
+  - name: CRYPLPEN
+    description: CRYP peripheral clock enable during CSleep mode
     bit_offset: 4
     bit_size: 1
   - name: HASHLPEN


### PR DESCRIPTION
The trait `rcc::RccPeripheral` is not implemented for CRYP on the H7 due to an apparent naming mismatch. This just changes the name for all registers `CRYPT` to `CRYP`.