### PR TITLE
Further timer fixes

### DIFF
--- a/data/registers/timer_l0.yaml
+++ b/data/registers/timer_l0.yaml
@@ -62,7 +62,7 @@ block/TIM_2CH:
   - name: SMCR
     description: slave mode control register
     byte_offset: 8
-    fieldset: SMCR_2CH
+    fieldset: SMCR_GP16
   - name: DIER
     description: DMA/Interrupt enable register
     byte_offset: 12
@@ -547,11 +547,6 @@ fieldset/DCR_GP16:
     description: DMA burst length
     bit_offset: 8
     bit_size: 5
-  - name: DBSS
-    description: DMA burst source selection
-    bit_offset: 16
-    bit_size: 4
-    enum: DBSS
 fieldset/DIER_1CH:
   extends: DIER_CORE
   description: DMA/Interrupt enable register
@@ -674,7 +669,7 @@ fieldset/EGR_GP16:
     description: Trigger generation
     bit_offset: 6
     bit_size: 1
-fieldset/SMCR_2CH:
+fieldset/SMCR_GP16:
   description: slave mode control register
   fields:
   - name: SMS
@@ -692,29 +687,6 @@ fieldset/SMCR_2CH:
     bit_offset: 7
     bit_size: 1
     enum: MSM
-  - name: ETF
-    description: External trigger filter
-    bit_offset: 8
-    bit_size: 4
-    enum: FilterValue
-  - name: ETPS
-    description: External trigger prescaler
-    bit_offset: 12
-    bit_size: 2
-    enum: ETPS
-  - name: ECE
-    description: External clock mode 2 enable
-    bit_offset: 14
-    bit_size: 1
-  - name: ETP
-    description: External trigger polarity
-    bit_offset: 15
-    bit_size: 1
-    enum: ETP
-fieldset/SMCR_GP16:
-  extends: SMCR_2CH
-  description: slave mode control register
-  fields:
   - name: ETF
     description: External trigger filter
     bit_offset: 8
@@ -857,30 +829,6 @@ enum/CMS:
   - name: CenterAligned3
     description: The counter counts up and down alternatively. Output compare interrupt flags are set both when the counter is counting up or down.
     value: 3
-enum/DBSS:
-  bit_size: 4
-  variants:
-  - name: Update
-    description: Update
-    value: 1
-  - name: CC1
-    description: CC1
-    value: 2
-  - name: CC2
-    description: CC2
-    value: 3
-  - name: CC3
-    description: CC3
-    value: 4
-  - name: CC4
-    description: CC4
-    value: 5
-  - name: COM
-    description: COM
-    value: 6
-  - name: Trigger
-    description: Trigger
-    value: 7
 enum/DIR:
   bit_size: 1
   variants:
@@ -1032,7 +980,7 @@ enum/SMS:
   bit_size: 3
   variants:
   - name: Disabled
-    description: Slave mode disabled - if CEN = ‘1 then the prescaler is clocked directly by the internal clock.
+    description: Slave mode disabled - if CEN = '1' then the prescaler is clocked directly by the internal clock.
     value: 0
   - name: Encoder_Mode_1
     description: Encoder mode 1 - Counter counts up/down on TI2FP1 edge depending on TI1FP2 level.

--- a/data/registers/timer_v1.yaml
+++ b/data/registers/timer_v1.yaml
@@ -414,6 +414,10 @@ block/TIM_GP16:
       stride: 4
     byte_offset: 52
     fieldset: CCR_1CH
+  - name: DCR
+    description: DMA control register
+    byte_offset: 72
+    fieldset: DCR_1CH_CMP
   - name: DMAR
     description: DMA address for full transfer
     byte_offset: 76
@@ -442,10 +446,6 @@ block/TIM_GP32:
       len: 4
       stride: 4
     byte_offset: 52
-  - name: DCR
-    description: DMA control register
-    byte_offset: 72
-    fieldset: DCR_1CH_CMP
 fieldset/AF1_1CH_CMP:
   description: alternate function register 1
   fields:
@@ -1159,6 +1159,10 @@ fieldset/DIER_2CH_CMP:
   extends: DIER_1CH_CMP
   description: DMA/Interrupt enable register
   fields:
+  - name: TIE
+    description: Trigger interrupt enable
+    bit_offset: 6
+    bit_size: 1
   - name: COMDE
     description: COM DMA request enable
     bit_offset: 13

--- a/data/registers/timer_v2.yaml
+++ b/data/registers/timer_v2.yaml
@@ -1361,6 +1361,10 @@ fieldset/DIER_2CH_CMP:
   extends: DIER_1CH_CMP
   description: DMA/Interrupt enable register
   fields:
+  - name: TIE
+    description: Trigger interrupt enable
+    bit_offset: 6
+    bit_size: 1
   - name: COMDE
     description: COM DMA request enable
     bit_offset: 13


### PR DESCRIPTION
- **Fix**: in timer_v1, I removed `DCR` from `block/TIM_GP16` by mistake in #484 :see_no_evil:
- **Fix**: timer_l0 does not support field `DBSS` in register `DCR`
- **Fix**: in timer_v1 and timer_v2, register `DIER` of `TIM_2CH_CMP` has field `TIE`
- Nitpick: in timer_l0, `fieldset/SMCR_2CH` is the same as `fieldset/GP_16`