### PR TITLE
Add 8 and 16 bit wide SPI data registers

### DIFF
--- a/data/registers/crc_v2.yaml
+++ b/data/registers/crc_v2.yaml
@@ -1,7 +1,7 @@
 block/CRC:
   description: Cyclic Redundancy Check calculation unit
   items:
-  - name: DR
+  - name: DR32
     description: Data register
     byte_offset: 0
   - name: DR16

--- a/data/registers/crc_v3.yaml
+++ b/data/registers/crc_v3.yaml
@@ -1,7 +1,7 @@
 block/CRC:
   description: Cyclic Redundancy Check calculation unit
   items:
-  - name: DR
+  - name: DR32
     description: Data register
     byte_offset: 0
   - name: DR16

--- a/data/registers/spi_v2.yaml
+++ b/data/registers/spi_v2.yaml
@@ -13,10 +13,14 @@ block/SPI:
     description: status register
     byte_offset: 8
     fieldset: SR
-  - name: DR
-    description: data register
+  - name: DR16
+    description: data register - half-word sized
     byte_offset: 12
-    fieldset: DR
+    bit_size: 16
+  - name: DR8
+    description: data register - byte sized
+    byte_offset: 12
+    bit_size: 8
   - name: CRCPR
     description: CRC polynomial register
     byte_offset: 16
@@ -169,13 +173,6 @@ fieldset/CRCPR:
   fields:
   - name: CRCPOLY
     description: CRC polynomial register
-    bit_offset: 0
-    bit_size: 16
-fieldset/DR:
-  description: data register
-  fields:
-  - name: DR
-    description: Data register
     bit_offset: 0
     bit_size: 16
 fieldset/I2SCFGR:

--- a/data/registers/spi_v3.yaml
+++ b/data/registers/spi_v3.yaml
@@ -31,16 +31,34 @@ block/SPI:
     byte_offset: 24
     access: Write
     fieldset: IFCR
-  - name: TXDR
+  - name: TXDR32
     description: Transmit Data Register
     byte_offset: 32
     access: Write
-    fieldset: TXDR
-  - name: RXDR
+  - name: TXDR16
+    description: Transmit Data Register - half-word sized
+    byte_offset: 32
+    bit_size: 16
+    access: Write
+  - name: TXDR8
+    description: Transmit Data Register - byte sized
+    byte_offset: 32
+    bit_size: 8
+    access: Write
+  - name: RXDR32
     description: Receive Data Register
     byte_offset: 48
     access: Read
-    fieldset: RXDR
+  - name: RXDR16
+    description: Receive Data Register - half-word sized
+    byte_offset: 48
+    bit_size: 16
+    access: Read
+  - name: RXDR8
+    description: Receive Data Register - byte sized
+    byte_offset: 48
+    bit_size: 8
+    access: Read
   - name: CRCPOLY
     description: Polynomial Register
     byte_offset: 64
@@ -324,13 +342,6 @@ fieldset/RXCRC:
     description: CRC register for receiver
     bit_offset: 0
     bit_size: 32
-fieldset/RXDR:
-  description: Receive Data Register
-  fields:
-  - name: RXDR
-    description: Receive data register
-    bit_offset: 0
-    bit_size: 32
 fieldset/SR:
   description: Status Register
   fields:
@@ -405,13 +416,6 @@ fieldset/TXCRC:
   fields:
   - name: TXCRC
     description: CRC register for transmitter
-    bit_offset: 0
-    bit_size: 32
-fieldset/TXDR:
-  description: Transmit Data Register
-  fields:
-  - name: TXDR
-    description: Transmit data register
     bit_offset: 0
     bit_size: 32
 fieldset/UDRDR:

--- a/data/registers/spi_v4.yaml
+++ b/data/registers/spi_v4.yaml
@@ -31,16 +31,34 @@ block/SPI:
     byte_offset: 24
     access: Write
     fieldset: IFCR
-  - name: TXDR
+  - name: TXDR32
     description: Transmit Data Register
     byte_offset: 32
     access: Write
-    fieldset: TXDR
-  - name: RXDR
+  - name: TXDR16
+    description: Transmit Data Register - half-word sized
+    byte_offset: 32
+    bit_size: 16
+    access: Write
+  - name: TXDR8
+    description: Transmit Data Register - byte sized
+    byte_offset: 32
+    bit_size: 8
+    access: Write
+  - name: RXDR32
     description: Receive Data Register
     byte_offset: 48
     access: Read
