### PR TITLE
stm32u5xx adc4 support

### DIFF
--- a/data/registers/adc_u5.yaml
+++ b/data/registers/adc_u5.yaml
@@ -1,714 +1,714 @@
 block/ADC:
   description: ADC.
   items:
-  - name: ADC_ISR
-    description: ADC interrupt and status register.
-    byte_offset: 0
-    fieldset: ADC_ISR
-  - name: ADC_IER
-    description: ADC interrupt enable register.
-    byte_offset: 4
-    fieldset: ADC_IER
-  - name: ADC_CR
-    description: ADC control register.
-    byte_offset: 8
-    fieldset: ADC_CR
-  - name: ADC_CFGR1
-    description: ADC configuration register.
-    byte_offset: 12
-    fieldset: ADC_CFGR1
-  - name: ADC_CFGR2
-    description: ADC configuration register 2.
-    byte_offset: 16
-    fieldset: ADC_CFGR2
-  - name: ADC_SMPR
-    description: ADC sample time register.
-    byte_offset: 20
-    fieldset: ADC_SMPR
-  - name: ADC_AWD1TR
-    description: ADC watchdog threshold register.
-    byte_offset: 32
-    fieldset: ADC_AWD1TR
-  - name: ADC_AWD2TR
-    description: ADC watchdog threshold register.
-    byte_offset: 36
-    fieldset: ADC_AWD2TR
-  - name: ADC_CHSELRMOD0
-    description: ADC channel selection register [alternate].
-    byte_offset: 40
-    fieldset: ADC_CHSELRMOD0
-  - name: ADC_CHSELRMOD1
-    description: ADC channel selection register [alternate].
-    byte_offset: 40
-    fieldset: ADC_CHSELRMOD1
-  - name: ADC_AWD3TR
-    description: ADC watchdog threshold register.
-    byte_offset: 44
-    fieldset: ADC_AWD3TR
-  - name: ADC_DR
-    description: ADC data register.
-    byte_offset: 64
-    access: Read
-    fieldset: ADC_DR
-  - name: ADC_PWR
-    description: ADC data register.
-    byte_offset: 68
-    fieldset: ADC_PWR
-  - name: ADC_AWD2CR
-    description: ADC Analog Watchdog 2 Configuration register.
-    byte_offset: 160
-    fieldset: ADC_AWD2CR
-  - name: ADC_AWD3CR
-    description: ADC Analog Watchdog 3 Configuration register.
-    byte_offset: 164
-    fieldset: ADC_AWD3CR
-  - name: ADC_CALFACT
-    description: ADC Calibration factor.
-    byte_offset: 196
-    fieldset: ADC_CALFACT
-  - name: ADC_OR
-    description: ADC option register.
-    byte_offset: 208
-    fieldset: ADC_OR
-  - name: ADC_CCR
-    description: ADC common configuration register.
-    byte_offset: 776
-    fieldset: ADC_CCR
-fieldset/ADC_AWD1TR:
+    - name: ISR
+      description: ADC interrupt and status register.
+      byte_offset: 0
+      fieldset: ISR
+    - name: IER
+      description: ADC interrupt enable register.
+      byte_offset: 4
+      fieldset: IER
+    - name: CR
+      description: ADC control register.
+      byte_offset: 8
+      fieldset: CR
+    - name: CFGR1
+      description: ADC configuration register.
+      byte_offset: 12
+      fieldset: CFGR1
+    - name: CFGR2
+      description: ADC configuration register 2.
+      byte_offset: 16
+      fieldset: CFGR2
+    - name: SMPR
+      description: ADC sample time register.
+      byte_offset: 20
+      fieldset: SMPR
+    - name: AWD1TR
+      description: ADC watchdog threshold register.
+      byte_offset: 32
+      fieldset: AWD1TR
+    - name: AWD2TR
+      description: ADC watchdog threshold register.
+      byte_offset: 36
+      fieldset: AWD2TR
+    - name: CHSELRMOD0
+      description: ADC channel selection register [alternate].
+      byte_offset: 40
+      fieldset: CHSELRMOD0
+    - name: CHSELRMOD1
+      description: ADC channel selection register [alternate].
+      byte_offset: 40
+      fieldset: CHSELRMOD1
+    - name: AWD3TR
+      description: ADC watchdog threshold register.
+      byte_offset: 44
+      fieldset: AWD3TR
+    - name: DR
+      description: ADC data register.
+      byte_offset: 64
+      access: Read
+      fieldset: DR
+    - name: PWRR
+      description: ADC data register.
+      byte_offset: 68
+      fieldset: PWRR
+    - name: AWD2CR
+      description: ADC Analog Watchdog 2 Configuration register.
+      byte_offset: 160
+      fieldset: AWD2CR
+    - name: AWD3CR
+      description: ADC Analog Watchdog 3 Configuration register.
+      byte_offset: 164
+      fieldset: AWD3CR
+    - name: CALFACT
+      description: ADC Calibration factor.
+      byte_offset: 196
+      fieldset: CALFACT
+    - name: OR
+      description: ADC option register.
+      byte_offset: 208
+      fieldset: OR
+    - name: CCR
+      description: ADC common configuration register.
+      byte_offset: 776
+      fieldset: CCR
+fieldset/AWD1TR:
   description: ADC watchdog threshold register.
   fields:
-  - name: LT1
-    description: LT1.
-    bit_offset: 0
-    bit_size: 12
-  - name: HT1
-    description: HT1.
-    bit_offset: 16
-    bit_size: 12
-fieldset/ADC_AWD2CR:
+    - name: LT1
+      description: LT1.
+      bit_offset: 0
+      bit_size: 12
+    - name: HT1
+      description: HT1.
+      bit_offset: 16
+      bit_size: 12
+fieldset/AWD2CR:
   description: ADC Analog Watchdog 2 Configuration register.
   fields:
