### PR TITLE
Use bool for ADC `CONT` fields

### DIFF
--- a/data/registers/adc_f3.yaml
+++ b/data/registers/adc_f3.yaml
@@ -148,7 +148,7 @@ fieldset/CFGR:
     bit_offset: 12
     bit_size: 1
   - name: CONT
-    description: Single / continuous conversion mode for regular conversions
+    description: Continuous conversion
     bit_offset: 13
     bit_size: 1
   - name: AUTDLY

--- a/data/registers/adc_f3_v2.yaml
+++ b/data/registers/adc_f3_v2.yaml
@@ -146,7 +146,7 @@ fieldset/CR2:
     bit_offset: 0
     bit_size: 1
   - name: CONT
-    description: continuous conversion
+    description: Continuous conversion
     bit_offset: 1
     bit_size: 1
   - name: CAL

--- a/data/registers/adc_g0.yaml
+++ b/data/registers/adc_g0.yaml
@@ -220,7 +220,7 @@ fieldset/CFGR1:
     bit_offset: 12
     bit_size: 1
   - name: CONT
-    description: ADC group regular continuous conversion mode
+    description: Continuous conversion
     bit_offset: 13
     bit_size: 1
   - name: WAIT

--- a/data/registers/adc_g4.yaml
+++ b/data/registers/adc_g4.yaml
@@ -159,7 +159,7 @@ fieldset/CFGR:
     bit_size: 1
     enum: OVRMOD
   - name: CONT
-    description: single / continuous conversion mode for regular conversions
+    description: Continuous conversion
     bit_offset: 13
     bit_size: 1
   - name: AUTDLY

--- a/data/registers/adc_h5.yaml
+++ b/data/registers/adc_h5.yaml
@@ -162,7 +162,6 @@ fieldset/CFGR:
     description: 'Single / Continuous conversion mode for regular conversions This bit is set and cleared by software. If it is set, regular conversion takes place continuously until it is cleared. Note: It is not possible to have both Discontinuous mode and Continuous mode enabled: it is forbidden to set both DISCEN = 1 and CONT = 1. The software is allowed to write this bit only when ADSTART = 0 (which ensures that no regular conversion is ongoing).'
     bit_offset: 13
     bit_size: 1
-    enum: CONT
   - name: AUTDLY
     description: 'Delayed conversion mode This bit is set and cleared by software to enable/disable the Auto Delayed Conversion mode.. Note: The software is allowed to write this bit only when ADSTART = 0 and JADSTART = 0 (which ensures that no conversion is ongoing).'
     bit_offset: 14
@@ -598,15 +597,6 @@ enum/AWD1SGL:
     value: 0
   - name: Single
     description: Analog watchdog 1 enabled on single channel selected in AWD1CH
-    value: 1
-enum/CONT:
-  bit_size: 1
-  variants:
-  - name: Single
-    description: Single conversion mode
-    value: 0
-  - name: Continuous
-    description: Continuous conversion mode
     value: 1
 enum/DMACFG:
   bit_size: 1

--- a/data/registers/adc_l0.yaml
+++ b/data/registers/adc_l0.yaml
@@ -115,7 +115,7 @@ fieldset/CFGR1:
     bit_size: 1
     enum: OVRMOD
   - name: CONT
-    description: Single / continuous conversion mode
+    description: Continuous conversion
     bit_offset: 13
     bit_size: 1
   - name: WAIT

--- a/data/registers/adc_u0.yaml
+++ b/data/registers/adc_u0.yaml
@@ -176,7 +176,7 @@ fieldset/CFGR1:
     bit_offset: 12
     bit_size: 1
   - name: CONT
-    description: ADC group regular continuous conversion mode
+    description: Continuous conversion
     bit_offset: 13
     bit_size: 1
   - name: WAIT

--- a/data/registers/adc_v1.yaml
+++ b/data/registers/adc_v1.yaml
@@ -99,7 +99,7 @@ fieldset/CFGR1:
     bit_size: 1
     enum: OVRMOD
   - name: CONT
-    description: Single / continuous conversion mode
+    description: Continuous conversion
     bit_offset: 13
     bit_size: 1
   - name: WAIT

--- a/data/registers/adc_v2.yaml
+++ b/data/registers/adc_v2.yaml
@@ -137,7 +137,6 @@ fieldset/CR2:
     description: Continuous conversion
     bit_offset: 1
     bit_size: 1
-    enum: CONT
   - name: DMA
     description: Direct memory access mode (for single ADC mode)
     bit_offset: 8
@@ -342,15 +341,6 @@ enum/AWDSGL:
     value: 0
   - name: SingleChannel
     description: Analog watchdog enabled on a single channel
-    value: 1
-enum/CONT:
-  bit_size: 1
-  variants:
-  - name: Single
-    description: Single conversion mode
-    value: 0
-  - name: Continuous
-    description: Continuous conversion mode
     value: 1
 enum/DDS:
   bit_size: 1

--- a/data/registers/adc_v4.yaml
+++ b/data/registers/adc_v4.yaml
@@ -182,7 +182,7 @@ fieldset/CFGR:
     bit_size: 1
     enum: OVRMOD
   - name: CONT
-    description: group regular continuous conversion mode
+    description: Continuous conversion
     bit_offset: 13
     bit_size: 1
   - name: AUTDLY


### PR DESCRIPTION
This field enables continuous conversion mode. Using just bool for this is more appropriate.