### PR TITLE
Small timer fixes and rearrangements

### DIFF
--- a/data/registers/timer_v1.yaml
+++ b/data/registers/timer_v1.yaml
@@ -46,15 +46,15 @@ block/TIM_1CH:
       stride: 4
     byte_offset: 52
     fieldset: CCR_1CH
+  - name: TISEL
+    description: input selection register
+    byte_offset: 104
+    fieldset: TISEL_1CH
   - name: OR
     description: |-
       Option register 1
       Note: Check Reference Manual to parse this register content
     byte_offset: 80
-  - name: TISEL
-    description: input selection register
-    byte_offset: 104
-    fieldset: TISEL_1CH
 block/TIM_1CH_CMP:
   extends: TIM_1CH
   description: 1-channel with one complementary output timers
@@ -212,14 +212,6 @@ block/TIM_2CH_CMP:
     description: break and dead-time register
     byte_offset: 68
     fieldset: BDTR_1CH_CMP
-  - name: DCR
-    description: DMA control register
-    byte_offset: 72
-    fieldset: DCR_1CH_CMP
-  - name: DMAR
-    description: DMA address for full transfer
-    byte_offset: 76
-    fieldset: DMAR_GP16
   - name: TISEL
     description: input selection register
     byte_offset: 104
@@ -240,7 +232,7 @@ block/TIM_ADV:
   - name: SMCR
     description: slave mode control register
     byte_offset: 8
-    fieldset: SMCR_ADV
+    fieldset: SMCR_GP16
   - name: DIER
     description: DMA/Interrupt enable register
     byte_offset: 12
@@ -422,10 +414,6 @@ block/TIM_GP16:
       stride: 4
     byte_offset: 52
     fieldset: CCR_1CH
-  - name: DCR
-    description: DMA control register
-    byte_offset: 72
-    fieldset: DCR_GP16
   - name: DMAR
     description: DMA address for full transfer
     byte_offset: 76
@@ -1118,15 +1106,6 @@ fieldset/DCR_1CH_CMP:
     description: DMA burst length
     bit_offset: 8
     bit_size: 5
-fieldset/DCR_GP16:
-  extends: DCR_1CH_CMP
-  description: DMA control register
-  fields:
-  - name: DBSS
-    description: DMA burst source selection
-    bit_offset: 16
-    bit_size: 4
-    enum: DBSS
 fieldset/DIER_1CH:
   extends: DIER_CORE
   description: DMA/Interrupt enable register
@@ -1199,10 +1178,6 @@ fieldset/DIER_ADV:
     array:
       len: 4
       stride: 1
-  - name: BIE
-    description: Break interrupt enable
-    bit_offset: 7
-    bit_size: 1
   - name: CCDE
     description: Capture/Compare x (x=1-4) DMA request enable
     bit_offset: 9
@@ -1394,29 +1369,6 @@ fieldset/SMCR_2CH:
     bit_offset: 7
     bit_size: 1
     enum: MSM
-fieldset/SMCR_ADV:
-  extends: SMCR_2CH
-  description: slave mode control register
-  fields:
-  - name: ETF
-    description: External trigger filter
-    bit_offset: 8
-    bit_size: 4
-    enum: FilterValue
-  - name: ETPS
-    description: External trigger prescaler
-    bit_offset: 12
-    bit_size: 2
-    enum: ETPS
-  - name: ECE
-    description: External clock mode 2 enable
-    bit_offset: 14
-    bit_size: 1
-  - name: ETP
-    description: External trigger polarity
-    bit_offset: 15
-    bit_size: 1
-    enum: ETP
 fieldset/SMCR_GP16:
   extends: SMCR_2CH
   description: slave mode control register
@@ -1543,7 +1495,7 @@ fieldset/SR_ADV:
       len: 4
       stride: 1
   - name: SBIF
-    description: System Break interrupt flag
+    description: System break interrupt flag
     bit_offset: 13
     bit_size: 1
   - name: CCIF5
@@ -1686,30 +1638,6 @@ enum/CMS:
   - name: CenterAligned3
     description: The counter counts up and down alternatively. Output compare interrupt flags are set both when the counter is counting up or down.
     value: 3
