### PR TITLE
Refactor timer taxonomy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 /sources
 /tmp
 .idea/
+Session.vim
 .DS_Store
 # transform*.yaml
 __pycache__

--- a/data/registers/timer_l0.yaml
+++ b/data/registers/timer_l0.yaml
@@ -1,125 +1,5 @@
-block/TIM_1CH:
-  extends: TIM_CORE
-  description: Virtual 1-channel timers
-  items:
-  - name: CR1
-    description: control register 1
-    byte_offset: 0
-    bit_size: 16
-    fieldset: CR1_1CH
-  - name: DIER
-    description: DMA/Interrupt enable register
-    byte_offset: 12
-    fieldset: DIER_1CH
-  - name: SR
-    description: status register
-    byte_offset: 16
-    fieldset: SR_1CH
-  - name: EGR
-    description: event generation register
-    byte_offset: 20
-    access: Write
-    bit_size: 16
-    fieldset: EGR_1CH
-  - name: CCMR_Input
-    description: capture/compare mode register 1 (input mode)
-    array:
-      len: 1
-      stride: 4
-    byte_offset: 24
-    fieldset: CCMR_Input_1CH
-  - name: CCMR_Output
-    description: capture/compare mode register 1 (output mode)
-    array:
-      len: 1
-      stride: 4
-    byte_offset: 24
-    fieldset: CCMR_Output_1CH
-  - name: CCER
-    description: capture/compare enable register
-    byte_offset: 32
-    fieldset: CCER_1CH
-  - name: CCR
-    description: capture/compare register x (x=1)
-    array:
-      len: 1
-      stride: 4
-    byte_offset: 52
-    fieldset: CCR_1CH
-  - name: OR
-    description: |-
-      Option register 1
-      Note: Check Reference Manual to parse this register content
-    byte_offset: 80
-block/TIM_2CH:
-  extends: TIM_1CH
-  description: 2-channel timers
-  items:
-  - name: CR2
-    description: control register 2
-    byte_offset: 4
-    fieldset: CR2_2CH
-  - name: SMCR
-    description: slave mode control register
-    byte_offset: 8
-    fieldset: SMCR_GP16
-  - name: DIER
-    description: DMA/Interrupt enable register
-    byte_offset: 12
-    fieldset: DIER_2CH
-  - name: SR
-    description: status register
-    byte_offset: 16
-    fieldset: SR_2CH
-  - name: EGR
-    description: event generation register
-    byte_offset: 20
-    access: Write
-    bit_size: 16
-    fieldset: EGR_2CH
-  - name: CCMR_Input
-    description: capture/compare mode register 1 (input mode)
-    array:
-      len: 1
-      stride: 4
-    byte_offset: 24
-    fieldset: CCMR_Input_2CH
-  - name: CCMR_Output
-    description: capture/compare mode register 1 (output mode)
-    array:
-      len: 1
-      stride: 4
-    byte_offset: 24
-    fieldset: CCMR_Output_2CH
-  - name: CCER
-    description: capture/compare enable register
-    byte_offset: 32
-    fieldset: CCER_2CH
-  - name: CCR
-    description: capture/compare register x (x=1-2)
-    array:
-      len: 2
-      stride: 4
-    byte_offset: 52
-    fieldset: CCR_1CH
-block/TIM_BASIC:
-  extends: TIM_BASIC_NO_CR2
-  description: Basic timers
-  items:
-  - name: CR2
-    description: control register 2
-    byte_offset: 4
-    fieldset: CR2_BASIC
-block/TIM_BASIC_NO_CR2:
-  extends: TIM_CORE
-  description: Virtual Basic timers without CR2 register for common part of TIM_BASIC and TIM_1CH_CMP
-  items:
-  - name: DIER
-    description: DMA/Interrupt enable register
-    byte_offset: 12
-    fieldset: DIER_BASIC_NO_CR2
 block/TIM_CORE:
-  description: Virtual timer for common part of TIM_BASIC and TIM_1CH
+  description: Virtual timer for common parts of all timers
   items:
   - name: CR1
     description: control register 1
@@ -152,55 +32,61 @@ block/TIM_CORE:
     description: auto-reload register
     byte_offset: 44
     fieldset: ARR_CORE
-block/TIM_GP16:
-  extends: TIM_2CH
-  description: General purpose 16-bit timers
+
+block/TIM_BASIC:
+  extends: TIM_CORE
+  description: Basic timers
+  items:
+  - name: CR2
+    description: control register 2
+    byte_offset: 4
+    fieldset: CR2_MMS
+  - name: DIER
+    description: DMA/Interrupt enable register
+    byte_offset: 12
+    fieldset: DIER_UPDMA
+
+block/TIM_1CH:
+  extends: TIM_CORE
+  description: 1-channel timers
   items:
   - name: CR1
     description: control register 1
     byte_offset: 0
     bit_size: 16
-    fieldset: CR1_GP16
-  - name: CR2
-    description: control register 2
-    byte_offset: 4
-    fieldset: CR2_GP16
-  - name: SMCR
-    description: slave mode control register
-    byte_offset: 8
-    fieldset: SMCR_GP16
+    fieldset: CR1_1CH
   - name: DIER
     description: DMA/Interrupt enable register
     byte_offset: 12
-    fieldset: DIER_GP16
+    fieldset: DIER_1CH
   - name: SR
     description: status register
     byte_offset: 16
-    fieldset: SR_GP16
+    fieldset: SR_1CH
   - name: EGR
     description: event generation register
     byte_offset: 20
     access: Write
     bit_size: 16
-    fieldset: EGR_GP16
+    fieldset: EGR_1CH
   - name: CCMR_Input
-    description: capture/compare mode register 1-2 (input mode)
+    description: capture/compare mode register 1 (input mode)
     array:
       len: 2
       stride: 4
     byte_offset: 24
-    fieldset: CCMR_Input_2CH
+    fieldset: CCMR_Input_1CH
   - name: CCMR_Output
-    description: capture/compare mode register 1-2 (output mode)
+    description: capture/compare mode register 1 (output mode)
     array:
       len: 2
       stride: 4
     byte_offset: 24
-    fieldset: CCMR_Output_GP16
+    fieldset: CCMR_Output_1CH
   - name: CCER
     description: capture/compare enable register
     byte_offset: 32
-    fieldset: CCER_GP16
+    fieldset: CCER_1CH
   - name: CCR
     description: capture/compare register x (x=1-4)
     array:
@@ -208,252 +94,85 @@ block/TIM_GP16:
       stride: 4
     byte_offset: 52
     fieldset: CCR_1CH
+  - name: OR
+    description: |-
+      Option register 1
+      Note: Check Reference Manual to parse this register content
+    byte_offset: 80
+
+block/TIM_2CH:
+  extends: TIM_1CH
+  description: 2-channel timers
+  items:
+  - name: CR1
+    description: control register 1
+    byte_offset: 0
+    bit_size: 16
+    fieldset: CR1_2CH
+  - name: CR2
+    description: control register 2
+    byte_offset: 4
+    fieldset: CR2_2CH
+  - name: SMCR
+    description: slave mode control register
+    byte_offset: 8
+    fieldset: SMCR_2CH
+  - name: DIER
+    description: DMA/Interrupt enable register
+    byte_offset: 12
+    fieldset: DIER_2CH
+  - name: SR
+    description: status register
+    byte_offset: 16
+    fieldset: SR_2CH
+  - name: EGR
+    description: event generation register
+    byte_offset: 20
+    access: Write
+    bit_size: 16
+    fieldset: EGR_2CH
+
+block/TIM_4CH:
+  extends: TIM_2CH
+  description: General purpose 16-bit timers
+  items:
+  - name: CR1
+    description: control register 1
+    byte_offset: 0
+    bit_size: 16
+    fieldset: CR1_4CH
+  - name: CR2
+    description: control register 2
+    byte_offset: 4
+    fieldset: CR2_TRIGDMA
+  - name: SMCR
+    description: slave mode control register
+    byte_offset: 8
+    fieldset: SMCR_4CH
+  - name: DIER
+    description: DMA/Interrupt enable register
+    byte_offset: 12
+    fieldset: DIER_4CH
+  - name: SR
+    description: status register
+    byte_offset: 16
+    fieldset: SR_4CH
+  - name: CCMR_Output
+    description: capture/compare mode register 1-2 (output mode)
+    array:
+      len: 2
+      stride: 4
+    byte_offset: 24
+    fieldset: CCMR_Output_4CH
   - name: DCR
     description: DMA control register
     byte_offset: 72
-    fieldset: DCR_GP16
+    fieldset: DCR_CCDMA
   - name: DMAR
     description: DMA address for full transfer
     byte_offset: 76
-    fieldset: DMAR_GP16
-fieldset/ARR_CORE:
-  description: auto-reload register
-  fields:
-  - name: ARR
-    description: Auto-reload value
-    bit_offset: 0
-    bit_size: 16
-fieldset/CCER_1CH:
-  description: capture/compare enable register
-  fields:
-  - name: CCE
-    description: Capture/Compare x (x=1) output enable
-    bit_offset: 0
-    bit_size: 1
-    array:
-      len: 1
-      stride: 4
-  - name: CCP
-    description: Capture/Compare x (x=1) output Polarity
-    bit_offset: 1
-    bit_size: 1
-    array:
-      len: 1
-      stride: 4
-  - name: CCNP
-    description: Capture/Compare x (x=1) output Polarity
-    bit_offset: 3
-    bit_size: 1
-    array:
-      len: 1
-      stride: 4
-fieldset/CCER_2CH:
-  extends: CCER_1CH
-  description: capture/compare enable register
-  fields:
-  - name: CCE
-    description: Capture/Compare x (x=1-2) output enable
-    bit_offset: 0
-    bit_size: 1
-    array:
-      len: 2
-      stride: 4
-  - name: CCP
-    description: Capture/Compare x (x=1-2) output Polarity
-    bit_offset: 1
-    bit_size: 1
-    array:
-      len: 2
-      stride: 4
-  - name: CCNP
-    description: Capture/Compare x (x=1-2) output Polarity
-    bit_offset: 3
-    bit_size: 1
-    array:
-      len: 2
-      stride: 4
-fieldset/CCER_GP16:
-  description: capture/compare enable register
-  fields:
-  - name: CCE
-    description: Capture/Compare x (x=1-4) output enable
-    bit_offset: 0
-    bit_size: 1
-    array:
-      len: 4
-      stride: 4
-  - name: CCP
-    description: Capture/Compare x (x=1-4) output Polarity
-    bit_offset: 1
-    bit_size: 1
-    array:
-      len: 4
-      stride: 4
-  - name: CCNP
-    description: Capture/Compare x (x=1-4) output Polarity
-    bit_offset: 3
-    bit_size: 1
-    array:
-      len: 4
-      stride: 4
-fieldset/CCMR_Input_1CH:
-  description: capture/compare mode register x (x=1) (input mode)
-  fields:
-  - name: CCS
-    description: Capture/Compare y selection
-    bit_offset: 0
-    bit_size: 2
-    array:
-      len: 1
-      stride: 8
-    enum: CCMR_Input_CCS
-  - name: ICPSC
-    description: Input capture y prescaler
-    bit_offset: 2
-    bit_size: 2
-    array:
-      len: 1
-      stride: 8
-  - name: ICF
-    description: Input capture y filter
-    bit_offset: 4
-    bit_size: 4
-    array:
-      len: 1
-      stride: 8
-    enum: FilterValue
-fieldset/CCMR_Input_2CH:
-  extends: CCMR_Input_1CH
-  description: capture/compare mode register x (x=1) (input mode)
-  fields:
-  - name: CCS
-    description: Capture/Compare y selection
-    bit_offset: 0
-    bit_size: 2
-    array:
-      len: 2
-      stride: 8
-    enum: CCMR_Input_CCS
-  - name: ICPSC
-    description: Input capture y prescaler
-    bit_offset: 2
-    bit_size: 2
-    array:
-      len: 2
-      stride: 8
-  - name: ICF
-    description: Input capture y filter
-    bit_offset: 4
-    bit_size: 4
-    array:
-      len: 2
-      stride: 8
-    enum: FilterValue
-fieldset/CCMR_Output_1CH:
-  description: capture/compare mode register x (x=1) (output mode)
-  fields:
-  - name: CCS
-    description: Capture/Compare y selection
-    bit_offset: 0
-    bit_size: 2
-    array:
-      len: 1
-      stride: 8
-    enum: CCMR_Output_CCS
-  - name: OCFE
-    description: Output compare y fast enable
-    bit_offset: 2
-    bit_size: 1
-    array:
-      len: 1
-      stride: 8
-  - name: OCPE
-    description: Output compare y preload enable
-    bit_offset: 3
-    bit_size: 1
-    array:
-      len: 1
-      stride: 8
-  - name: OCM
-    description: Output compare y mode
-    bit_offset: 4
-    bit_size: 3
-    array:
-      len: 1
-      stride: 8
-    enum: OCM
-fieldset/CCMR_Output_2CH:
-  extends: CCMR_Output_1CH
-  description: capture/compare mode register x (x=1) (output mode)
-  fields:
-  - name: CCS
-    description: Capture/Compare y selection
-    bit_offset: 0
-    bit_size: 2
-    array:
-      len: 2
-      stride: 8
-    enum: CCMR_Output_CCS
-  - name: OCFE
-    description: Output compare y fast enable
-    bit_offset: 2
-    bit_size: 1
-    array:
-      len: 2
-      stride: 8
-  - name: OCPE
-    description: Output compare y preload enable
-    bit_offset: 3
-    bit_size: 1
-    array:
-      len: 2
-      stride: 8
-  - name: OCM
-    description: Output compare y mode
-    bit_offset: 4
-    bit_size: 3
-    array:
-      len: 2
-      stride: 8
-    enum: OCM
-fieldset/CCMR_Output_GP16:
-  extends: CCMR_Output_2CH
-  description: capture/compare mode register x (x=1-2) (output mode)
-  fields:
-  - name: OCCE
-    description: Output compare y clear enable
-    bit_offset: 7
-    bit_size: 1
-    array:
-      len: 2
-      stride: 8
-fieldset/CCR_1CH:
-  description: capture/compare register x (x=1-4,6)
-  fields:
-  - name: CCR
-    description: capture/compare x (x=1-4,6) value
-    bit_offset: 0
-    bit_size: 16
-fieldset/CNT_CORE:
-  description: counter
-  fields:
-  - name: CNT
-    description: counter value
-    bit_offset: 0
-    bit_size: 16
-  - name: UIFCPY
-    description: UIF copy
-    bit_offset: 31
-    bit_size: 1
-fieldset/CR1_1CH:
-  extends: CR1_CORE
-  description: control register 1
-  fields:
-  - name: CKD
-    description: Clock division
-    bit_offset: 8
-    bit_size: 2
-    enum: CKD
+
+# CR1 register
 fieldset/CR1_CORE:
   description: control register 1
   fields:
@@ -478,12 +197,17 @@ fieldset/CR1_CORE:
     description: Auto-reload preload enable
     bit_offset: 7
     bit_size: 1
-  - name: UIFREMAP
-    description: UIF status bit remapping enable
-    bit_offset: 11
-    bit_size: 1
-fieldset/CR1_GP16:
+fieldset/CR1_1CH:
   extends: CR1_CORE
+  description: control register 1
+  fields:
+  - name: CKD
+    description: Clock division
+    bit_offset: 8
+    bit_size: 2
+    enum: CKD
+fieldset/CR1_2CH:
+  extends: CR1_1CH
   description: control register 1
   fields:
   - name: DIR
@@ -496,34 +220,25 @@ fieldset/CR1_GP16:
     bit_offset: 5
     bit_size: 2
     enum: CMS
-  - name: CKD
-    description: Clock division
-    bit_offset: 8
-    bit_size: 2
-    enum: CKD
+fieldset/CR1_4CH:
+  extends: CR1_2CH
+  description: control register 1
+  fields: []
+
+# CR2 register
+fieldset/CR2_MMS:
+  description: control register 2
+  fields:
+  - name: MMS
+    description: Master mode selection
+    bit_offset: 4
+    bit_size: 3
+    enum: MMS
 fieldset/CR2_2CH:
+  extends: CR2_MMS
   description: control register 2
-  fields:
-  - name: MMS
-    description: Master mode selection
-    bit_offset: 4
-    bit_size: 3
-    enum: MMS
-  - name: TI1S
-    description: TI1 selection
-    bit_offset: 7
-    bit_size: 1
-    enum: TI1S
-fieldset/CR2_BASIC:
-  description: control register 2
-  fields:
-  - name: MMS
-    description: Master mode selection
-    bit_offset: 4
-    bit_size: 3
-    enum: MMS
-fieldset/CR2_GP16:
-  extends: CR2_BASIC
+  fields: []
+fieldset/CR2_CCDMA:
   description: control register 2
   fields:
   - name: CCDS
@@ -531,145 +246,23 @@ fieldset/CR2_GP16:
     bit_offset: 3
     bit_size: 1
     enum: CCDS
+fieldset/CR2_TRIGDMA:
+  extends: CR2_CCDMA
+  description: control register 2
+  fields:
+  - name: MMS
+    description: Master mode selection
+    bit_offset: 4
+    bit_size: 3
+    enum: MMS
   - name: TI1S
     description: TI1 selection
     bit_offset: 7
     bit_size: 1
     enum: TI1S
-fieldset/DCR_GP16:
-  description: DMA control register
-  fields:
-  - name: DBA
-    description: DMA base address
-    bit_offset: 0
-    bit_size: 5
-  - name: DBL
-    description: DMA burst length
-    bit_offset: 8
-    bit_size: 5
-fieldset/DIER_1CH:
-  extends: DIER_CORE
-  description: DMA/Interrupt enable register
-  fields:
-  - name: CCIE
-    description: Capture/Compare x (x=1) interrupt enable
-    bit_offset: 1
-    bit_size: 1
-    array:
-      len: 1
-      stride: 1
-fieldset/DIER_2CH:
-  extends: DIER_1CH
-  description: DMA/Interrupt enable register
-  fields:
-  - name: CCIE
-    description: Capture/Compare x (x=1-2) interrupt enable
-    bit_offset: 1
-    bit_size: 1
-    array:
-      len: 2
-      stride: 1
-  - name: TIE
-    description: Trigger interrupt enable
-    bit_offset: 6
-    bit_size: 1
-fieldset/DIER_BASIC_NO_CR2:
-  extends: DIER_CORE
-  description: DMA/Interrupt enable register
-  fields:
-  - name: UDE
-    description: Update DMA request enable
-    bit_offset: 8
-    bit_size: 1
-fieldset/DIER_CORE:
-  description: DMA/Interrupt enable register
-  fields:
-  - name: UIE
-    description: Update interrupt enable
-    bit_offset: 0
-    bit_size: 1
-fieldset/DIER_GP16:
-  extends: DIER_BASIC_NO_CR2
-  description: DMA/Interrupt enable register
-  fields:
-  - name: CCIE
-    description: Capture/Compare x (x=1-4) interrupt enable
-    bit_offset: 1
-    bit_size: 1
-    array:
-      len: 4
-      stride: 1
-  - name: TIE
-    description: Trigger interrupt enable
-    bit_offset: 6
-    bit_size: 1
-  - name: CCDE
-    description: Capture/Compare x (x=1-4) DMA request enable
-    bit_offset: 9
-    bit_size: 1
-    array:
-      len: 4
-      stride: 1
-  - name: TDE
-    description: Trigger DMA request enable
-    bit_offset: 14
-    bit_size: 1
-fieldset/DMAR_GP16:
-  description: DMA address for full transfer
-  fields:
-  - name: DMAB
-    description: DMA register for burst accesses
-    bit_offset: 0
-    bit_size: 16
-fieldset/EGR_1CH:
-  extends: EGR_CORE
-  description: event generation register
-  fields:
-  - name: CCG
-    description: Capture/compare x (x=1) generation
-    bit_offset: 1
-    bit_size: 1
-    array:
-      len: 1
-      stride: 1
-fieldset/EGR_2CH:
-  extends: EGR_1CH
-  description: event generation register
-  fields:
-  - name: CCG
-    description: Capture/compare x (x=1-2) generation
-    bit_offset: 1
-    bit_size: 1
-    array:
-      len: 2
-      stride: 1
-  - name: TG
-    description: Trigger generation
-    bit_offset: 6
-    bit_size: 1
-fieldset/EGR_CORE:
-  description: event generation register
-  fields:
-  - name: UG
-    description: Update generation
-    bit_offset: 0
-    bit_size: 1
-fieldset/EGR_GP16:
-  extends: EGR_CORE
-  description: event generation register
-  fields:
-  - name: CCG
-    description: Capture/compare x (x=1-4) generation
-    bit_offset: 1
-    bit_size: 1
-    array:
-      len: 4
-      stride: 1
-  - name: TG
-    description: Trigger generation
-    bit_offset: 6
-    bit_size: 1
-fieldset/SMCR_GP16:
+
+# SMCR register
+fieldset/SMCR_2CH:
   description: slave mode control register
   fields:
   - name: SMS
@@ -706,46 +299,75 @@ fieldset/SMCR_GP16:
     bit_offset: 15
     bit_size: 1
     enum: ETP
-fieldset/SR_1CH:
-  extends: SR_CORE
-  description: status register
+fieldset/SMCR_TRIGDMA:
+  extends: SMCR_2CH
+  description: slave mode control register
+  fields: []
+fieldset/SMCR_4CH:
+  extends: SMCR_TRIGDMA
+  description: slave mode control register
+  fields: []
+
+# DIER register
+fieldset/DIER_CORE:
+  description: DMA/Interrupt enable register
   fields:
-  - name: CCIF
-    description: Capture/compare x (x=1) interrupt flag
+  - name: UIE
+    description: Update interrupt enable
+    bit_offset: 0
+    bit_size: 1
+fieldset/DIER_UPDMA:
+  extends: DIER_CORE
+  description: DMA/Interrupt enable register
+  fields:
+  - name: UDE
+    description: Update DMA request enable
+    bit_offset: 8
+    bit_size: 1
+fieldset/DIER_1CH:
+  extends: DIER_CORE
+  description: DMA/Interrupt enable register
+  fields:
+  - name: CCIE
+    description: Capture/Compare x (x=1-4) interrupt enable
     bit_offset: 1
     bit_size: 1
     array:
-      len: 1
+      len: 4
       stride: 1
-  - name: CCOF
-    description: Capture/Compare x (x=1) overcapture flag
-    bit_offset: 9
-    bit_size: 1
-    array:
-      len: 1
-      stride: 1
-fieldset/SR_2CH:
-  extends: SR_1CH
-  description: status register
+fieldset/DIER_2CH:
+  extends: DIER_1CH
+  description: DMA/Interrupt enable register
   fields:
-  - name: CCIF
-    description: Capture/compare x (x=1-2) interrupt flag
-    bit_offset: 1
-    bit_size: 1
-    array:
-      len: 2
-      stride: 1
-  - name: TIF
-    description: Trigger interrupt flag
+  - name: TIE
+    description: Trigger interrupt enable
     bit_offset: 6
     bit_size: 1
-  - name: CCOF
-    description: Capture/Compare x (x=1-2) overcapture flag
+fieldset/DIER_CCDMA:
+  extends: DIER_1CH
+  description: DMA/Interrupt enable register
+  fields:
+  - name: CCDE
+    description: Capture/Compare x (x=1-4) DMA request enable
     bit_offset: 9
     bit_size: 1
     array:
