### PR TITLE
vrefint: Remove fieldset

### DIFF
--- a/data/registers/vrefintcal_v1.yaml
+++ b/data/registers/vrefintcal_v1.yaml
@@ -4,12 +4,5 @@ block/VREFINTCAL:
   - name: DATA
     description: Factory calibration
     byte_offset: 0
-    access: Read
-    fieldset: DATA
-fieldset/DATA:
-  description: Factory calibration data
-  fields:
-  - name: VALUE
-    description: Calibration value
-    bit_offset: 0
     bit_size: 16
+    access: Read


### PR DESCRIPTION
The fieldset forces a 32bit word align during read. This causes a panic on devices where the vrefint value is stored at a 16bit word and not 32bit word boundry.

Fixes #504