### PR TITLE
STM32G0: Fix USBSEL Variants for selecting HSE and PLL1_Q as USB Clock

### DIFF
--- a/data/registers/rcc_g0.yaml
+++ b/data/registers/rcc_g0.yaml
@@ -1884,9 +1884,9 @@ enum/USBSEL:
   - name: HSI48
     description: HSI48 used as USB clock source
     value: 0
-  - name: PLL1_Q
-    description: PLLQCLK used as USB clock source
-    value: 1
   - name: HSE
     description: HSE used as USB clock source
+    value: 1
+  - name: PLL1_Q
+    description: PLLQCLK used as USB clock source
     value: 2


### PR DESCRIPTION
This is a fix for https://github.com/embassy-rs/embassy/issues/3223

This swaps the values of HSE and PLL1_Q variants so that they are correct.

Note that the register definition 5.4.22 in reference manual RM0444 is wrong but that this fix matches the c header files provided by ST for STM32Cube.

```c
// stm32g0xx_hal_rcc_ex.h#L437 

#if defined(RCC_CCIPR2_USBSEL)
/** @defgroup RCCEx_USB_Clock_Source USB Clock Source
   * @{
   */
#if defined(RCC_HSI48_SUPPORT)
#define RCC_USBCLKSOURCE_HSI48         0x00000000U            /*!< HSI48 oscillator clock selected as USB clock */
#endif /* RCC_HSI48_SUPPORT */
#define RCC_USBCLKSOURCE_HSE           RCC_CCIPR2_USBSEL_0  /*!< HSE oscillator clock selected as USB clock */
#define RCC_USBCLKSOURCE_PLL           RCC_CCIPR2_USBSEL_1  /*!< PLL "Q" selected as USB clock */
/**
   * @}
   */
#endif /* RCC_CCIPR2_USBSEL */
```

For PLL we need to set bit `RCC_CCIPR2_USBSEL_1`. And `RCC_CCIPR2_USBSEL_1 = 0x2`:

```c
// stm32g0b1xx.h#L6910

#define RCC_CCIPR2_USBSEL_Pos             (12U)
#define RCC_CCIPR2_USBSEL_Msk             (0x3UL << RCC_CCIPR2_USBSEL_Pos)     /*!< 0x00003000 */
#define RCC_CCIPR2_USBSEL                 RCC_CCIPR2_USBSEL_Msk
#define RCC_CCIPR2_USBSEL_0               (0x1UL << RCC_CCIPR2_USBSEL_Pos)      /*!< 0x00001000 */
#define RCC_CCIPR2_USBSEL_1               (0x2UL << RCC_CCIPR2_USBSEL_Pos)      /*!< 0x00002000 */
```

See also: https://klipper.discourse.group/t/stm32g0-usb-clock-config/4487/2 


Tested on STM32G0B1RETx