### PR TITLE
make address of registers show as hex

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -85,7 +85,7 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 [[package]]
 name = "chiptool"
 version = "0.1.0"
-source = "git+https://github.com/embassy-rs/chiptool?rev=247ccbe44669ac716393247e56693a396e641e4a#247ccbe44669ac716393247e56693a396e641e4a"
+source = "git+https://github.com/embassy-rs/chiptool?rev=1c198ae678ebd426751513f0deab6fbd6f8b8211#1c198ae678ebd426751513f0deab6fbd6f8b8211"
 dependencies = [
  "anyhow",
  "clap",

--- a/stm32-data-gen/Cargo.toml
+++ b/stm32-data-gen/Cargo.toml
@@ -17,7 +17,7 @@ quick-xml = { version = "0.26.0", features = ["serialize"] }
 regex = "1.7.1"
 serde = { version = "1.0.157", features = ["derive"] }
 serde_yaml = "0.9.19"
-chiptool = { git = "https://github.com/embassy-rs/chiptool", rev="247ccbe44669ac716393247e56693a396e641e4a" }
+chiptool = { git = "https://github.com/embassy-rs/chiptool", rev = "1c198ae678ebd426751513f0deab6fbd6f8b8211" }
 serde_json = "1.0.94"
 rayon = { version = "1.7.0", optional = true }
 stm32-data-serde = { version = "0.1.0", path = "../stm32-data-serde" }

--- a/stm32-metapac-gen/Cargo.toml
+++ b/stm32-metapac-gen/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 regex = "1.7.1"
-chiptool = { git = "https://github.com/embassy-rs/chiptool", rev="247ccbe44669ac716393247e56693a396e641e4a" }
+chiptool = { git = "https://github.com/embassy-rs/chiptool", rev = "1c198ae678ebd426751513f0deab6fbd6f8b8211" }
 serde = { version = "1.0.157", features = [ "derive" ] }
 serde_json = "1.0.94"
 proc-macro2 = "1.0.52"

--- a/stm32-metapac-gen/src/data.rs
+++ b/stm32-metapac-gen/src/data.rs
@@ -158,7 +158,10 @@ pub mod ir {
         pub items: Vec<BlockItem>,
     }
 
-    #[derive(Debug, Eq, PartialEq, Clone, Deserialize)]
+    // Notice:
+    // BlockItem has custom Debug implement,
+    // when modify the struct, make sure Debug impl reflect the change.
+    #[derive(Eq, PartialEq, Clone, Deserialize)]
     pub struct BlockItem {
         pub name: String,
         pub description: Option<String>,
@@ -167,6 +170,20 @@ pub mod ir {
         pub byte_offset: u32,
 
         pub inner: BlockItemInner,
+    }
+
+    // Notice:
+    // Debug implement AFFECT OUTPUT METAPAC, modify with caution
+    impl std::fmt::Debug for BlockItem {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            f.debug_struct("BlockItem")
+                .field("name", &self.name)
+                .field("description", &self.description)
+                .field("array", &self.array)
+                .field("byte_offset", &format_args!("{:#x}", self.byte_offset))
+                .field("inner", &self.inner)
+                .finish()
+        }
     }
 
     #[derive(EnumDebug, Eq, PartialEq, Clone, Deserialize)]
@@ -274,13 +291,30 @@ pub struct Chip {
     pub packages: Vec<Package>,
 }
 
-#[derive(Debug, Eq, PartialEq, Clone, Deserialize)]
+// Notice:
+// MemoryRegion has custom Debug implement,
+// when modify the struct, make sure Debug impl reflect the change.
+#[derive(Eq, PartialEq, Clone, Deserialize)]
 pub struct MemoryRegion {
     pub name: String,
     pub kind: MemoryRegionKind,
     pub address: u32,
     pub size: u32,
     pub settings: Option<FlashSettings>,
+}
+
+// Notice:
+// Debug implement AFFECT OUTPUT METAPAC, modify with caution
+impl std::fmt::Debug for MemoryRegion {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("MemoryRegion")
+            .field("name", &self.name)
+            .field("kind", &self.kind)
+            .field("address", &format_args!("{:#x}", self.address))
+            .field("size", &self.size)
+            .field("settings", &self.settings)
+            .finish()
+    }
 }
 
 #[derive(Debug, Eq, PartialEq, Clone, Deserialize)]
