### PR TITLE
updated l4plus and l5 rcc registers

### DIFF
--- a/data/registers/rcc_l4plus.yaml
+++ b/data/registers/rcc_l4plus.yaml
@@ -311,7 +311,7 @@ fieldset/AHB2ENR:
     description: Random Number Generator clock enable
     bit_offset: 18
     bit_size: 1
-  - name: OSPIMEN
+  - name: OCTOSPIMEN
     description: OctoSPI IO manager clock enable
     bit_offset: 20
     bit_size: 1
@@ -390,7 +390,7 @@ fieldset/AHB2RSTR:
     description: Random number generator reset
     bit_offset: 18
     bit_size: 1
-  - name: OSPIMRST
+  - name: OCTOSPIMRST
     description: OCTOSPI IO manager reset
     bit_offset: 20
     bit_size: 1
@@ -485,7 +485,7 @@ fieldset/AHB2SMENR:
     description: Random Number Generator clocks enable during Sleep and Stop modes
     bit_offset: 18
     bit_size: 1
-  - name: OSPIMSMEN
+  - name: OCTOSPIMSMEN
     description: OctoSPI IO manager clocks enable during Sleep and Stop modes
     bit_offset: 20
     bit_size: 1
@@ -504,11 +504,11 @@ fieldset/AHB3ENR:
     description: Flexible memory controller clock enable
     bit_offset: 0
     bit_size: 1
-  - name: OSPI1EN
+  - name: OCTOSPI1EN
     description: OctoSPI1 memory interface clock enable
     bit_offset: 8
     bit_size: 1
-  - name: OSPI2EN
+  - name: OCTOSPI2EN
     description: OSPI2EN memory interface clock enable
     bit_offset: 9
     bit_size: 1
@@ -519,11 +519,11 @@ fieldset/AHB3RSTR:
     description: Flexible memory controller reset
     bit_offset: 0
     bit_size: 1
-  - name: OSPI1RST
+  - name: OCTOSPI1RST
     description: OctoSPI1 memory interface reset
     bit_offset: 8
     bit_size: 1
-  - name: OSPI2RST
+  - name: OCTOSPI2RST
     description: OctOSPI2 memory interface reset
     bit_offset: 9
     bit_size: 1
@@ -534,11 +534,11 @@ fieldset/AHB3SMENR:
     description: Flexible memory controller clocks enable during Sleep and Stop modes
     bit_offset: 0
     bit_size: 1
-  - name: OSPI1SMEN
+  - name: OCTOSPI1SMEN
     description: OctoSPI1 memory interface clocks enable during Sleep and Stop modes
     bit_offset: 8
     bit_size: 1
-  - name: OCTOSPI2
+  - name: OCTOSPI2SMEN
     description: OctoSPI2 memory interface clocks enable during Sleep and Stop modes
     bit_offset: 9
     bit_size: 1
@@ -1197,11 +1197,11 @@ fieldset/CCIPR2:
     description: division factor for LTDC clock
     bit_offset: 16
     bit_size: 2
-  - name: OSPISEL
+  - name: OCTOSPISEL
     description: Octospi clock source selection
     bit_offset: 20
     bit_size: 2
-    enum: OSPISEL
+    enum: OCTOSPISEL
 fieldset/CFGR:
   description: Clock configuration register
   fields:
@@ -1962,7 +1962,7 @@ enum/MSIRGSEL:
   - name: CR
     description: MSI Range is provided by MSIRANGE[3:0] in the RCC_CR register
     value: 1
-enum/OSPISEL:
+enum/OCTOSPISEL:
   bit_size: 2
   variants:
   - name: SYS

--- a/data/registers/rcc_l5.yaml
+++ b/data/registers/rcc_l5.yaml
@@ -556,8 +556,8 @@ fieldset/AHB3ENR:
     description: Flexible memory controller clock enable
     bit_offset: 0
     bit_size: 1
-  - name: OSPI1EN
-    description: OSPI1EN
+  - name: OCTOSPI1EN
+    description: OCTOSPI1EN
     bit_offset: 8
     bit_size: 1
 fieldset/AHB3RSTR:
@@ -567,8 +567,8 @@ fieldset/AHB3RSTR:
     description: Flexible memory controller reset
     bit_offset: 0
     bit_size: 1
-  - name: OSPI1RST
-    description: OSPI1RST
+  - name: OCTOSPI1RST
+    description: OCTOSPI1RST
     bit_offset: 8
     bit_size: 1
 fieldset/AHB3SECSR:
@@ -578,8 +578,8 @@ fieldset/AHB3SECSR:
     description: FSMCSECF
     bit_offset: 0
     bit_size: 1
-  - name: OSPI1SECF
-    description: OSPI1SECF
+  - name: OCTOSPI1SECF
+    description: OCTOSPI1SECF
     bit_offset: 8
     bit_size: 1
 fieldset/AHB3SMENR:
@@ -589,8 +589,8 @@ fieldset/AHB3SMENR:
     description: Flexible memory controller clocks enable during Sleep and Stop modes
     bit_offset: 0
     bit_size: 1
-  - name: OSPI1SMEN
-    description: OSPI1SMEN
+  - name: OCTOSPI1SMEN
+    description: OCTOSPI1SMEN
     bit_offset: 8
     bit_size: 1
 fieldset/APB1ENR1:
@@ -1412,7 +1412,7 @@ fieldset/CCIPR2:
     description: SDMMC clock selection
     bit_offset: 14
     bit_size: 1
-  - name: OSPISEL
+  - name: OCTOSPISEL
     description: Octospi clock source selection
     bit_offset: 20
     bit_size: 2


### PR DESCRIPTION
Update octospi register labels for l4plus series and l5 series chips. Required for https://github.com/embassy-rs/embassy/pull/2672