-  - name: AWD2CH0
-    description: AWD2CH0.
-    bit_offset: 0
-    bit_size: 1
-  - name: AWD2CH1
-    description: AWD2CH1.
-    bit_offset: 1
-    bit_size: 1
-  - name: AWD2CH2
-    description: AWD2CH2.
-    bit_offset: 2
-    bit_size: 1
-  - name: AWD2CH3
-    description: AWD2CH3.
-    bit_offset: 3
-    bit_size: 1
-  - name: AWD2CH4
-    description: AWD2CH4.
-    bit_offset: 4
-    bit_size: 1
-  - name: AWD2CH5
-    description: AWD2CH5.
-    bit_offset: 5
-    bit_size: 1
-  - name: AWD2CH6
-    description: AWD2CH6.
-    bit_offset: 6
-    bit_size: 1
-  - name: AWD2CH7
-    description: AWD2CH7.
-    bit_offset: 7
-    bit_size: 1
-  - name: AWD2CH8
-    description: AWD2CH8.
-    bit_offset: 8
-    bit_size: 1
-  - name: AWD2CH9
-    description: AWD2CH9.
-    bit_offset: 9
-    bit_size: 1
-  - name: AWD2CH10
-    description: AWD2CH10.
-    bit_offset: 10
-    bit_size: 1
-  - name: AWD2CH11
-    description: AWD2CH11.
-    bit_offset: 11
-    bit_size: 1
-  - name: AWD2CH12
-    description: AWD2CH12.
-    bit_offset: 12
-    bit_size: 1
-  - name: AWD2CH13
-    description: AWD2CH13.
-    bit_offset: 13
-    bit_size: 1
-  - name: AWD2CH14
-    description: AWD2CH14.
-    bit_offset: 14
-    bit_size: 1
-  - name: AWD2CH15
-    description: AWD2CH15.
-    bit_offset: 15
-    bit_size: 1
-  - name: AWD2CH16
-    description: AWD2CH16.
-    bit_offset: 16
-    bit_size: 1
-  - name: AWD2CH17
-    description: AWD2CH17.
-    bit_offset: 17
-    bit_size: 1
-  - name: AWD2CH18
-    description: AWD2CH18.
-    bit_offset: 18
-    bit_size: 1
-  - name: AWD2CH19
-    description: AWD2CH19.
-    bit_offset: 19
-    bit_size: 1
-  - name: AWD2CH20
-    description: AWD2CH20.
-    bit_offset: 20
-    bit_size: 1
-  - name: AWD2CH21
-    description: AWD2CH21.
-    bit_offset: 21
-    bit_size: 1
-  - name: AWD2CH22
-    description: AWD2CH22.
-    bit_offset: 22
-    bit_size: 1
-  - name: AWD2CH23
-    description: AWD2CH23.
-    bit_offset: 23
-    bit_size: 1
-fieldset/ADC_AWD2TR:
+    - name: AWD2CH0
+      description: AWD2CH0.
+      bit_offset: 0
+      bit_size: 1
+    - name: AWD2CH1
+      description: AWD2CH1.
+      bit_offset: 1
+      bit_size: 1
+    - name: AWD2CH2
+      description: AWD2CH2.
+      bit_offset: 2
+      bit_size: 1
+    - name: AWD2CH3
+      description: AWD2CH3.
+      bit_offset: 3
+      bit_size: 1
+    - name: AWD2CH4
+      description: AWD2CH4.
+      bit_offset: 4
+      bit_size: 1
+    - name: AWD2CH5
+      description: AWD2CH5.
+      bit_offset: 5
+      bit_size: 1
+    - name: AWD2CH6
+      description: AWD2CH6.
+      bit_offset: 6
+      bit_size: 1
+    - name: AWD2CH7
+      description: AWD2CH7.
+      bit_offset: 7
+      bit_size: 1
+    - name: AWD2CH8
+      description: AWD2CH8.
+      bit_offset: 8
+      bit_size: 1
+    - name: AWD2CH9
+      description: AWD2CH9.
+      bit_offset: 9
+      bit_size: 1
+    - name: AWD2CH10
+      description: AWD2CH10.
+      bit_offset: 10
+      bit_size: 1
+    - name: AWD2CH11
+      description: AWD2CH11.
+      bit_offset: 11
+      bit_size: 1
+    - name: AWD2CH12
+      description: AWD2CH12.
+      bit_offset: 12
+      bit_size: 1
+    - name: AWD2CH13
+      description: AWD2CH13.
+      bit_offset: 13
+      bit_size: 1
+    - name: AWD2CH14
+      description: AWD2CH14.
+      bit_offset: 14
+      bit_size: 1
+    - name: AWD2CH15
+      description: AWD2CH15.
+      bit_offset: 15
+      bit_size: 1
+    - name: AWD2CH16
+      description: AWD2CH16.
+      bit_offset: 16
+      bit_size: 1
+    - name: AWD2CH17
+      description: AWD2CH17.
+      bit_offset: 17
+      bit_size: 1
+    - name: AWD2CH18
+      description: AWD2CH18.
+      bit_offset: 18
+      bit_size: 1
+    - name: AWD2CH19
+      description: AWD2CH19.
+      bit_offset: 19
+      bit_size: 1
+    - name: AWD2CH20
+      description: AWD2CH20.
+      bit_offset: 20
+      bit_size: 1
+    - name: AWD2CH21
+      description: AWD2CH21.
+      bit_offset: 21
+      bit_size: 1
+    - name: AWD2CH22
+      description: AWD2CH22.
+      bit_offset: 22
+      bit_size: 1
+    - name: AWD2CH23
+      description: AWD2CH23.
+      bit_offset: 23
+      bit_size: 1
+fieldset/AWD2TR:
   description: ADC watchdog threshold register.
   fields:
-  - name: LT2
-    description: LT2.
-    bit_offset: 0
-    bit_size: 12
-  - name: HT2
-    description: HT2.
-    bit_offset: 16
-    bit_size: 12
-fieldset/ADC_AWD3CR:
+    - name: LT2
+      description: LT2.
+      bit_offset: 0
+      bit_size: 12
+    - name: HT2
+      description: HT2.
+      bit_offset: 16
+      bit_size: 12
+fieldset/AWD3CR:
   description: ADC Analog Watchdog 3 Configuration register.
   fields:
-  - name: AWD3CH0
-    description: AWD3CH0.
-    bit_offset: 0
-    bit_size: 1
-  - name: AWD3CH1
-    description: AWD3CH1.
-    bit_offset: 1
-    bit_size: 1
-  - name: AWD3CH2
-    description: AWD3CH2.
-    bit_offset: 2
-    bit_size: 1
-  - name: AWD3CH3
-    description: AWD3CH3.
-    bit_offset: 3
-    bit_size: 1
-  - name: AWD3CH4
-    description: AWD3CH4.
-    bit_offset: 4
-    bit_size: 1
-  - name: AWD3CH5
-    description: AWD3CH5.
-    bit_offset: 5
-    bit_size: 1
-  - name: AWD3CH6
-    description: AWD3CH6.
-    bit_offset: 6
-    bit_size: 1
-  - name: AWD3CH7
-    description: AWD3CH7.
-    bit_offset: 7
-    bit_size: 1
-  - name: AWD3CH8
-    description: AWD3CH8.
-    bit_offset: 8
-    bit_size: 1
-  - name: AWD3CH9
-    description: AWD3CH9.
-    bit_offset: 9
-    bit_size: 1
-  - name: AWD3CH10
-    description: AWD3CH10.
-    bit_offset: 10
-    bit_size: 1
-  - name: AWD3CH11
-    description: AWD3CH11.
-    bit_offset: 11
-    bit_size: 1
-  - name: AWD3CH12
-    description: AWD3CH12.
-    bit_offset: 12
-    bit_size: 1
-  - name: AWD3CH13
-    description: AWD3CH13.
-    bit_offset: 13
-    bit_size: 1
-  - name: AWD3CH14
-    description: AWD3CH14.
-    bit_offset: 14
-    bit_size: 1
-  - name: AWD3CH15
-    description: AWD3CH15.
-    bit_offset: 15
-    bit_size: 1
-  - name: AWD3CH16
-    description: AWD3CH16.
-    bit_offset: 16
-    bit_size: 1
-  - name: AWD3CH17
-    description: AWD3CH17.
-    bit_offset: 17
-    bit_size: 1
-  - name: AWD3CH18
-    description: AWD3CH18.
-    bit_offset: 18
-    bit_size: 1
-  - name: AWD3CH19
-    description: AWD3CH19.
-    bit_offset: 19
-    bit_size: 1
-  - name: AWD3CH20
-    description: AWD3CH20.
-    bit_offset: 20
-    bit_size: 1
-  - name: AWD3CH21
-    description: AWD3CH21.
-    bit_offset: 21
-    bit_size: 1
-  - name: AWD3CH22
-    description: AWD3CH22.
-    bit_offset: 22
-    bit_size: 1
-  - name: AWD3CH23
-    description: AWD3CH23.
-    bit_offset: 23
-    bit_size: 1
-fieldset/ADC_AWD3TR:
+    - name: AWD3CH0
+      description: AWD3CH0.
+      bit_offset: 0
+      bit_size: 1
+    - name: AWD3CH1
+      description: AWD3CH1.
+      bit_offset: 1
+      bit_size: 1
+    - name: AWD3CH2
+      description: AWD3CH2.
+      bit_offset: 2
+      bit_size: 1
+    - name: AWD3CH3
+      description: AWD3CH3.
+      bit_offset: 3
+      bit_size: 1
+    - name: AWD3CH4
+      description: AWD3CH4.
+      bit_offset: 4
+      bit_size: 1
+    - name: AWD3CH5
+      description: AWD3CH5.
+      bit_offset: 5
+      bit_size: 1
+    - name: AWD3CH6
+      description: AWD3CH6.
+      bit_offset: 6
+      bit_size: 1
+    - name: AWD3CH7
+      description: AWD3CH7.
+      bit_offset: 7
+      bit_size: 1
+    - name: AWD3CH8
+      description: AWD3CH8.
+      bit_offset: 8
+      bit_size: 1
+    - name: AWD3CH9
+      description: AWD3CH9.
+      bit_offset: 9
+      bit_size: 1
+    - name: AWD3CH10
+      description: AWD3CH10.
+      bit_offset: 10
+      bit_size: 1
+    - name: AWD3CH11
+      description: AWD3CH11.
+      bit_offset: 11
+      bit_size: 1
+    - name: AWD3CH12
+      description: AWD3CH12.
+      bit_offset: 12
+      bit_size: 1
+    - name: AWD3CH13
+      description: AWD3CH13.
+      bit_offset: 13
+      bit_size: 1
+    - name: AWD3CH14
+      description: AWD3CH14.
+      bit_offset: 14
+      bit_size: 1
+    - name: AWD3CH15
+      description: AWD3CH15.
+      bit_offset: 15
+      bit_size: 1
+    - name: AWD3CH16
+      description: AWD3CH16.
+      bit_offset: 16
+      bit_size: 1
+    - name: AWD3CH17
+      description: AWD3CH17.
+      bit_offset: 17
+      bit_size: 1
+    - name: AWD3CH18
+      description: AWD3CH18.
+      bit_offset: 18
+      bit_size: 1
+    - name: AWD3CH19
+      description: AWD3CH19.
+      bit_offset: 19
+      bit_size: 1
+    - name: AWD3CH20
+      description: AWD3CH20.
+      bit_offset: 20
+      bit_size: 1
+    - name: AWD3CH21
+      description: AWD3CH21.
+      bit_offset: 21
+      bit_size: 1
+    - name: AWD3CH22
+      description: AWD3CH22.
+      bit_offset: 22
+      bit_size: 1
+    - name: AWD3CH23
+      description: AWD3CH23.
+      bit_offset: 23
+      bit_size: 1
+fieldset/AWD3TR:
   description: ADC watchdog threshold register.
   fields:
