### PR TITLE
feat: Add STM32H7 SPDIFRX support

### DIFF
--- a/data/registers/spdifrx_h7.yaml
+++ b/data/registers/spdifrx_h7.yaml
@@ -1,0 +1,293 @@
+block/SPDIFRX:
+  description: Receiver Interface
+  items:
+  - name: CR
+    description: Control register
+    byte_offset: 0
+    fieldset: CR
+  - name: IMR
+    description: Interrupt mask register
+    byte_offset: 4
+    fieldset: IMR
+  - name: SR
+    description: Status register
+    byte_offset: 8
+    access: Read
+    fieldset: SR
+  - name: IFCR
+    description: Interrupt Flag Clear register
+    byte_offset: 12
+    access: Write
+    fieldset: IFCR
+  - name: FMT0_DR
+    description: Data input register
+    byte_offset: 16
+    access: Read
+    fieldset: FMT0_DR
+  - name: FMT1_DR
+    description: Data input register
+    byte_offset: 16
+    access: Read
+    fieldset: FMT1_DR
+  - name: FMT2_DR
+    description: Data input register
+    byte_offset: 16
+    access: Read
+    fieldset: FMT2_DR
+  - name: CSR
+    description: Channel Status register
+    byte_offset: 20
+    access: Read
+    fieldset: CSR
+  - name: DIR
+    description: Debug Information register
+    byte_offset: 24
+    access: Read
+    fieldset: DIR
+fieldset/CR:
+  description: Control register
+  fields:
+  - name: SPDIFEN
+    description: Peripheral Block Enable
+    bit_offset: 0
+    bit_size: 2
+  - name: RXDMAEN
+    description: Receiver DMA ENable for data flow
+    bit_offset: 2
+    bit_size: 1
+  - name: RXSTEO
+    description: STerEO Mode
+    bit_offset: 3
+    bit_size: 1
+  - name: DRFMT
+    description: RX Data format
+    bit_offset: 4
+    bit_size: 2
+  - name: PMSK
+    description: Mask Parity error bit
+    bit_offset: 6
+    bit_size: 1
+  - name: VMSK
+    description: Mask of Validity bit
+    bit_offset: 7
+    bit_size: 1
+  - name: CUMSK
+    description: Mask of channel status and user bits
+    bit_offset: 8
+    bit_size: 1
+  - name: PTMSK
+    description: Mask of Preamble Type bits
+    bit_offset: 9
+    bit_size: 1
+  - name: CBDMAEN
+    description: Control Buffer DMA ENable for control flow
+    bit_offset: 10
+    bit_size: 1
+  - name: CHSEL
+    description: Channel Selection
+    bit_offset: 11
+    bit_size: 1
+  - name: NBTR
+    description: Maximum allowed re-tries during synchronization phase
+    bit_offset: 12
+    bit_size: 2
+  - name: WFA
+    description: Wait For Activity
+    bit_offset: 14
+    bit_size: 1
+  - name: INSEL
+    description: input selection
+    bit_offset: 16
+    bit_size: 3
+  - name: CKSEN
+    description: Symbol Clock Enable
+    bit_offset: 20
+    bit_size: 1
+  - name: CKSBKPEN
+    description: Backup Symbol Clock Enable
+    bit_offset: 21
+    bit_size: 1
+fieldset/CSR:
+  description: Channel Status register
+  fields:
+  - name: USR
+    description: User data information
+    bit_offset: 0
+    bit_size: 16
+  - name: CS
+    description: Channel A status information
+    bit_offset: 16
+    bit_size: 8
+  - name: SOB
+    description: Start Of Block
+    bit_offset: 24
+    bit_size: 1
+fieldset/DIR:
+  description: Debug Information register
+  fields:
+  - name: THI
+    description: Threshold HIGH
+    bit_offset: 0
+    bit_size: 13
+  - name: TLO
+    description: Threshold LOW
+    bit_offset: 16
+    bit_size: 13
+fieldset/FMT0_DR:
+  description: FMT0 data input register
+  fields:
+  - name: DR
+    description: Parity Error bit
+    bit_offset: 0
+    bit_size: 24
+  - name: PE
+    description: Parity Error bit
+    bit_offset: 24
+    bit_size: 1
+  - name: V
+    description: Validity bit
+    bit_offset: 25
+    bit_size: 1
+  - name: U
+    description: User bit
+    bit_offset: 26
+    bit_size: 1
+  - name: C
+    description: Channel Status bit
+    bit_offset: 27
+    bit_size: 1
+  - name: PT
+    description: Preamble Type
+    bit_offset: 28
+    bit_size: 2
+fieldset/FMT1_DR:
+  description: FMT1 data input register
+  fields:
+  - name: PE
+    description: Parity Error bit
+    bit_offset: 0
+    bit_size: 1
+  - name: V
+    description: Validity bit
+    bit_offset: 1
+    bit_size: 1
+  - name: U
+    description: User bit
+    bit_offset: 2
+    bit_size: 1
+  - name: C
+    description: Channel Status bit
+    bit_offset: 3
+    bit_size: 1
+  - name: PT
+    description: Preamble Type
+    bit_offset: 4
+    bit_size: 2
+  - name: DR
+    description: Parity Error bit
+    bit_offset: 8
+    bit_size: 24
+fieldset/FMT2_DR:
+  description: FMT2 data input register
+  fields:
+  - name: DRNL1
+    description: Channel A data value
+    bit_offset: 0
+    bit_size: 16
+  - name: DRNL2
+    description: Channel B data value
+    bit_offset: 16
+    bit_size: 16
+fieldset/IFCR:
+  description: Interrupt Flag Clear register
+  fields:
+  - name: PERRCF
+    description: Clears the Parity error flag
+    bit_offset: 2
+    bit_size: 1
+  - name: OVRCF
+    description: Clears the Overrun error flag
+    bit_offset: 3
+    bit_size: 1
+  - name: SBDCF
+    description: Clears the Synchronization Block Detected flag
+    bit_offset: 4
+    bit_size: 1
+  - name: SYNCDCF
+    description: Clears the Synchronization Done flag
+    bit_offset: 5
+    bit_size: 1
+fieldset/IMR:
+  description: Interrupt mask register
+  fields:
+  - name: RXNEIE
+    description: RXNE interrupt enable
+    bit_offset: 0
+    bit_size: 1
+  - name: CSRNEIE
+    description: Control Buffer Ready Interrupt Enable
+    bit_offset: 1
+    bit_size: 1
+  - name: PERRIE
+    description: Parity error interrupt enable
+    bit_offset: 2
+    bit_size: 1
+  - name: OVRIE
+    description: Overrun error Interrupt Enable
+    bit_offset: 3
+    bit_size: 1
+  - name: SBLKIE
+    description: Synchronization Block Detected Interrupt Enable
+    bit_offset: 4
+    bit_size: 1
+  - name: SYNCDIE
+    description: Synchronization Done
+    bit_offset: 5
+    bit_size: 1
+  - name: IFEIE
+    description: Serial Interface Error Interrupt Enable
+    bit_offset: 6
+    bit_size: 1
+fieldset/SR:
+  description: Status register
+  fields:
+  - name: RXNE
+    description: Read data register not empty
+    bit_offset: 0
+    bit_size: 1
+  - name: CSRNE
+    description: Control Buffer register is not empty
+    bit_offset: 1
+    bit_size: 1
+  - name: PERR
+    description: Parity error
+    bit_offset: 2
+    bit_size: 1
+  - name: OVR
+    description: Overrun error
+    bit_offset: 3
+    bit_size: 1
+  - name: SBD
+    description: Synchronization Block Detected
+    bit_offset: 4
+    bit_size: 1
+  - name: SYNCD
+    description: Synchronization Done
+    bit_offset: 5
+    bit_size: 1
+  - name: FERR
+    description: Framing error
+    bit_offset: 6
+    bit_size: 1
+  - name: SERR
+    description: Synchronization error
+    bit_offset: 7
+    bit_size: 1
+  - name: TERR
+    description: Time-out error
+    bit_offset: 8
+    bit_size: 1
+  - name: WIDTH
+    description: Duration of 5 symbols counted with SPDIF_CLK
+    bit_offset: 16
+    bit_size: 15

