### PR TITLE
Update offsets for mdio h7 and f7

### DIFF
--- a/data/registers/mdios_v1.yaml
+++ b/data/registers/mdios_v1.yaml
@@ -37,7 +37,7 @@ block/MDIOS:
     array:
       len: 32
       stride: 4
-    byte_offset: 28
+    byte_offset: 256
     access: Read
     fieldset: DINR
   - name: DOUTR
@@ -45,7 +45,7 @@ block/MDIOS:
     array:
       len: 32
       stride: 4
-    byte_offset: 156
+    byte_offset: 384
     fieldset: DOUTR
 fieldset/CLRFR:
   description: MDIOS clear flag register


### PR DESCRIPTION
According to Stm32 RM 0399
MDIOS_DINRx should start at 0x100, after reserved section.

Discussed at https://matrix.to/#/!YoLPkieCYHGzdjUhOK:matrix.org/$yITO9mef_jjcXBFsWWAA1xvRcVZsbPZ_5smrpVRYPMI?via=matrix.org