-  - name: LT3
-    description: LT3.
-    bit_offset: 0
-    bit_size: 12
-  - name: HT3
-    description: HT3.
-    bit_offset: 16
-    bit_size: 12
-fieldset/ADC_CALFACT:
+    - name: LT3
+      description: LT3.
+      bit_offset: 0
+      bit_size: 12
+    - name: HT3
+      description: HT3.
+      bit_offset: 16
+      bit_size: 12
+fieldset/CALFACT:
   description: ADC Calibration factor.
   fields:
-  - name: CALFACT
-    description: CALFACT.
-    bit_offset: 0
-    bit_size: 7
-fieldset/ADC_CCR:
+    - name: CALFACT
+      description: CALFACT.
+      bit_offset: 0
+      bit_size: 7
+fieldset/CCR:
   description: ADC common configuration register.
   fields:
-  - name: PRESC
-    description: PRESC.
-    bit_offset: 18
-    bit_size: 4
-  - name: VREFEN
-    description: VREFEN.
-    bit_offset: 22
-    bit_size: 1
-  - name: VSENSESEL
-    description: VSENSESEL.
-    bit_offset: 23
-    bit_size: 1
-  - name: VBATEN
-    description: VBATEN.
-    bit_offset: 24
-    bit_size: 1
-fieldset/ADC_CFGR1:
+    - name: PRESC
+      description: PRESC.
+      bit_offset: 18
+      bit_size: 4
+    - name: VREFEN
+      description: VREFEN.
+      bit_offset: 22
+      bit_size: 1
+    - name: VSENSESEL
+      description: VSENSESEL.
+      bit_offset: 23
+      bit_size: 1
+    - name: VBATEN
+      description: VBATEN.
+      bit_offset: 24
+      bit_size: 1
+fieldset/CFGR1:
   description: ADC configuration register.
   fields:
-  - name: DMAEN
-    description: DMAEN.
-    bit_offset: 0
-    bit_size: 1
-  - name: DMACFG
-    description: DMACFG.
-    bit_offset: 1
-    bit_size: 1
-  - name: RES
-    description: RES.
-    bit_offset: 2
-    bit_size: 2
-  - name: SCANDIR
-    description: SCANDIR.
-    bit_offset: 4
-    bit_size: 1
-  - name: ALIGN
-    description: ALIGN.
-    bit_offset: 5
-    bit_size: 1
-  - name: EXTSEL
-    description: EXTSEL.
-    bit_offset: 6
-    bit_size: 3
-  - name: EXTEN
-    description: EXTEN.
-    bit_offset: 10
-    bit_size: 2
-  - name: OVRMOD
-    description: OVRMOD.
-    bit_offset: 12
-    bit_size: 1
-  - name: CONT
-    description: CONT.
-    bit_offset: 13
-    bit_size: 1
-  - name: WAIT
-    description: WAIT.
-    bit_offset: 14
-    bit_size: 1
-  - name: DISCEN
-    description: DISCEN.
-    bit_offset: 16
-    bit_size: 1
-  - name: CHSELRMOD
-    description: CHSELRMOD.
-    bit_offset: 21
-    bit_size: 1
-  - name: AWD1SGL
-    description: AWD1SGL.
-    bit_offset: 22
-    bit_size: 1
-  - name: AWD1EN
-    description: AWD1EN.
-    bit_offset: 23
-    bit_size: 1
-  - name: AWD1CH
-    description: AWD1CH.
-    bit_offset: 26
-    bit_size: 5
-fieldset/ADC_CFGR2:
+    - name: DMAEN
+      description: DMAEN.
+      bit_offset: 0
+      bit_size: 1
+    - name: DMACFG
+      description: DMACFG.
+      bit_offset: 1
+      bit_size: 1
+    - name: RES
+      description: RES.
+      bit_offset: 2
+      bit_size: 2
+    - name: SCANDIR
+      description: SCANDIR.
+      bit_offset: 4
+      bit_size: 1
+    - name: ALIGN
+      description: ALIGN.
+      bit_offset: 5
+      bit_size: 1
+    - name: EXTSEL
+      description: EXTSEL.
+      bit_offset: 6
+      bit_size: 3
+    - name: EXTEN
+      description: EXTEN.
+      bit_offset: 10
+      bit_size: 2
+    - name: OVRMOD
+      description: OVRMOD.
+      bit_offset: 12
+      bit_size: 1
+    - name: CONT
+      description: CONT.
+      bit_offset: 13
+      bit_size: 1
+    - name: WAIT
+      description: WAIT.
+      bit_offset: 14
+      bit_size: 1
+    - name: DISCEN
+      description: DISCEN.
+      bit_offset: 16
+      bit_size: 1
+    - name: CHSELRMOD
+      description: CHSELRMOD.
+      bit_offset: 21
+      bit_size: 1
+    - name: AWD1SGL
+      description: AWD1SGL.
+      bit_offset: 22
+      bit_size: 1
+    - name: AWD1EN
+      description: AWD1EN.
+      bit_offset: 23
+      bit_size: 1
+    - name: AWD1CH
+      description: AWD1CH.
+      bit_offset: 26
+      bit_size: 5
+fieldset/CFGR2:
   description: ADC configuration register 2.
   fields:
