### PR TITLE
Add cryp v3

### DIFF
--- a/data/registers/cryp_v3.yaml
+++ b/data/registers/cryp_v3.yaml
@@ -1,0 +1,189 @@
+block/CRYP:
+  description: Cryptographic processor.
+  items:
+    - name: CR
+      description: control register.
+      byte_offset: 0
+      fieldset: CR
+    - name: SR
+      description: status register.
+      byte_offset: 4
+      access: Read
+      fieldset: SR
+    - name: DIN
+      description: data input register.
+      byte_offset: 8
+    - name: DOUT
+      description: data output register.
+      byte_offset: 12
+      access: Read
+    - name: DMACR
+      description: DMA control register.
+      byte_offset: 16
+      fieldset: DMACR
+    - name: IMSCR
+      description: interrupt mask set/clear register.
+      byte_offset: 20
+      fieldset: IMSCR
+    - name: RISR
+      description: raw interrupt status register.
+      byte_offset: 24
+      access: Read
+      fieldset: RISR
+    - name: MISR
+      description: masked interrupt status register.
+      byte_offset: 28
+      access: Read
+      fieldset: MISR
+    - name: KEY
+      description: Cluster KEY%s, containing K?LR, K?RR.
+      array:
+        len: 4
+        stride: 8
+      byte_offset: 32
+      block: KEY
+    - name: INIT
+      description: Cluster INIT%s, containing IV?LR, IV?RR.
+      array:
+        len: 2
+        stride: 8
+      byte_offset: 64
+      block: INIT
+    - name: CSGCMCCMR
+      description: context swap register.
+      array:
+        len: 8
+        stride: 4
+      byte_offset: 80
+    - name: CSGCMR
+      description: context swap register.
+      array:
+        len: 8
+        stride: 4
+      byte_offset: 112
+block/INIT:
+  description: Cluster INIT%s, containing IV?LR, IV?RR.
+  items:
+    - name: IVLR
+      description: initialization vector registers.
+      byte_offset: 0
+    - name: IVRR
+      description: initialization vector registers.
+      byte_offset: 4
+block/KEY:
+  description: Cluster KEY%s, containing K?LR, K?RR.
+  items:
+    - name: KLR
+      description: key registers.
+      byte_offset: 0
+      access: Write
+    - name: KRR
+      description: key registers.
+      byte_offset: 4
+      access: Write
+fieldset/CR:
+  description: control register.
+  fields:
+    - name: ALGODIR
+      description: Algorithm direction.
+      bit_offset: 2
+      bit_size: 1
+    - name: ALGOMODE0
+      description: Algorithm mode.
+      bit_offset: 3
+      bit_size: 3
+    - name: DATATYPE
+      description: Data type selection.
+      bit_offset: 6
+      bit_size: 2
+    - name: KEYSIZE
+      description: Key size selection (AES mode only).
+      bit_offset: 8
+      bit_size: 2
+    - name: FFLUSH
+      description: FIFO flush.
+      bit_offset: 14
+      bit_size: 1
+    - name: CRYPEN
+      description: Cryptographic processor enable.
+      bit_offset: 15
+      bit_size: 1
+    - name: GCM_CCMPH
+      description: GCM_CCMPH.
+      bit_offset: 16
+      bit_size: 2
+    - name: ALGOMODE3
+      description: ALGOMODE.
+      bit_offset: 19
+      bit_size: 1
+    - name: NPBLB
+      description: Number of Padding Bytes in Last Block of payload.
+      bit_offset: 20
+      bit_size: 4
+fieldset/DMACR:
+  description: DMA control register.
+  fields:
+    - name: DIEN
+      description: DMA input enable.
+      bit_offset: 0
+      bit_size: 1
+    - name: DOEN
+      description: DMA output enable.
+      bit_offset: 1
+      bit_size: 1
+fieldset/IMSCR:
+  description: interrupt mask set/clear register.
+  fields:
+    - name: INIM
+      description: Input FIFO service interrupt mask.
+      bit_offset: 0
+      bit_size: 1
+    - name: OUTIM
+      description: Output FIFO service interrupt mask.
+      bit_offset: 1
+      bit_size: 1
+fieldset/MISR:
+  description: masked interrupt status register.
+  fields:
+    - name: INMIS
+      description: Input FIFO service masked interrupt status.
+      bit_offset: 0
+      bit_size: 1
+    - name: OUTMIS
+      description: Output FIFO service masked interrupt status.
+      bit_offset: 1
+      bit_size: 1
+fieldset/RISR:
+  description: raw interrupt status register.
+  fields:
+    - name: INRIS
+      description: Input FIFO service raw interrupt status.
+      bit_offset: 0
+      bit_size: 1
+    - name: OUTRIS
+      description: Output FIFO service raw interrupt status.
+      bit_offset: 1
+      bit_size: 1
+fieldset/SR:
+  description: status register.
+  fields:
+    - name: IFEM
+      description: Input FIFO empty.
+      bit_offset: 0
+      bit_size: 1
+    - name: IFNF
+      description: Input FIFO not full.
+      bit_offset: 1
+      bit_size: 1
+    - name: OFNE
+      description: Output FIFO not empty.
+      bit_offset: 2
+      bit_size: 1
+    - name: OFFU
+      description: Output FIFO full.
+      bit_offset: 3
+      bit_size: 1
+    - name: BUSY
+      description: Busy bit.
+      bit_offset: 4
+      bit_size: 1

--- a/stm32-data-gen/src/chips.rs
+++ b/stm32-data-gen/src/chips.rs
@@ -538,7 +538,7 @@ impl PeriMatcher {
             (".*:HASH:hash1_v4_0", ("hash", "v3", "HASH")),
             (".*:CRYP:cryp1_v1_0.*", ("cryp", "v1", "CRYP")),
             (".*:CRYP:cryp1_v2_0.*", ("cryp", "v2", "CRYP")),
-            (".*:CRYP:cryp1_v2_2.*", ("cryp", "v2", "CRYP")),
+            (".*:CRYP:cryp1_v2_2.*", ("cryp", "v3", "CRYP")),
             ("STM32G0.1.*:.*:COMP:.*", ("comp", "v1", "COMP")),
             ("STM32G4.*:.*:COMP:.*", ("comp", "v2", "COMP")),
             ("STM32WL.*:.*:COMP:.*", ("comp", "v3", "COMP")),


### PR DESCRIPTION
Adds a third CRYP register definition. cryp_v3 differs from cryp_v2 only in the NPBLB field of the CR register. For some unknown reason, none of the autogenerated register definitions seem to have this field. This change manually adds this field. Change is based on register definition from ST manual RM0399.