### PR TITLE
Added missing CCMR for `lptip_v1b_h7`

### DIFF
--- a/data/registers/lptim_v1b_h7.yaml
+++ b/data/registers/lptim_v1b_h7.yaml
@@ -37,6 +37,49 @@ block/LPTIM:
     description: LPTIM configuration register 2.
     byte_offset: 36
     fieldset: CFGR2
+  - name: RCR
+    description: LPTIM repetition register.
+    byte_offset: 40
+    fieldset: RCR
+  - name: CCMR
+    description: LPTIM capture/compare mode register.
+    array:
+      len: 2
+      stride: 2
+    byte_offset: 44
+    fieldset: CCMR
+enum/CCP_Input:
+  bit_size: 2
+  variants:
+  - name: Rising
+    value: 0
+  - name: Falling
+    value: 1
+  - name: Both
+    value: 3
+enum/CCP_Output:
+  bit_size: 2
+  variants:
+  - name: ActiveHigh
+    value: 0
+  - name: ActiveLow
+    value: 1
+enum/CCSEL:
+  bit_size: 1
+  variants:
+  - name: OutputCompare
+    description: channel is configured in output PWM mode
+    value: 0
+  - name: InputCapture
+    description: channel is configured in input capture mode
+    value: 1
+fieldset/RCR:
+  description: LPTIM repetition register.
+  fields:
+  - name: REP
+    description: Repetition register value REP is the repetition value for the LPTIM.
+    bit_offset: 0
+    bit_size: 8
 fieldset/ARR:
   description: LPTIM autoreload register.
   fields:
@@ -44,6 +87,56 @@ fieldset/ARR:
     description: Auto reload value ARR is the autoreload value for the LPTIM. This value must be strictly greater than the CCRx[15:0] value.
     bit_offset: 0
     bit_size: 16
+fieldset/CCMR:
+  description: LPTIM capture/compare mode register 1.
+  fields:
+  - name: CCSEL
+    description: Capture/compare 1 selection This bitfield defines the direction of the channel input (capture) or output mode.
+    bit_offset: 0
+    bit_size: 1
+    array:
+      len: 2
+      stride: 16
+    enum: CCSEL
+  - name: CCE
+    description: Capture/compare 1 output enable. This bit determines if a capture of the counter value can actually be done into the input capture/compare register 1 (LPTIM_CCR1) or not.
+    bit_offset: 1
+    bit_size: 1
+    array:
+      len: 2
+      stride: 16
+  - name: CCP_Input
+    description: Capture/compare 1 output polarity. Only bit2 is used to set polarity when output mode is enabled, bit3 is don't care. This field is used to select the IC1 polarity for capture operations.
+    bit_offset: 2
+    bit_size: 2
+    array:
+      len: 2
+      stride: 16
+    enum: CCP_Input
+  - name: CCP_Output
+    description: Capture/compare 1 output polarity. Only bit2 is used to set polarity when output mode is enabled, bit3 is don't care. This field is used to select the IC1 polarity for capture operations.
+    bit_offset: 2
+    bit_size: 2
+    array:
+      len: 2
+      stride: 16
+    enum: CCP_Output
+  - name: ICPSC
+    description: Input capture 1 prescaler This bitfield defines the ratio of the prescaler acting on the CC1 input (IC1).
+    bit_offset: 8
+    bit_size: 2
+    array:
+      len: 2
+      stride: 16
+    enum: Filter
+  - name: ICF
+    description: Input capture 1 filter This bitfield defines the number of consecutive equal samples that should be detected when a level change occurs on an external input capture signal before it is considered as a valid level transition. An internal clock source must be present to use this feature.
+    bit_offset: 12
+    bit_size: 2
+    array:
+      len: 2
+      stride: 16
+    enum: Filter
 fieldset/CFGR:
   description: LPTIM configuration register.
   fields:


### PR DESCRIPTION
There were missing registers, enums, etc. For the LPTIM devices.