-    fieldset: RXDR
+  - name: RXDR16
+    description: Receive Data Register - half-word sized
+    byte_offset: 48
+    bit_size: 16
+    access: Read
+  - name: RXDR8
+    description: Receive Data Register - byte sized
+    byte_offset: 48
+    bit_size: 8
+    access: Read
   - name: CRCPOLY
     description: Polynomial Register
     byte_offset: 64
@@ -323,13 +341,6 @@ fieldset/RXCRC:
     description: CRC register for receiver
     bit_offset: 0
     bit_size: 32
-fieldset/RXDR:
-  description: Receive Data Register
-  fields:
-  - name: RXDR
-    description: Receive data register
-    bit_offset: 0
-    bit_size: 32
 fieldset/SR:
   description: Status Register
   fields:
@@ -400,13 +411,6 @@ fieldset/TXCRC:
   fields:
   - name: TXCRC
     description: CRC register for transmitter
-    bit_offset: 0
-    bit_size: 32
-fieldset/TXDR:
-  description: Transmit Data Register
-  fields:
-  - name: TXDR
-    description: Transmit data register
     bit_offset: 0
     bit_size: 32
 fieldset/UDRDR:

--- a/data/registers/spi_v5.yaml
+++ b/data/registers/spi_v5.yaml
@@ -34,16 +34,34 @@ block/SPI:
   - name: AUTOCR
     byte_offset: 28
     fieldset: AUTOCR
-  - name: TXDR
+  - name: TXDR32
     description: Transmit Data Register
     byte_offset: 32
     access: Write
-    fieldset: TXDR
-  - name: RXDR
+  - name: TXDR16
+    description: Transmit Data Register - half-word sized
+    byte_offset: 32
+    bit_size: 16
+    access: Write
+  - name: TXDR8
+    description: Transmit Data Register - byte sized
+    byte_offset: 32
+    bit_size: 8
+    access: Write
+  - name: RXDR32
     description: Receive Data Register
     byte_offset: 48
     access: Read
-    fieldset: RXDR
+  - name: RXDR16
+    description: Receive Data Register - half-word sized
+    byte_offset: 48
+    bit_size: 16
+    access: Read
+  - name: RXDR8
+    description: Receive Data Register - byte sized
+    byte_offset: 48
+    bit_size: 8
+    access: Read
   - name: CRCPOLY
     description: Polynomial Register
     byte_offset: 64
@@ -348,13 +366,6 @@ fieldset/RXCRC:
     description: CRC register for receiver
     bit_offset: 0
     bit_size: 32
-fieldset/RXDR:
-  description: Receive Data Register
-  fields:
-  - name: RXDR
-    description: Receive data register
-    bit_offset: 0
-    bit_size: 32
 fieldset/SR:
   description: Status Register
   fields:
@@ -425,13 +436,6 @@ fieldset/TXCRC:
   fields:
   - name: TXCRC
     description: CRC register for transmitter
-    bit_offset: 0
-    bit_size: 32
-fieldset/TXDR:
-  description: Transmit Data Register
-  fields:
-  - name: TXDR
-    description: Transmit data register
     bit_offset: 0
     bit_size: 32
 fieldset/UDRDR:


### PR DESCRIPTION
Most SPI peripherals are sensitive to the bit width of reads/writes to DR/TXDR/RXDR. This PR adds 8 and 16 bit wide versions of those registers to permit such accesses to be generated. This is the same approach already used for the [CRC DR](https://github.com/embassy-rs/stm32-data/blob/main/data/registers/crc_v2.yaml#L7) in crc_v2.yaml and crc_v3.yaml.

* spi_v1: This version is not sensitive to the bit width of the read or write. Only the low 8 bits are used.

* spi_v2: This version is sensitive to the bit width of the read or write. Data packing is automatically performed based on the width of the access. From the STM32G4 reference manual:
![2024-04-05-133820_863x359_scrot](https://github.com/embassy-rs/stm32-data/assets/606010/7424c5e8-17dd-42e7-ad0d-83f9b25f2980)

* spi_v3, spi_v4, spi_v5: These versions are sensitive to the bit width of the read or write. From the STM32U5 reference manual:
![2024-04-05-132902_633x407_scrot](https://github.com/embassy-rs/stm32-data/assets/606010/f34b753c-e413-401b-b5a8-e900abb2b63a)