-  - name: OVSE
-    description: OVSE.
-    bit_offset: 0
-    bit_size: 1
-  - name: OVSR
-    description: OVSR.
-    bit_offset: 2
-    bit_size: 3
-  - name: OVSS
-    description: OVSS.
-    bit_offset: 5
-    bit_size: 4
-  - name: TOVS
-    description: TOVS.
-    bit_offset: 9
-    bit_size: 1
-  - name: LFTRIG
-    description: LFTRIG.
-    bit_offset: 29
-    bit_size: 1
-fieldset/ADC_CHSELRMOD0:
+    - name: OVSE
+      description: OVSE.
+      bit_offset: 0
+      bit_size: 1
+    - name: OVSR
+      description: OVSR.
+      bit_offset: 2
+      bit_size: 3
+    - name: OVSS
+      description: OVSS.
+      bit_offset: 5
+      bit_size: 4
+    - name: TOVS
+      description: TOVS.
+      bit_offset: 9
+      bit_size: 1
+    - name: LFTRIG
+      description: LFTRIG.
+      bit_offset: 29
+      bit_size: 1
+fieldset/CHSELRMOD0:
   description: ADC channel selection register [alternate].
   fields:
-  - name: CHSEL
-    description: CHSEL.
-    bit_offset: 0
-    bit_size: 24
-fieldset/ADC_CHSELRMOD1:
+    - name: CHSEL
+      description: CHSEL.
+      bit_offset: 0
+      bit_size: 24
+fieldset/CHSELRMOD1:
   description: ADC channel selection register [alternate].
   fields:
-  - name: SQ1
-    description: SQ1.
-    bit_offset: 0
-    bit_size: 4
-  - name: SQ2
-    description: SQ2.
-    bit_offset: 4
-    bit_size: 4
-  - name: SQ3
-    description: SQ3.
-    bit_offset: 8
-    bit_size: 4
-  - name: SQ4
-    description: SQ4.
-    bit_offset: 12
-    bit_size: 4
-  - name: SQ5
-    description: SQ5.
-    bit_offset: 16
-    bit_size: 4
-  - name: SQ6
-    description: SQ6.
-    bit_offset: 20
-    bit_size: 4
-  - name: SQ7
-    description: SQ7.
-    bit_offset: 24
-    bit_size: 4
-  - name: SQ8
-    description: SQ8.
-    bit_offset: 28
-    bit_size: 4
-fieldset/ADC_CR:
+    - name: SQ1
+      description: SQ1.
+      bit_offset: 0
+      bit_size: 4
+    - name: SQ2
+      description: SQ2.
+      bit_offset: 4
+      bit_size: 4
+    - name: SQ3
+      description: SQ3.
+      bit_offset: 8
+      bit_size: 4
+    - name: SQ4
+      description: SQ4.
+      bit_offset: 12
+      bit_size: 4
+    - name: SQ5
+      description: SQ5.
+      bit_offset: 16
+      bit_size: 4
+    - name: SQ6
+      description: SQ6.
+      bit_offset: 20
+      bit_size: 4
+    - name: SQ7
+      description: SQ7.
+      bit_offset: 24
+      bit_size: 4
+    - name: SQ8
+      description: SQ8.
+      bit_offset: 28
+      bit_size: 4
+fieldset/CR:
   description: ADC control register.
   fields:
-  - name: ADEN
-    description: ADEN.
-    bit_offset: 0
-    bit_size: 1
-  - name: ADDIS
-    description: ADDIS.
-    bit_offset: 1
-    bit_size: 1
-  - name: ADSTART
-    description: ADSTART.
-    bit_offset: 2
-    bit_size: 1
-  - name: ADSTP
-    description: ADSTP.
-    bit_offset: 4
-    bit_size: 1
-  - name: ADVREGEN
-    description: ADVREGEN.
-    bit_offset: 28
-    bit_size: 1
-  - name: ADCAL
-    description: ADCAL.
-    bit_offset: 31
-    bit_size: 1
-fieldset/ADC_DR:
+    - name: ADEN
+      description: ADEN.
+      bit_offset: 0
+      bit_size: 1
+    - name: ADDIS
+      description: ADDIS.
+      bit_offset: 1
+      bit_size: 1
+    - name: ADSTART
+      description: ADSTART.
+      bit_offset: 2
+      bit_size: 1
+    - name: ADSTP
+      description: ADSTP.
+      bit_offset: 4
+      bit_size: 1
+    - name: ADVREGEN
+      description: ADVREGEN.
+      bit_offset: 28
+      bit_size: 1
+    - name: ADCAL
+      description: ADCAL.
+      bit_offset: 31
+      bit_size: 1
+fieldset/DR:
   description: ADC data register.
   fields:
-  - name: DATA
-    description: DATA.
-    bit_offset: 0
-    bit_size: 16
-fieldset/ADC_IER:
+    - name: DATA
+      description: DATA.
+      bit_offset: 0
+      bit_size: 16
+fieldset/IER:
   description: ADC interrupt enable register.
   fields:
-  - name: ADRDYIE
-    description: ADRDYIE.
-    bit_offset: 0
-    bit_size: 1
-  - name: EOSMPIE
-    description: EOSMPIE.
-    bit_offset: 1
-    bit_size: 1
-  - name: EOCIE
-    description: EOCIE.
-    bit_offset: 2
-    bit_size: 1
-  - name: EOSIE
-    description: EOSIE.
-    bit_offset: 3
-    bit_size: 1
-  - name: OVRIE
-    description: OVRIE.
-    bit_offset: 4
-    bit_size: 1
-  - name: AWD1IE
-    description: AWD1IE.
-    bit_offset: 7
-    bit_size: 1
-  - name: AWD2IE
-    description: AWD2IE.
-    bit_offset: 8
-    bit_size: 1
-  - name: AWD3IE
-    description: AWD3IE.
-    bit_offset: 9
-    bit_size: 1
-  - name: EOCALIE
-    description: EOCALIE.
-    bit_offset: 11
-    bit_size: 1
-  - name: LDORDYIE
-    description: LDORDYIE.
-    bit_offset: 12
-    bit_size: 1
-fieldset/ADC_ISR:
+    - name: ADRDYIE
+      description: ADRDYIE.
+      bit_offset: 0
+      bit_size: 1
+    - name: EOSMPIE
+      description: EOSMPIE.
+      bit_offset: 1
+      bit_size: 1
+    - name: EOCIE
+      description: EOCIE.
+      bit_offset: 2
+      bit_size: 1
+    - name: EOSIE
+      description: EOSIE.
+      bit_offset: 3
+      bit_size: 1
+    - name: OVRIE
+      description: OVRIE.
+      bit_offset: 4
+      bit_size: 1
+    - name: AWD1IE
+      description: AWD1IE.
+      bit_offset: 7
+      bit_size: 1
+    - name: AWD2IE
+      description: AWD2IE.
+      bit_offset: 8
+      bit_size: 1
+    - name: AWD3IE
+      description: AWD3IE.
+      bit_offset: 9
+      bit_size: 1
+    - name: EOCALIE
+      description: EOCALIE.
+      bit_offset: 11
+      bit_size: 1
+    - name: LDORDYIE
+      description: LDORDYIE.
+      bit_offset: 12
+      bit_size: 1
+fieldset/ISR:
   description: ADC interrupt and status register.
   fields:
