### PR TITLE
Fix mislabeling for h7ab octospi rcc registers

### DIFF
--- a/data/registers/rcc_h7ab.yaml
+++ b/data/registers/rcc_h7ab.yaml
@@ -486,8 +486,8 @@ fieldset/AHB3ENR:
     description: FMC Peripheral Clocks Enable
     bit_offset: 12
     bit_size: 1
-  - name: QUADSPIEN
-    description: QUADSPI and QUADSPI Delay Clock Enable
+  - name: OCTOSPI1EN
+    description: OCTOSPI1 and OCTOSPI1 Delay Clock Enable
     bit_offset: 14
     bit_size: 1
   - name: SDMMC1EN
@@ -549,8 +549,8 @@ fieldset/AHB3LPENR:
     description: FMC Peripheral Clocks Enable During CSleep Mode
     bit_offset: 12
     bit_size: 1
-  - name: QUADSPILPEN
-    description: QUADSPI and QUADSPI Delay Clock Enable During CSleep Mode
+  - name: OCTOSPI1LPEN
+    description: OCTOSPI1 and OCTOSPI1 Delay Clock Enable During CSleep Mode
     bit_offset: 14
     bit_size: 1
   - name: SDMMC1LPEN
@@ -608,8 +608,8 @@ fieldset/AHB3RSTR:
     description: FMC block reset
     bit_offset: 12
     bit_size: 1
-  - name: QUADSPIRST
-    description: QUADSPI and QUADSPI delay block reset
+  - name: OCTOSPI1RST
+    description: OCTOSPI1 and OCTOSPI1 delay block reset
     bit_offset: 14
     bit_size: 1
   - name: SDMMC1RST


### PR DESCRIPTION
H7ab does not have quadspi, but octospi. This fixes the generation of rcc blocks for the octospi1 peripheral