-enum/DBSS:
-  bit_size: 4
-  variants:
-  - name: Update
-    description: Update
-    value: 1
-  - name: CC1
-    description: CC1
-    value: 2
-  - name: CC2
-    description: CC2
-    value: 3
-  - name: CC3
-    description: CC3
-    value: 4
-  - name: CC4
-    description: CC4
-    value: 5
-  - name: COM
-    description: COM
-    value: 6
-  - name: Trigger
-    description: Trigger
-    value: 7
 enum/DIR:
   bit_size: 1
   variants:

--- a/data/registers/timer_v2.yaml
+++ b/data/registers/timer_v2.yaml
@@ -229,6 +229,13 @@ block/TIM_2CH_CMP:
       stride: 4
     byte_offset: 52
     fieldset: CCR_1CH
+  - name: CCR_DITHER
+    description: capture/compare register x (x=1-2) (Dither mode enabled)
+    array:
+      len: 2
+      stride: 4
+    byte_offset: 52
+    fieldset: CCR_DITHER_1CH
   - name: BDTR
     description: break and dead-time register
     byte_offset: 68
@@ -298,6 +305,10 @@ block/TIM_ADV:
       stride: 4
     byte_offset: 52
     fieldset: CCR_1CH
+  - name: ECR
+    description: encoder control register
+    byte_offset: 88
+    fieldset: ECR_GP16
   - name: BDTR
     description: break and dead-time register
     byte_offset: 68
@@ -322,10 +333,6 @@ block/TIM_ADV:
     description: capture/compare mode register 3
     byte_offset: 80
     fieldset: CCMR3_ADV
-  - name: TISEL
-    description: input selection register
-    byte_offset: 92
-    fieldset: TISEL_GP16
   - name: AF1
     description: alternate function register 1
     byte_offset: 96
@@ -334,6 +341,10 @@ block/TIM_ADV:
     description: alternate function register 2
     byte_offset: 100
     fieldset: AF2_ADV
+  - name: TISEL
+    description: input selection register
+    byte_offset: 92
+    fieldset: TISEL_GP16
 block/TIM_BASIC:
   extends: TIM_BASIC_NO_CR2
   description: Basic timers
@@ -455,10 +466,13 @@ block/TIM_GP16:
     description: encoder control register
     byte_offset: 88
     fieldset: ECR_GP16
-  - name: TISEL
-    description: input selection register
-    byte_offset: 92
-    fieldset: TISEL_GP16
+  - name: DCR
+    description: DMA control register
+    byte_offset: 988
+    fieldset: DCR_1CH_CMP
+  - name: DMAR
+    description: DMA address for full transfer
+    byte_offset: 992
   - name: AF1
     description: alternate function register 1
     byte_offset: 96
@@ -467,13 +481,10 @@ block/TIM_GP16:
     description: alternate function register 2
     byte_offset: 100
     fieldset: AF2_1CH_CMP
-  - name: DCR
-    description: DMA control register
-    byte_offset: 988
-    fieldset: DCR_1CH_CMP
-  - name: DMAR
-    description: DMA address for full transfer
-    byte_offset: 992
+  - name: TISEL
+    description: input selection register
+    byte_offset: 92
+    fieldset: TISEL_GP16
 block/TIM_GP32:
   extends: TIM_GP16
   description: General purpose 32-bit timers


### PR DESCRIPTION
- **Fix**: timer_v1 does not support field DBSS in register DCR
- Nitpick: in timer_v1, `block/TIM_2CH_CMP` does not need to override `DCR` and `DMAR`, because they are inherited from `block/TIM_1CH_CMP`
- Nitpick: in timer_v1, `fieldset/SMCR_ADV` was the same as `fieldset/SMCR_GP16`
- Nitpick: in timer_v1, `fieldset/DIER_ADV` does not need to override `BIE`, because it is inherited from `fieldset/DIER_1CH_CMP`
- **Fix**: in timer_v2, `block/TIM_2CH_CMP` should define `CCR_DITHER` as an array of len 2 (same as `CCR`)
- **Fix**: in timer_v2, `block/TIM_ADV` should define `ECR`
- Nitpick: in timer_v2, I put some registers in the same order as in timer_v1, to remove noise from the textual diff between timer_v1.yaml and timer_v2.yaml

I'm learning about the different types of STM32 timers and I created a [Google Sheet](https://docs.google.com/spreadsheets/d/1eeiW_iYWhJE245WIJOh_zEd9_FOLs4A49rqMteGU7Eo/edit?usp=sharing) with an overview of the various registers and their fields for different timer types and versions (only `v1` and `v2` at the moment, but I also want to have a look at `l0`). I found these fixes as irregularities in the table.