### PR TITLE
Generate ALL_CHIPS and ALL_PERIPHERAL_VERSIONS metadata

### DIFF
--- a/stm32-metapac-gen/res/src/lib.rs
+++ b/stm32-metapac-gen/res/src/lib.rs
@@ -13,4 +13,6 @@ include!(env!("STM32_METAPAC_PAC_PATH"));
 pub mod metadata {
     include!("metadata.rs");
     include!(env!("STM32_METAPAC_METADATA_PATH"));
+    include!("all_chips.rs");
+    include!("all_peripheral_versions.rs");
 }


### PR DESCRIPTION
As discussed in https://github.com/embassy-rs/embassy/pull/3005, let's export the list of all chip names and the list of all versions of all peripherals in the metadata, to be used in build.rs in embassy-stm32.