@@ -320,7 +354,10 @@ pub struct Package {
     pub package: String,
 }
 
-#[derive(Debug, Eq, PartialEq, Clone, Deserialize)]
+// Notice:
+// Peripheral has custom Debug implement,
+// when modify struct, make sure Debug impl reflect the change.
+#[derive(Eq, PartialEq, Clone, Deserialize)]
 pub struct Peripheral {
     pub name: String,
     pub address: u64,
@@ -334,6 +371,22 @@ pub struct Peripheral {
     pub dma_channels: Vec<PeripheralDmaChannel>,
     #[serde(default)]
     pub interrupts: Vec<PeripheralInterrupt>,
+}
+
+// Notice:
+// Debug implement AFFECT OUTPUT METAPAC, modify with caution
+impl std::fmt::Debug for Peripheral {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Peripheral")
+            .field("name", &self.name)
+            .field("address", &format_args!("{:#x}", self.address))
+            .field("registers", &self.registers)
+            .field("rcc", &self.rcc)
+            .field("pins", &self.pins)
+            .field("dma_channels", &self.dma_channels)
+            .field("interrupts", &self.interrupts)
+            .finish()
+    }
 }
 
 #[derive(Debug, Eq, PartialEq, Clone, Deserialize)]


### PR DESCRIPTION
combine with embassy-rs/chiptool#27, this will make address of registers show as hex in output metapac, which align with RM, and make a little bit easier for us to comapre output with RM using eyes.

This doesn't touch stm32-data-gen, so there shouldn't be any changes in output json.

example of stm32-metapac changes:

stm32-metapac/src/chips/metadata_XXXX.rs

```diff
 Peripheral {
     name: "ADC1",
-    address: 1073816576,
+    address: 0x40012400,
     registers: None,
```

stm32-metapac/src/chips/stm32XXXXXX/metadata.rs

```diff
 MemoryRegion {
     name: "BANK_1",
     kind: MemoryRegionKind::Flash,
-    address: 134217728,
+    address: 0x8000000,
```

stm32-metapac/src/peripherals/XXX.rs

```diff
 #[doc = "sample time register 1"]
 #[inline(always)]
 pub const fn smpr1(self) -> crate::common::Reg<regs::Smpr1, crate::common::RW> {
-    unsafe { crate::common::Reg::from_ptr(self.ptr.add(12usize) as _) }
+    unsafe { crate::common::Reg::from_ptr(self.ptr.add(0x0cusize) as _) }
 }
```

^ I would proposal use uppercase hex instead.
`0x0Cusize` is a little bit easier to read than `0x0cusize`.
What would you think?


and all hex value 0 will write as 0x0

```diff
  #[doc = "status register"]
  #[inline(always)]
  pub const fn sr(self) -> crate::common::Reg<regs::Sr, crate::common::RW> {
-     unsafe { crate::common::Reg::from_ptr(self.ptr.add(0usize) as _) }
+     unsafe { crate::common::Reg::from_ptr(self.ptr.add(0x0usize) as _) }
 }
```

```diff
 pub mod vals {
     #[repr(u8)]
     #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
     pub enum Dualmod {
         #[doc = "Independent mode."]
-        INDEPENDENT = 0,
+        INDEPENDENT = 0x0,
         #[doc = "Combined regular simultaneous + injected simultaneous mode"]
         REGULARINJECTED = 0x01,
```

will need

- [ ] aceept embassy-rs/chiptool#27
- [ ] rebase to remove my repo from codebase
- [ ] regenerate Cargo.lock 