-      len: 2
+      len: 4
       stride: 1
+fieldset/DIER_TRIGDMA:
+  extends: DIER_CCDMA
+  description: DMA/Interrupt enable register
+  fields:
+  - name: TDE
+    description: Trigger DMA request enable
+    bit_offset: 14
+    bit_size: 1
+fieldset/DIER_4CH:
+  extends: DIER_TRIGDMA
+  description: DMA/Interrupt enable register
+  fields: []
+
+# SR register
 fieldset/SR_CORE:
   description: status register
   fields:
@@ -753,7 +375,7 @@ fieldset/SR_CORE:
     description: Update interrupt flag
     bit_offset: 0
     bit_size: 1
-fieldset/SR_GP16:
+fieldset/SR_1CH:
   extends: SR_CORE
   description: status register
   fields:
@@ -764,10 +386,6 @@ fieldset/SR_GP16:
     array:
       len: 4
       stride: 1
-  - name: TIF
-    description: Trigger interrupt flag
-    bit_offset: 6
-    bit_size: 1
   - name: CCOF
     description: Capture/Compare x (x=1-4) overcapture flag
     bit_offset: 9
@@ -775,6 +393,189 @@ fieldset/SR_GP16:
     array:
       len: 4
       stride: 1
+fieldset/SR_2CH:
+  extends: SR_1CH
+  description: status register
+  fields:
+  - name: TIF
+    description: Trigger interrupt flag
+    bit_offset: 6
+    bit_size: 1
+fieldset/SR_4CH:
+  extends: SR_2CH
+  description: status register
+  fields: []
+
+# EGR register
+fieldset/EGR_CORE:
+  description: event generation register
+  fields:
+  - name: UG
+    description: Update generation
+    bit_offset: 0
+    bit_size: 1
+fieldset/EGR_1CH:
+  extends: EGR_CORE
+  description: event generation register
+  fields:
+  - name: CCG
+    description: Capture/compare x (x=1-4) generation
+    bit_offset: 1
+    bit_size: 1
+    array:
+      len: 4
+      stride: 1
+fieldset/EGR_2CH:
+  extends: EGR_1CH
+  description: event generation register
+  fields:
+  - name: TG
+    description: Trigger generation
+    bit_offset: 6
+    bit_size: 1
+
+# CCMR register
+fieldset/CCMR_Input_1CH:
+  description: capture/compare mode register (input mode)
+  fields:
+  - name: CCS
+    description: Capture/Compare y selection
+    bit_offset: 0
+    bit_size: 2
+    array:
+      len: 2
+      stride: 8
+    enum: CCMR_Input_CCS
+  - name: ICPSC
+    description: Input capture y prescaler
+    bit_offset: 2
+    bit_size: 2
+    array:
+      len: 2
+      stride: 8
+  - name: ICF
+    description: Input capture y filter
+    bit_offset: 4
+    bit_size: 4
+    array:
+      len: 2
+      stride: 8
+    enum: FilterValue
+fieldset/CCMR_Output_1CH:
+  description: capture/compare mode register (output mode)
+  fields:
+  - name: CCS
+    description: Capture/Compare y selection
+    bit_offset: 0
+    bit_size: 2
+    array:
+      len: 2
+      stride: 8
+    enum: CCMR_Output_CCS
+  - name: OCFE
+    description: Output compare y fast enable
+    bit_offset: 2
+    bit_size: 1
+    array:
+      len: 2
+      stride: 8
+  - name: OCPE
+    description: Output compare y preload enable
+    bit_offset: 3
+    bit_size: 1
+    array:
+      len: 2
+      stride: 8
+  - name: OCM
+    description: Output compare y mode
+    bit_offset: 4
+    bit_size: 3
+    array:
+      len: 2
+      stride: 8
+    enum: OCM
+fieldset/CCMR_Output_4CH:
+  extends: CCMR_Output_1CH
+  description: capture/compare mode register (output mode)
+  fields:
+  - name: OCCE
+    description: Output compare y clear enable
+    bit_offset: 7
+    bit_size: 1
+    array:
+      len: 2
+      stride: 8
+
+# CCER register
+fieldset/CCER_1CH:
+  description: capture/compare enable register
+  fields:
+  - name: CCE
+    description: Capture/Compare x (x=1-4) output enable
+    bit_offset: 0
+    bit_size: 1
+    array:
+      len: 4
+      stride: 4
+  - name: CCP
+    description: Capture/Compare x (x=1-4) output Polarity
+    bit_offset: 1
+    bit_size: 1
+    array:
+      len: 4
+      stride: 4
+  - name: CCNP
+    description: Capture/Compare x (x=1-4) output Polarity
+    bit_offset: 3
+    bit_size: 1
+    array:
+      len: 4
+      stride: 4
+
+# CNT register
+fieldset/CNT_CORE:
+  description: counter
+  fields:
+  - name: CNT
+    description: counter value
+    bit_offset: 0
+    bit_size: 16
+  - name: UIFCPY
+    description: UIF copy
+    bit_offset: 31
+    bit_size: 1
+
+# ARR register
+fieldset/ARR_CORE:
+  description: auto-reload register
+  fields:
+  - name: ARR
+    description: Auto-reload value
+    bit_offset: 0
+    bit_size: 16
+
+# CCR register
+fieldset/CCR_1CH:
+  description: capture/compare register x (x=1-4,6)
+  fields:
+  - name: CCR
+    description: capture/compare x (x=1-4,6) value
+    bit_offset: 0
+    bit_size: 16
+
+# DCR register
+fieldset/DCR_CCDMA:
+  description: DMA control register
+  fields:
+  - name: DBA
+    description: DMA base address
+    bit_offset: 0
+    bit_size: 5
+  - name: DBL
+    description: DMA burst length
+    bit_offset: 8
+    bit_size: 5
+
 enum/CCDS:
   bit_size: 1
   variants:

--- a/data/registers/timer_v1.yaml
+++ b/data/registers/timer_v1.yaml
@@ -1,331 +1,5 @@
-block/TIM_1CH:
-  extends: TIM_CORE
-  description: 1-channel timers
-  items:
-  - name: CR1
-    description: control register 1
-    byte_offset: 0
-    bit_size: 16
-    fieldset: CR1_1CH
-  - name: DIER
-    description: DMA/Interrupt enable register
-    byte_offset: 12
-    fieldset: DIER_1CH
-  - name: SR
-    description: status register
-    byte_offset: 16
-    fieldset: SR_1CH
-  - name: EGR
-    description: event generation register
-    byte_offset: 20
-    access: Write
-    bit_size: 16
-    fieldset: EGR_1CH
-  - name: CCMR_Input
-    description: capture/compare mode register 1 (input mode)
-    array:
-      len: 1
-      stride: 4
-    byte_offset: 24
-    fieldset: CCMR_Input_1CH
-  - name: CCMR_Output
-    description: capture/compare mode register 1 (output mode)
-    array:
-      len: 1
-      stride: 4
-    byte_offset: 24
-    fieldset: CCMR_Output_1CH
-  - name: CCER
-    description: capture/compare enable register
-    byte_offset: 32
-    fieldset: CCER_1CH
-  - name: CCR
-    description: capture/compare register x (x=1)
-    array:
-      len: 1
-      stride: 4
-    byte_offset: 52
-    fieldset: CCR_1CH
-  - name: TISEL
-    description: input selection register
-    byte_offset: 104
-    fieldset: TISEL_1CH
-  - name: OR
-    description: |-
-      Option register 1
-      Note: Check Reference Manual to parse this register content
-    byte_offset: 80
-block/TIM_1CH_CMP:
-  extends: TIM_1CH
-  description: 1-channel with one complementary output timers
-  items:
-  - name: CR2
-    description: control register 2
-    byte_offset: 4
-    fieldset: CR2_1CH_CMP
-  - name: DIER
-    description: DMA/Interrupt enable register
-    byte_offset: 12
-    fieldset: DIER_1CH_CMP
-  - name: SR
-    description: status register
-    byte_offset: 16
-    fieldset: SR_1CH_CMP
-  - name: EGR
-    description: event generation register
-    byte_offset: 20
-    access: Write
-    bit_size: 16
-    fieldset: EGR_1CH_CMP
-  - name: CCER
-    description: capture/compare enable register
-    byte_offset: 32
-    fieldset: CCER_1CH_CMP
-  - name: RCR
-    description: repetition counter register
-    byte_offset: 48
-    bit_size: 16
-    fieldset: RCR_1CH_CMP
-  - name: BDTR
-    description: break and dead-time register
-    byte_offset: 68
-    fieldset: BDTR_1CH_CMP
-  - name: DCR
-    description: DMA control register
-    byte_offset: 72
-    fieldset: DCR_1CH_CMP
-  - name: DMAR
-    description: DMA address for full transfer
-    byte_offset: 76
-    fieldset: DMAR_GP16
-  - name: AF1
-    description: alternate function register 1
-    byte_offset: 96
-    fieldset: AF1_1CH_CMP
-block/TIM_2CH:
-  extends: TIM_1CH
-  description: 2-channel timers
-  items:
-  - name: CR2
-    description: control register 2
-    byte_offset: 4
-    fieldset: CR2_2CH
-  - name: SMCR
-    description: slave mode control register
-    byte_offset: 8
-    fieldset: SMCR_2CH
-  - name: DIER
-    description: DMA/Interrupt enable register
-    byte_offset: 12
-    fieldset: DIER_2CH
-  - name: SR
-    description: status register
-    byte_offset: 16
-    fieldset: SR_2CH
-  - name: EGR
-    description: event generation register
-    byte_offset: 20
-    access: Write
-    bit_size: 16
-    fieldset: EGR_2CH
-  - name: CCMR_Input
-    description: capture/compare mode register 1 (input mode)
-    array:
-      len: 1
-      stride: 4
-    byte_offset: 24
-    fieldset: CCMR_Input_2CH
-  - name: CCMR_Output
-    description: capture/compare mode register 1 (output mode)
-    array:
-      len: 1
-      stride: 4
-    byte_offset: 24
-    fieldset: CCMR_Output_2CH
-  - name: CCER
-    description: capture/compare enable register
-    byte_offset: 32
-    fieldset: CCER_2CH
-  - name: CCR
-    description: capture/compare register x (x=1-2)
-    array:
-      len: 2
-      stride: 4
-    byte_offset: 52
-    fieldset: CCR_1CH
-  - name: TISEL
-    description: input selection register
-    byte_offset: 104
-    fieldset: TISEL_2CH
-block/TIM_2CH_CMP:
-  extends: TIM_1CH_CMP
-  description: 2-channel with one complementary output timers
-  items:
-  - name: CR2
-    description: control register 2
-    byte_offset: 4
-    fieldset: CR2_2CH_CMP
-  - name: SMCR
-    description: slave mode control register
-    byte_offset: 8
-    fieldset: SMCR_2CH
-  - name: DIER
-    description: DMA/Interrupt enable register
-    byte_offset: 12
-    fieldset: DIER_2CH_CMP
-  - name: SR
-    description: status register
-    byte_offset: 16
-    fieldset: SR_2CH_CMP
-  - name: EGR
-    description: event generation register
-    byte_offset: 20
-    access: Write
-    bit_size: 16
-    fieldset: EGR_2CH_CMP
-  - name: CCMR_Input
-    description: capture/compare mode register 1 (input mode)
-    array:
-      len: 2
-      stride: 4
-    byte_offset: 24
-    fieldset: CCMR_Input_1CH
-  - name: CCMR_Output
-    description: capture/compare mode register 1 (output mode)
-    array:
-      len: 2
-      stride: 4
-    byte_offset: 24
-    fieldset: CCMR_Output_1CH
-  - name: CCER
-    description: capture/compare enable register
-    byte_offset: 32
-    fieldset: CCER_2CH_CMP
-  - name: CCR
-    description: capture/compare register x (x=1-2)
-    array:
-      len: 2
-      stride: 4
-    byte_offset: 52
-    fieldset: CCR_1CH
-  - name: BDTR
-    description: break and dead-time register
-    byte_offset: 68
-    fieldset: BDTR_1CH_CMP
-  - name: TISEL
-    description: input selection register
-    byte_offset: 104
-    fieldset: TISEL_2CH
-block/TIM_ADV:
-  extends: TIM_2CH_CMP
-  description: Advanced Control timers
-  items:
-  - name: CR1
-    description: control register 1
-    byte_offset: 0
-    bit_size: 16
-    fieldset: CR1_GP16
-  - name: CR2
-    description: control register 2
-    byte_offset: 4
-    fieldset: CR2_ADV
-  - name: SMCR
-    description: slave mode control register
-    byte_offset: 8
-    fieldset: SMCR_GP16
-  - name: DIER
-    description: DMA/Interrupt enable register
-    byte_offset: 12
-    fieldset: DIER_ADV
-  - name: SR
-    description: status register
-    byte_offset: 16
-    fieldset: SR_ADV
-  - name: EGR
-    description: event generation register
-    byte_offset: 20
-    access: Write
-    bit_size: 16
-    fieldset: EGR_ADV
-  - name: CCMR_Input
-    description: capture/compare mode register 1-2 (input mode)
-    array:
-      len: 2
-      stride: 4
-    byte_offset: 24
-    fieldset: CCMR_Input_2CH
-  - name: CCMR_Output
-    description: capture/compare mode register 1-2 (output mode)
-    array:
-      len: 2
-      stride: 4
-    byte_offset: 24
-    fieldset: CCMR_Output_GP16
-  - name: CCER
-    description: capture/compare enable register
-    byte_offset: 32
-    fieldset: CCER_ADV
-  - name: RCR
-    description: repetition counter register
-    byte_offset: 48
-    bit_size: 16
-    fieldset: RCR_ADV
-  - name: CCR
-    description: capture/compare register x (x=1-4)
-    array:
-      len: 4
-      stride: 4
-    byte_offset: 52
-    fieldset: CCR_1CH
-  - name: BDTR
-    description: break and dead-time register
-    byte_offset: 68
-    fieldset: BDTR_ADV
-  - name: DMAR
-    description: DMA address for full transfer
-    byte_offset: 76
-  - name: CCMR3
-    description: capture/compare mode register 3
-    byte_offset: 84
-    fieldset: CCMR3_ADV
-  - name: CCR5
-    description: capture/compare register 5
-    byte_offset: 88
-    fieldset: CCR5_ADV
-  - name: CCR6
-    description: capture/compare register 6
-    byte_offset: 92
-    fieldset: CCR_1CH
-  - name: AF1
-    description: alternate function register 1
-    byte_offset: 96
-    fieldset: AF1_ADV
-  - name: AF2
-    description: alternate function register 2
-    byte_offset: 100
-    fieldset: AF2_ADV
-  - name: TISEL
-    description: input selection register
-    byte_offset: 104
-    fieldset: TISEL_GP16
-block/TIM_BASIC:
-  extends: TIM_BASIC_NO_CR2
-  description: Basic timers
-  items:
-  - name: CR2
-    description: control register 2
-    byte_offset: 4
-    fieldset: CR2_BASIC
-block/TIM_BASIC_NO_CR2:
-  extends: TIM_CORE
-  description: Virtual Basic timers without CR2 register for common part of TIM_BASIC and TIM_1CH_CMP
-  items:
-  - name: DIER
-    description: DMA/Interrupt enable register
-    byte_offset: 12
-    fieldset: DIER_BASIC_NO_CR2
 block/TIM_CORE:
-  description: Virtual timer for common part of TIM_BASIC and TIM_1CH
+  description: Virtual timer for common parts of all timers
   items:
   - name: CR1
     description: control register 1
@@ -358,55 +32,61 @@ block/TIM_CORE:
     description: auto-reload register
     byte_offset: 44
     fieldset: ARR_CORE
-block/TIM_GP16:
-  extends: TIM_2CH
-  description: General purpose 16-bit timers
+
+block/TIM_BASIC:
+  extends: TIM_CORE
+  description: Basic timers
+  items:
+  - name: CR2
+    description: control register 2
+    byte_offset: 4
+    fieldset: CR2_MMS
+  - name: DIER
+    description: DMA/Interrupt enable register
+    byte_offset: 12
+    fieldset: DIER_UPDMA
+
+block/TIM_1CH:
+  extends: TIM_CORE
+  description: 1-channel timers
   items:
   - name: CR1
     description: control register 1
     byte_offset: 0
     bit_size: 16
-    fieldset: CR1_GP16
-  - name: CR2
-    description: control register 2
-    byte_offset: 4
-    fieldset: CR2_GP16
-  - name: SMCR
-    description: slave mode control register
-    byte_offset: 8
-    fieldset: SMCR_GP16
+    fieldset: CR1_1CH
   - name: DIER
     description: DMA/Interrupt enable register
     byte_offset: 12
-    fieldset: DIER_GP16
+    fieldset: DIER_1CH
   - name: SR
     description: status register
     byte_offset: 16
-    fieldset: SR_GP16
+    fieldset: SR_1CH
   - name: EGR
     description: event generation register
     byte_offset: 20
     access: Write
     bit_size: 16
-    fieldset: EGR_GP16
+    fieldset: EGR_1CH
   - name: CCMR_Input
-    description: capture/compare mode register 1-2 (input mode)
+    description: capture/compare mode register 1 (input mode)
     array:
       len: 2
       stride: 4
     byte_offset: 24
-    fieldset: CCMR_Input_2CH
+    fieldset: CCMR_Input_1CH
   - name: CCMR_Output
-    description: capture/compare mode register 1-2 (output mode)
+    description: capture/compare mode register 1 (output mode)
     array:
       len: 2
       stride: 4
     byte_offset: 24
-    fieldset: CCMR_Output_GP16
+    fieldset: CCMR_Output_1CH
   - name: CCER
     description: capture/compare enable register
     byte_offset: 32
-    fieldset: CCER_GP16
+    fieldset: CCER_1CH
   - name: CCR
     description: capture/compare register x (x=1-4)
     array:
@@ -414,24 +94,94 @@ block/TIM_GP16:
       stride: 4
     byte_offset: 52
     fieldset: CCR_1CH
-  - name: DCR
-    description: DMA control register
-    byte_offset: 72
-    fieldset: DCR_1CH_CMP
-  - name: DMAR
-    description: DMA address for full transfer
-    byte_offset: 76
-    fieldset: DMAR_GP16
-  - name: AF1
-    description: alternate function register 1
-    byte_offset: 96
-    fieldset: AF1_GP16
   - name: TISEL
     description: input selection register
     byte_offset: 104
-    fieldset: TISEL_GP16
-block/TIM_GP32:
-  extends: TIM_GP16
+    fieldset: TISEL_1CH
+  - name: OR
+    description: |-
+      Option register 1
+      Note: Check Reference Manual to parse this register content
+    byte_offset: 80
+
+block/TIM_2CH:
+  extends: TIM_1CH
+  description: 2-channel timers
+  items:
+  - name: CR1
+    description: control register 1
+    byte_offset: 0
+    bit_size: 16
+    fieldset: CR1_2CH
+  - name: CR2
+    description: control register 2
+    byte_offset: 4
+    fieldset: CR2_2CH
+  - name: SMCR
+    description: slave mode control register
+    byte_offset: 8
+    fieldset: SMCR_2CH
+  - name: DIER
+    description: DMA/Interrupt enable register
+    byte_offset: 12
+    fieldset: DIER_2CH
+  - name: SR
+    description: status register
+    byte_offset: 16
+    fieldset: SR_2CH
+  - name: EGR
+    description: event generation register
+    byte_offset: 20
+    access: Write
+    bit_size: 16
+    fieldset: EGR_2CH
+
+block/TIM_4CH:
+  extends: TIM_2CH
+  description: General purpose 16-bit timers
+  items:
+  - name: CR1
+    description: control register 1
+    byte_offset: 0
+    bit_size: 16
+    fieldset: CR1_4CH
+  - name: CR2
+    description: control register 2
+    byte_offset: 4
+    fieldset: CR2_TRIGDMA
+  - name: SMCR
+    description: slave mode control register
+    byte_offset: 8
+    fieldset: SMCR_4CH
+  - name: DIER
+    description: DMA/Interrupt enable register
+    byte_offset: 12
+    fieldset: DIER_4CH
+  - name: SR
+    description: status register
+    byte_offset: 16
+    fieldset: SR_4CH
+  - name: CCMR_Output
+    description: capture/compare mode register 1-2 (output mode)
+    array:
+      len: 2
+      stride: 4
+    byte_offset: 24
+    fieldset: CCMR_Output_4CH
+  - name: DCR
+    description: DMA control register
+    byte_offset: 72
+    fieldset: DCR_CCDMA
+  - name: DMAR
+    description: DMA address for full transfer
+    byte_offset: 76
+  - name: AF1
+    description: alternate function register 1
+    byte_offset: 96
+    fieldset: AF1_4CH
+
+block/TIM_32BIT:
+  extends: TIM_4CH
   description: General purpose 32-bit timers
   items:
   - name: CNT
@@ -446,298 +196,644 @@ block/TIM_GP32:
       len: 4
       stride: 4
     byte_offset: 52
-fieldset/AF1_1CH_CMP:
-  description: alternate function register 1
-  fields:
-  - name: BKINE
-    description: TIMx_BKIN input enable
-    bit_offset: 0
-    bit_size: 1
-  - name: BKCMPE
-    description: TIM_BRK_CMPx (x=1-2) enable
-    bit_offset: 1
-    bit_size: 1
-    array:
-      len: 2
-      stride: 1
-  - name: BKDF1BKE
-    description: BRK DFSDM1_BREAKx enable (x=0 if TIM15, x=1 if TIM16, x=2 if TIM17)
-    bit_offset: 8
-    bit_size: 1
-  - name: BKINP
-    description: TIMx_BKIN input polarity
-    bit_offset: 9
-    bit_size: 1
-    enum: BKINP
-  - name: BKCMPP
-    description: TIM_BRK_CMPx (x=1-2) input polarity
-    bit_offset: 10
-    bit_size: 1
-    array:
-      len: 2
-      stride: 1
-    enum: BKINP
-fieldset/AF1_ADV:
-  extends: AF1_1CH_CMP
-  description: alternate function register 1
-  fields:
-  - name: ETRSEL
-    description: etr_in source selection
-    bit_offset: 14
-    bit_size: 4
-fieldset/AF1_GP16:
-  description: alternate function register 1
-  fields:
-  - name: ETRSEL
-    description: etr_in source selection
-    bit_offset: 14
-    bit_size: 4
-fieldset/AF2_ADV:
-  description: alternate function register 2
-  fields:
-  - name: BK2INE
-    description: TIMx_BKIN2 input enable
-    bit_offset: 0
-    bit_size: 1
-  - name: BK2CMPE
-    description: TIM_BRK2_CMPx (x=1-8) enable
-    bit_offset: 1
-    bit_size: 1
-    array:
-      len: 1
-      stride: 8
-  - name: BK2DF1BK1E
-    description: BRK2 DFSDM1_BREAK1 enable
-    bit_offset: 8
-    bit_size: 1
-  - name: BK2INP
-    description: TIMx_BK2IN input polarity
-    bit_offset: 9
-    bit_size: 1
-    enum: BKINP
-  - name: BK2CMPP
-    description: TIM_BRK2_CMPx (x=1-4) input polarity
-    bit_offset: 10
-    bit_size: 1
-    array:
-      len: 2
-      stride: 1
-    enum: BKINP
-fieldset/ARR_CORE:
-  description: auto-reload register
-  fields:
-  - name: ARR
-    description: Auto-reload value
-    bit_offset: 0
+
+block/TIM_ADV1CH:
+  extends: TIM_1CH
+  description: 1-channel with one complementary output timers
+  items:
+  - name: CR2
+    description: control register 2
+    byte_offset: 4
+    fieldset: CR2_ADV1CH
+  - name: DIER
+    description: DMA/Interrupt enable register
+    byte_offset: 12
+    fieldset: DIER_ADV1CH
+  - name: SR
+    description: status register
+    byte_offset: 16
+    fieldset: SR_ADV1CH
+  - name: EGR
+    description: event generation register
+    byte_offset: 20
+    access: Write
     bit_size: 16
