### PR TITLE
Add OTGHS to USB_OTG_HS fallback clocks

### DIFF
--- a/stm32-data-gen/src/rcc.rs
+++ b/stm32-data-gen/src/rcc.rs
@@ -305,7 +305,7 @@ impl ParsedRccs {
             ("I2C5", &["I2C1235"]),
             ("USB", &["USB", "CLK48", "ICLK"]),
             ("USB_OTG_FS", &["USB", "CLK48", "ICLK"]),
-            ("USB_OTG_HS", &["USB", "USBPHYC", "CLK48", "ICLK"]),
+            ("USB_OTG_HS", &["USB", "USBPHYC", "OTGHS", "CLK48", "ICLK"]),
         ];
 
         let rcc = self.rccs.get(rcc_version)?;


### PR DESCRIPTION
This is needed for STM32U5 series USB_OTH_HS.