-  - name: ADRDY
-    description: ADRDY.
-    bit_offset: 0
-    bit_size: 1
-  - name: EOSMP
-    description: EOSMP.
-    bit_offset: 1
-    bit_size: 1
-  - name: EOC
-    description: EOC.
-    bit_offset: 2
-    bit_size: 1
-  - name: EOS
-    description: EOS.
-    bit_offset: 3
-    bit_size: 1
-  - name: OVR
-    description: OVR.
-    bit_offset: 4
-    bit_size: 1
-  - name: AWD1
-    description: AWD1.
-    bit_offset: 7
-    bit_size: 1
-  - name: AWD2
-    description: AWD2.
-    bit_offset: 8
-    bit_size: 1
-  - name: AWD3
-    description: AWD3.
-    bit_offset: 9
-    bit_size: 1
-  - name: EOCAL
-    description: EOCAL.
-    bit_offset: 11
-    bit_size: 1
-  - name: LDORDY
-    description: LDORDY.
-    bit_offset: 12
-    bit_size: 1
-fieldset/ADC_OR:
+    - name: ADRDY
+      description: ADRDY.
+      bit_offset: 0
+      bit_size: 1
+    - name: EOSMP
+      description: EOSMP.
+      bit_offset: 1
+      bit_size: 1
+    - name: EOC
+      description: EOC.
+      bit_offset: 2
+      bit_size: 1
+    - name: EOS
+      description: EOS.
+      bit_offset: 3
+      bit_size: 1
+    - name: OVR
+      description: OVR.
+      bit_offset: 4
+      bit_size: 1
+    - name: AWD1
+      description: AWD1.
+      bit_offset: 7
+      bit_size: 1
+    - name: AWD2
+      description: AWD2.
+      bit_offset: 8
+      bit_size: 1
+    - name: AWD3
+      description: AWD3.
+      bit_offset: 9
+      bit_size: 1
+    - name: EOCAL
+      description: EOCAL.
+      bit_offset: 11
+      bit_size: 1
+    - name: LDORDY
+      description: LDORDY.
+      bit_offset: 12
+      bit_size: 1
+fieldset/OR:
   description: ADC option register.
   fields:
-  - name: CHN21SEL
-    description: CHN21SEL.
-    bit_offset: 0
-    bit_size: 1
-fieldset/ADC_PWR:
+    - name: CHN21SEL
+      description: CHN21SEL.
+      bit_offset: 0
+      bit_size: 1
+fieldset/PWRR:
   description: ADC data register.
   fields:
-  - name: AUTOFF
-    description: AUTOFF.
-    bit_offset: 0
-    bit_size: 1
-  - name: DPD
-    description: DPD.
-    bit_offset: 1
-    bit_size: 1
-  - name: VREFPROT
-    description: VREFPROT.
-    bit_offset: 2
-    bit_size: 1
-  - name: VREFSECSMP
-    description: VREFSECSMP.
-    bit_offset: 3
-    bit_size: 1
-fieldset/ADC_SMPR:
+    - name: AUTOFF
+      description: AUTOFF.
+      bit_offset: 0
+      bit_size: 1
+    - name: DPD
+      description: DPD.
+      bit_offset: 1
+      bit_size: 1
+    - name: VREFPROT
+      description: VREFPROT.
+      bit_offset: 2
+      bit_size: 1
+    - name: VREFSECSMP
+      description: VREFSECSMP.
+      bit_offset: 3
+      bit_size: 1
+fieldset/SMPR:
   description: ADC sample time register.
   fields:
-  - name: SMP1
-    description: SMP1.
-    bit_offset: 0
-    bit_size: 3
-  - name: SMP2
-    description: SMP2.
-    bit_offset: 4
-    bit_size: 3
-  - name: SMPSEL0
-    description: SMPSEL0.
-    bit_offset: 8
-    bit_size: 1
-  - name: SMPSEL1
-    description: SMPSEL1.
-    bit_offset: 9
-    bit_size: 1
-  - name: SMPSEL2
-    description: SMPSEL2.
-    bit_offset: 10
-    bit_size: 1
-  - name: SMPSEL3
-    description: SMPSEL3.
-    bit_offset: 11
-    bit_size: 1
-  - name: SMPSEL4
-    description: SMPSEL4.
-    bit_offset: 12
-    bit_size: 1
-  - name: SMPSEL5
-    description: SMPSEL5.
-    bit_offset: 13
-    bit_size: 1
-  - name: SMPSEL6
-    description: SMPSEL6.
-    bit_offset: 14
-    bit_size: 1
-  - name: SMPSEL7
-    description: SMPSEL7.
-    bit_offset: 15
-    bit_size: 1
-  - name: SMPSEL8
-    description: SMPSEL8.
-    bit_offset: 16
-    bit_size: 1
-  - name: SMPSEL9
-    description: SMPSEL9.
-    bit_offset: 17
-    bit_size: 1
-  - name: SMPSEL10
-    description: SMPSEL10.
-    bit_offset: 18
-    bit_size: 1
-  - name: SMPSEL11
-    description: SMPSEL11.
-    bit_offset: 19
-    bit_size: 1
-  - name: SMPSEL12
-    description: SMPSEL12.
-    bit_offset: 20
-    bit_size: 1
-  - name: SMPSEL13
-    description: SMPSEL13.
-    bit_offset: 21
-    bit_size: 1
-  - name: SMPSEL14
-    description: SMPSEL14.
-    bit_offset: 22
-    bit_size: 1
-  - name: SMPSEL15
-    description: SMPSEL15.
-    bit_offset: 23
-    bit_size: 1
-  - name: SMPSEL16
-    description: SMPSEL16.
-    bit_offset: 24
-    bit_size: 1
-  - name: SMPSEL17
-    description: SMPSEL17.
-    bit_offset: 25
-    bit_size: 1
-  - name: SMPSEL18
-    description: SMPSEL18.
-    bit_offset: 26
-    bit_size: 1
-  - name: SMPSEL19
-    description: SMPSEL19.
-    bit_offset: 27
-    bit_size: 1
-  - name: SMPSEL20
-    description: SMPSEL20.
-    bit_offset: 28
-    bit_size: 1
-  - name: SMPSEL21
-    description: SMPSEL21.
-    bit_offset: 29
-    bit_size: 1
-  - name: SMPSEL22
-    description: SMPSEL22.
-    bit_offset: 30
-    bit_size: 1
-  - name: SMPSEL23
-    description: SMPSEL23.
-    bit_offset: 31
-    bit_size: 1
+    - name: SMP1
+      description: SMP1.
+      bit_offset: 0
+      bit_size: 3
+    - name: SMP2
+      description: SMP2.
+      bit_offset: 4
+      bit_size: 3
+    - name: SMPSEL0
+      description: SMPSEL0.
+      bit_offset: 8
+      bit_size: 1
+    - name: SMPSEL1
+      description: SMPSEL1.
+      bit_offset: 9
+      bit_size: 1
+    - name: SMPSEL2
+      description: SMPSEL2.
+      bit_offset: 10
+      bit_size: 1
+    - name: SMPSEL3
+      description: SMPSEL3.
+      bit_offset: 11
+      bit_size: 1
+    - name: SMPSEL4
+      description: SMPSEL4.
+      bit_offset: 12
+      bit_size: 1
+    - name: SMPSEL5
+      description: SMPSEL5.
+      bit_offset: 13
+      bit_size: 1
+    - name: SMPSEL6
+      description: SMPSEL6.
+      bit_offset: 14
+      bit_size: 1
+    - name: SMPSEL7
+      description: SMPSEL7.
+      bit_offset: 15
+      bit_size: 1
+    - name: SMPSEL8
+      description: SMPSEL8.
+      bit_offset: 16
+      bit_size: 1
+    - name: SMPSEL9
+      description: SMPSEL9.
+      bit_offset: 17
+      bit_size: 1
+    - name: SMPSEL10
+      description: SMPSEL10.
+      bit_offset: 18
+      bit_size: 1
+    - name: SMPSEL11
+      description: SMPSEL11.
+      bit_offset: 19
+      bit_size: 1
+    - name: SMPSEL12
+      description: SMPSEL12.
+      bit_offset: 20
+      bit_size: 1
+    - name: SMPSEL13
+      description: SMPSEL13.
+      bit_offset: 21
+      bit_size: 1
+    - name: SMPSEL14
+      description: SMPSEL14.
+      bit_offset: 22
+      bit_size: 1
+    - name: SMPSEL15
+      description: SMPSEL15.
+      bit_offset: 23
+      bit_size: 1
+    - name: SMPSEL16
+      description: SMPSEL16.
+      bit_offset: 24
+      bit_size: 1
+    - name: SMPSEL17
+      description: SMPSEL17.
+      bit_offset: 25
+      bit_size: 1
+    - name: SMPSEL18
+      description: SMPSEL18.
+      bit_offset: 26
+      bit_size: 1
+    - name: SMPSEL19
+      description: SMPSEL19.
+      bit_offset: 27
+      bit_size: 1
+    - name: SMPSEL20
+      description: SMPSEL20.
+      bit_offset: 28
+      bit_size: 1
+    - name: SMPSEL21
+      description: SMPSEL21.
+      bit_offset: 29
+      bit_size: 1
+    - name: SMPSEL22
+      description: SMPSEL22.
+      bit_offset: 30
+      bit_size: 1
+    - name: SMPSEL23
+      description: SMPSEL23.
+      bit_offset: 31
+      bit_size: 1