--- a/stm32-data-gen/src/dma.rs
+++ b/stm32-data-gen/src/dma.rs
@@ -143,6 +143,12 @@ impl DmaChannels {
                             for (request_name, request_num) in y {
                                 let parts: Vec<_> = request_name.split('_').collect();
                                 let target_peri_name = parts[0];
+
+                                let target_peri_name = match target_peri_name {
+                                    "SPDIF" => "SPDIFRX1",
+                                    x => x,
+                                };
+
                                 let request = {
                                     if parts.len() < 2 {
                                         target_peri_name
@@ -259,6 +265,7 @@ impl DmaChannels {
                             if target_name != "MEMTOMEM" {
                                 let target_peri_name = match target_peri_name {
                                     "LPUART" => "LPUART1",
+                                    "SPDIF" => "SPDIFRX1",
                                     x => x,
                                 };
                                 for request in target_requests {

--- a/stm32-data-gen/src/header.rs
+++ b/stm32-data-gen/src/header.rs
@@ -174,6 +174,7 @@ impl Defines {
                 "OCTOSPI2",
                 &["OCTOSPI2_R_BASE", "OCTOSPI2_R_BASE_NS", "OCTOSPI2_REG_BASE"],
             ),
+            ("SPDIFRX1", &["SPDIFRX_BASE"]),
             ("FLASH", &["FLASH_R_BASE", "FLASH_REG_BASE"]),
             ("DAC", &["DAC1_BASE", "DAC_BASE"]),
             ("DAC1", &["DAC1_BASE", "DAC_BASE"]),

--- a/stm32-data-gen/src/normalize_peris.rs
+++ b/stm32-data-gen/src/normalize_peris.rs
@@ -7,6 +7,7 @@ static NORMALIZE: &[(&str, &str)] = &[
     ("SUBGHZ", "SUBGHZSPI"),
     ("USB_DRD_FS", "USB"),
     ("SBS", "SYSCFG"),
+    ("SPDIFRX", "SPDIFRX1")
 ];
 
 pub fn normalize_peri_name(name: &str) -> &str {

--- a/stm32-data-gen/src/perimap.rs
+++ b/stm32-data-gen/src/perimap.rs
@@ -197,6 +197,7 @@ pub static PERIMAP: RegexMap<(&str, &str, &str)> = RegexMap::new(&[
     (".*:SDIO:sdmmc_v1_2", ("sdmmc", "v1", "SDMMC")),
     (".*:SDMMC:sdmmc_v1_3", ("sdmmc", "v1", "SDMMC")),
     (".*:SPDIFRX:spdifrx1_v1_0", ("spdifrx", "v1", "SPDIFRX")),
+    (".*:SPDIFRX:spdifrx1_H7", ("spdifrx", "h7", "SPDIFRX")),
     // # USB
     ("STM32(F1|L1).*:USB:.*", ("usb", "v1", "USB")),
     ("STM32(F1|L1).*:USBRAM:.*", ("usbram", "16x1_512", "USBRAM")),


### PR DESCRIPTION
The STM32H7 SPDIFRX peripheral is slightly different from the existing one in the F4 and F7 series, so this adds support for the new version. The change is in the data register that can now have three different mappings, depending on a setting in the control register.

~~There is one problem that I don't know how to solve. This does not yet enable the `spdifrx` feature flag when building for (in my case) the `STM32H723VG` in embassy. I am trying to implement support for SPDIFRX there and this is the chip I will test it on.~~
I think that's not true, only my rust-analyzer tricking me. The verbose build does show `--cfg spdifrx` and `-cfg spdifrx_h7`.