### PR TITLE
Correct 'CRYPT' to 'CRYP' in RCC

### DIFF
--- a/data/registers/rcc_h7ab.yaml
+++ b/data/registers/rcc_h7ab.yaml
@@ -345,8 +345,8 @@ fieldset/AHB2ENR:
     description: DCMI peripheral clock
     bit_offset: 0
     bit_size: 1
-  - name: CRYPTEN
-    description: CRYPT peripheral clock enable
+  - name: CRYPEN
+    description: CRYP peripheral clock enable
     bit_offset: 4
     bit_size: 1
   - name: HASHEN
@@ -392,8 +392,8 @@ fieldset/AHB2LPENR:
     description: DCMI peripheral clock enable during csleep mode
     bit_offset: 0
     bit_size: 1
-  - name: CRYPTLPEN
-    description: CRYPT peripheral clock enable during CSleep mode
+  - name: CRYPLPEN
+    description: CRYP peripheral clock enable during CSleep mode
     bit_offset: 4
     bit_size: 1
   - name: HASHLPEN
@@ -439,8 +439,8 @@ fieldset/AHB2RSTR:
     description: DCMI block reset
     bit_offset: 0
     bit_size: 1
-  - name: CRYPTRST
-    description: Cryptography block reset
+  - name: CRYPRST
+    description: CRYPography block reset
     bit_offset: 4
     bit_size: 1
   - name: HASHRST

--- a/data/registers/rcc_h7rm0433.yaml
+++ b/data/registers/rcc_h7rm0433.yaml
@@ -425,8 +425,8 @@ fieldset/AHB2ENR:
     description: DCMI peripheral clock
     bit_offset: 0
     bit_size: 1
-  - name: CRYPTEN
-    description: CRYPT peripheral clock enable
+  - name: CRYPEN
+    description: CRYP peripheral clock enable
     bit_offset: 4
     bit_size: 1
   - name: HASHEN
@@ -468,8 +468,8 @@ fieldset/AHB2LPENR:
     description: DCMI peripheral clock enable during csleep mode
     bit_offset: 0
     bit_size: 1
-  - name: CRYPTLPEN
-    description: CRYPT peripheral clock enable during CSleep mode
+  - name: CRYPLPEN
+    description: CRYP peripheral clock enable during CSleep mode
     bit_offset: 4
     bit_size: 1
   - name: HASHLPEN
@@ -511,8 +511,8 @@ fieldset/AHB2RSTR:
     description: DCMI block reset
     bit_offset: 0
     bit_size: 1
-  - name: CRYPTRST
-    description: Cryptography block reset
+  - name: CRYPRST
+    description: CRYPography block reset
     bit_offset: 4
     bit_size: 1
   - name: HASHRST
@@ -1872,8 +1872,8 @@ fieldset/C1_AHB2ENR:
     description: DCMI peripheral clock
     bit_offset: 0
     bit_size: 1
-  - name: CRYPTEN
-    description: CRYPT peripheral clock enable
+  - name: CRYPEN
+    description: CRYP peripheral clock enable
     bit_offset: 4
     bit_size: 1
   - name: HASHEN
@@ -1907,8 +1907,8 @@ fieldset/C1_AHB2LPENR:
     description: DCMI peripheral clock enable during csleep mode
     bit_offset: 0
     bit_size: 1
-  - name: CRYPTLPEN
-    description: CRYPT peripheral clock enable during CSleep mode
+  - name: CRYPLPEN
+    description: CRYP peripheral clock enable during CSleep mode
     bit_offset: 4
     bit_size: 1
   - name: HASHLPEN


### PR DESCRIPTION
Missed these two files the other day. This should be all the locations where 'CRYP' is spelled 'CRYPT'.