### PR TITLE
Fixed quadspi/octospi mismatch for h7 chips

### DIFF
--- a/data/registers/rcc_h7.yaml
+++ b/data/registers/rcc_h7.yaml
@@ -558,10 +558,6 @@ fieldset/AHB3ENR:
     description: OCTOSPI2 and OCTOSPI2 delay block enable
     bit_offset: 14
     bit_size: 1
-  - name: QUADSPIEN
-    description: QUADSPI and QUADSPI Delay Clock Enable
-    bit_offset: 14
-    bit_size: 1
   - name: SDMMC1EN
     description: SDMMC1 and SDMMC1 Delay Clock Enable
     bit_offset: 16
@@ -625,10 +621,6 @@ fieldset/AHB3LPENR:
     description: OCTOSPI1 and OCTOSPI1 delay block enable during CSleep Mode
     bit_offset: 14
     bit_size: 1
-  - name: QUADSPILPEN
-    description: QUADSPI and QUADSPI Delay Clock Enable During CSleep Mode
-    bit_offset: 14
-    bit_size: 1
   - name: SDMMC1LPEN
     description: SDMMC1 and SDMMC1 Delay Clock Enable During CSleep Mode
     bit_offset: 16
@@ -686,10 +678,6 @@ fieldset/AHB3RSTR:
     bit_size: 1
   - name: OCTOSPI1RST
     description: OCTOSPI1 and OCTOSPI1 delay block reset
-    bit_offset: 14
-    bit_size: 1
-  - name: QUADSPIRST
-    description: QUADSPI and QUADSPI delay block reset
     bit_offset: 14
     bit_size: 1
   - name: SDMMC1RST
@@ -1974,13 +1962,17 @@ fieldset/C1_AHB3ENR:
     description: FMC Peripheral Clocks Enable
     bit_offset: 12
     bit_size: 1
-  - name: QUADSPIEN
-    description: QUADSPI and QUADSPI Delay Clock Enable
+  - name: OCTOSPI1EN
+    description: OCTOSPI1 and OCTOSPI1 Delay Clock Enable
     bit_offset: 14
     bit_size: 1
   - name: SDMMC1EN
     description: SDMMC1 and SDMMC1 Delay Clock Enable
     bit_offset: 16
+    bit_size: 1
+  - name: OCTOSPI1EN
+    description: OCTOSPI1 and OCTOSPI1 Delay Clock Enable
+    bit_offset: 19
     bit_size: 1
 fieldset/C1_AHB3LPENR:
   description: RCC AHB3 Sleep Clock Register
@@ -2005,8 +1997,8 @@ fieldset/C1_AHB3LPENR:
     description: FMC Peripheral Clocks Enable During CSleep Mode
     bit_offset: 12
     bit_size: 1
-  - name: QUADSPILPEN
-    description: QUADSPI and QUADSPI Delay Clock Enable During CSleep Mode
+  - name: OCTOSPI1LPEN
+    description: OCTOSPI1 and OCTOSPI1 delay block enable during CSleep Mode
     bit_offset: 14
     bit_size: 1
   - name: SDMMC1LPEN
@@ -3064,11 +3056,6 @@ fieldset/D1CCIPR:
     enum: FMCSEL
   - name: OCTOSPISEL
     description: OCTOSPI kernel clock source selection
-    bit_offset: 4
-    bit_size: 2
-    enum: FMCSEL
-  - name: QUADSPISEL
-    description: QUADSPI kernel clock source selection
     bit_offset: 4
     bit_size: 2
     enum: FMCSEL


### PR DESCRIPTION
Found additional mismatch between datasheet for the h7 chips for the octospi rcc definitions. H7 had some definitions for the quadspi peripheral which should have been octospi1. The H7A doesn't have a quadspi peripheral according to the reference manual.