### PR TITLE
render multi-line document properly

### DIFF
--- a/stm32-data-gen/src/chips.rs
+++ b/stm32-data-gen/src/chips.rs
@@ -114,6 +114,7 @@ struct PeriMatcher {
 
 impl PeriMatcher {
     fn new() -> Self {
+        #[rustfmt::skip]
         const PERIMAP: &[(&str, (&str, &str, &str))] = &[
             (".*:USART:sci2_v1_1", ("usart", "v1", "USART")),
             (".*:USART:sci2_v1_2_F1", ("usart", "v1", "USART")),
@@ -220,10 +221,7 @@ impl PeriMatcher {
             ("STM32G0.*:ADC\\d*_COMMON:.*", ("adccommon", "v3", "ADC_COMMON")),
             ("STM32U0.*:ADC\\d*_COMMON:.*", ("adccommon", "v3", "ADC_COMMON")),
             ("STM32G4.*:ADC\\d*_COMMON:.*", ("adccommon", "v4", "ADC_COMMON")),
-            (
-                "STM32(L[45]|W[BL]).*:ADC\\d*_COMMON:.*",
-                ("adccommon", "v3", "ADC_COMMON"),
-            ),
+            ("STM32(L[45]|W[BL]).*:ADC\\d*_COMMON:.*", ("adccommon", "v3", "ADC_COMMON")),
             ("STM32F3.*:ADC\\d*_COMMON:.*", ("adccommon", "f3", "ADC_COMMON")),
             ("STM32F[247].*:ADC\\d*_COMMON:.*", ("adccommon", "v2", "ADC_COMMON")),
             ("STM32H50.*:ADC\\d*_COMMON:.*", ("adccommon", "h50", "ADC_COMMON")),
@@ -247,10 +245,7 @@ impl PeriMatcher {
             ("STM32L5.*:SYSCFG:.*", ("syscfg", "l5", "SYSCFG")),
             ("STM32G0.*:SYSCFG:.*", ("syscfg", "g0", "SYSCFG")),
             ("STM32G4.*:SYSCFG:.*", ("syscfg", "g4", "SYSCFG")),
-            (
-                "STM32H7(45|47|55|57|42|43|53|50).*:SYSCFG:.*",
-                ("syscfg", "h7od", "SYSCFG"),
-            ),
+            ("STM32H7(45|47|55|57|42|43|53|50).*:SYSCFG:.*", ("syscfg", "h7od", "SYSCFG")),
             ("STM32H7.*:SYSCFG:.*", ("syscfg", "h7", "SYSCFG")),
             ("STM32U0.*:SYSCFG:.*", ("syscfg", "u0", "SYSCFG")),
             ("STM32U5.*:SYSCFG:.*", ("syscfg", "u5", "SYSCFG")),
@@ -511,10 +506,7 @@ impl PeriMatcher {
             // timer_v2 for STM32Gx/Hx/Ux/Wx (and Cx) serials
             ("STM32U5.*:TIM(3|4):.*", ("timer", "v2", "TIM_GP32")),
             ("STM32(G4|H5|U0|U5|WBA).*:TIM(1|8|20):.*", ("timer", "v2", "TIM_ADV")),
-            (
-                "STM32(G4|H5|U0|U5|WBA).*:TIM(2|5|23|24):.*",
-                ("timer", "v2", "TIM_GP32"),
-            ),
+            ("STM32(G4|H5|U0|U5|WBA).*:TIM(2|5|23|24):.*", ("timer", "v2", "TIM_GP32")),
             ("STM32(G4|H5|U0|U5|WBA).*:TIM(3|4):.*", ("timer", "v2", "TIM_GP16")),
             ("STM32(G4|H5|U0|U5|WBA).*:TIM(6|7):.*", ("timer", "v2", "TIM_BASIC")),
             ("STM32(G4|H5|U0|U5|WBA).*:TIM(13|14):.*", ("timer", "v2", "TIM_1CH")),
@@ -614,30 +606,12 @@ impl PeriMatcher {
             ("STM32WL.*:TAMP:.*", ("tamp", "wl", "TAMP")),
             (".*:OCTOSPIM:OCTOSPIM:.*", ("octospim", "v1", "OCTOSPIM")),
             // it's actually STM32L4+, not STM32L4
-            (
-                "STM32L4.*:OCTOSPI[12]:OCTOSPI:octospi_v1_0.*",
-                ("octospi", "v1", "OCTOSPI"),
-            ),
-            (
-                "STM32H7.*:OCTOSPI[12]:OCTOSPI:octospi_v2_1H7AB.*",
-                ("octospi", "v1", "OCTOSPI"),
-            ),
-            (
-                "STM32U5[34].*:OCTOSPI[12]:OCTOSPI:octospi_v1_0L5.*",
-                ("octospi", "v1", "OCTOSPI"),
-            ),
-            (
-                "STM32U5[AFG789].*:OCTOSPI[12]:OCTOSPI:octospi1_v3_0.*",
-                ("octospi", "v1", "OCTOSPI"),
-            ),
-            (
-                "STM32L5.*:OCTOSPI[12]:OCTOSPI:octospi_v1_0L5.*",
-                ("octospi", "v2", "OCTOSPI"),
-            ),
-            (
-                "STM32H5.*:OCTOSPI[12]:OCTOSPI:octospi1_v5_1.*",
-                ("octospi", "v2", "OCTOSPI"),
-            ),
+            ("STM32L4.*:OCTOSPI[12]:OCTOSPI:octospi_v1_0.*", ("octospi", "v1", "OCTOSPI")),
+            ("STM32H7.*:OCTOSPI[12]:OCTOSPI:octospi_v2_1H7AB.*", ("octospi", "v1", "OCTOSPI")),
+            ("STM32U5[34].*:OCTOSPI[12]:OCTOSPI:octospi_v1_0L5.*", ("octospi", "v1", "OCTOSPI")),
+            ("STM32U5[AFG789].*:OCTOSPI[12]:OCTOSPI:octospi1_v3_0.*", ("octospi", "v1", "OCTOSPI")),
+            ( "STM32L5.*:OCTOSPI[12]:OCTOSPI:octospi_v1_0L5.*", ("octospi", "v2", "OCTOSPI")),
+            ("STM32H5.*:OCTOSPI[12]:OCTOSPI:octospi1_v5_1.*", ("octospi", "v2", "OCTOSPI")),
             ("STM32L4.*:GFXMMU:.*", ("gfxmmu", "v1", "GFXMMU")),
             ("STM32U5.*:GFXMMU:.*", ("gfxmmu", "v2", "GFXMMU")),
             ("STM32U5.*:ICACHE:.*", ("icache", "v1_3crr", "ICACHE")),
@@ -1274,15 +1248,11 @@ fn process_core(
         .filter_map(|ip| {
             let version = &ip.version;
             let instance = &ip.instance_name;
-            if let Some(dma) = dma_channels
+            dma_channels
                 .0
                 .get(version)
                 .or_else(|| dma_channels.0.get(&format!("{version}:{instance}")))
-            {
-                Some((ip.name.clone(), instance.clone(), dma))
-            } else {
-                None
-            }
+                .map(|dma| (ip.name.clone(), instance.clone(), dma))
         })
         .collect();
     dmas.sort_by_key(|(name, instance, _)| {
@@ -1325,8 +1295,8 @@ fn process_core(
                 );
             }
         }
-            chs.sort_by_key(|ch| (ch.channel.clone(), ch.dmamux.clone(), ch.request));
-            p.dma_channels = chs;
+        chs.sort_by_key(|ch| (ch.channel.clone(), ch.dmamux.clone(), ch.request));
+        p.dma_channels = chs;
     }
 
     let mut core = stm32_data_serde::chip::Core {

--- a/stm32-data-gen/src/normalize_peris.rs
+++ b/stm32-data-gen/src/normalize_peris.rs
@@ -11,7 +11,8 @@ static NORMALIZE: &[(&str, &str)] = &[
 
 pub fn normalize_peri_name(name: &str) -> &str {
     if let Some((_, res)) = NORMALIZE.iter().find(|(n, _)| *n == name) {
-        return res;
+        res
+    } else {
+        name
     }
-    return name;
 }

--- a/stm32-metapac-gen/Cargo.toml
+++ b/stm32-metapac-gen/Cargo.toml
@@ -4,10 +4,9 @@ version = "0.1.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 
-
 [dependencies]
 regex = "1.7.1"
-chiptool = { git = "https://github.com/embassy-rs/chiptool", rev = "1c198ae678ebd426751513f0deab6fbd6f8b8211" }
+chiptool = { git = "https://github.com/eZioPan/chiptool", rev = "481e9d5f063e6f59ff0a34d25f9ce55c2f4b1421" }
 serde = { version = "1.0.157", features = [ "derive" ] }
 serde_json = "1.0.94"
 proc-macro2 = "1.0.52"


### PR DESCRIPTION
and some clippy fix.

---

will need a 


- [ ] Accept embassy-rs/chiptool#31
- [ ] Rebase to remove my fork from codebase.

---

This PR doesn't change function of stm32-data-gen, so there should be no change in ci diff.

---

BELOW IS OUT OF DATE, SEE embassy-rs/chiptool#31 INSTEAD

---

Render metapac document from one-line to multi-line.

eg.

from

```rust stm32-metapac/src/peripherals/cordic_v1.rs
#[doc = "Scaling factor. Input value has been multiplied by 2^(-n) before for argument. Output value will need to be multiplied by 2^n later for results."]
```

to

```rust
#[doc = "Scaling factor.  "]
#[doc = "Input value has been multiplied by 2^(-n) before for argument.  "]
#[doc = "Output value will need to be multiplied by 2^n later for results."]
```

![after](https://github.com/embassy-rs/stm32-data/assets/10928361/657465d8-42c2-4eba-b209-bd420f92dac5)

---