--- a/data/registers/adc_u5.yaml
+++ b/data/registers/adc_u5.yaml
@@ -1,0 +1,714 @@
+block/ADC4:
+  description: ADC4.
+  items:
+  - name: ADC_ISR
+    description: ADC interrupt and status register.
+    byte_offset: 0
+    fieldset: ADC_ISR
+  - name: ADC_IER
+    description: ADC interrupt enable register.
+    byte_offset: 4
+    fieldset: ADC_IER
+  - name: ADC_CR
+    description: ADC control register.
+    byte_offset: 8
+    fieldset: ADC_CR
+  - name: ADC_CFGR1
+    description: ADC configuration register.
+    byte_offset: 12
+    fieldset: ADC_CFGR1
+  - name: ADC_CFGR2
+    description: ADC configuration register 2.
+    byte_offset: 16
+    fieldset: ADC_CFGR2
+  - name: ADC_SMPR
+    description: ADC sample time register.
+    byte_offset: 20
+    fieldset: ADC_SMPR
+  - name: ADC_AWD1TR
+    description: ADC watchdog threshold register.
+    byte_offset: 32
+    fieldset: ADC_AWD1TR
+  - name: ADC_AWD2TR
+    description: ADC watchdog threshold register.
+    byte_offset: 36
+    fieldset: ADC_AWD2TR
+  - name: ADC_CHSELRMOD0
+    description: ADC channel selection register [alternate].
+    byte_offset: 40
+    fieldset: ADC_CHSELRMOD0
+  - name: ADC_CHSELRMOD1
+    description: ADC channel selection register [alternate].
+    byte_offset: 40
+    fieldset: ADC_CHSELRMOD1
+  - name: ADC_AWD3TR
+    description: ADC watchdog threshold register.
+    byte_offset: 44
+    fieldset: ADC_AWD3TR
+  - name: ADC_DR
+    description: ADC data register.
+    byte_offset: 64
+    access: Read
+    fieldset: ADC_DR
+  - name: ADC_PWR
+    description: ADC data register.
+    byte_offset: 68
+    fieldset: ADC_PWR
+  - name: ADC_AWD2CR
+    description: ADC Analog Watchdog 2 Configuration register.
+    byte_offset: 160
+    fieldset: ADC_AWD2CR
+  - name: ADC_AWD3CR
+    description: ADC Analog Watchdog 3 Configuration register.
+    byte_offset: 164
+    fieldset: ADC_AWD3CR
+  - name: ADC_CALFACT
+    description: ADC Calibration factor.
+    byte_offset: 196
+    fieldset: ADC_CALFACT
+  - name: ADC_OR
+    description: ADC option register.
+    byte_offset: 208
+    fieldset: ADC_OR
+  - name: ADC_CCR
+    description: ADC common configuration register.
+    byte_offset: 776
+    fieldset: ADC_CCR
+fieldset/ADC_AWD1TR:
+  description: ADC watchdog threshold register.
+  fields:
+  - name: LT1
+    description: LT1.
+    bit_offset: 0
+    bit_size: 12
+  - name: HT1
+    description: HT1.
+    bit_offset: 16
+    bit_size: 12
+fieldset/ADC_AWD2CR:
+  description: ADC Analog Watchdog 2 Configuration register.
+  fields:
+  - name: AWD2CH0
+    description: AWD2CH0.
+    bit_offset: 0
+    bit_size: 1
+  - name: AWD2CH1
+    description: AWD2CH1.
+    bit_offset: 1
+    bit_size: 1
+  - name: AWD2CH2
+    description: AWD2CH2.
+    bit_offset: 2
+    bit_size: 1
+  - name: AWD2CH3
+    description: AWD2CH3.
+    bit_offset: 3
+    bit_size: 1
+  - name: AWD2CH4
+    description: AWD2CH4.
+    bit_offset: 4
+    bit_size: 1
+  - name: AWD2CH5
+    description: AWD2CH5.
+    bit_offset: 5
+    bit_size: 1
+  - name: AWD2CH6
+    description: AWD2CH6.
+    bit_offset: 6
+    bit_size: 1
+  - name: AWD2CH7
+    description: AWD2CH7.
+    bit_offset: 7
+    bit_size: 1
+  - name: AWD2CH8
+    description: AWD2CH8.
+    bit_offset: 8
+    bit_size: 1
+  - name: AWD2CH9
+    description: AWD2CH9.
+    bit_offset: 9
+    bit_size: 1
+  - name: AWD2CH10
+    description: AWD2CH10.
+    bit_offset: 10
+    bit_size: 1
+  - name: AWD2CH11
+    description: AWD2CH11.
+    bit_offset: 11
+    bit_size: 1
+  - name: AWD2CH12
+    description: AWD2CH12.
+    bit_offset: 12
+    bit_size: 1
+  - name: AWD2CH13
+    description: AWD2CH13.
+    bit_offset: 13
+    bit_size: 1
+  - name: AWD2CH14
+    description: AWD2CH14.
+    bit_offset: 14
+    bit_size: 1
+  - name: AWD2CH15
+    description: AWD2CH15.
+    bit_offset: 15
+    bit_size: 1
+  - name: AWD2CH16
+    description: AWD2CH16.
+    bit_offset: 16
+    bit_size: 1
+  - name: AWD2CH17
+    description: AWD2CH17.
+    bit_offset: 17
+    bit_size: 1
+  - name: AWD2CH18
+    description: AWD2CH18.
+    bit_offset: 18
+    bit_size: 1
+  - name: AWD2CH19
+    description: AWD2CH19.
+    bit_offset: 19
+    bit_size: 1
+  - name: AWD2CH20
+    description: AWD2CH20.
+    bit_offset: 20
+    bit_size: 1
+  - name: AWD2CH21
+    description: AWD2CH21.
+    bit_offset: 21
+    bit_size: 1
+  - name: AWD2CH22
+    description: AWD2CH22.
+    bit_offset: 22
+    bit_size: 1
+  - name: AWD2CH23
+    description: AWD2CH23.
+    bit_offset: 23
+    bit_size: 1
+fieldset/ADC_AWD2TR:
+  description: ADC watchdog threshold register.
+  fields:
+  - name: LT2
+    description: LT2.
+    bit_offset: 0
+    bit_size: 12
+  - name: HT2
+    description: HT2.
+    bit_offset: 16
+    bit_size: 12
+fieldset/ADC_AWD3CR:
+  description: ADC Analog Watchdog 3 Configuration register.
+  fields:
+  - name: AWD3CH0
+    description: AWD3CH0.
+    bit_offset: 0
+    bit_size: 1
+  - name: AWD3CH1
+    description: AWD3CH1.
+    bit_offset: 1
+    bit_size: 1
+  - name: AWD3CH2
+    description: AWD3CH2.
+    bit_offset: 2
+    bit_size: 1
+  - name: AWD3CH3
+    description: AWD3CH3.
+    bit_offset: 3
+    bit_size: 1
+  - name: AWD3CH4
+    description: AWD3CH4.
+    bit_offset: 4
+    bit_size: 1
+  - name: AWD3CH5
+    description: AWD3CH5.
+    bit_offset: 5
+    bit_size: 1
+  - name: AWD3CH6
+    description: AWD3CH6.
+    bit_offset: 6
+    bit_size: 1
+  - name: AWD3CH7
+    description: AWD3CH7.
+    bit_offset: 7
+    bit_size: 1
+  - name: AWD3CH8
+    description: AWD3CH8.
+    bit_offset: 8
+    bit_size: 1
+  - name: AWD3CH9
+    description: AWD3CH9.
+    bit_offset: 9
+    bit_size: 1
+  - name: AWD3CH10
+    description: AWD3CH10.
+    bit_offset: 10
+    bit_size: 1
+  - name: AWD3CH11
+    description: AWD3CH11.
+    bit_offset: 11
+    bit_size: 1
+  - name: AWD3CH12
+    description: AWD3CH12.
+    bit_offset: 12
+    bit_size: 1
+  - name: AWD3CH13
+    description: AWD3CH13.
+    bit_offset: 13
+    bit_size: 1
+  - name: AWD3CH14
+    description: AWD3CH14.
+    bit_offset: 14
+    bit_size: 1
+  - name: AWD3CH15
+    description: AWD3CH15.
+    bit_offset: 15
+    bit_size: 1
+  - name: AWD3CH16
+    description: AWD3CH16.
+    bit_offset: 16
+    bit_size: 1
+  - name: AWD3CH17
+    description: AWD3CH17.
+    bit_offset: 17
+    bit_size: 1
+  - name: AWD3CH18
+    description: AWD3CH18.
+    bit_offset: 18
+    bit_size: 1
+  - name: AWD3CH19
+    description: AWD3CH19.
+    bit_offset: 19
+    bit_size: 1
+  - name: AWD3CH20
+    description: AWD3CH20.
+    bit_offset: 20
+    bit_size: 1
+  - name: AWD3CH21
+    description: AWD3CH21.
+    bit_offset: 21
+    bit_size: 1
+  - name: AWD3CH22
+    description: AWD3CH22.
+    bit_offset: 22
+    bit_size: 1
+  - name: AWD3CH23
+    description: AWD3CH23.
+    bit_offset: 23
+    bit_size: 1
+fieldset/ADC_AWD3TR:
+  description: ADC watchdog threshold register.
+  fields:
+  - name: LT3
+    description: LT3.
+    bit_offset: 0
+    bit_size: 12
+  - name: HT3
+    description: HT3.
+    bit_offset: 16
+    bit_size: 12
+fieldset/ADC_CALFACT:
+  description: ADC Calibration factor.
+  fields:
+  - name: CALFACT
+    description: CALFACT.
+    bit_offset: 0
+    bit_size: 7
+fieldset/ADC_CCR:
+  description: ADC common configuration register.
+  fields:
+  - name: PRESC
+    description: PRESC.
+    bit_offset: 18
+    bit_size: 4
+  - name: VREFEN
+    description: VREFEN.
+    bit_offset: 22
+    bit_size: 1
+  - name: VSENSESEL
+    description: VSENSESEL.
+    bit_offset: 23
+    bit_size: 1
+  - name: VBATEN
+    description: VBATEN.
+    bit_offset: 24
+    bit_size: 1
+fieldset/ADC_CFGR1:
+  description: ADC configuration register.
+  fields:
+  - name: DMAEN
+    description: DMAEN.
+    bit_offset: 0
+    bit_size: 1
+  - name: DMACFG
+    description: DMACFG.
+    bit_offset: 1
+    bit_size: 1
+  - name: RES
+    description: RES.
+    bit_offset: 2
+    bit_size: 2
+  - name: SCANDIR
+    description: SCANDIR.
+    bit_offset: 4
+    bit_size: 1
+  - name: ALIGN
+    description: ALIGN.
+    bit_offset: 5
+    bit_size: 1
+  - name: EXTSEL
+    description: EXTSEL.
+    bit_offset: 6
+    bit_size: 3
+  - name: EXTEN
+    description: EXTEN.
+    bit_offset: 10
+    bit_size: 2
+  - name: OVRMOD
+    description: OVRMOD.
+    bit_offset: 12
+    bit_size: 1
+  - name: CONT
+    description: CONT.
+    bit_offset: 13
+    bit_size: 1
+  - name: WAIT
+    description: WAIT.
+    bit_offset: 14
+    bit_size: 1
+  - name: DISCEN
+    description: DISCEN.
+    bit_offset: 16
+    bit_size: 1
+  - name: CHSELRMOD
+    description: CHSELRMOD.
+    bit_offset: 21
+    bit_size: 1
+  - name: AWD1SGL
+    description: AWD1SGL.
+    bit_offset: 22
+    bit_size: 1
+  - name: AWD1EN
+    description: AWD1EN.
+    bit_offset: 23
+    bit_size: 1
+  - name: AWD1CH
+    description: AWD1CH.
+    bit_offset: 26
+    bit_size: 5
+fieldset/ADC_CFGR2:
+  description: ADC configuration register 2.
+  fields:
+  - name: OVSE
+    description: OVSE.
+    bit_offset: 0
+    bit_size: 1
+  - name: OVSR
+    description: OVSR.
+    bit_offset: 2
+    bit_size: 3
+  - name: OVSS
+    description: OVSS.
+    bit_offset: 5
+    bit_size: 4
+  - name: TOVS
+    description: TOVS.
+    bit_offset: 9
+    bit_size: 1
+  - name: LFTRIG
+    description: LFTRIG.
+    bit_offset: 29
+    bit_size: 1
+fieldset/ADC_CHSELRMOD0:
+  description: ADC channel selection register [alternate].
+  fields:
+  - name: CHSEL
+    description: CHSEL.
+    bit_offset: 0
+    bit_size: 24
+fieldset/ADC_CHSELRMOD1:
+  description: ADC channel selection register [alternate].
+  fields:
+  - name: SQ1
+    description: SQ1.
+    bit_offset: 0
+    bit_size: 4
+  - name: SQ2
+    description: SQ2.
+    bit_offset: 4
+    bit_size: 4
+  - name: SQ3
+    description: SQ3.
+    bit_offset: 8
+    bit_size: 4
+  - name: SQ4
+    description: SQ4.
+    bit_offset: 12
+    bit_size: 4
+  - name: SQ5
+    description: SQ5.
+    bit_offset: 16
+    bit_size: 4
+  - name: SQ6
+    description: SQ6.
+    bit_offset: 20
+    bit_size: 4
+  - name: SQ7
+    description: SQ7.
+    bit_offset: 24
+    bit_size: 4
+  - name: SQ8
+    description: SQ8.
+    bit_offset: 28
+    bit_size: 4
+fieldset/ADC_CR:
+  description: ADC control register.
+  fields:
+  - name: ADEN
+    description: ADEN.
+    bit_offset: 0
+    bit_size: 1
+  - name: ADDIS
+    description: ADDIS.
+    bit_offset: 1
+    bit_size: 1
+  - name: ADSTART
+    description: ADSTART.
+    bit_offset: 2
+    bit_size: 1
+  - name: ADSTP
+    description: ADSTP.
+    bit_offset: 4
+    bit_size: 1
+  - name: ADVREGEN
+    description: ADVREGEN.
+    bit_offset: 28
+    bit_size: 1
+  - name: ADCAL
+    description: ADCAL.
+    bit_offset: 31
+    bit_size: 1
+fieldset/ADC_DR:
+  description: ADC data register.
+  fields:
+  - name: DATA
+    description: DATA.
+    bit_offset: 0
+    bit_size: 16
+fieldset/ADC_IER:
+  description: ADC interrupt enable register.
+  fields:
+  - name: ADRDYIE
+    description: ADRDYIE.
+    bit_offset: 0
+    bit_size: 1
+  - name: EOSMPIE
+    description: EOSMPIE.
+    bit_offset: 1
+    bit_size: 1
+  - name: EOCIE
+    description: EOCIE.
+    bit_offset: 2
+    bit_size: 1
+  - name: EOSIE
+    description: EOSIE.
+    bit_offset: 3
+    bit_size: 1
+  - name: OVRIE
+    description: OVRIE.
+    bit_offset: 4
+    bit_size: 1
+  - name: AWD1IE
+    description: AWD1IE.
+    bit_offset: 7
+    bit_size: 1
+  - name: AWD2IE
+    description: AWD2IE.
+    bit_offset: 8
+    bit_size: 1
+  - name: AWD3IE
+    description: AWD3IE.
+    bit_offset: 9
+    bit_size: 1
+  - name: EOCALIE
+    description: EOCALIE.
+    bit_offset: 11
+    bit_size: 1
+  - name: LDORDYIE
+    description: LDORDYIE.
+    bit_offset: 12
+    bit_size: 1
+fieldset/ADC_ISR:
+  description: ADC interrupt and status register.
+  fields:
+  - name: ADRDY
+    description: ADRDY.
+    bit_offset: 0
+    bit_size: 1
+  - name: EOSMP
+    description: EOSMP.
+    bit_offset: 1
+    bit_size: 1
+  - name: EOC
+    description: EOC.
+    bit_offset: 2
+    bit_size: 1
+  - name: EOS
+    description: EOS.
+    bit_offset: 3
+    bit_size: 1
+  - name: OVR
+    description: OVR.
+    bit_offset: 4
+    bit_size: 1
+  - name: AWD1
+    description: AWD1.
+    bit_offset: 7
+    bit_size: 1
+  - name: AWD2
+    description: AWD2.
+    bit_offset: 8
+    bit_size: 1
+  - name: AWD3
+    description: AWD3.
+    bit_offset: 9
+    bit_size: 1
+  - name: EOCAL
+    description: EOCAL.
+    bit_offset: 11
+    bit_size: 1
+  - name: LDORDY
+    description: LDORDY.
+    bit_offset: 12
+    bit_size: 1
+fieldset/ADC_OR:
+  description: ADC option register.
+  fields:
+  - name: CHN21SEL
+    description: CHN21SEL.
+    bit_offset: 0
+    bit_size: 1
+fieldset/ADC_PWR:
+  description: ADC data register.
+  fields:
+  - name: AUTOFF
+    description: AUTOFF.
+    bit_offset: 0
+    bit_size: 1
+  - name: DPD
+    description: DPD.
+    bit_offset: 1
+    bit_size: 1
+  - name: VREFPROT
+    description: VREFPROT.
+    bit_offset: 2
+    bit_size: 1
+  - name: VREFSECSMP
+    description: VREFSECSMP.
+    bit_offset: 3
+    bit_size: 1
+fieldset/ADC_SMPR:
+  description: ADC sample time register.
+  fields:
+  - name: SMP1
+    description: SMP1.
+    bit_offset: 0
+    bit_size: 3
+  - name: SMP2
+    description: SMP2.
+    bit_offset: 4
+    bit_size: 3
+  - name: SMPSEL0
+    description: SMPSEL0.
+    bit_offset: 8
+    bit_size: 1
+  - name: SMPSEL1
+    description: SMPSEL1.
+    bit_offset: 9
+    bit_size: 1
+  - name: SMPSEL2
+    description: SMPSEL2.
+    bit_offset: 10
+    bit_size: 1
+  - name: SMPSEL3
+    description: SMPSEL3.
+    bit_offset: 11
+    bit_size: 1
+  - name: SMPSEL4
+    description: SMPSEL4.
+    bit_offset: 12
+    bit_size: 1
+  - name: SMPSEL5
+    description: SMPSEL5.
+    bit_offset: 13
+    bit_size: 1
+  - name: SMPSEL6
+    description: SMPSEL6.
+    bit_offset: 14
+    bit_size: 1
+  - name: SMPSEL7
+    description: SMPSEL7.
+    bit_offset: 15
+    bit_size: 1
+  - name: SMPSEL8
+    description: SMPSEL8.
+    bit_offset: 16
+    bit_size: 1
+  - name: SMPSEL9
+    description: SMPSEL9.
+    bit_offset: 17
+    bit_size: 1
+  - name: SMPSEL10
+    description: SMPSEL10.
+    bit_offset: 18
+    bit_size: 1
+  - name: SMPSEL11
+    description: SMPSEL11.
+    bit_offset: 19
+    bit_size: 1
+  - name: SMPSEL12
+    description: SMPSEL12.
+    bit_offset: 20
+    bit_size: 1
+  - name: SMPSEL13
+    description: SMPSEL13.
+    bit_offset: 21
+    bit_size: 1
+  - name: SMPSEL14
+    description: SMPSEL14.
+    bit_offset: 22
+    bit_size: 1
+  - name: SMPSEL15
+    description: SMPSEL15.
+    bit_offset: 23
+    bit_size: 1
+  - name: SMPSEL16
+    description: SMPSEL16.
+    bit_offset: 24
+    bit_size: 1
+  - name: SMPSEL17
+    description: SMPSEL17.
+    bit_offset: 25
+    bit_size: 1
+  - name: SMPSEL18
+    description: SMPSEL18.
+    bit_offset: 26
+    bit_size: 1
+  - name: SMPSEL19
+    description: SMPSEL19.
+    bit_offset: 27
+    bit_size: 1
+  - name: SMPSEL20
+    description: SMPSEL20.
+    bit_offset: 28
+    bit_size: 1
+  - name: SMPSEL21
+    description: SMPSEL21.
+    bit_offset: 29
+    bit_size: 1
+  - name: SMPSEL22
+    description: SMPSEL22.
+    bit_offset: 30
+    bit_size: 1
+  - name: SMPSEL23
+    description: SMPSEL23.
+    bit_offset: 31
+    bit_size: 1