-fieldset/BDTR_1CH_CMP:
-  description: break and dead-time register
+    fieldset: EGR_ADV1CH
+  - name: CCER
+    description: capture/compare enable register
+    byte_offset: 32
+    fieldset: CCER_ADV1CH
+  - name: RCR
+    description: repetition counter register
+    byte_offset: 48
+    bit_size: 16
+    fieldset: RCR_ADV1CH
+  - name: BDTR
+    description: break and dead-time register
+    byte_offset: 68
+    fieldset: BDTR_ADV1CH
+  - name: DCR
+    description: DMA control register
+    byte_offset: 72
+    fieldset: DCR_CCDMA
+  - name: DMAR
+    description: DMA address for full transfer
+    byte_offset: 76
+  - name: AF1
+    description: alternate function register 1
+    byte_offset: 96
+    fieldset: AF1_ADV1CH
+
+block/TIM_ADV2CH:
+  extends: TIM_ADV1CH
+  description: 2-channel with one complementary output timers
+  items:
+  - name: CR2
+    description: control register 2
+    byte_offset: 4
+    fieldset: CR2_ADV2CH
+  - name: SMCR
+    description: slave mode control register
+    byte_offset: 8
+    fieldset: SMCR_TRIGDMA
+  - name: DIER
+    description: DMA/Interrupt enable register
+    byte_offset: 12
+    fieldset: DIER_ADV2CH
+  - name: SR
+    description: status register
+    byte_offset: 16
+    fieldset: SR_ADV2CH
+  - name: EGR
+    description: event generation register
+    byte_offset: 20
+    access: Write
+    bit_size: 16
+    fieldset: EGR_ADV2CH
+
+block/TIM_ADV4CH:
+  extends: TIM_ADV2CH
+  description: Advanced Control timers
+  items:
+  - name: CR1
+    description: control register 1
+    byte_offset: 0
+    bit_size: 16
+    fieldset: CR1_4CH
+  - name: CR2
+    description: control register 2
+    byte_offset: 4
+    fieldset: CR2_ADV4CH
+  - name: SMCR
+    description: slave mode control register
+    byte_offset: 8
+    fieldset: SMCR_ADV4CH
+  - name: DIER
+    description: DMA/Interrupt enable register
+    byte_offset: 12
+    fieldset: DIER_ADV4CH
+  - name: SR
+    description: status register
+    byte_offset: 16
+    fieldset: SR_ADV4CH
+  - name: CCMR_Output
+    description: capture/compare mode register 1-2 (output mode)
+    array:
+      len: 2
+      stride: 4
+    byte_offset: 24
+    fieldset: CCMR_Output_4CH
+  - name: RCR
+    description: repetition counter register
+    byte_offset: 48
+    bit_size: 16
+    fieldset: RCR_ADV4CH
+  - name: CCMR3_Output
+    description: capture/compare mode register 3 (output mode)
+    byte_offset: 84
+    fieldset: CCMR3_Output_ADV4CH
+  - name: CCR5
+    description: capture/compare register 5
+    byte_offset: 88
+    fieldset: CCR5_ADV4CH
+  - name: CCR6
+    description: capture/compare register 6
+    byte_offset: 92
+    fieldset: CCR_1CH
+  - name: AF1
+    description: alternate function register 1
+    byte_offset: 96
+    fieldset: AF1_ADV4CH
+  - name: AF2
+    description: alternate function register 2
+    byte_offset: 100
+    fieldset: AF2_ADV4CH
+
+
+
+# CR1 register
+fieldset/CR1_CORE:
+  description: control register 1
   fields:
-  - name: DTG
-    description: Dead-time generator setup
+  - name: CEN
+    description: Counter enable
     bit_offset: 0
-    bit_size: 8
-  - name: LOCK
-    description: Lock configuration
-    bit_offset: 8
-    bit_size: 2
-    enum: LOCK
-  - name: OSSI
-    description: Off-state selection for Idle mode
-    bit_offset: 10
     bit_size: 1
-    enum: OSSI
-  - name: OSSR
-    description: Off-state selection for Run mode
+  - name: UDIS
+    description: Update disable
+    bit_offset: 1
+    bit_size: 1
+  - name: URS
+    description: Update request source
+    bit_offset: 2
+    bit_size: 1
+    enum: URS
+  - name: OPM
+    description: One-pulse mode enbaled
+    bit_offset: 3
+    bit_size: 1
+  - name: ARPE
+    description: Auto-reload preload enable
+    bit_offset: 7
+    bit_size: 1
+  - name: UIFREMAP
+    description: UIF status bit remapping enable
     bit_offset: 11
     bit_size: 1
-    enum: OSSR
-  - name: BKE
-    description: Break x (x=1) enable
+fieldset/CR1_1CH:
+  extends: CR1_CORE
+  description: control register 1
+  fields:
+  - name: CKD
+    description: Clock division
+    bit_offset: 8
+    bit_size: 2
+    enum: CKD
+fieldset/CR1_2CH:
+  extends: CR1_1CH
+  description: control register 1
+  fields: []
+fieldset/CR1_4CH:
+  extends: CR1_2CH
+  description: control register 1
+  fields:
+  - name: DIR
+    description: Direction
+    bit_offset: 4
+    bit_size: 1
+    enum: DIR
+  - name: CMS
+    description: Center-aligned mode selection
+    bit_offset: 5
+    bit_size: 2
+    enum: CMS
+
+# CR2 register
+fieldset/CR2_MMS:
+  description: control register 2
+  fields:
+  - name: MMS
+    description: Master mode selection
+    bit_offset: 4
+    bit_size: 3
+    enum: MMS
+fieldset/CR2_2CH:
+  extends: CR2_MMS
+  description: control register 2
+  fields:
+  - name: TI1S
+    description: TI1 selection
+    bit_offset: 7
+    bit_size: 1
+    enum: TI1S
+fieldset/CR2_CCDMA:
+  description: control register 2
+  fields:
+  - name: CCDS
+    description: Capture/compare DMA selection
+    bit_offset: 3
+    bit_size: 1
+    enum: CCDS
+fieldset/CR2_TRIGDMA:
+  extends: CR2_2CH
+  description: control register 2
+  fields:
+  - name: CCDS
+    description: Capture/compare DMA selection
+    bit_offset: 3
+    bit_size: 1
+    enum: CCDS
+fieldset/CR2_ADV1CH:
+  extends: CR2_CCDMA
+  description: control register 2
+  fields:
+  - name: CCPC
+    description: Capture/compare preloaded control
+    bit_offset: 0
+    bit_size: 1
+  - name: CCUS
+    description: Capture/compare control update selection
+    bit_offset: 2
+    bit_size: 1
+  - name: OIS
+    description: Output Idle state x (x=1-6)
+    bit_offset: 8
+    bit_size: 1
+    array:
+      len: 6
+      stride: 2
+  - name: OISN
+    description: Output Idle state x N x (x=1-4)
+    bit_offset: 9
+    bit_size: 1
+    array:
+      len: 4
+      stride: 2
+fieldset/CR2_ADV2CH:
+  extends: CR2_ADV1CH
+  description: control register 2
+  fields:
+  - name: MMS
+    description: Master mode selection
+    bit_offset: 4
+    bit_size: 3
+    enum: MMS
+  - name: TI1S
+    description: TI1 selection
+    bit_offset: 7
+    bit_size: 1
+    enum: TI1S
+fieldset/CR2_ADV4CH:
+  extends: CR2_ADV2CH
+  description: control register 2
+  fields:
+  - name: MMS2
+    description: Master mode selection 2
+    bit_offset: 20
+    bit_size: 4
+    enum: MMS2
+
+# SMCR register
+fieldset/SMCR_2CH:
+  description: slave mode control register
+  fields:
+  - name: SMS
+    description: Slave mode selection
+    bit_offset:
+    - start: 0
+      end: 2
+    - start: 16
+      end: 16
+    bit_size: 4
+    enum: SMS
+  - name: TS
+    description: Trigger selection
+    bit_offset:
+    - start: 4
+      end: 6
+    - start: 20
+      end: 21
+    bit_size: 5
+    enum: TS
+  - name: MSM
+    description: Master/Slave mode
+    bit_offset: 7
+    bit_size: 1
+    enum: MSM
+fieldset/SMCR_TRIGDMA:
+  extends: SMCR_2CH
+  description: slave mode control register
+  fields: []
+fieldset/SMCR_4CH:
+  extends: SMCR_TRIGDMA
+  description: slave mode control register
+  fields:
+  - name: ETF
+    description: External trigger filter
+    bit_offset: 8
+    bit_size: 4
+    enum: FilterValue
+  - name: ETPS
+    description: External trigger prescaler
     bit_offset: 12
-    bit_size: 1
-    array:
-      len: 1
-      stride: 12
-  - name: BKP
-    description: Break x (x=1) polarity
-    bit_offset: 13
-    bit_size: 1
-    array:
-      len: 1
-      stride: 12
-    enum: BKP
-  - name: AOE
-    description: Automatic output enable
+    bit_size: 2
+    enum: ETPS
+  - name: ECE
+    description: External clock mode 2 enable
     bit_offset: 14
     bit_size: 1
-  - name: MOE
-    description: Main output enable
+  - name: ETP
+    description: External trigger polarity
     bit_offset: 15
     bit_size: 1
-  - name: BKF
-    description: Break x (x=1) filter
-    bit_offset: 16
-    bit_size: 4
-    array:
-      len: 1
-      stride: 4
-    enum: FilterValue
-fieldset/BDTR_ADV:
-  extends: BDTR_1CH_CMP
-  description: break and dead-time register
+    enum: ETP
+fieldset/SMCR_ADV4CH:
+  extends: SMCR_4CH
+  description: slave mode control register
+  fields: []
+
+# DIER register
+fieldset/DIER_CORE:
+  description: DMA/Interrupt enable register
   fields:
-  - name: BKE
-    description: Break x (x=1,2) enable
-    bit_offset: 12
+  - name: UIE
+    description: Update interrupt enable
+    bit_offset: 0
+    bit_size: 1
+fieldset/DIER_UPDMA:
+  extends: DIER_CORE
+  description: DMA/Interrupt enable register
+  fields:
+  - name: UDE
+    description: Update DMA request enable
+    bit_offset: 8
+    bit_size: 1
+fieldset/DIER_1CH:
+  extends: DIER_CORE
+  description: DMA/Interrupt enable register
+  fields:
+  - name: CCIE
+    description: Capture/Compare x (x=1-4) interrupt enable
+    bit_offset: 1
     bit_size: 1
     array:
-      len: 2
-      stride: 12
-  - name: BKP
-    description: Break x (x=1,2) polarity
+      len: 4
+      stride: 1
+fieldset/DIER_2CH:
+  extends: DIER_1CH
+  description: DMA/Interrupt enable register
+  fields:
+  - name: TIE
+    description: Trigger interrupt enable
+    bit_offset: 6
+    bit_size: 1
+fieldset/DIER_CCDMA:
+  extends: DIER_1CH
+  description: DMA/Interrupt enable register
+  fields:
+  - name: CCDE
+    description: Capture/Compare x (x=1-4) DMA request enable
+    bit_offset: 9
+    bit_size: 1
+    array:
+      len: 4
+      stride: 1
+fieldset/DIER_TRIGDMA:
+  extends: DIER_CCDMA
+  description: DMA/Interrupt enable register
+  fields:
+  - name: TDE
+    description: Trigger DMA request enable
+    bit_offset: 14
+    bit_size: 1
+fieldset/DIER_4CH:
+  extends: DIER_TRIGDMA
+  description: DMA/Interrupt enable register
+  fields: []
+fieldset/DIER_ADV1CH:
+  extends: DIER_UPDMA
+  description: DMA/Interrupt enable register
+  fields:
+  - name: CCIE
+    description: Capture/Compare x (x=1-4) interrupt enable
+    bit_offset: 1
+    bit_size: 1
+    array:
+      len: 4
+      stride: 1
+  - name: COMIE
+    description: COM interrupt enable
+    bit_offset: 5
+    bit_size: 1
+  - name: BIE
+    description: Break interrupt enable
+    bit_offset: 7
+    bit_size: 1
+  - name: CCDE
+    description: Capture/Compare x (x=1-4) DMA request enable
+    bit_offset: 9
+    bit_size: 1
+    array:
+      len: 4
+      stride: 1
+fieldset/DIER_ADV2CH:
+  extends: DIER_ADV1CH
+  description: DMA/Interrupt enable register
+  fields:
+  - name: COMDE
+    description: COM DMA request enable
     bit_offset: 13
     bit_size: 1
+  - name: TDE
+    description: Trigger DMA request enable
+    bit_offset: 14
+    bit_size: 1
+fieldset/DIER_ADV4CH:
+  extends: DIER_ADV2CH
+  description: DMA/Interrupt enable register
+  fields: []
+
+# SR register
+fieldset/SR_CORE:
+  description: status register
+  fields:
+  - name: UIF
+    description: Update interrupt flag
+    bit_offset: 0
+    bit_size: 1
+fieldset/SR_1CH:
+  extends: SR_CORE
+  description: status register
+  fields:
+  - name: CCIF
+    description: Capture/compare x (x=1-4) interrupt flag
+    bit_offset: 1
+    bit_size: 1
+    array:
+      len: 4
+      stride: 1
+  - name: CCOF
+    description: Capture/Compare x (x=1-4) overcapture flag
+    bit_offset: 9
+    bit_size: 1
+    array:
+      len: 4
+      stride: 1
+fieldset/SR_2CH:
+  extends: SR_1CH
+  description: status register
+  fields:
+  - name: TIF
+    description: Trigger interrupt flag
+    bit_offset: 6
+    bit_size: 1
+fieldset/SR_4CH:
+  extends: SR_2CH
+  description: status register
+  fields: []
+fieldset/SR_ADV1CH:
+  extends: SR_1CH
+  description: status register
+  fields:
+  - name: COMIF
+    description: COM interrupt flag
+    bit_offset: 5
+    bit_size: 1
+  - name: BIF
+    description: Break x (x=1,2) interrupt flag
+    bit_offset: 7
+    bit_size: 1
     array:
       len: 2
-      stride: 12
-    enum: BKP
-  - name: BKF
-    description: Break x (x=1,2) filter
+      stride: 1
+fieldset/SR_ADV2CH:
+  extends: SR_ADV1CH
+  description: status register
+  fields:
+  - name: TIF
+    description: Trigger interrupt flag
+    bit_offset: 6
+    bit_size: 1
+fieldset/SR_ADV4CH:
+  extends: SR_ADV2CH
+  description: status register
+  fields:
+  - name: SBIF
+    description: System break interrupt flag
+    bit_offset: 13
+    bit_size: 1
+  - name: CCIF5
+    description: Capture/compare 5 interrupt flag
     bit_offset: 16
+    bit_size: 1
+  - name: CCIF6
+    description: Capture/compare 6 interrupt flag
+    bit_offset: 17
+    bit_size: 1
+
+# EGR register
+fieldset/EGR_CORE:
+  description: event generation register
+  fields:
+  - name: UG
+    description: Update generation
+    bit_offset: 0
+    bit_size: 1
+fieldset/EGR_1CH:
+  extends: EGR_CORE
+  description: event generation register
+  fields:
+  - name: CCG
+    description: Capture/compare x (x=1-4) generation
+    bit_offset: 1
+    bit_size: 1
+    array:
+      len: 4
+      stride: 1
+fieldset/EGR_2CH:
+  extends: EGR_1CH
+  description: event generation register
+  fields:
+  - name: TG
+    description: Trigger generation
+    bit_offset: 6
+    bit_size: 1
+fieldset/EGR_ADV1CH:
+  extends: EGR_1CH
+  description: event generation register
+  fields:
+  - name: COMG
+    description: Capture/Compare control update generation
+    bit_offset: 5
+    bit_size: 1
+  - name: BG
+    description: Break x (x=1-2) generation
+    bit_offset: 7
+    bit_size: 1
+    array:
+      len: 2
+      stride: 1
+fieldset/EGR_ADV2CH:
+  extends: EGR_ADV1CH
+  description: event generation register
+  fields:
+  - name: TG
+    description: Trigger generation
+    bit_offset: 6
+    bit_size: 1
+
+# CCMR register
+fieldset/CCMR_Input_1CH:
+  description: capture/compare mode register (input mode)
+  fields:
+  - name: CCS
+    description: Capture/Compare y selection
+    bit_offset: 0
+    bit_size: 2
+    array:
+      len: 2
+      stride: 8
+    enum: CCMR_Input_CCS
+  - name: ICPSC
+    description: Input capture y prescaler
+    bit_offset: 2
+    bit_size: 2
+    array:
+      len: 2
+      stride: 8
+  - name: ICF
+    description: Input capture y filter
+    bit_offset: 4
     bit_size: 4
     array:
       len: 2
-      stride: 4
+      stride: 8
     enum: FilterValue
-fieldset/CCER_1CH:
-  description: capture/compare enable register
+fieldset/CCMR_Output_1CH:
+  description: capture/compare mode register (output mode)
   fields:
-  - name: CCE
-    description: Capture/Compare x (x=1) output enable
+  - name: CCS
+    description: Capture/Compare y selection
     bit_offset: 0
-    bit_size: 1
+    bit_size: 2
     array:
-      len: 1
-      stride: 4
-  - name: CCP
-    description: Capture/Compare x (x=1) output Polarity
-    bit_offset: 1
-    bit_size: 1
-    array:
-      len: 1
-      stride: 4
-  - name: CCNP
-    description: Capture/Compare x (x=1) output Polarity
-    bit_offset: 3
-    bit_size: 1
-    array:
-      len: 1
-      stride: 4
-fieldset/CCER_1CH_CMP:
-  extends: CCER_1CH
-  description: capture/compare enable register
-  fields:
-  - name: CCNE
-    description: Capture/Compare x (x=1) complementary output enable
+      len: 2
+      stride: 8
+    enum: CCMR_Output_CCS
+  - name: OCFE
+    description: Output compare y fast enable
     bit_offset: 2
     bit_size: 1
     array:
-      len: 1
-      stride: 4
-fieldset/CCER_2CH:
-  extends: CCER_1CH
-  description: capture/compare enable register
-  fields:
-  - name: CCE
-    description: Capture/Compare x (x=1-2) output enable
-    bit_offset: 0
-    bit_size: 1
-    array:
       len: 2
-      stride: 4
-  - name: CCP
-    description: Capture/Compare x (x=1-2) output Polarity
-    bit_offset: 1
-    bit_size: 1
-    array:
-      len: 2
-      stride: 4
-  - name: CCNP
-    description: Capture/Compare x (x=1-2) output Polarity
+      stride: 8
+  - name: OCPE
+    description: Output compare y preload enable
     bit_offset: 3
     bit_size: 1
     array:
       len: 2
-      stride: 4
-fieldset/CCER_2CH_CMP:
-  extends: CCER_2CH
-  description: capture/compare enable register
+      stride: 8
+  - name: OCM
+    description: Output compare y mode
+    bit_offset: 4
+    bit_size: 3
+    array:
+      len: 2
+      stride: 8
+    enum: OCM
+fieldset/CCMR_Output_4CH:
+  extends: CCMR_Output_1CH
+  description: capture/compare mode register (output mode)
   fields:
-  - name: CCNE
-    description: Capture/Compare x (x=1) complementary output enable
-    bit_offset: 2
+  - name: OCCE
+    description: Output compare y clear enable
+    bit_offset: 7
     bit_size: 1
     array:
-      len: 1
-      stride: 4
-fieldset/CCER_ADV:
-  extends: CCER_2CH_CMP
-  description: capture/compare enable register
-  fields:
-  - name: CCE
-    description: Capture/Compare x (x=1-6) output enable
-    bit_offset: 0
-    bit_size: 1
-    array:
-      len: 6
-      stride: 4
-  - name: CCP
-    description: Capture/Compare x (x=1-6) output Polarity
-    bit_offset: 1
-    bit_size: 1
-    array:
-      len: 6
-      stride: 4
-  - name: CCNE
-    description: Capture/Compare x (x=1-3) complementary output enable
-    bit_offset: 2
-    bit_size: 1
-    array:
-      len: 3
-      stride: 4
-  - name: CCNP
-    description: Capture/Compare x (x=1-4) output Polarity
-    bit_offset: 3
-    bit_size: 1
-    array:
-      len: 4
-      stride: 4
-fieldset/CCER_GP16:
-  description: capture/compare enable register
-  fields:
-  - name: CCE
-    description: Capture/Compare x (x=1-4) output enable
-    bit_offset: 0
-    bit_size: 1
-    array:
-      len: 4
-      stride: 4
-  - name: CCP
-    description: Capture/Compare x (x=1-4) output Polarity
-    bit_offset: 1
-    bit_size: 1
-    array:
-      len: 4
-      stride: 4
-  - name: CCNP
-    description: Capture/Compare x (x=1-4) output Polarity
-    bit_offset: 3
-    bit_size: 1
-    array:
-      len: 4
-      stride: 4
-fieldset/CCMR3_ADV:
+      len: 2
+      stride: 8
+fieldset/CCMR3_Output_ADV4CH:
   description: capture/compare mode register 3
   fields:
   - name: OCFE
@@ -769,156 +865,45 @@ fieldset/CCMR3_ADV:
     array:
       len: 2
       stride: 8
-fieldset/CCMR_Input_1CH:
-  description: capture/compare mode register x (x=1) (input mode)
+
+# CCER register
+fieldset/CCER_1CH:
+  description: capture/compare enable register
   fields:
-  - name: CCS
-    description: Capture/Compare y selection
+  - name: CCE
+    description: Capture/Compare x (x=1-4) output enable
     bit_offset: 0
-    bit_size: 2
-    array:
-      len: 1
-      stride: 8
-    enum: CCMR_Input_CCS
-  - name: ICPSC
-    description: Input capture y prescaler
-    bit_offset: 2
-    bit_size: 2
-    array:
-      len: 1
-      stride: 8
-  - name: ICF
-    description: Input capture y filter
-    bit_offset: 4
-    bit_size: 4
-    array:
-      len: 1
-      stride: 8
-    enum: FilterValue
-fieldset/CCMR_Input_2CH:
-  extends: CCMR_Input_1CH
-  description: capture/compare mode register x (x=1) (input mode)
-  fields:
-  - name: CCS
-    description: Capture/Compare y selection
-    bit_offset: 0
-    bit_size: 2
-    array:
-      len: 2
-      stride: 8
-    enum: CCMR_Input_CCS
-  - name: ICPSC
-    description: Input capture y prescaler
-    bit_offset: 2
-    bit_size: 2
-    array:
-      len: 2
-      stride: 8
-  - name: ICF
-    description: Input capture y filter
-    bit_offset: 4
-    bit_size: 4
-    array:
-      len: 2
-      stride: 8
-    enum: FilterValue
-fieldset/CCMR_Output_1CH:
-  description: capture/compare mode register x (x=1) (output mode)
-  fields:
-  - name: CCS
-    description: Capture/Compare y selection
-    bit_offset: 0
-    bit_size: 2
-    array:
-      len: 1
-      stride: 8
-    enum: CCMR_Output_CCS
-  - name: OCFE
-    description: Output compare y fast enable
-    bit_offset: 2
     bit_size: 1
     array:
-      len: 1
-      stride: 8
-  - name: OCPE
-    description: Output compare y preload enable
+      len: 4
+      stride: 4
+  - name: CCP
+    description: Capture/Compare x (x=1-4) output Polarity
+    bit_offset: 1
+    bit_size: 1
+    array:
+      len: 4
+      stride: 4
+  - name: CCNP
+    description: Capture/Compare x (x=1-4) output Polarity
     bit_offset: 3
     bit_size: 1
     array:
-      len: 1
-      stride: 8
-  - name: OCM
-    description: Output compare y mode
-    bit_offset: 4
-    bit_size: 3
-    array:
-      len: 1
-      stride: 8
-    enum: OCM
-fieldset/CCMR_Output_2CH:
-  extends: CCMR_Output_1CH
-  description: capture/compare mode register x (x=1) (output mode)
+      len: 4
+      stride: 4
+fieldset/CCER_ADV1CH:
+  extends: CCER_1CH
+  description: capture/compare enable register
   fields:
-  - name: CCS
-    description: Capture/Compare y selection
-    bit_offset: 0
-    bit_size: 2
-    array:
-      len: 2
-      stride: 8
-    enum: CCMR_Output_CCS
-  - name: OCFE
-    description: Output compare y fast enable
+  - name: CCNE
+    description: Capture/Compare x (x=1-3) complementary output enable
     bit_offset: 2
-    bit_size: 1
-    array:
-      len: 2
-      stride: 8
-  - name: OCPE
-    description: Output compare y preload enable
-    bit_offset: 3
-    bit_size: 1
-    array:
-      len: 2
-      stride: 8
-  - name: OCM
-    description: Output compare y mode
-    bit_offset: 4
-    bit_size: 3
-    array:
-      len: 2
-      stride: 8
-    enum: OCM
-fieldset/CCMR_Output_GP16:
-  extends: CCMR_Output_2CH
-  description: capture/compare mode register x (x=1-2) (output mode)
-  fields:
-  - name: OCCE
-    description: Output compare y clear enable
-    bit_offset: 7
-    bit_size: 1
-    array:
-      len: 2
-      stride: 8
-fieldset/CCR5_ADV:
-  extends: CCR_1CH
-  description: capture/compare register 5
-  fields:
-  - name: GC5C
-    description: Group channel 5 and channel x (x=1-3)
-    bit_offset: 29
     bit_size: 1
     array:
       len: 3
-      stride: 1
-    enum: GC5C
-fieldset/CCR_1CH:
-  description: capture/compare register x (x=1-4,6)
-  fields:
-  - name: CCR
-    description: capture/compare x (x=1-4,6) value
-    bit_offset: 0
-    bit_size: 16
+      stride: 4
+
+# CNT register
 fieldset/CNT_CORE:
   description: counter
   fields:
@@ -930,172 +915,110 @@ fieldset/CNT_CORE:
     description: UIF copy
     bit_offset: 31
     bit_size: 1
-fieldset/CR1_1CH:
-  extends: CR1_CORE
-  description: control register 1
+
+# ARR register
+fieldset/ARR_CORE:
+  description: auto-reload register
   fields:
-  - name: CKD
-    description: Clock division
+  - name: ARR
+    description: Auto-reload value
+    bit_offset: 0
+    bit_size: 16
+
+# RCR register
+fieldset/RCR_ADV1CH:
+  description: repetition counter register
+  fields:
+  - name: REP
+    description: Repetition counter value
+    bit_offset: 0
+    bit_size: 8
+fieldset/RCR_ADV4CH:
+  description: repetition counter register
+  fields:
+  - name: REP
+    description: Repetition counter value
+    bit_offset: 0
+    bit_size: 16
+
+# CCR register
+fieldset/CCR_1CH:
+  description: capture/compare register x (x=1-4,6)
+  fields:
+  - name: CCR
+    description: capture/compare x (x=1-4,6) value
+    bit_offset: 0
+    bit_size: 16
+fieldset/CCR5_ADV4CH:
+  extends: CCR_1CH
+  description: capture/compare register 5
+  fields:
+  - name: GC5C
+    description: Group channel 5 and channel x (x=1-3)
+    bit_offset: 29
+    bit_size: 1
+    array:
+      len: 3
+      stride: 1
+    enum: GC5C
+
+# BDTR register
+fieldset/BDTR_ADV1CH:
+  description: break and dead-time register
+  fields:
+  - name: DTG
+    description: Dead-time generator setup
+    bit_offset: 0
+    bit_size: 8
+  - name: LOCK
+    description: Lock configuration
     bit_offset: 8
     bit_size: 2
-    enum: CKD
-fieldset/CR1_CORE:
-  description: control register 1
-  fields:
-  - name: CEN
-    description: Counter enable
-    bit_offset: 0
+    enum: LOCK
+  - name: OSSI
+    description: Off-state selection for Idle mode
+    bit_offset: 10
     bit_size: 1
-  - name: UDIS
-    description: Update disable
-    bit_offset: 1
-    bit_size: 1
-  - name: URS
-    description: Update request source
-    bit_offset: 2
-    bit_size: 1
-    enum: URS
-  - name: OPM
-    description: One-pulse mode enbaled
-    bit_offset: 3
-    bit_size: 1
-  - name: ARPE
-    description: Auto-reload preload enable
-    bit_offset: 7
-    bit_size: 1
-  - name: UIFREMAP
-    description: UIF status bit remapping enable
+    enum: OSSI
+  - name: OSSR
+    description: Off-state selection for Run mode
     bit_offset: 11
     bit_size: 1
-fieldset/CR1_GP16:
-  extends: CR1_CORE
-  description: control register 1
-  fields:
-  - name: DIR
-    description: Direction
-    bit_offset: 4
-    bit_size: 1
-    enum: DIR
-  - name: CMS
-    description: Center-aligned mode selection
-    bit_offset: 5
-    bit_size: 2
-    enum: CMS
-  - name: CKD
-    description: Clock division
-    bit_offset: 8
-    bit_size: 2
-    enum: CKD
-fieldset/CR2_1CH_CMP:
-  description: control register 2
-  fields:
-  - name: CCPC
-    description: Capture/compare preloaded control
-    bit_offset: 0
-    bit_size: 1
-  - name: CCUS
-    description: Capture/compare control update selection
-    bit_offset: 2
-    bit_size: 1
-  - name: CCDS
-    description: Capture/compare DMA selection
-    bit_offset: 3
-    bit_size: 1
-    enum: CCDS
-  - name: OIS
-    description: Output Idle state x (x=1)
-    bit_offset: 8
-    bit_size: 1
-    array:
-      len: 1
-      stride: 2
-  - name: OISN
-    description: Output Idle state x (x=1)
-    bit_offset: 9
-    bit_size: 1
-    array:
-      len: 1
-      stride: 2
-fieldset/CR2_2CH:
-  description: control register 2
-  fields:
-  - name: MMS
-    description: Master mode selection
-    bit_offset: 4
-    bit_size: 3
-    enum: MMS
-  - name: TI1S
-    description: TI1 selection
-    bit_offset: 7
-    bit_size: 1
-    enum: TI1S
-fieldset/CR2_2CH_CMP:
-  extends: CR2_1CH_CMP
-  description: control register 2
-  fields:
-  - name: MMS
-    description: Master mode selection
-    bit_offset: 4
-    bit_size: 3
-    enum: MMS
-  - name: TI1S
-    description: TI1 selection
-    bit_offset: 7
-    bit_size: 1
-    enum: TI1S
-  - name: OIS
-    description: Output Idle state x (x=1,2)
-    bit_offset: 8
+    enum: OSSR
+  - name: BKE
+    description: Break x (x=1,2) enable
+    bit_offset: 12
     bit_size: 1
     array:
       len: 2
-      stride: 2
-fieldset/CR2_ADV:
-  extends: CR2_2CH_CMP
-  description: control register 2
-  fields:
-  - name: OIS
-    description: Output Idle state x (x=1-6)
-    bit_offset: 8
+      stride: 12
+  - name: BKP
+    description: Break x (x=1,2) polarity
+    bit_offset: 13
     bit_size: 1
     array:
-      len: 6
-      stride: 2
-  - name: OISN
-    description: Output Idle state x N x (x=1-4)
-    bit_offset: 9
+      len: 2
+      stride: 12
+    enum: BKP
+  - name: AOE
+    description: Automatic output enable
+    bit_offset: 14
     bit_size: 1
-    array:
-      len: 4
-      stride: 2
-  - name: MMS2
-    description: Master mode selection 2
-    bit_offset: 20
+  - name: MOE
+    description: Main output enable
+    bit_offset: 15
+    bit_size: 1
+  - name: BKF
+    description: Break x (x=1,2) filter
+    bit_offset: 16
     bit_size: 4
-    enum: MMS2
-fieldset/CR2_BASIC:
-  description: control register 2
-  fields:
-  - name: MMS
-    description: Master mode selection
-    bit_offset: 4
-    bit_size: 3
-    enum: MMS
-fieldset/CR2_GP16:
-  extends: CR2_BASIC
-  description: control register 2
-  fields:
-  - name: CCDS
-    description: Capture/compare DMA selection
-    bit_offset: 3
-    bit_size: 1
-    enum: CCDS
-  - name: TI1S
-    description: TI1 selection
-    bit_offset: 7
-    bit_size: 1
-    enum: TI1S
-fieldset/DCR_1CH_CMP:
+    array:
+      len: 2
+      stride: 4
+    enum: FilterValue
+
+# DCR register
+fieldset/DCR_CCDMA:
   description: DMA control register
   fields:
   - name: DBA
@@ -1106,461 +1029,94 @@ fieldset/DCR_1CH_CMP:
     description: DMA burst length
     bit_offset: 8
     bit_size: 5
-fieldset/DIER_1CH:
-  extends: DIER_CORE
-  description: DMA/Interrupt enable register
+
+# AF1 register
+fieldset/AF1_4CH:
+  description: alternate function register 1
   fields:
-  - name: CCIE
-    description: Capture/Compare x (x=1) interrupt enable
-    bit_offset: 1
-    bit_size: 1
-    array:
-      len: 1
-      stride: 1
-fieldset/DIER_1CH_CMP:
-  extends: DIER_1CH
-  description: DMA/Interrupt enable register
-  fields:
-  - name: COMIE
-    description: COM interrupt enable
-    bit_offset: 5
-    bit_size: 1
-  - name: BIE
-    description: Break interrupt enable
-    bit_offset: 7
-    bit_size: 1
-  - name: UDE
-    description: Update DMA request enable
-    bit_offset: 8
-    bit_size: 1
-  - name: CCDE
-    description: Capture/Compare x (x=1) DMA request enable
-    bit_offset: 9
-    bit_size: 1
-    array:
-      len: 1
-      stride: 1
-fieldset/DIER_2CH:
-  extends: DIER_1CH
-  description: DMA/Interrupt enable register
-  fields:
-  - name: CCIE
-    description: Capture/Compare x (x=1-2) interrupt enable
-    bit_offset: 1
-    bit_size: 1
-    array:
-      len: 2
-      stride: 1
-  - name: TIE
-    description: Trigger interrupt enable
-    bit_offset: 6
-    bit_size: 1
-fieldset/DIER_2CH_CMP:
-  extends: DIER_1CH_CMP
-  description: DMA/Interrupt enable register
-  fields:
-  - name: TIE
-    description: Trigger interrupt enable
-    bit_offset: 6
-    bit_size: 1
-  - name: COMDE
-    description: COM DMA request enable
-    bit_offset: 13
-    bit_size: 1
-  - name: TDE
-    description: Trigger DMA request enable
+  - name: ETRSEL
+    description: etr_in source selection
     bit_offset: 14
-    bit_size: 1
-fieldset/DIER_ADV:
-  extends: DIER_2CH_CMP
-  description: DMA/Interrupt enable register
-  fields:
-  - name: CCIE
-    description: Capture/Compare x (x=1-4) interrupt enable
-    bit_offset: 1
-    bit_size: 1
-    array:
-      len: 4
-      stride: 1
-  - name: CCDE
-    description: Capture/Compare x (x=1-4) DMA request enable
-    bit_offset: 9
-    bit_size: 1
-    array:
-      len: 4
-      stride: 1
-fieldset/DIER_BASIC_NO_CR2:
-  extends: DIER_CORE
-  description: DMA/Interrupt enable register
-  fields:
-  - name: UDE
-    description: Update DMA request enable
-    bit_offset: 8
-    bit_size: 1
-fieldset/DIER_CORE:
-  description: DMA/Interrupt enable register
-  fields:
-  - name: UIE
-    description: Update interrupt enable
-    bit_offset: 0
-    bit_size: 1
-fieldset/DIER_GP16:
-  extends: DIER_BASIC_NO_CR2
-  description: DMA/Interrupt enable register
-  fields:
-  - name: CCIE
-    description: Capture/Compare x (x=1-4) interrupt enable
-    bit_offset: 1
-    bit_size: 1
-    array:
-      len: 4
-      stride: 1
-  - name: TIE
-    description: Trigger interrupt enable
-    bit_offset: 6
-    bit_size: 1
-  - name: CCDE
-    description: Capture/Compare x (x=1-4) DMA request enable
-    bit_offset: 9
-    bit_size: 1
-    array:
-      len: 4
-      stride: 1
-  - name: TDE
-    description: Trigger DMA request enable
-    bit_offset: 14
-    bit_size: 1
-fieldset/DMAR_GP16:
-  description: DMA address for full transfer
-  fields:
-  - name: DMAB
-    description: DMA register for burst accesses
-    bit_offset: 0
-    bit_size: 16
-fieldset/EGR_1CH:
-  extends: EGR_CORE
-  description: event generation register
-  fields:
-  - name: CCG
-    description: Capture/compare x (x=1) generation
-    bit_offset: 1
-    bit_size: 1
-    array:
-      len: 1
-      stride: 1
-fieldset/EGR_1CH_CMP:
-  extends: EGR_1CH
-  description: event generation register
-  fields:
-  - name: COMG
-    description: Capture/Compare control update generation
-    bit_offset: 5
-    bit_size: 1
-  - name: BG
-    description: Break x (x=1) generation
-    bit_offset: 7
-    bit_size: 1
-    array:
-      len: 1
-      stride: 1
-fieldset/EGR_2CH:
-  extends: EGR_1CH
-  description: event generation register
-  fields:
-  - name: CCG
-    description: Capture/compare x (x=1-2) generation
-    bit_offset: 1
-    bit_size: 1
-    array:
-      len: 2
-      stride: 1
-  - name: TG
-    description: Trigger generation
-    bit_offset: 6
-    bit_size: 1
-fieldset/EGR_2CH_CMP:
-  extends: EGR_1CH_CMP
-  description: event generation register
-  fields:
-  - name: CCG
-    description: Capture/compare x (x=1,2) generation
-    bit_offset: 1
-    bit_size: 1
-    array:
-      len: 2
-      stride: 1
-  - name: TG
-    description: Trigger generation
-    bit_offset: 6
-    bit_size: 1
-fieldset/EGR_ADV:
-  extends: EGR_2CH_CMP
-  description: event generation register
-  fields:
-  - name: CCG
-    description: Capture/compare x (x=1-4) generation
-    bit_offset: 1
-    bit_size: 1
-    array:
-      len: 4
-      stride: 1
-  - name: BG
-    description: Break x (x=1-2) generation
-    bit_offset: 7
-    bit_size: 1
-    array:
-      len: 2
-      stride: 1
-fieldset/EGR_CORE:
-  description: event generation register
-  fields:
-  - name: UG
-    description: Update generation
-    bit_offset: 0
-    bit_size: 1
-fieldset/EGR_GP16:
-  extends: EGR_CORE
-  description: event generation register
-  fields:
-  - name: CCG
-    description: Capture/compare x (x=1-4) generation
-    bit_offset: 1
-    bit_size: 1
-    array:
-      len: 4
-      stride: 1
-  - name: TG
-    description: Trigger generation
-    bit_offset: 6
-    bit_size: 1
-fieldset/RCR_1CH_CMP:
-  description: repetition counter register
-  fields:
-  - name: REP
-    description: Repetition counter value
-    bit_offset: 0
-    bit_size: 8
-fieldset/RCR_ADV:
-  description: repetition counter register
-  fields:
-  - name: REP
-    description: Repetition counter value
-    bit_offset: 0
-    bit_size: 16
-fieldset/SMCR_2CH:
-  description: slave mode control register
-  fields:
-  - name: SMS
-    description: Slave mode selection
-    bit_offset:
-    - start: 0
-      end: 2
-    - start: 16
-      end: 16
     bit_size: 4
-    enum: SMS
-  - name: TS
-    description: Trigger selection
-    bit_offset:
-    - start: 4
-      end: 6
-    - start: 20
-      end: 21
-    bit_size: 5
-    enum: TS
-  - name: MSM
-    description: Master/Slave mode
-    bit_offset: 7
-    bit_size: 1
-    enum: MSM
-fieldset/SMCR_GP16:
-  extends: SMCR_2CH
-  description: slave mode control register
+fieldset/AF1_ADV1CH:
+  description: alternate function register 1
   fields:
-  - name: ETF
-    description: External trigger filter
-    bit_offset: 8
-    bit_size: 4
-    enum: FilterValue
-  - name: ETPS
-    description: External trigger prescaler
-    bit_offset: 12
-    bit_size: 2
-    enum: ETPS
-  - name: ECE
-    description: External clock mode 2 enable
-    bit_offset: 14
-    bit_size: 1
-  - name: ETP
-    description: External trigger polarity
-    bit_offset: 15
-    bit_size: 1
-    enum: ETP
-fieldset/SR_1CH:
-  extends: SR_CORE
-  description: status register
-  fields:
-  - name: CCIF
-    description: Capture/compare x (x=1) interrupt flag
-    bit_offset: 1
-    bit_size: 1
-    array:
-      len: 1
-      stride: 1
-  - name: CCOF
-    description: Capture/Compare x (x=1) overcapture flag
-    bit_offset: 9
-    bit_size: 1
-    array:
-      len: 1
-      stride: 1
-fieldset/SR_1CH_CMP:
-  extends: SR_1CH
-  description: status register
-  fields:
-  - name: COMIF
-    description: COM interrupt flag
-    bit_offset: 5
-    bit_size: 1
-  - name: BIF
-    description: Break x (x=1) interrupt flag
-    bit_offset: 7
-    bit_size: 1
-    array:
-      len: 1
-      stride: 1
-fieldset/SR_2CH:
-  extends: SR_1CH
-  description: status register
-  fields:
-  - name: CCIF
-    description: Capture/compare x (x=1-2) interrupt flag
-    bit_offset: 1
-    bit_size: 1
-    array:
-      len: 2
-      stride: 1
-  - name: TIF
-    description: Trigger interrupt flag
-    bit_offset: 6
-    bit_size: 1
-  - name: CCOF
-    description: Capture/Compare x (x=1-2) overcapture flag
-    bit_offset: 9
-    bit_size: 1
-    array:
-      len: 2
-      stride: 1
-fieldset/SR_2CH_CMP:
-  extends: SR_1CH_CMP
-  description: status register
-  fields:
-  - name: CCIF
-    description: Capture/compare x (x=1,2) interrupt flag
-    bit_offset: 1
-    bit_size: 1
-    array:
-      len: 2
-      stride: 1
-  - name: TIF
-    description: Trigger interrupt flag
-    bit_offset: 6
-    bit_size: 1
-  - name: CCOF
-    description: Capture/Compare x (x=1,2) overcapture flag
-    bit_offset: 9
-    bit_size: 1
-    array:
-      len: 2
-      stride: 1
-fieldset/SR_ADV:
-  extends: SR_2CH_CMP
-  description: status register
-  fields:
-  - name: CCIF
-    description: Capture/compare x (x=1-4) interrupt flag
-    bit_offset: 1
-    bit_size: 1
-    array:
-      len: 4
-      stride: 1
-  - name: BIF
-    description: Break x (x=1,2) interrupt flag
-    bit_offset: 7
-    bit_size: 1
-    array:
-      len: 2
-      stride: 1
-  - name: CCOF
-    description: Capture/Compare x (x=1-4) overcapture flag
-    bit_offset: 9
-    bit_size: 1
-    array:
-      len: 4
-      stride: 1
-  - name: SBIF
-    description: System break interrupt flag
-    bit_offset: 13
-    bit_size: 1
-  - name: CCIF5
-    description: Capture/compare 5 interrupt flag
-    bit_offset: 16
-    bit_size: 1
-  - name: CCIF6
-    description: Capture/compare 6 interrupt flag
-    bit_offset: 17
-    bit_size: 1
-fieldset/SR_CORE:
-  description: status register
-  fields:
-  - name: UIF
-    description: Update interrupt flag
+  - name: BKINE
+    description: TIMx_BKIN input enable
     bit_offset: 0
     bit_size: 1
-fieldset/SR_GP16:
-  extends: SR_CORE
-  description: status register
-  fields:
-  - name: CCIF
-    description: Capture/compare x (x=1-4) interrupt flag
+  - name: BKCMPE
+    description: TIM_BRK_CMPx (x=1-2) enable
     bit_offset: 1
     bit_size: 1
     array:
-      len: 4
+      len: 2
       stride: 1
-  - name: TIF
-    description: Trigger interrupt flag
-    bit_offset: 6
+  - name: BKDF1BKE
+    description: BRK DFSDM1_BREAKx enable (x=0 if TIM15, x=1 if TIM16, x=2 if TIM17)
+    bit_offset: 8
     bit_size: 1
-  - name: CCOF
-    description: Capture/Compare x (x=1-4) overcapture flag
+  - name: BKINP
+    description: TIMx_BKIN input polarity
     bit_offset: 9
     bit_size: 1
+    enum: BKINP
+  - name: BKCMPP
+    description: TIM_BRK_CMPx (x=1-2) input polarity
+    bit_offset: 10
+    bit_size: 1
     array:
-      len: 4
+      len: 2
       stride: 1
+    enum: BKINP
+fieldset/AF1_ADV4CH:
+  extends: AF1_ADV1CH
+  description: alternate function register 1
+  fields:
+  - name: ETRSEL
+    description: etr_in source selection
+    bit_offset: 14
+    bit_size: 4
+
+# AF2 register
+fieldset/AF2_CCDMA:
+  description: alternate function register 2
+  fields: []
+fieldset/AF2_ADV4CH:
+  extends: AF2_CCDMA
+  description: alternate function register 2
+  fields:
+  - name: BK2INE
+    description: TIMx_BKIN2 input enable
+    bit_offset: 0
+    bit_size: 1
+  - name: BK2CMPE
+    description: TIM_BRK2_CMPx (x=1-2) enable
+    bit_offset: 1
+    bit_size: 1
+    array:
+      len: 2
+      stride: 1
+  - name: BK2DF1BK1E
+    description: BRK2 DFSDM1_BREAK1 enable
+    bit_offset: 8
+    bit_size: 1
+  - name: BK2INP
+    description: TIMx_BK2IN input polarity
+    bit_offset: 9
+    bit_size: 1
+    enum: BKINP
+  - name: BK2CMPP
+    description: TIM_BRK2_CMPx (x=1-4) input polarity
+    bit_offset: 10
+    bit_size: 1
+    array:
+      len: 2
+      stride: 1
+    enum: BKINP
+
+# TISEL register
 fieldset/TISEL_1CH:
