### PR TITLE
Add LTDC support for STM32H7 mcus

### DIFF
--- a/stm32-data-gen/src/chips.rs
+++ b/stm32-data-gen/src/chips.rs
@@ -272,6 +272,7 @@ impl PeriMatcher {
             (".*:JPEG:jpeg1_v1_0", ("jpeg", "v1", "JPEG")),
             (".*:LTDC:lcdtft1_v1_0", ("ltdc", "v1", "LTDC")),
             (".*:LTDC:lcdtft1_v1_1", ("ltdc", "v1", "LTDC")),
+            (".*:LTDC:lcdtft2_v1_0", ("ltdc", "v1", "LTDC")),
             (".*:DSIHOST:dsihost1_v1_0", ("dsihost", "v1", "DSIHOST")),
             (".*:DSIHOST:dsihost1_v1_0_SHARK", ("dsihost", "v1", "DSIHOST")),
             (".*:DSIHOST:dsihost1_v2_0", ("dsihost", "v2", "DSIHOST")),


### PR DESCRIPTION
This PR allows the embassy-stm32 library to match on the LTDC peripheral missed by the existing `chips.rs` perimap. This was originally done to get embassy to expose an stm32h735g-dk LTDC peripheral but it also applies to many other stm32h7 mcus.