--- a/data/registers/adc_u5.yaml
+++ b/data/registers/adc_u5.yaml
@@ -1,5 +1,5 @@
-block/ADC4:
-  description: ADC4.
+block/ADC:
+  description: ADC.
   items:
   - name: ADC_ISR
     description: ADC interrupt and status register.

--- a/stm32-data-gen/src/perimap.rs
+++ b/stm32-data-gen/src/perimap.rs
@@ -116,6 +116,7 @@ pub static PERIMAP: RegexMap<(&str, &str, &str)> = RegexMap::new(&[
     ("STM32H50.*:ADC\\d*_COMMON:.*", ("adccommon", "h50", "ADC_COMMON")),
     ("STM32H5.*:ADC\\d*_COMMON:.*", ("adccommon", "h5", "ADC_COMMON")),
     ("STM32H7.*:ADC\\d*_COMMON:.*", ("adccommon", "v4", "ADC_COMMON")),
+    ("STM32U5.*:ADC:.*", ("adc", "u5", "ADC")),
     ("STM32F373.*:SDADC:.*", ("sdadc", "v1", "SDADC")),
     ("STM32F301.*:SDADC:.*", ("sdadc", "v1", "SDADC")),
     ("STM32G4.*:OPAMP:G4_tsmc90_fastOpamp", ("opamp", "g4", "OPAMP")),


### PR DESCRIPTION
Closes #502 
this code should work for adding adc4 support to the stm32u5xx family, I didn't get any answers on my issue, so I'm hoping what I have is ok. The only thing I'm somewhat unsure of is where I should've put the chips.rs entry.