-  description: input selection register
-  fields:
-  - name: TISEL
-    description: Selects TIM_TIx (x=1) input
-    bit_offset: 0
-    bit_size: 4
-    array:
-      len: 1
-      stride: 8
-fieldset/TISEL_2CH:
-  extends: TISEL_1CH
-  description: input selection register
-  fields:
-  - name: TISEL
-    description: Selects TIM_TIx (x=1-2) input
-    bit_offset: 0
-    bit_size: 4
-    array:
-      len: 2
-      stride: 8
-fieldset/TISEL_GP16:
   description: input selection register
   fields:
   - name: TISEL
@@ -1570,6 +1126,7 @@ fieldset/TISEL_GP16:
     array:
       len: 4
       stride: 8
+
 enum/BKINP:
   bit_size: 1
   variants:

--- a/data/registers/timer_v2.yaml
+++ b/data/registers/timer_v2.yaml
@@ -1,368 +1,5 @@
-block/TIM_1CH:
-  extends: TIM_CORE
-  description: 1-channel timers
-  items:
-  - name: CR1
-    description: control register 1
-    byte_offset: 0
-    bit_size: 16
-    fieldset: CR1_1CH
-  - name: DIER
-    description: DMA/Interrupt enable register
-    byte_offset: 12
-    fieldset: DIER_1CH
-  - name: SR
-    description: status register
-    byte_offset: 16
-    fieldset: SR_1CH
-  - name: EGR
-    description: event generation register
-    byte_offset: 20
-    access: Write
-    bit_size: 16
-    fieldset: EGR_1CH
-  - name: CCMR_Input
-    description: capture/compare mode register 1 (input mode)
-    array:
-      len: 1
-      stride: 4
-    byte_offset: 24
-    fieldset: CCMR_Input_1CH
-  - name: CCMR_Output
-    description: capture/compare mode register 1 (output mode)
-    array:
-      len: 1
-      stride: 4
-    byte_offset: 24
-    fieldset: CCMR_Output_1CH
-  - name: CCER
-    description: capture/compare enable register
-    byte_offset: 32
-    fieldset: CCER_1CH
-  - name: CCR
-    description: capture/compare register x (x=1) (Dither mode disabled)
-    array:
-      len: 1
-      stride: 4
-    byte_offset: 52
-    fieldset: CCR_1CH
-  - name: CCR_DITHER
-    description: capture/compare register x (x=1) (Dither mode enabled)
-    array:
-      len: 1
-      stride: 4
-    byte_offset: 52
-    fieldset: CCR_DITHER_1CH
-  - name: TISEL
-    description: input selection register
-    byte_offset: 92
-    fieldset: TISEL_1CH
-  - name: OR
-    description: |-
-      Option register 1
-      Note: Check Reference Manual to parse this register content
-    byte_offset: 104
-block/TIM_1CH_CMP:
-  extends: TIM_1CH
-  description: 1-channel with one complementary output timers
-  items:
-  - name: CR2
-    description: control register 2
-    byte_offset: 4
-    fieldset: CR2_1CH_CMP
-  - name: DIER
-    description: DMA/Interrupt enable register
-    byte_offset: 12
-    fieldset: DIER_1CH_CMP
-  - name: SR
-    description: status register
-    byte_offset: 16
-    fieldset: SR_1CH_CMP
-  - name: EGR
-    description: event generation register
-    byte_offset: 20
-    access: Write
-    bit_size: 16
-    fieldset: EGR_1CH_CMP
-  - name: CCER
-    description: capture/compare enable register
-    byte_offset: 32
-    fieldset: CCER_1CH_CMP
-  - name: RCR
-    description: repetition counter register
-    byte_offset: 48
-    bit_size: 16
-    fieldset: RCR_1CH_CMP
-  - name: BDTR
-    description: break and dead-time register
-    byte_offset: 68
-    fieldset: BDTR_1CH_CMP
-  - name: DTR2
-    description: break and dead-time register
-    byte_offset: 84
-    fieldset: DTR2_1CH_CMP
-  - name: AF1
-    description: alternate function register 1
-    byte_offset: 96
-    fieldset: AF1_1CH_CMP
-  - name: AF2
-    description: alternate function register 2
-    byte_offset: 100
-    fieldset: AF2_1CH_CMP
-  - name: DCR
-    description: DMA control register
-    byte_offset: 988
-    fieldset: DCR_1CH_CMP
-  - name: DMAR
-    description: DMA address for full transfer
-    byte_offset: 992
-block/TIM_2CH:
-  extends: TIM_1CH
-  description: 2-channel timers
-  items:
-  - name: CR2
-    description: control register 2
-    byte_offset: 4
-    fieldset: CR2_2CH
-  - name: SMCR
-    description: slave mode control register
-    byte_offset: 8
-    fieldset: SMCR_2CH
-  - name: DIER
-    description: DMA/Interrupt enable register
-    byte_offset: 12
-    fieldset: DIER_2CH
-  - name: SR
-    description: status register
-    byte_offset: 16
-    fieldset: SR_2CH
-  - name: EGR
-    description: event generation register
-    byte_offset: 20
-    access: Write
-    bit_size: 16
-    fieldset: EGR_2CH
-  - name: CCMR_Input
-    description: capture/compare mode register 1 (input mode)
-    array:
-      len: 1
-      stride: 4
-    byte_offset: 24
-    fieldset: CCMR_Input_2CH
-  - name: CCMR_Output
-    description: capture/compare mode register 1 (output mode)
-    array:
-      len: 1
-      stride: 4
-    byte_offset: 24
-    fieldset: CCMR_Output_2CH
-  - name: CCER
-    description: capture/compare enable register
-    byte_offset: 32
-    fieldset: CCER_2CH
-  - name: CCR
-    description: capture/compare register x (x=1-2) (Dither mode disabled)
-    array:
-      len: 2
-      stride: 4
-    byte_offset: 52
-    fieldset: CCR_1CH
-  - name: CCR_DITHER
-    description: capture/compare register x (x=1-2) (Dither mode enabled)
-    array:
-      len: 2
-      stride: 4
-    byte_offset: 52
-    fieldset: CCR_DITHER_1CH
-  - name: TISEL
-    description: input selection register
-    byte_offset: 92
-    fieldset: TISEL_2CH
-block/TIM_2CH_CMP:
-  extends: TIM_1CH_CMP
-  description: 2-channel with one complementary output timers
-  items:
-  - name: CR2
-    description: control register 2
-    byte_offset: 4
-    fieldset: CR2_2CH_CMP
-  - name: SMCR
-    description: slave mode control register
-    byte_offset: 8
-    fieldset: SMCR_2CH_CMP
-  - name: DIER
-    description: DMA/Interrupt enable register
-    byte_offset: 12
-    fieldset: DIER_2CH_CMP
-  - name: SR
-    description: status register
-    byte_offset: 16
-    fieldset: SR_2CH_CMP
-  - name: EGR
-    description: event generation register
-    byte_offset: 20
-    access: Write
-    bit_size: 16
-    fieldset: EGR_2CH_CMP
-  - name: CCMR_Input
-    description: capture/compare mode register 1 (input mode)
-    array:
-      len: 2
-      stride: 4
-    byte_offset: 24
-    fieldset: CCMR_Input_1CH
-  - name: CCMR_Output
-    description: capture/compare mode register 1 (output mode)
-    array:
-      len: 2
-      stride: 4
-    byte_offset: 24
-    fieldset: CCMR_Output_1CH
-  - name: CCER
-    description: capture/compare enable register
-    byte_offset: 32
-    fieldset: CCER_2CH_CMP
-  - name: CCR
-    description: capture/compare register x (x=1-2)
-    array:
-      len: 2
-      stride: 4
-    byte_offset: 52
-    fieldset: CCR_1CH
-  - name: CCR_DITHER
-    description: capture/compare register x (x=1-2) (Dither mode enabled)
-    array:
-      len: 2
-      stride: 4
-    byte_offset: 52
-    fieldset: CCR_DITHER_1CH
-  - name: BDTR
-    description: break and dead-time register
-    byte_offset: 68
-    fieldset: BDTR_1CH_CMP
-  - name: TISEL
-    description: input selection register
-    byte_offset: 92
-    fieldset: TISEL_2CH
-block/TIM_ADV:
-  extends: TIM_2CH_CMP
-  description: Advanced Control timers
-  items:
-  - name: CR1
-    description: control register 1
-    byte_offset: 0
-    bit_size: 16
-    fieldset: CR1_GP16
-  - name: CR2
-    description: control register 2
-    byte_offset: 4
-    fieldset: CR2_ADV
-  - name: SMCR
-    description: slave mode control register
-    byte_offset: 8
-    fieldset: SMCR_ADV
-  - name: DIER
-    description: DMA/Interrupt enable register
-    byte_offset: 12
-    fieldset: DIER_ADV
-  - name: SR
-    description: status register
-    byte_offset: 16
-    fieldset: SR_ADV
-  - name: EGR
-    description: event generation register
-    byte_offset: 20
-    access: Write
-    bit_size: 16
-    fieldset: EGR_ADV
-  - name: CCMR_Input
-    description: capture/compare mode register 1-2 (input mode)
-    array:
-      len: 2
-      stride: 4
-    byte_offset: 24
-    fieldset: CCMR_Input_2CH
-  - name: CCMR_Output
-    description: capture/compare mode register 1-2 (output mode)
-    array:
-      len: 2
-      stride: 4
-    byte_offset: 24
-    fieldset: CCMR_Output_GP16
-  - name: CCER
-    description: capture/compare enable register
-    byte_offset: 32
-    fieldset: CCER_ADV
-  - name: RCR
-    description: repetition counter register
-    byte_offset: 48
-    bit_size: 16
-    fieldset: RCR_ADV
-  - name: CCR
-    description: capture/compare register x (x=1-4)
-    array:
-      len: 4
-      stride: 4
-    byte_offset: 52
-    fieldset: CCR_1CH
-  - name: ECR
-    description: encoder control register
-    byte_offset: 88
-    fieldset: ECR_GP16
-  - name: BDTR
-    description: break and dead-time register
-    byte_offset: 68
-    fieldset: BDTR_ADV
-  - name: CCR5
-    description: capture/compare register 5 (Dither mode disabled)
-    byte_offset: 72
-    fieldset: CCR5_ADV
-  - name: CCR5_DITHER
-    description: capture/compare register 5 (Dither mode enabled)
-    byte_offset: 72
-    fieldset: CCR5_DITHER_ADV
-  - name: CCR6
-    description: capture/compare register 6 (Dither mode disabled)
-    byte_offset: 76
-    fieldset: CCR_1CH
-  - name: CCR6_DITHER
-    description: capture/compare register 6 (Dither mode enabled)
-    byte_offset: 76
-    fieldset: CCR_DITHER_1CH
-  - name: CCMR3
-    description: capture/compare mode register 3
-    byte_offset: 80
-    fieldset: CCMR3_ADV
-  - name: AF1
-    description: alternate function register 1
-    byte_offset: 96
-    fieldset: AF1_ADV
-  - name: AF2
-    description: alternate function register 2
-    byte_offset: 100
-    fieldset: AF2_ADV
-  - name: TISEL
-    description: input selection register
-    byte_offset: 92
-    fieldset: TISEL_GP16
-block/TIM_BASIC:
-  extends: TIM_BASIC_NO_CR2
-  description: Basic timers
-  items:
-  - name: CR2
-    description: control register 2
-    byte_offset: 4
-    fieldset: CR2_BASIC
-block/TIM_BASIC_NO_CR2:
-  extends: TIM_CORE
-  description: Virtual Basic timers without CR2 register for common part of TIM_BASIC and TIM_1CH_CMP
-  items:
-  - name: DIER
-    description: DMA/Interrupt enable register
-    byte_offset: 12
-    fieldset: DIER_BASIC_NO_CR2
 block/TIM_CORE:
-  description: Virtual timer for common part of TIM_BASIC and TIM_1CH
+  description: Virtual timer for common parts of all timers
   items:
   - name: CR1
     description: control register 1
@@ -392,14 +29,125 @@ block/TIM_CORE:
     byte_offset: 40
     bit_size: 16
   - name: ARR
-    description: auto-reload register (Dither mode disabled)
+    description: auto-reload register
     byte_offset: 44
     fieldset: ARR_CORE
   - name: ARR_DITHER
-    description: auto-reload register (Dither mode enabled)
+    description: auto-reload register (dither mode enabled)
     byte_offset: 44
     fieldset: ARR_DITHER_CORE
-block/TIM_GP16:
+
+block/TIM_BASIC:
+  extends: TIM_CORE
+  description: Basic timers
+  items:
+  - name: CR2
+    description: control register 2
+    byte_offset: 4
+    fieldset: CR2_MMS
+  - name: DIER
+    description: DMA/Interrupt enable register
+    byte_offset: 12
+    fieldset: DIER_UPDMA
+
+block/TIM_1CH:
+  extends: TIM_CORE
+  description: 1-channel timers
+  items:
+  - name: CR1
+    description: control register 1
+    byte_offset: 0
+    bit_size: 16
+    fieldset: CR1_1CH
+  - name: DIER
+    description: DMA/Interrupt enable register
+    byte_offset: 12
+    fieldset: DIER_1CH
+  - name: SR
+    description: status register
+    byte_offset: 16
+    fieldset: SR_1CH
+  - name: EGR
+    description: event generation register
+    byte_offset: 20
+    access: Write
+    bit_size: 16
+    fieldset: EGR_1CH
+  - name: CCMR_Input
+    description: capture/compare mode register 1 (input mode)
+    array:
+      len: 2
+      stride: 4
+    byte_offset: 24
+    fieldset: CCMR_Input_1CH
+  - name: CCMR_Output
+    description: capture/compare mode register 1 (output mode)
+    array:
+      len: 2
+      stride: 4
+    byte_offset: 24
+    fieldset: CCMR_Output_1CH
+  - name: CCER
+    description: capture/compare enable register
+    byte_offset: 32
+    fieldset: CCER_1CH
+  - name: CCR
+    description: capture/compare register x (x=1-4)
+    array:
+      len: 4
+      stride: 4
+    byte_offset: 52
+    fieldset: CCR_1CH
+  - name: CCR_DITHER
+    description: capture/compare register x (x=1-4) (dither mode enabled)
+    array:
+      len: 4
+      stride: 4
+    byte_offset: 52
+    fieldset: CCR_DITHER_1CH
+  - name: TISEL
+    description: input selection register
+    byte_offset: 92
+    fieldset: TISEL_1CH
+  - name: OR
+    description: |-
+      Option register 1
+      Note: Check Reference Manual to parse this register content
+    byte_offset: 104
+
+block/TIM_2CH:
+  extends: TIM_1CH
+  description: 2-channel timers
+  items:
+  - name: CR1
+    description: control register 1
+    byte_offset: 0
+    bit_size: 16
+    fieldset: CR1_2CH
+  - name: CR2
+    description: control register 2
+    byte_offset: 4
+    fieldset: CR2_2CH
+  - name: SMCR
+    description: slave mode control register
+    byte_offset: 8
+    fieldset: SMCR_2CH
+  - name: DIER
+    description: DMA/Interrupt enable register
+    byte_offset: 12
+    fieldset: DIER_2CH
+  - name: SR
+    description: status register
+    byte_offset: 16
+    fieldset: SR_2CH
+  - name: EGR
+    description: event generation register
+    byte_offset: 20
+    access: Write
+    bit_size: 16
+    fieldset: EGR_2CH
+
+block/TIM_4CH:
   extends: TIM_2CH
   description: General purpose 16-bit timers
   items:
@@ -407,461 +155,833 @@ block/TIM_GP16:
     description: control register 1
     byte_offset: 0
     bit_size: 16
-    fieldset: CR1_GP16
+    fieldset: CR1_4CH
   - name: CR2
     description: control register 2
     byte_offset: 4
-    fieldset: CR2_GP16
+    fieldset: CR2_TRIGDMA
   - name: SMCR
     description: slave mode control register
     byte_offset: 8
-    fieldset: SMCR_GP16
+    fieldset: SMCR_4CH
   - name: DIER
     description: DMA/Interrupt enable register
     byte_offset: 12
-    fieldset: DIER_GP16
+    fieldset: DIER_4CH
   - name: SR
     description: status register
     byte_offset: 16
-    fieldset: SR_GP16
-  - name: EGR
-    description: event generation register
-    byte_offset: 20
-    access: Write
-    bit_size: 16
-    fieldset: EGR_GP16
-  - name: CCMR_Input
-    description: capture/compare mode register 1-2 (input mode)
-    array:
-      len: 2
-      stride: 4
-    byte_offset: 24
-    fieldset: CCMR_Input_2CH
+    fieldset: SR_4CH
   - name: CCMR_Output
     description: capture/compare mode register 1-2 (output mode)
     array:
       len: 2
       stride: 4
     byte_offset: 24
-    fieldset: CCMR_Output_GP16
-  - name: CCER
-    description: capture/compare enable register
-    byte_offset: 32
-    fieldset: CCER_GP16
-  - name: CCR
-    description: capture/compare register x (x=1-4) (Dither mode disabled)
-    array:
-      len: 4
-      stride: 4
-    byte_offset: 52
-    fieldset: CCR_1CH
-  - name: CCR_DITHER
-    description: capture/compare register x (x=1-4) (Dither mode enabled)
-    array:
-      len: 4
-      stride: 4
-    byte_offset: 52
-    fieldset: CCR_DITHER_1CH
-  - name: ECR
-    description: encoder control register
-    byte_offset: 88
-    fieldset: ECR_GP16
+    fieldset: CCMR_Output_4CH
   - name: DCR
     description: DMA control register
     byte_offset: 988
-    fieldset: DCR_1CH_CMP
+    fieldset: DCR_CCDMA
+  - name: DMAR
+    description: DMA address for full transfer
+    byte_offset: 992
+  - name: ECR
+    description: encoder control register
+    byte_offset: 88
+    fieldset: ECR_4CH
+  - name: AF1
+    description: alternate function register 1
+    byte_offset: 96
+    fieldset: AF1_4CH
+  - name: AF2
+    description: alternate function register 2
+    byte_offset: 100
+    fieldset: AF2_CCDMA
+
+block/TIM_32BIT:
+  extends: TIM_4CH
+  description: General purpose 32-bit timers
+  items:
+  - name: CNT
+    description: counter
+    byte_offset: 36
+  - name: CNT_DITHER
+    description: counter (dither mode enabled)
+    byte_offset: 36
+    fieldset: CNT_DITHER_32BIT
+  - name: ARR
+    description: auto-reload register
+    byte_offset: 44
+  - name: ARR_DITHER
+    description: auto-reload register (dither mode enabled)
+    byte_offset: 44
+    fieldset: ARR_DITHER_32BIT
+  - name: CCR
+    description: capture/compare register x (x=1-4)
+    array:
+      len: 4
+      stride: 4
+    byte_offset: 52
+  - name: CCR_DITHER
+    description: capture/compare register x (x=1-4) (dither mode enabled)
+    array:
+      len: 4
+      stride: 4
+    byte_offset: 52
+    fieldset: CCR_DITHER_32BIT
+
+block/TIM_ADV1CH:
+  extends: TIM_1CH
+  description: 1-channel with one complementary output timers
+  items:
+  - name: CR2
+    description: control register 2
+    byte_offset: 4
+    fieldset: CR2_ADV1CH
+  - name: DIER
+    description: DMA/Interrupt enable register
+    byte_offset: 12
+    fieldset: DIER_ADV1CH
+  - name: SR
+    description: status register
+    byte_offset: 16
+    fieldset: SR_ADV1CH
+  - name: EGR
+    description: event generation register
+    byte_offset: 20
+    access: Write
+    bit_size: 16
+    fieldset: EGR_ADV1CH
+  - name: CCER
+    description: capture/compare enable register
+    byte_offset: 32
+    fieldset: CCER_ADV1CH
+  - name: RCR
+    description: repetition counter register
+    byte_offset: 48
+    bit_size: 16
+    fieldset: RCR_ADV1CH
+  - name: BDTR
+    description: break and dead-time register
+    byte_offset: 68
+    fieldset: BDTR_ADV1CH
+  - name: DTR2
+    description: break and dead-time register
+    byte_offset: 84
+    fieldset: DTR2_ADV1CH
+  - name: DCR
+    description: DMA control register
+    byte_offset: 988
+    fieldset: DCR_CCDMA
   - name: DMAR
     description: DMA address for full transfer
     byte_offset: 992
   - name: AF1
     description: alternate function register 1
     byte_offset: 96
-    fieldset: AF1_GP16
+    fieldset: AF1_ADV1CH
   - name: AF2
     description: alternate function register 2
     byte_offset: 100
-    fieldset: AF2_1CH_CMP
-  - name: TISEL
-    description: input selection register
-    byte_offset: 92
-    fieldset: TISEL_GP16
-block/TIM_GP32:
-  extends: TIM_GP16
-  description: General purpose 32-bit timers
+    fieldset: AF2_CCDMA
+
+block/TIM_ADV2CH:
+  extends: TIM_ADV1CH
+  description: 2-channel with one complementary output timers
   items:
-  - name: CNT
-    description: counter (Dither mode disabled)
-    byte_offset: 36
-  - name: CNT_DITHER
-    description: counter (Dither mode enbled)
-    byte_offset: 36
-    fieldset: CNT_DITHER_GP32
-  - name: ARR
-    description: auto-reload register (Dither mode disabled)
-    byte_offset: 44
-  - name: ARR_DITHER
-    description: auto-reload register (Dither mode enabled)
-    byte_offset: 44
-    fieldset: ARR_DITHER_GP32
-  - name: CCR
-    description: capture/compare register x (x=1-4) (Dither mode disabled)
+  - name: CR2
+    description: control register 2
+    byte_offset: 4
+    fieldset: CR2_ADV2CH
+  - name: SMCR
+    description: slave mode control register
+    byte_offset: 8
+    fieldset: SMCR_TRIGDMA
+  - name: DIER
+    description: DMA/Interrupt enable register
+    byte_offset: 12
+    fieldset: DIER_ADV2CH
+  - name: SR
+    description: status register
+    byte_offset: 16
+    fieldset: SR_ADV2CH
+  - name: EGR
+    description: event generation register
+    byte_offset: 20
+    access: Write
+    bit_size: 16
+    fieldset: EGR_ADV2CH
+
+block/TIM_ADV4CH:
+  extends: TIM_ADV2CH
+  description: Advanced Control timers
+  items:
+  - name: CR1
+    description: control register 1
+    byte_offset: 0
+    bit_size: 16
+    fieldset: CR1_4CH
+  - name: CR2
+    description: control register 2
+    byte_offset: 4
+    fieldset: CR2_ADV4CH
+  - name: SMCR
+    description: slave mode control register
+    byte_offset: 8
+    fieldset: SMCR_ADV4CH
+  - name: DIER
+    description: DMA/Interrupt enable register
+    byte_offset: 12
+    fieldset: DIER_ADV4CH
+  - name: SR
+    description: status register
+    byte_offset: 16
+    fieldset: SR_ADV4CH
+  - name: CCMR_Output
+    description: capture/compare mode register 1-2 (output mode)
     array:
-      len: 4
+      len: 2
       stride: 4
-    byte_offset: 52
-  - name: CCR_DITHER
-    description: capture/compare register x (x=1-4) (Dither mode enabled)
-    array:
-      len: 4
-      stride: 4
-    byte_offset: 52
-    fieldset: CCR_DITHER_GP32
-fieldset/AF1_1CH_CMP:
-  description: alternate function register 1
+    byte_offset: 24
+    fieldset: CCMR_Output_4CH
+  - name: RCR
+    description: repetition counter register
+    byte_offset: 48
+    bit_size: 16
+    fieldset: RCR_ADV4CH
+  - name: CCMR3_Output
+    description: capture/compare mode register 3 (output mode)
+    byte_offset: 80
+    fieldset: CCMR3_Output_ADV4CH
+  - name: CCR5
+    description: capture/compare register 5
+    byte_offset: 72
+    fieldset: CCR5_ADV4CH
+  - name: CCR5_DITHER
+    description: capture/compare register 5 (dither mode enabled)
+    byte_offset: 72
+    fieldset: CCR5_DITHER_ADV4CH
+  - name: CCR6
+    description: capture/compare register 6
+    byte_offset: 76
+    fieldset: CCR_1CH
+  - name: CCR6_DITHER
+    description: capture/compare register 6 (dither mode enabled)
+    byte_offset: 76
+    fieldset: CCR_DITHER_1CH
+  - name: ECR
+    description: encoder control register
+    byte_offset: 88
+    fieldset: ECR_4CH
+  - name: AF1
+    description: alternate function register 1
+    byte_offset: 96
+    fieldset: AF1_ADV4CH
+  - name: AF2
+    description: alternate function register 2
+    byte_offset: 100
+    fieldset: AF2_ADV4CH
+
+
+
+# CR1 register
+fieldset/CR1_CORE:
+  description: control register 1
   fields:
-  - name: BKINE
-    description: TIMx_BKIN input enable
+  - name: CEN
+    description: Counter enable
     bit_offset: 0
     bit_size: 1
-  - name: BKCMPE
-    description: TIM_BRK_CMPx (x=1-8) enable
+  - name: UDIS
+    description: Update disable
     bit_offset: 1
     bit_size: 1
-    array:
-      len: 8
-      stride: 1
-  - name: BKINP
-    description: TIMx_BKIN input polarity
-    bit_offset: 9
+  - name: URS
+    description: Update request source
+    bit_offset: 2
     bit_size: 1
-    enum: BKINP
-  - name: BKCMPP
-    description: TIM_BRK_CMPx (x=1-4) input polarity
-    bit_offset: 10
+    enum: URS
+  - name: OPM
+    description: One-pulse mode enbaled
+    bit_offset: 3
     bit_size: 1
-    array:
-      len: 4
-      stride: 1
-    enum: BKINP
-fieldset/AF1_ADV:
-  extends: AF1_1CH_CMP
-  description: alternate function register 1
-  fields:
-  - name: ETRSEL
-    description: etr_in source selection
-    bit_offset: 14
-    bit_size: 4
-fieldset/AF1_GP16:
-  description: alternate function register 1
-  fields:
-  - name: ETRSEL
-    description: etr_in source selection
-    bit_offset: 14
-    bit_size: 4
-fieldset/AF2_1CH_CMP:
-  description: alternate function register 2
-  fields:
-  - name: OCRSEL
-    description: ocref_clr source selection
-    bit_offset: 16
-    bit_size: 3
-fieldset/AF2_ADV:
-  extends: AF2_1CH_CMP
-  description: alternate function register 2
-  fields:
-  - name: BK2INE
-    description: TIMx_BKIN2 input enable
-    bit_offset: 0
+  - name: ARPE
+    description: Auto-reload preload enable
+    bit_offset: 7
     bit_size: 1
-  - name: BK2CMPE
-    description: TIM_BRK2_CMPx (x=1-8) enable
-    bit_offset: 1
-    bit_size: 1
-    array:
-      len: 8
-      stride: 1
-  - name: BK2INP
-    description: TIMx_BK2IN input polarity
-    bit_offset: 9
-    bit_size: 1
-    enum: BKINP
-  - name: BK2CMPP
-    description: TIM_BRK2_CMPx (x=1-4) input polarity
-    bit_offset: 10
-    bit_size: 1
-    array:
-      len: 4
-      stride: 1
-    enum: BKINP
-fieldset/ARR_CORE:
-  description: auto-reload register (Dither mode disabled)
-  fields:
-  - name: ARR
-    description: Auto-reload value
-    bit_offset: 0
-    bit_size: 16
-fieldset/ARR_DITHER_CORE:
-  description: auto-reload register (Dither mode enabled)
-  fields:
-  - name: DITHER
-    description: Dither value
-    bit_offset: 0
-    bit_size: 4
-  - name: ARR
-    description: Auto-reload value
-    bit_offset: 4
-    bit_size: 16
-fieldset/ARR_DITHER_GP32:
-  description: auto-reload register (Dither mode enabled)
-  fields:
-  - name: DITHER
-    description: Dither value
-    bit_offset: 0
-    bit_size: 4
-  - name: ARR
-    description: Auto-reload value
-    bit_offset: 4
-    bit_size: 28
-fieldset/BDTR_1CH_CMP:
-  description: break and dead-time register
-  fields:
-  - name: DTG
-    description: Dead-time generator setup
-    bit_offset: 0
-    bit_size: 8
-  - name: LOCK
-    description: Lock configuration
-    bit_offset: 8
-    bit_size: 2
-    enum: LOCK
-  - name: OSSI
-    description: Off-state selection for Idle mode
-    bit_offset: 10
-    bit_size: 1
-    enum: OSSI
-  - name: OSSR
-    description: Off-state selection for Run mode
+  - name: UIFREMAP
+    description: UIF status bit remapping enable
     bit_offset: 11
     bit_size: 1
-    enum: OSSR
-  - name: BKE
-    description: Break x (x=1) enable
+  - name: DITHEN
+    description: Dithering enable
     bit_offset: 12
     bit_size: 1
-    array:
-      len: 1
-      stride: 12
-  - name: BKP
-    description: Break x (x=1) polarity
-    bit_offset: 13
+fieldset/CR1_1CH:
+  extends: CR1_CORE
+  description: control register 1
+  fields:
+  - name: CKD
+    description: Clock division
+    bit_offset: 8
+    bit_size: 2
+    enum: CKD
+fieldset/CR1_2CH:
+  extends: CR1_1CH
+  description: control register 1
+  fields: []
+fieldset/CR1_4CH:
+  extends: CR1_2CH
+  description: control register 1
+  fields:
+  - name: DIR
+    description: Direction
+    bit_offset: 4
+    bit_size: 1
+    enum: DIR
+  - name: CMS
+    description: Center-aligned mode selection
+    bit_offset: 5
+    bit_size: 2
+    enum: CMS
+
+# CR2 register
+fieldset/CR2_MMS:
+  description: control register 2
+  fields:
+  - name: MMS
+    description: Master mode selection
+    bit_offset:
+    - start: 4
+      end: 6
+    - start: 25
+      end: 25
+    bit_size: 4
+    enum: MMS
+fieldset/CR2_2CH:
+  extends: CR2_MMS
+  description: control register 2
+  fields:
+  - name: TI1S
+    description: TI1 selection
+    bit_offset: 7
+    bit_size: 1
+    enum: TI1S
+fieldset/CR2_CCDMA:
+  description: control register 2
+  fields:
+  - name: CCDS
+    description: Capture/compare DMA selection
+    bit_offset: 3
+    bit_size: 1
+    enum: CCDS
+fieldset/CR2_TRIGDMA:
+  extends: CR2_2CH
+  description: control register 2
+  fields:
+  - name: CCDS
+    description: Capture/compare DMA selection
+    bit_offset: 3
+    bit_size: 1
+    enum: CCDS
+fieldset/CR2_ADV1CH:
+  extends: CR2_CCDMA
+  description: control register 2
+  fields:
+  - name: CCPC
+    description: Capture/compare preloaded control
+    bit_offset: 0
+    bit_size: 1
+  - name: CCUS
+    description: Capture/compare control update selection
+    bit_offset: 2
+    bit_size: 1
+  - name: OIS
+    description: Output Idle state x (x=1-6)
+    bit_offset: 8
     bit_size: 1
     array:
-      len: 1
-      stride: 12
-    enum: BKP
-  - name: AOE
-    description: Automatic output enable
+      len: 6
+      stride: 2
+  - name: OISN
+    description: Output Idle state x N x (x=1-4)
+    bit_offset: 9
+    bit_size: 1
+    array:
+      len: 4
+      stride: 2
+fieldset/CR2_ADV2CH:
+  extends: CR2_ADV1CH
+  description: control register 2
+  fields:
+  - name: MMS
+    description: Master mode selection
+    bit_offset:
+    - start: 4
+      end: 6
+    - start: 25
+      end: 25
+    bit_size: 4
+    enum: MMS
+  - name: TI1S
+    description: TI1 selection
+    bit_offset: 7
+    bit_size: 1
+    enum: TI1S
+fieldset/CR2_ADV4CH:
+  extends: CR2_ADV2CH
+  description: control register 2
+  fields:
+  - name: MMS2
+    description: Master mode selection 2
+    bit_offset: 20
+    bit_size: 4
+    enum: MMS2
+
+# SMCR register
+fieldset/SMCR_2CH:
+  description: slave mode control register
+  fields:
+  - name: SMS
+    description: Slave mode selection
+    bit_offset:
+    - start: 0
+      end: 2
+    - start: 16
+      end: 16
+    bit_size: 4
+    enum: SMS
+  - name: TS
+    description: Trigger selection
+    bit_offset:
+    - start: 4
+      end: 6
+    - start: 20
+      end: 21
+    bit_size: 5
+    enum: TS
+  - name: MSM
+    description: Master/Slave mode
+    bit_offset: 7
+    bit_size: 1
+    enum: MSM
+fieldset/SMCR_TRIGDMA:
+  extends: SMCR_2CH
+  description: slave mode control register
+  fields:
+  - name: SMSPE
+    description: SMS preload enable
+    bit_offset: 24
+    bit_size: 1
+fieldset/SMCR_4CH:
+  extends: SMCR_TRIGDMA
+  description: slave mode control register
+  fields:
+  - name: ETF
+    description: External trigger filter
+    bit_offset: 8
+    bit_size: 4
+    enum: FilterValue
+  - name: ETPS
+    description: External trigger prescaler
+    bit_offset: 12
+    bit_size: 2
+    enum: ETPS
+  - name: ECE
+    description: External clock mode 2 enable
     bit_offset: 14
     bit_size: 1
-  - name: MOE
-    description: Main output enable
+  - name: ETP
+    description: External trigger polarity
     bit_offset: 15
     bit_size: 1
-  - name: BKF
-    description: Break x (x=1) filter
-    bit_offset: 16
-    bit_size: 4
-    array:
-      len: 1
-      stride: 4
-    enum: FilterValue
-  - name: BKDSRM
-    description: Break x (x=1) Disarm
-    bit_offset: 26
+    enum: ETP
+  - name: SMSPS
+    description: SMS preload source
+    bit_offset: 25
     bit_size: 1
-    array:
-      len: 1
-      stride: 1
-    enum: BKDSRM
-  - name: BKBID
-    description: Break x (x=1) bidirectional
-    bit_offset: 28
-    bit_size: 1
-    array:
-      len: 1
-      stride: 1
-    enum: BKBID
-fieldset/BDTR_ADV:
-  extends: BDTR_1CH_CMP
-  description: break and dead-time register
+    enum: SMSPS
+fieldset/SMCR_ADV4CH:
+  extends: SMCR_4CH
+  description: slave mode control register
   fields:
-  - name: BKE
-    description: Break x (x=1,2) enable
-    bit_offset: 12
+  - name: OCCS
+    description: OCREF clear selection
+    bit_offset: 3
+    bit_size: 1
+    enum: OCCS
+
+# DIER register
+fieldset/DIER_CORE:
+  description: DMA/Interrupt enable register
+  fields:
+  - name: UIE
+    description: Update interrupt enable
+    bit_offset: 0
+    bit_size: 1
+fieldset/DIER_UPDMA:
+  extends: DIER_CORE
+  description: DMA/Interrupt enable register
+  fields:
+  - name: UDE
+    description: Update DMA request enable
+    bit_offset: 8
+    bit_size: 1
+fieldset/DIER_1CH:
+  extends: DIER_CORE
+  description: DMA/Interrupt enable register
+  fields:
+  - name: CCIE
+    description: Capture/Compare x (x=1-4) interrupt enable
+    bit_offset: 1
     bit_size: 1
     array:
-      len: 2
-      stride: 12
-  - name: BKP
-    description: Break x (x=1,2) polarity
+      len: 4
+      stride: 1
+fieldset/DIER_2CH:
+  extends: DIER_1CH
+  description: DMA/Interrupt enable register
+  fields:
+  - name: TIE
+    description: Trigger interrupt enable
+    bit_offset: 6
+    bit_size: 1
+fieldset/DIER_CCDMA:
+  extends: DIER_1CH
+  description: DMA/Interrupt enable register
+  fields:
+  - name: CCDE
+    description: Capture/Compare x (x=1-4) DMA request enable
+    bit_offset: 9
+    bit_size: 1
+    array:
+      len: 4
+      stride: 1
+fieldset/DIER_TRIGDMA:
+  extends: DIER_CCDMA
+  description: DMA/Interrupt enable register
+  fields:
+  - name: TDE
+    description: Trigger DMA request enable
+    bit_offset: 14
+    bit_size: 1
+fieldset/DIER_4CH:
+  extends: DIER_TRIGDMA
+  description: DMA/Interrupt enable register
+  fields:
+  - name: IDXIE
+    description: Index interrupt enable
+    bit_offset: 20
+    bit_size: 1
+  - name: DIRIE
+    description: Direction change interrupt enable
+    bit_offset: 21
+    bit_size: 1
+  - name: IERRIE
+    description: Index error interrupt enable
+    bit_offset: 22
+    bit_size: 1
+  - name: TERRIE
+    description: Transition error interrupt enable
+    bit_offset: 23
+    bit_size: 1
+fieldset/DIER_ADV1CH:
+  extends: DIER_UPDMA
+  description: DMA/Interrupt enable register
+  fields:
+  - name: CCIE
+    description: Capture/Compare x (x=1-4) interrupt enable
+    bit_offset: 1
+    bit_size: 1
+    array:
+      len: 4
+      stride: 1
+  - name: COMIE
+    description: COM interrupt enable
+    bit_offset: 5
+    bit_size: 1
+  - name: BIE
+    description: Break interrupt enable
+    bit_offset: 7
+    bit_size: 1
+  - name: CCDE
+    description: Capture/Compare x (x=1-4) DMA request enable
+    bit_offset: 9
+    bit_size: 1
+    array:
+      len: 4
+      stride: 1
+fieldset/DIER_ADV2CH:
+  extends: DIER_ADV1CH
+  description: DMA/Interrupt enable register
+  fields:
+  - name: COMDE
+    description: COM DMA request enable
     bit_offset: 13
     bit_size: 1
+  - name: TDE
+    description: Trigger DMA request enable
+    bit_offset: 14
+    bit_size: 1
+fieldset/DIER_ADV4CH:
+  extends: DIER_ADV2CH
+  description: DMA/Interrupt enable register
+  fields:
+  - name: IDXIE
+    description: Index interrupt enable
+    bit_offset: 20
+    bit_size: 1
+  - name: DIRIE
+    description: Direction change interrupt enable
+    bit_offset: 21
+    bit_size: 1
+  - name: IERRIE
+    description: Index error interrupt enable
+    bit_offset: 22
+    bit_size: 1
+  - name: TERRIE
+    description: Transition error interrupt enable
+    bit_offset: 23
+    bit_size: 1
+
+# SR register
+fieldset/SR_CORE:
+  description: status register
+  fields:
+  - name: UIF
+    description: Update interrupt flag
+    bit_offset: 0
+    bit_size: 1
+fieldset/SR_1CH:
+  extends: SR_CORE
+  description: status register
+  fields:
+  - name: CCIF
+    description: Capture/compare x (x=1-4) interrupt flag
+    bit_offset: 1
+    bit_size: 1
+    array:
+      len: 4
+      stride: 1
+  - name: CCOF
+    description: Capture/Compare x (x=1-4) overcapture flag
+    bit_offset: 9
+    bit_size: 1
+    array:
+      len: 4
+      stride: 1
+fieldset/SR_2CH:
+  extends: SR_1CH
+  description: status register
+  fields:
+  - name: TIF
+    description: Trigger interrupt flag
+    bit_offset: 6
+    bit_size: 1
+fieldset/SR_4CH:
+  extends: SR_2CH
+  description: status register
+  fields:
+  - name: IDXIF
+    description: Index interrupt flag
+    bit_offset: 20
+    bit_size: 1
+  - name: DIRIF
+    description: Direction change interrupt flag
+    bit_offset: 21
+    bit_size: 1
+  - name: IERRIF
+    description: Index error interrupt flag
+    bit_offset: 22
+    bit_size: 1
+  - name: TERRIF
+    description: Transition error interrupt flag
+    bit_offset: 23
+    bit_size: 1
+fieldset/SR_ADV1CH:
+  extends: SR_1CH
+  description: status register
+  fields:
+  - name: COMIF
+    description: COM interrupt flag
+    bit_offset: 5
+    bit_size: 1
+  - name: BIF
+    description: Break x (x=1,2) interrupt flag
+    bit_offset: 7
+    bit_size: 1
     array:
       len: 2
-      stride: 12
-    enum: BKP
-  - name: BKF
-    description: Break x (x=1,2) filter
+      stride: 1
+fieldset/SR_ADV2CH:
+  extends: SR_ADV1CH
+  description: status register
+  fields:
+  - name: TIF
+    description: Trigger interrupt flag
+    bit_offset: 6
+    bit_size: 1
+fieldset/SR_ADV4CH:
+  extends: SR_ADV2CH
+  description: status register
+  fields:
+  - name: SBIF
+    description: System break interrupt flag
+    bit_offset: 13
+    bit_size: 1
+  - name: CCIF5
+    description: Capture/compare 5 interrupt flag
     bit_offset: 16
+    bit_size: 1
+  - name: CCIF6
+    description: Capture/compare 6 interrupt flag
+    bit_offset: 17
+    bit_size: 1
+  - name: IDXIF
+    description: Index interrupt flag
+    bit_offset: 20
+    bit_size: 1
+  - name: DIRIF
+    description: Direction change interrupt flag
+    bit_offset: 21
+    bit_size: 1
+  - name: IERRIF
+    description: Index error interrupt flag
+    bit_offset: 22
+    bit_size: 1
+  - name: TERRIF
+    description: Transition error interrupt flag
+    bit_offset: 23
+    bit_size: 1
+
+# EGR register
+fieldset/EGR_CORE:
+  description: event generation register
+  fields:
+  - name: UG
+    description: Update generation
+    bit_offset: 0
+    bit_size: 1
+fieldset/EGR_1CH:
+  extends: EGR_CORE
+  description: event generation register
+  fields:
+  - name: CCG
+    description: Capture/compare x (x=1-4) generation
+    bit_offset: 1
+    bit_size: 1
+    array:
+      len: 4
+      stride: 1
+fieldset/EGR_2CH:
+  extends: EGR_1CH
+  description: event generation register
+  fields:
+  - name: TG
+    description: Trigger generation
+    bit_offset: 6
+    bit_size: 1
+fieldset/EGR_ADV1CH:
+  extends: EGR_1CH
+  description: event generation register
+  fields:
+  - name: COMG
+    description: Capture/Compare control update generation
+    bit_offset: 5
+    bit_size: 1
+  - name: BG
+    description: Break x (x=1-2) generation
+    bit_offset: 7
+    bit_size: 1
+    array:
+      len: 2
+      stride: 1
+fieldset/EGR_ADV2CH:
+  extends: EGR_ADV1CH
+  description: event generation register
+  fields:
+  - name: TG
+    description: Trigger generation
+    bit_offset: 6
+    bit_size: 1
+
+# CCMR register
+fieldset/CCMR_Input_1CH:
+  description: capture/compare mode register (input mode)
+  fields:
+  - name: CCS
+    description: Capture/Compare y selection
+    bit_offset: 0
+    bit_size: 2
+    array:
+      len: 2
+      stride: 8
+    enum: CCMR_Input_CCS
+  - name: ICPSC
+    description: Input capture y prescaler
+    bit_offset: 2
+    bit_size: 2
+    array:
+      len: 2
+      stride: 8
+  - name: ICF
+    description: Input capture y filter
+    bit_offset: 4
     bit_size: 4
     array:
       len: 2
-      stride: 4
+      stride: 8
     enum: FilterValue
-  - name: BKDSRM
-    description: Break x (x=1,2) Disarm
-    bit_offset: 26
-    bit_size: 1
-    array:
-      len: 2
-      stride: 1
-    enum: BKDSRM
-  - name: BKBID
-    description: Break x (x=1,2) bidirectional
-    bit_offset: 28
-    bit_size: 1
-    array:
-      len: 2
-      stride: 1
-    enum: BKBID
-fieldset/CCER_1CH:
-  description: capture/compare enable register
+fieldset/CCMR_Output_1CH:
+  description: capture/compare mode register (output mode)
   fields:
-  - name: CCE
-    description: Capture/Compare x (x=1) output enable
+  - name: CCS
+    description: Capture/Compare y selection
     bit_offset: 0
-    bit_size: 1
+    bit_size: 2
     array:
-      len: 1
-      stride: 4
-  - name: CCP
-    description: Capture/Compare x (x=1) output Polarity
-    bit_offset: 1
-    bit_size: 1
-    array:
-      len: 1
-      stride: 4
-  - name: CCNP
-    description: Capture/Compare x (x=1) output Polarity
-    bit_offset: 3
-    bit_size: 1
-    array:
-      len: 1
-      stride: 4
-fieldset/CCER_1CH_CMP:
-  extends: CCER_1CH
-  description: capture/compare enable register
-  fields:
-  - name: CCNE
-    description: Capture/Compare x (x=1) complementary output enable
+      len: 2
+      stride: 8
+    enum: CCMR_Output_CCS
+  - name: OCFE
+    description: Output compare y fast enable
     bit_offset: 2
     bit_size: 1
     array:
-      len: 1
-      stride: 4
-fieldset/CCER_2CH:
-  extends: CCER_1CH
-  description: capture/compare enable register
-  fields:
-  - name: CCE
-    description: Capture/Compare x (x=1-2) output enable
-    bit_offset: 0
-    bit_size: 1
-    array:
       len: 2
-      stride: 4
-  - name: CCP
-    description: Capture/Compare x (x=1-2) output Polarity
-    bit_offset: 1
-    bit_size: 1
-    array:
-      len: 2
-      stride: 4
-  - name: CCNP
-    description: Capture/Compare x (x=1-2) output Polarity
+      stride: 8
+  - name: OCPE
+    description: Output compare y preload enable
     bit_offset: 3
     bit_size: 1
     array:
       len: 2
-      stride: 4
-fieldset/CCER_2CH_CMP:
-  extends: CCER_2CH
-  description: capture/compare enable register
+      stride: 8
+  - name: OCM
+    description: Output compare y mode
+    bit_offset:
+    - start: 4
+      end: 6
+    - start: 16
+      end: 16
+    bit_size: 4
+    array:
+      len: 2
+      stride: 8
+    enum: OCM
+fieldset/CCMR_Output_4CH:
+  extends: CCMR_Output_1CH
+  description: capture/compare mode register (output mode)
   fields:
-  - name: CCNE
-    description: Capture/Compare x (x=1) complementary output enable
-    bit_offset: 2
+  - name: OCCE
+    description: Output compare y clear enable
+    bit_offset: 7
     bit_size: 1
     array:
-      len: 1
-      stride: 4
-fieldset/CCER_ADV:
-  extends: CCER_2CH_CMP
-  description: capture/compare enable register
-  fields:
-  - name: CCE
-    description: Capture/Compare x (x=1-6) output enable
-    bit_offset: 0
-    bit_size: 1
-    array:
-      len: 6
-      stride: 4
-  - name: CCP
-    description: Capture/Compare x (x=1-6) output Polarity
-    bit_offset: 1
-    bit_size: 1
-    array:
-      len: 6
-      stride: 4
-  - name: CCNE
-    description: Capture/Compare x (x=1-4) complementary output enable
-    bit_offset: 2
-    bit_size: 1
-    array:
-      len: 4
-      stride: 4
-  - name: CCNP
-    description: Capture/Compare x (x=1-4) output Polarity
-    bit_offset: 3
-    bit_size: 1
-    array:
-      len: 4
-      stride: 4
-fieldset/CCER_GP16:
-  description: capture/compare enable register
-  fields:
-  - name: CCE
-    description: Capture/Compare x (x=1-4) output enable
-    bit_offset: 0
-    bit_size: 1
-    array:
-      len: 4
-      stride: 4
-  - name: CCP
-    description: Capture/Compare x (x=1-4) output Polarity
-    bit_offset: 1
-    bit_size: 1
-    array:
-      len: 4
-      stride: 4
-  - name: CCNP
-    description: Capture/Compare x (x=1-4) output Polarity
-    bit_offset: 3
-    bit_size: 1
-    array:
-      len: 4
-      stride: 4
-fieldset/CCMR3_ADV:
+      len: 2
+      stride: 8
+fieldset/CCMR3_Output_ADV4CH:
   description: capture/compare mode register 3
   fields:
   - name: OCFE
@@ -897,198 +1017,45 @@ fieldset/CCMR3_ADV:
     array:
       len: 2
       stride: 8
-fieldset/CCMR_Input_1CH:
-  description: capture/compare mode register x (x=1) (input mode)
+
+# CCER register
+fieldset/CCER_1CH:
+  description: capture/compare enable register
   fields:
-  - name: CCS
-    description: Capture/Compare y selection
+  - name: CCE
+    description: Capture/Compare x (x=1-4) output enable
     bit_offset: 0
-    bit_size: 2
-    array:
-      len: 1
-      stride: 8
-    enum: CCMR_Input_CCS
-  - name: ICPSC
-    description: Input capture y prescaler
-    bit_offset: 2
-    bit_size: 2
-    array:
-      len: 1
-      stride: 8
-  - name: ICF
-    description: Input capture y filter
-    bit_offset: 4
-    bit_size: 4
-    array:
-      len: 1
-      stride: 8
-    enum: FilterValue
-fieldset/CCMR_Input_2CH:
-  extends: CCMR_Input_1CH
-  description: capture/compare mode register x (x=1) (input mode)
-  fields:
-  - name: CCS
-    description: Capture/Compare y selection
-    bit_offset: 0
-    bit_size: 2
-    array:
-      len: 2
-      stride: 8
-    enum: CCMR_Input_CCS
-  - name: ICPSC
-    description: Input capture y prescaler
-    bit_offset: 2
-    bit_size: 2
-    array:
-      len: 2
-      stride: 8
-  - name: ICF
-    description: Input capture y filter
-    bit_offset: 4
-    bit_size: 4
-    array:
-      len: 2
-      stride: 8
-    enum: FilterValue
-fieldset/CCMR_Output_1CH:
-  description: capture/compare mode register x (x=1) (output mode)
-  fields:
-  - name: CCS
-    description: Capture/Compare y selection
-    bit_offset: 0
-    bit_size: 2
-    array:
-      len: 1
-      stride: 8
-    enum: CCMR_Output_CCS
-  - name: OCFE
-    description: Output compare y fast enable
-    bit_offset: 2
     bit_size: 1
     array:
-      len: 1
-      stride: 8
-  - name: OCPE
-    description: Output compare y preload enable
+      len: 4
+      stride: 4
+  - name: CCP
+    description: Capture/Compare x (x=1-4) output Polarity
+    bit_offset: 1
+    bit_size: 1
+    array:
+      len: 4
+      stride: 4
+  - name: CCNP
+    description: Capture/Compare x (x=1-4) output Polarity
     bit_offset: 3
     bit_size: 1
     array:
-      len: 1
-      stride: 8
-  - name: OCM
-    description: Output compare y mode
-    bit_offset:
-    - start: 4
-      end: 6
-    - start: 16
-      end: 16
-    bit_size: 4
-    array:
-      len: 1
-      stride: 8
-    enum: OCM
-fieldset/CCMR_Output_2CH:
-  extends: CCMR_Output_1CH
-  description: capture/compare mode register x (x=1) (output mode)
+      len: 4
+      stride: 4
+fieldset/CCER_ADV1CH:
+  extends: CCER_1CH
+  description: capture/compare enable register
   fields:
-  - name: CCS
-    description: Capture/Compare y selection
-    bit_offset: 0
-    bit_size: 2
-    array:
-      len: 2
-      stride: 8
-    enum: CCMR_Output_CCS
-  - name: OCFE
-    description: Output compare y fast enable
+  - name: CCNE
+    description: Capture/Compare x (x=1-4) complementary output enable
     bit_offset: 2
     bit_size: 1
     array:
-      len: 2
-      stride: 8
-  - name: OCPE
-    description: Output compare y preload enable
-    bit_offset: 3
-    bit_size: 1
-    array:
-      len: 2
-      stride: 8
-  - name: OCM
-    description: Output compare y mode
-    bit_offset:
-    - start: 4
-      end: 6
-    - start: 16
-      end: 16
-    bit_size: 4
-    array:
-      len: 2
-      stride: 8
-    enum: OCM
-fieldset/CCMR_Output_GP16:
-  extends: CCMR_Output_2CH
-  description: capture/compare mode register x (x=1-2) (output mode)
-  fields:
-  - name: OCCE
-    description: Output compare y clear enable
-    bit_offset: 7
-    bit_size: 1
-    array:
-      len: 2
-      stride: 8
-fieldset/CCR5_ADV:
-  extends: CCR_1CH
-  description: capture/compare register 5 (Dither mode disabled)
-  fields:
-  - name: GC5C
-    description: Group channel 5 and channel x (x=1-3)
-    bit_offset: 29
-    bit_size: 1
-    array:
-      len: 3
-      stride: 1
-    enum: GC5C
-fieldset/CCR5_DITHER_ADV:
-  extends: CCR_DITHER_1CH
-  description: capture/compare register 5 (Dither mode enabled)
-  fields:
-  - name: GC5C
-    description: Group channel 5 and channel x (x=1-3)
-    bit_offset: 29
-    bit_size: 1
-    array:
-      len: 3
-      stride: 1
-    enum: GC5C
-fieldset/CCR_1CH:
-  description: capture/compare register x (x=1-4,6) (Dither mode disabled)
-  fields:
-  - name: CCR
-    description: capture/compare x (x=1-4,6) value
-    bit_offset: 0
-    bit_size: 16
-fieldset/CCR_DITHER_1CH:
-  description: capture/compare register x (x=1-4,6) (Dither mode enabled)
-  fields:
-  - name: DITHER
-    description: capture/compare x (x=1-4,6) value
-    bit_offset: 0
-    bit_size: 4
-  - name: CCR
-    description: capture/compare x (x=1-4,6) value
-    bit_offset: 4
-    bit_size: 16
-fieldset/CCR_DITHER_GP32:
-  description: capture/compare register x (x=1-4,6) (Dither mode enabled)
-  fields:
-  - name: DITHER
-    description: Dither value
-    bit_offset: 0
-    bit_size: 4
-  - name: CCR
-    description: capture/compare x (x=1-4,6) value
-    bit_offset: 4
-    bit_size: 28
+      len: 4
+      stride: 4
+
+# CNT register
 fieldset/CNT_CORE:
   description: counter
   fields:
@@ -1100,8 +1067,8 @@ fieldset/CNT_CORE:
     description: UIF copy
     bit_offset: 31
     bit_size: 1
-fieldset/CNT_DITHER_GP32:
-  description: counter (Dither mode enabled)
+fieldset/CNT_DITHER_32BIT:
+  description: counter (dither mode enabled)
   fields:
   - name: CNT
     description: counter value
@@ -1111,188 +1078,182 @@ fieldset/CNT_DITHER_GP32:
     description: UIF copy
     bit_offset: 31
     bit_size: 1
-fieldset/CR1_1CH:
-  extends: CR1_CORE
-  description: control register 1
+
+# ARR register
+fieldset/ARR_CORE:
+  description: auto-reload register
   fields:
-  - name: CKD
-    description: Clock division
+  - name: ARR
+    description: Auto-reload value
+    bit_offset: 0
+    bit_size: 16
+fieldset/ARR_DITHER_CORE:
+  description: auto-reload register (Dither mode enabled)
+  fields:
+  - name: DITHER
+    description: Dither value
+    bit_offset: 0
+    bit_size: 4
+  - name: ARR
+    description: Auto-reload value
+    bit_offset: 4
+    bit_size: 16
+fieldset/ARR_DITHER_32BIT:
+  description: auto-reload register (Dither mode enabled)
+  fields:
+  - name: DITHER
+    description: Dither value
+    bit_offset: 0
+    bit_size: 4
+  - name: ARR
+    description: Auto-reload value
+    bit_offset: 4
+    bit_size: 28
+
+# RCR register
+fieldset/RCR_ADV1CH:
+  description: repetition counter register
+  fields:
+  - name: REP
+    description: Repetition counter value
+    bit_offset: 0
+    bit_size: 8
+fieldset/RCR_ADV4CH:
+  description: repetition counter register
+  fields:
+  - name: REP
+    description: Repetition counter value
+    bit_offset: 0
+    bit_size: 16
+
+# CCR register
+fieldset/CCR_1CH:
+  description: capture/compare register x (x=1-4,6)
+  fields:
+  - name: CCR
+    description: capture/compare x (x=1-4,6) value
+    bit_offset: 0
+    bit_size: 16
+fieldset/CCR5_ADV4CH:
+  extends: CCR_1CH
+  description: capture/compare register 5
+  fields:
+  - name: GC5C
+    description: Group channel 5 and channel x (x=1-3)
+    bit_offset: 29
+    bit_size: 1
+    array:
+      len: 3
+      stride: 1
+    enum: GC5C
+fieldset/CCR_DITHER_1CH:
+  description: capture/compare register x (x=1-4,6) (Dither mode enabled)
+  fields:
+  - name: DITHER
+    description: capture/compare x (x=1-4,6) value
+    bit_offset: 0
+    bit_size: 4
+  - name: CCR
+    description: capture/compare x (x=1-4,6) value
+    bit_offset: 4
+    bit_size: 16
+fieldset/CCR5_DITHER_ADV4CH:
+  extends: CCR_DITHER_1CH
+  description: capture/compare register 5
+  fields:
+  - name: GC5C
+    description: Group channel 5 and channel x (x=1-3)
+    bit_offset: 29
+    bit_size: 1
+    array:
+      len: 3
+      stride: 1
+    enum: GC5C
+fieldset/CCR_DITHER_32BIT:
+  description: capture/compare register x (x=1-4,6) (Dither mode enabled)
+  fields:
+  - name: DITHER
+    description: Dither value
+    bit_offset: 0
+    bit_size: 4
+  - name: CCR
+    description: capture/compare x (x=1-4,6) value
+    bit_offset: 4
+    bit_size: 28
+
+# BDTR register
+fieldset/BDTR_ADV1CH:
+  description: break and dead-time register
+  fields:
+  - name: DTG
+    description: Dead-time generator setup
+    bit_offset: 0
+    bit_size: 8
+  - name: LOCK
+    description: Lock configuration
     bit_offset: 8
     bit_size: 2
-    enum: CKD
-fieldset/CR1_CORE:
-  description: control register 1
-  fields:
-  - name: CEN
-    description: Counter enable
-    bit_offset: 0
+    enum: LOCK
+  - name: OSSI
+    description: Off-state selection for Idle mode
+    bit_offset: 10
     bit_size: 1
-  - name: UDIS
-    description: Update disable
-    bit_offset: 1
-    bit_size: 1
-  - name: URS
-    description: Update request source
-    bit_offset: 2
-    bit_size: 1
-    enum: URS
-  - name: OPM
-    description: One-pulse mode enbaled
-    bit_offset: 3
-    bit_size: 1
-  - name: ARPE
-    description: Auto-reload preload enable
-    bit_offset: 7
-    bit_size: 1
-  - name: UIFREMAP
-    description: UIF status bit remapping enable
+    enum: OSSI
+  - name: OSSR
+    description: Off-state selection for Run mode
     bit_offset: 11
     bit_size: 1
-  - name: DITHEN
-    description: Dithering enable
+    enum: OSSR
+  - name: BKE
+    description: Break x (x=1,2) enable
     bit_offset: 12
-    bit_size: 1
-fieldset/CR1_GP16:
-  extends: CR1_CORE
-  description: control register 1
-  fields:
-  - name: DIR
-    description: Direction
-    bit_offset: 4
-    bit_size: 1
-    enum: DIR
-  - name: CMS
-    description: Center-aligned mode selection
-    bit_offset: 5
-    bit_size: 2
-    enum: CMS
-  - name: CKD
-    description: Clock division
-    bit_offset: 8
-    bit_size: 2
-    enum: CKD
-fieldset/CR2_1CH_CMP:
-  description: control register 2
-  fields:
-  - name: CCPC
-    description: Capture/compare preloaded control
-    bit_offset: 0
-    bit_size: 1
-  - name: CCUS
-    description: Capture/compare control update selection
-    bit_offset: 2
-    bit_size: 1
-  - name: CCDS
-    description: Capture/compare DMA selection
-    bit_offset: 3
-    bit_size: 1
-    enum: CCDS
-  - name: OIS
-    description: Output Idle state x (x=1)
-    bit_offset: 8
-    bit_size: 1
-    array:
-      len: 1
-      stride: 2
-  - name: OISN
-    description: Output Idle state x (x=1)
-    bit_offset: 9
-    bit_size: 1
-    array:
-      len: 1
-      stride: 2
-fieldset/CR2_2CH:
-  description: control register 2
-  fields:
-  - name: MMS
-    description: Master mode selection
-    bit_offset:
-    - start: 4
-      end: 6
-    - start: 25
-      end: 25
-    bit_size: 4
-    enum: MMS
-  - name: TI1S
-    description: TI1 selection
-    bit_offset: 7
-    bit_size: 1
-    enum: TI1S
-fieldset/CR2_2CH_CMP:
-  extends: CR2_1CH_CMP
-  description: control register 2
-  fields:
-  - name: MMS
-    description: Master mode selection
-    bit_offset:
-    - start: 4
-      end: 6
-    - start: 25
-      end: 25
-    bit_size: 4
-    enum: MMS
-  - name: TI1S
-    description: TI1 selection
-    bit_offset: 7
-    bit_size: 1
-    enum: TI1S
-  - name: OIS
-    description: Output Idle state x (x=1,2)
-    bit_offset: 8
     bit_size: 1
     array:
       len: 2
-      stride: 2
-fieldset/CR2_ADV:
-  extends: CR2_2CH_CMP
-  description: control register 2
-  fields:
-  - name: OIS
-    description: Output Idle state x (x=1-6)
-    bit_offset: 8
+      stride: 12
+  - name: BKP
+    description: Break x (x=1,2) polarity
+    bit_offset: 13
     bit_size: 1
     array:
-      len: 6
-      stride: 2
-  - name: OISN
-    description: Output Idle state x N x (x=1-4)
-    bit_offset: 9
+      len: 2
+      stride: 12
+    enum: BKP
+  - name: AOE
+    description: Automatic output enable
+    bit_offset: 14
+    bit_size: 1
+  - name: MOE
+    description: Main output enable
+    bit_offset: 15
+    bit_size: 1
+  - name: BKF
+    description: Break x (x=1,2) filter
+    bit_offset: 16
+    bit_size: 4
+    array:
+      len: 2
+      stride: 4
+    enum: FilterValue
+  - name: BKDSRM
+    description: Break x (x=1,2) Disarm
+    bit_offset: 26
     bit_size: 1
     array:
-      len: 4
-      stride: 2
-  - name: MMS2
-    description: Master mode selection 2
-    bit_offset: 20
-    bit_size: 4
-    enum: MMS2
-fieldset/CR2_BASIC:
-  description: control register 2
-  fields:
-  - name: MMS
-    description: Master mode selection
-    bit_offset:
-    - start: 4
-      end: 6
-    - start: 25
-      end: 25
-    bit_size: 4
-    enum: MMS
-fieldset/CR2_GP16:
-  extends: CR2_BASIC
-  description: control register 2
-  fields:
-  - name: CCDS
-    description: Capture/compare DMA selection
-    bit_offset: 3
+      len: 2
+      stride: 1
+    enum: BKDSRM
+  - name: BKBID
+    description: Break x (x=1,2) bidirectional
+    bit_offset: 28
     bit_size: 1
-    enum: CCDS
-  - name: TI1S
-    description: TI1 selection
-    bit_offset: 7
-    bit_size: 1
-    enum: TI1S
-fieldset/DCR_1CH_CMP:
+    array:
+      len: 2
+      stride: 1
+    enum: BKBID
+
+# DCR register
+fieldset/DCR_CCDMA:
   description: DMA control register
   fields:
   - name: DBA
@@ -1308,167 +1269,9 @@ fieldset/DCR_1CH_CMP:
     bit_offset: 16
     bit_size: 4
     enum: DBSS
-fieldset/DIER_1CH:
-  extends: DIER_CORE
-  description: DMA/Interrupt enable register
-  fields:
-  - name: CCIE
-    description: Capture/Compare x (x=1) interrupt enable
-    bit_offset: 1
-    bit_size: 1
-    array:
-      len: 1
-      stride: 1
-fieldset/DIER_1CH_CMP:
-  extends: DIER_1CH
-  description: DMA/Interrupt enable register
-  fields:
-  - name: COMIE
-    description: COM interrupt enable
-    bit_offset: 5
-    bit_size: 1
-  - name: BIE
-    description: Break interrupt enable
-    bit_offset: 7
-    bit_size: 1
-  - name: UDE
-    description: Update DMA request enable
-    bit_offset: 8
-    bit_size: 1
-  - name: CCDE
-    description: Capture/Compare x (x=1) DMA request enable
-    bit_offset: 9
-    bit_size: 1
-    array:
-      len: 1
-      stride: 1
-fieldset/DIER_2CH:
-  extends: DIER_1CH
-  description: DMA/Interrupt enable register
-  fields:
-  - name: CCIE
-    description: Capture/Compare x (x=1-2) interrupt enable
-    bit_offset: 1
-    bit_size: 1
-    array:
-      len: 2
-      stride: 1
-  - name: TIE
-    description: Trigger interrupt enable
-    bit_offset: 6
-    bit_size: 1
-fieldset/DIER_2CH_CMP:
-  extends: DIER_1CH_CMP
-  description: DMA/Interrupt enable register
-  fields:
-  - name: TIE
-    description: Trigger interrupt enable
-    bit_offset: 6
-    bit_size: 1
-  - name: COMDE
-    description: COM DMA request enable
-    bit_offset: 13
-    bit_size: 1
-  - name: TDE
-    description: Trigger DMA request enable
-    bit_offset: 14
-    bit_size: 1
-fieldset/DIER_ADV:
-  extends: DIER_2CH_CMP
-  description: DMA/Interrupt enable register
-  fields:
-  - name: CCIE
-    description: Capture/Compare x (x=1-4) interrupt enable
-    bit_offset: 1
-    bit_size: 1
-    array:
-      len: 4
-      stride: 1
-  - name: BIE
-    description: Break interrupt enable
-    bit_offset: 7
-    bit_size: 1
-  - name: CCDE
-    description: Capture/Compare x (x=1) DMA request enable
-    bit_offset: 9
-    bit_size: 1
-    array:
-      len: 4
-      stride: 1
-  - name: IDXIE
-    description: Index interrupt enable
-    bit_offset: 20
-    bit_size: 1
-  - name: DIRIE
-    description: Direction change interrupt enable
-    bit_offset: 21
-    bit_size: 1
-  - name: IERRIE
-    description: Index error interrupt enable
-    bit_offset: 22
-    bit_size: 1
-  - name: TERRIE
-    description: Transition error interrupt enable
-    bit_offset: 23
-    bit_size: 1
-fieldset/DIER_BASIC_NO_CR2:
-  extends: DIER_CORE
-  description: DMA/Interrupt enable register
-  fields:
-  - name: UDE
-    description: Update DMA request enable
-    bit_offset: 8
-    bit_size: 1
-fieldset/DIER_CORE:
-  description: DMA/Interrupt enable register
-  fields:
-  - name: UIE
-    description: Update interrupt enable
-    bit_offset: 0
-    bit_size: 1
-fieldset/DIER_GP16:
-  extends: DIER_BASIC_NO_CR2
-  description: DMA/Interrupt enable register
-  fields:
-  - name: CCIE
-    description: Capture/Compare x (x=1-4) interrupt enable
-    bit_offset: 1
-    bit_size: 1
-    array:
-      len: 4
-      stride: 1
-  - name: TIE
-    description: Trigger interrupt enable
-    bit_offset: 6
-    bit_size: 1
-  - name: CCDE
-    description: Capture/Compare x (x=1-4) DMA request enable
-    bit_offset: 9
-    bit_size: 1
-    array:
-      len: 4
-      stride: 1
-  - name: TDE
-    description: Trigger DMA request enable
-    bit_offset: 14
-    bit_size: 1
-  - name: IDXIE
-    description: Index interrupt enable
-    bit_offset: 20
-    bit_size: 1
-  - name: DIRIE
-    description: Direction change interrupt enable
-    bit_offset: 21
-    bit_size: 1
-  - name: IERRIE
-    description: Index error interrupt enable
-    bit_offset: 22
-    bit_size: 1
-  - name: TERRIE
-    description: Transition error interrupt enable
-    bit_offset: 23
-    bit_size: 1
-fieldset/DTR2_1CH_CMP:
+
+# DTR2 register
+fieldset/DTR2_ADV1CH:
   description: deadtime register 2
   fields:
   - name: DTGF
@@ -1484,7 +1287,9 @@ fieldset/DTR2_1CH_CMP:
     description: Deadtime preload enable
     bit_offset: 17
     bit_size: 1
-fieldset/ECR_GP16:
+
+# ECR register
+fieldset/ECR_4CH:
   description: encoder control register
   fields:
   - name: IE
@@ -1518,412 +1323,90 @@ fieldset/ECR_GP16:
     description: Pulse width prescaler
     bit_offset: 24
     bit_size: 2
-fieldset/EGR_1CH:
-  extends: EGR_CORE
-  description: event generation register
+
+# AF1 register
+fieldset/AF1_4CH:
+  description: alternate function register 1
   fields:
-  - name: CCG
-    description: Capture/compare x (x=1) generation
-    bit_offset: 1
-    bit_size: 1
-    array:
-      len: 1
-      stride: 1
-fieldset/EGR_1CH_CMP:
-  extends: EGR_1CH
-  description: event generation register
-  fields:
-  - name: COMG
-    description: Capture/Compare control update generation
-    bit_offset: 5
-    bit_size: 1
-  - name: BG
-    description: Break x (x=1) generation
-    bit_offset: 7
-    bit_size: 1
-    array:
-      len: 1
-      stride: 1
-fieldset/EGR_2CH:
-  extends: EGR_1CH
-  description: event generation register
-  fields:
-  - name: CCG
-    description: Capture/compare x (x=1-2) generation
-    bit_offset: 1
-    bit_size: 1
-    array:
-      len: 2
-      stride: 1
-  - name: TG
-    description: Trigger generation
-    bit_offset: 6
-    bit_size: 1
-fieldset/EGR_2CH_CMP:
-  extends: EGR_1CH_CMP
-  description: event generation register
-  fields:
-  - name: CCG
-    description: Capture/compare x (x=1,2) generation
-    bit_offset: 1
-    bit_size: 1
-    array:
-      len: 2
-      stride: 1
-  - name: TG
-    description: Trigger generation
-    bit_offset: 6
-    bit_size: 1
-fieldset/EGR_ADV:
-  extends: EGR_2CH_CMP
-  description: event generation register
-  fields:
-  - name: CCG
-    description: Capture/compare x (x=1-4) generation
-    bit_offset: 1
-    bit_size: 1
-    array:
-      len: 4
-      stride: 1
-  - name: BG
-    description: Break x (x=1-2) generation
-    bit_offset: 7
-    bit_size: 1
-    array:
-      len: 2
-      stride: 1
-fieldset/EGR_CORE:
-  description: event generation register
-  fields:
-  - name: UG
-    description: Update generation
-    bit_offset: 0
-    bit_size: 1
-fieldset/EGR_GP16:
-  extends: EGR_CORE
-  description: event generation register
-  fields:
-  - name: CCG
-    description: Capture/compare x (x=1-4) generation
-    bit_offset: 1
-    bit_size: 1
-    array:
-      len: 4
-      stride: 1
-  - name: TG
-    description: Trigger generation
-    bit_offset: 6
-    bit_size: 1
-fieldset/RCR_1CH_CMP:
-  description: repetition counter register
-  fields:
-  - name: REP
-    description: Repetition counter value
-    bit_offset: 0
-    bit_size: 8
-fieldset/RCR_ADV:
-  description: repetition counter register
-  fields:
-  - name: REP
-    description: Repetition counter value
-    bit_offset: 0
-    bit_size: 16
-fieldset/SMCR_2CH:
-  description: slave mode control register
-  fields:
-  - name: SMS
-    description: Slave mode selection
-    bit_offset:
-    - start: 0
-      end: 2
-    - start: 16
-      end: 16
-    bit_size: 4
-    enum: SMS
-  - name: TS
-    description: Trigger selection
-    bit_offset:
-    - start: 4
-      end: 6
-    - start: 20
-      end: 21
-    bit_size: 5
-    enum: TS
-  - name: MSM
-    description: Master/Slave mode
-    bit_offset: 7
-    bit_size: 1
-    enum: MSM
-fieldset/SMCR_2CH_CMP:
-  extends: SMCR_2CH
-  description: slave mode control register
-  fields:
-  - name: SMSPE
-    description: SMS preload enable
-    bit_offset: 24
-    bit_size: 1
-fieldset/SMCR_ADV:
-  extends: SMCR_2CH_CMP
-  description: slave mode control register
-  fields:
-  - name: OCCS
-    description: OCREF clear selection
-    bit_offset: 3
-    bit_size: 1
-    enum: OCCS
-  - name: ETF
-    description: External trigger filter
-    bit_offset: 8
-    bit_size: 4
-    enum: FilterValue
-  - name: ETPS
-    description: External trigger prescaler
-    bit_offset: 12
-    bit_size: 2
-    enum: ETPS
-  - name: ECE
-    description: External clock mode 2 enable
+  - name: ETRSEL
+    description: etr_in source selection
     bit_offset: 14
-    bit_size: 1
-  - name: ETP
-    description: External trigger polarity
-    bit_offset: 15
-    bit_size: 1
-    enum: ETP
-  - name: SMSPS
-    description: SMS preload source
-    bit_offset: 25
-    bit_size: 1
-    enum: SMSPS
-fieldset/SMCR_GP16:
-  extends: SMCR_2CH
-  description: slave mode control register
-  fields:
-  - name: ETF
-    description: External trigger filter
-    bit_offset: 8
     bit_size: 4
-    enum: FilterValue
-  - name: ETPS
-    description: External trigger prescaler
-    bit_offset: 12
-    bit_size: 2
-    enum: ETPS
-  - name: ECE
-    description: External clock mode 2 enable
+fieldset/AF1_ADV1CH:
+  description: alternate function register 1
+  fields:
+  - name: BKINE
+    description: TIMx_BKIN input enable
+    bit_offset: 0
+    bit_size: 1
+  - name: BKCMPE
+    description: TIM_BRK_CMPx (x=1-8) enable
+    bit_offset: 1
+    bit_size: 1
+    array:
+      len: 8
+      stride: 1
+  - name: BKINP
+    description: TIMx_BKIN input polarity
+    bit_offset: 9
+    bit_size: 1
+    enum: BKINP
+  - name: BKCMPP
+    description: TIM_BRK_CMPx (x=1-3) input polarity
+    bit_offset: 10
+    bit_size: 1
+    array:
+      len: 4
+      stride: 1
+    enum: BKINP
+fieldset/AF1_ADV4CH:
+  extends: AF1_ADV1CH
+  description: alternate function register 1
+  fields:
+  - name: ETRSEL
+    description: etr_in source selection
     bit_offset: 14
-    bit_size: 1
-  - name: ETP
-    description: External trigger polarity
-    bit_offset: 15
-    bit_size: 1
-    enum: ETP
-  - name: SMSPE
-    description: SMS preload enable
-    bit_offset: 24
-    bit_size: 1
-  - name: SMSPS
-    description: SMS preload source
-    bit_offset: 25
-    bit_size: 1
-    enum: SMSPS
-fieldset/SR_1CH:
-  extends: SR_CORE
-  description: status register
+    bit_size: 4
+
+# AF2 register
+fieldset/AF2_CCDMA:
+  description: alternate function register 2
   fields:
-  - name: CCIF
-    description: Capture/compare x (x=1) interrupt flag
-    bit_offset: 1
-    bit_size: 1
-    array:
-      len: 1
-      stride: 1
-  - name: CCOF
-    description: Capture/Compare x (x=1) overcapture flag
-    bit_offset: 9
-    bit_size: 1
-    array:
-      len: 1
-      stride: 1
-fieldset/SR_1CH_CMP:
-  extends: SR_1CH
-  description: status register
-  fields:
-  - name: COMIF
-    description: COM interrupt flag
-    bit_offset: 5
-    bit_size: 1
-  - name: BIF
-    description: Break x (x=1) interrupt flag
-    bit_offset: 7
-    bit_size: 1
-    array:
-      len: 1
-      stride: 1
-fieldset/SR_2CH:
-  extends: SR_1CH
-  description: status register
-  fields:
-  - name: CCIF
-    description: Capture/compare x (x=1-2) interrupt flag
-    bit_offset: 1
-    bit_size: 1
-    array:
-      len: 2
-      stride: 1
-  - name: TIF
-    description: Trigger interrupt flag
-    bit_offset: 6
-    bit_size: 1
-  - name: CCOF
-    description: Capture/Compare x (x=1-2) overcapture flag
-    bit_offset: 9
-    bit_size: 1
-    array:
-      len: 2
-      stride: 1
-fieldset/SR_2CH_CMP:
-  extends: SR_1CH_CMP
-  description: status register
-  fields:
-  - name: CCIF
-    description: Capture/compare x (x=1,2) interrupt flag
-    bit_offset: 1
-    bit_size: 1
-    array:
-      len: 2
-      stride: 1
-  - name: TIF
-    description: Trigger interrupt flag
-    bit_offset: 6
-    bit_size: 1
-  - name: CCOF
-    description: Capture/Compare x (x=1,2) overcapture flag
-    bit_offset: 9
-    bit_size: 1
-    array:
-      len: 2
-      stride: 1
-fieldset/SR_ADV:
-  extends: SR_2CH_CMP
-  description: status register
-  fields:
-  - name: CCIF
-    description: Capture/compare x (x=1-4) interrupt flag
-    bit_offset: 1
-    bit_size: 1
-    array:
-      len: 4
-      stride: 1
-  - name: BIF
-    description: Break x (x=1,2) interrupt flag
-    bit_offset: 7
-    bit_size: 1
-    array:
-      len: 2
-      stride: 1
-  - name: CCOF
-    description: Capture/Compare x (x=1-4) overcapture flag
-    bit_offset: 9
-    bit_size: 1
-    array:
-      len: 4
-      stride: 1
-  - name: SBIF
-    description: System break interrupt flag
-    bit_offset: 13
-    bit_size: 1
-  - name: CCIF5
-    description: Capture/compare 5 interrupt flag
+  - name: OCRSEL
+    description: ocref_clr source selection
     bit_offset: 16
-    bit_size: 1
-  - name: CCIF6
-    description: Capture/compare 6 interrupt flag
-    bit_offset: 17
-    bit_size: 1
-  - name: IDXIF
-    description: Index interrupt flag
-    bit_offset: 20
-    bit_size: 1
-  - name: DIRIF
-    description: Direction change interrupt flag
-    bit_offset: 21
-    bit_size: 1
-  - name: IERRIF
-    description: Index error interrupt flag
-    bit_offset: 22
-    bit_size: 1
-  - name: TERRIF
-    description: Transition error interrupt flag
-    bit_offset: 23
-    bit_size: 1
-fieldset/SR_CORE:
-  description: status register
+    bit_size: 3
+fieldset/AF2_ADV4CH:
+  extends: AF2_CCDMA
+  description: alternate function register 2
   fields:
-  - name: UIF
-    description: Update interrupt flag
+  - name: BK2INE
+    description: TIMx_BKIN2 input enable
     bit_offset: 0
     bit_size: 1
-fieldset/SR_GP16:
-  extends: SR_CORE
-  description: status register
-  fields:
-  - name: CCIF
-    description: Capture/compare x (x=1-4) interrupt flag
+  - name: BK2CMPE
+    description: TIM_BRK2_CMPx (x=1-8) enable
     bit_offset: 1
     bit_size: 1
     array:
-      len: 4
+      len: 8
       stride: 1
-  - name: TIF
-    description: Trigger interrupt flag
-    bit_offset: 6
-    bit_size: 1
-  - name: CCOF
-    description: Capture/Compare x (x=1-4) overcapture flag
+  - name: BK2INP
+    description: TIMx_BK2IN input polarity
     bit_offset: 9
     bit_size: 1
+    enum: BKINP
+  - name: BK2CMPP
+    description: TIM_BRK2_CMPx (x=1-4) input polarity
+    bit_offset: 10
+    bit_size: 1
     array:
       len: 4
       stride: 1
-  - name: IDXIF
-    description: Index interrupt flag
-    bit_offset: 20
-    bit_size: 1
-  - name: DIRIF
-    description: Direction change interrupt flag
-    bit_offset: 21
-    bit_size: 1
-  - name: IERRIF
-    description: Index error interrupt flag
-    bit_offset: 22
-    bit_size: 1
-  - name: TERRIF
-    description: Transition error interrupt flag
-    bit_offset: 23
-    bit_size: 1
+    enum: BKINP
+
+# TISEL register
 fieldset/TISEL_1CH:
-  description: input selection register
-  fields:
-  - name: TISEL
-    description: Selects TIM_TIx (x=1) input
-    bit_offset: 0
-    bit_size: 4
-    array:
-      len: 1
-      stride: 8
-fieldset/TISEL_2CH:
-  extends: TISEL_1CH
-  description: input selection register
-  fields:
-  - name: TISEL
-    description: Selects TIM_TIx (x=1-2) input
-    bit_offset: 0
-    bit_size: 4
-    array:
-      len: 2
-      stride: 8
-fieldset/TISEL_GP16:
   description: input selection register
   fields:
   - name: TISEL
@@ -1933,6 +1416,7 @@ fieldset/TISEL_GP16:
     array:
       len: 4
       stride: 8
+
 enum/BKBID:
   bit_size: 1
   variants:

--- a/stm32-data-gen/src/perimap.rs
+++ b/stm32-data-gen/src/perimap.rs
@@ -384,35 +384,35 @@ pub static PERIMAP: RegexMap<(&str, &str, &str)> = RegexMap::new(&[
     //
     // AN4013 Table 2: STM32Fx serials
     // Override for STM32Fx serials
-    ("STM32F1.*:TIM(2|5):.*", ("timer", "v1", "TIM_GP16")),
+    ("STM32F1.*:TIM(2|5):.*", ("timer", "v1", "TIM_4CH")),
     // Normal STM32Fx serials
-    ("STM32F.*:TIM(1|8|20):.*", ("timer", "v1", "TIM_ADV")),
-    ("STM32F.*:TIM(2|5):.*", ("timer", "v1", "TIM_GP32")),
-    ("STM32F.*:TIM(3|4|19):.*", ("timer", "v1", "TIM_GP16")),
+    ("STM32F.*:TIM(1|8|20):.*", ("timer", "v1", "TIM_ADV4CH")),
+    ("STM32F.*:TIM(2|5):.*", ("timer", "v1", "TIM_32BIT")),
+    ("STM32F.*:TIM(3|4|19):.*", ("timer", "v1", "TIM_4CH")),
     ("STM32F.*:TIM(6|7|18):.*", ("timer", "v1", "TIM_BASIC")),
     ("STM32F.*:TIM(10|11|13|14):.*", ("timer", "v1", "TIM_1CH")),
     ("STM32F.*:TIM(9|12):.*", ("timer", "v1", "TIM_2CH")),
-    ("STM32F.*:TIM15:.*", ("timer", "v1", "TIM_2CH_CMP")),
-    ("STM32F.*:TIM(16|17):.*", ("timer", "v1", "TIM_1CH_CMP")),
+    ("STM32F.*:TIM15:.*", ("timer", "v1", "TIM_ADV2CH")),
+    ("STM32F.*:TIM(16|17):.*", ("timer", "v1", "TIM_ADV1CH")),
     ("STM32F.*:HRTIM:.*", ("hrtim", "v1", "HRTIM")),
     // LPTIM for STM32Fx serials
     ("STM32(F4|F7).*:LPTIM.*:.*", ("lptim", "v1a", "LPTIM")),
     // AN4013 Table 3: STM32Lx serials
     // Override for STM32L0 serial
-    ("STM32L0.*:TIM(2|3):.*", ("timer", "l0", "TIM_GP16")),
+    ("STM32L0.*:TIM(2|3):.*", ("timer", "l0", "TIM_4CH")),
     ("STM32L0.*:TIM(6|7):.*", ("timer", "l0", "TIM_BASIC")),
     ("STM32L0.*:TIM(21|22):.*", ("timer", "l0", "TIM_2CH")),
     // Override for STM32L1 serials
-    ("STM32L1.*:TIM2:.*", ("timer", "v1", "TIM_GP16")),
+    ("STM32L1.*:TIM2:.*", ("timer", "v1", "TIM_4CH")),
     // Normal STM32Lx serials
-    ("STM32L.*:TIM(1|8):.*", ("timer", "v1", "TIM_ADV")),
-    ("STM32L.*:TIM(2|5):.*", ("timer", "v1", "TIM_GP32")),
-    ("STM32L.*:TIM(3|4):.*", ("timer", "v1", "TIM_GP16")),
+    ("STM32L.*:TIM(1|8):.*", ("timer", "v1", "TIM_ADV4CH")),
+    ("STM32L.*:TIM(2|5):.*", ("timer", "v1", "TIM_32BIT")),
+    ("STM32L.*:TIM(3|4):.*", ("timer", "v1", "TIM_4CH")),
     ("STM32L.*:TIM(6|7):.*", ("timer", "v1", "TIM_BASIC")),
     ("STM32L.*:TIM(10|11):.*", ("timer", "v1", "TIM_1CH")),
     ("STM32L.*:TIM(9|21|22):.*", ("timer", "v1", "TIM_2CH")),
-    ("STM32L.*:TIM15:.*", ("timer", "v1", "TIM_2CH_CMP")),
-    ("STM32L.*:TIM(16|17):.*", ("timer", "v1", "TIM_1CH_CMP")),
+    ("STM32L.*:TIM15:.*", ("timer", "v1", "TIM_ADV2CH")),
+    ("STM32L.*:TIM(16|17):.*", ("timer", "v1", "TIM_ADV1CH")),
     // LPTIM for STM32Lx
     ("STM32L5.*:LPTIM.*:.*", ("lptim", "v1c", "LPTIM")),
     ("STM32L4[PQRS].*:LPTIM.*:.*", ("lptim", "v1b", "LPTIM")),
@@ -420,28 +420,28 @@ pub static PERIMAP: RegexMap<(&str, &str, &str)> = RegexMap::new(&[
     ("STM32L0.*:LPTIM.*:.*", ("lptim", "v1", "LPTIM")),
     // AN4013 Table 4: STM32Gx/Hx/Ux/Wx (and Cx) serials
     // timer_v2 for STM32Gx/Hx/Ux/Wx (and Cx) serials
-    ("STM32U5.*:TIM(3|4):.*", ("timer", "v2", "TIM_GP32")),
-    ("STM32(G4|H5|U0|U5|WBA).*:TIM(1|8|20):.*", ("timer", "v2", "TIM_ADV")),
+    ("STM32U5.*:TIM(3|4):.*", ("timer", "v2", "TIM_32BIT")),
+    ("STM32(G4|H5|U0|U5|WBA).*:TIM(1|8|20):.*", ("timer", "v2", "TIM_ADV4CH")),
     (
         "STM32(G4|H5|U0|U5|WBA).*:TIM(2|5|23|24):.*",
-        ("timer", "v2", "TIM_GP32"),
+        ("timer", "v2", "TIM_32BIT"),
     ),
-    ("STM32(G4|H5|U0|U5|WBA).*:TIM(3|4):.*", ("timer", "v2", "TIM_GP16")),
+    ("STM32(G4|H5|U0|U5|WBA).*:TIM(3|4):.*", ("timer", "v2", "TIM_4CH")),
     ("STM32(G4|H5|U0|U5|WBA).*:TIM(6|7):.*", ("timer", "v2", "TIM_BASIC")),
     ("STM32(G4|H5|U0|U5|WBA).*:TIM(13|14):.*", ("timer", "v2", "TIM_1CH")),
     ("STM32(G4|H5|U0|U5|WBA).*:TIM12:.*", ("timer", "v2", "TIM_2CH")),
-    ("STM32(G4|H5|U0|U5|WBA).*:TIM15:.*", ("timer", "v2", "TIM_2CH_CMP")),
-    ("STM32(G4|H5|U0|U5|WBA).*:TIM(16|17):.*", ("timer", "v2", "TIM_1CH_CMP")),
+    ("STM32(G4|H5|U0|U5|WBA).*:TIM15:.*", ("timer", "v2", "TIM_ADV2CH")),
+    ("STM32(G4|H5|U0|U5|WBA).*:TIM(16|17):.*", ("timer", "v2", "TIM_ADV1CH")),
     ("STM32G4.*:HRTIM1:.*", ("hrtim", "v2", "HRTIM")),
     // timer_v1 for STM32Gx/Hx/Ux/Wx (and Cx) serials
-    ("STM32(C|G0|H7|WB|WL).*:TIM(1|8|20):.*", ("timer", "v1", "TIM_ADV")),
-    ("STM32(C|G0|H7|WB|WL).*:TIM(2|5|23|24):.*", ("timer", "v1", "TIM_GP32")),
-    ("STM32(C|G0|H7|WB|WL).*:TIM(3|4):.*", ("timer", "v1", "TIM_GP16")),
+    ("STM32(C|G0|H7|WB|WL).*:TIM(1|8|20):.*", ("timer", "v1", "TIM_ADV4CH")),
+    ("STM32(C|G0|H7|WB|WL).*:TIM(2|5|23|24):.*", ("timer", "v1", "TIM_32BIT")),
+    ("STM32(C|G0|H7|WB|WL).*:TIM(3|4):.*", ("timer", "v1", "TIM_4CH")),
     ("STM32(C|G0|H7|WB|WL).*:TIM(6|7):.*", ("timer", "v1", "TIM_BASIC")),
     ("STM32(C|G0|H7|WB|WL).*:TIM(13|14):.*", ("timer", "v1", "TIM_1CH")),
     ("STM32(C|G0|H7|WB|WL).*:TIM12:.*", ("timer", "v1", "TIM_2CH")),
-    ("STM32(C|G0|H7|WB|WL).*:TIM15:.*", ("timer", "v1", "TIM_2CH_CMP")),
-    ("STM32(C|G0|H7|WB|WL).*:TIM(16|17):.*", ("timer", "v1", "TIM_1CH_CMP")),
+    ("STM32(C|G0|H7|WB|WL).*:TIM15:.*", ("timer", "v1", "TIM_ADV2CH")),
+    ("STM32(C|G0|H7|WB|WL).*:TIM(16|17):.*", ("timer", "v1", "TIM_ADV1CH")),
     ("STM32[CGHUW].*:HRTIM1?:.*", ("hrtim", "v1", "HRTIM")),
     // LPTIM for STM32Gx/Hx/Ux/Wx (and Cx) serials
     ("STM32U0.*:LPTIM.*:.*", ("lptim", "v2b", "LPTIM")),

--- a/stm32-data-gen/src/registers.rs
+++ b/stm32-data-gen/src/registers.rs
@@ -15,13 +15,10 @@ impl Registers {
 
         for f in glob::glob("data/registers/*")? {
             let f = f?;
-            let ff = f
-                .file_name()
-                .unwrap()
-                .to_string_lossy()
-                .strip_suffix(".yaml")
-                .unwrap()
-                .to_string();
+            let ff = f.file_name().unwrap().to_string_lossy();
+            let Some(ff) = ff.strip_suffix(".yaml") else { continue };
+            let ff = ff.to_string();
+
             let ir: IR = serde_yaml::from_str(&std::fs::read_to_string(&f)?)
                 .map_err(|e| anyhow!("failed to parse {f:?}: {e:?}"))?;
 


### PR DESCRIPTION
This PR accompanies https://github.com/embassy-rs/embassy/pull/3123. It simplifies the register definitions for timers, unifies the naming of timers and supports the type-safe timer taxonomy from that PR.

However, as a necessary trade-off, it exposes registers and register fields for all channels even for timers that don't have the full number of channels: for example, all four CCR registers are exposed for `Tim1ch`. The idea here is that `Tim1ch` represents a timer that is _at least as capable_ as a 1-channel timer, but might have up to 4 channels. For example, this allows us to implement a PWM driver that works for all timers with channels (it requires only the functionality of `Tim1ch`), but still supports up to 4 channels for timers that have them (so it can be used with `Tim4ch` or `TimAdv2ch`).

The idea is that the higher-level code ensures that only the available channels are used. For example, the `SimplePwm` driver ensures this by accessing only those channels that correspond to pins that belong to the timer peripheral: if there is a pin for channel 3, then the timer surely supports channel 3!