### PR TITLE
FMC Base Address Fix

### DIFF
--- a/d.ps1
+++ b/d.ps1
@@ -6,7 +6,7 @@ param (
     [string]$peri
 )
 
-$REV="74b97817d4c4ed0db9d19a8eac46720b3c5b0d57"
+$REV="709c1060ac2ec57f6042f2b4eb9cf8c1821a6c57"
 
 Switch ($CMD)
 {

--- a/stm32-data-gen/src/header.rs
+++ b/stm32-data-gen/src/header.rs
@@ -185,7 +185,7 @@ impl Defines {
                 &["ADC1_COMMON_BASE", "ADC_COMMON_BASE", "ADC1_COMMON", "ADC_COMMON"],
             ),
             ("CAN", &["CAN_BASE", "CAN1_BASE"]),
-            ("FMC", &["FMC_BASE", "FMC_R_BASE"]),
+            ("FMC", &["FMC_R_BASE", "FMC_R_BASE_NS"]),
             ("FSMC", &["FSMC_R_BASE"]),
             ("USB", &["USB_BASE", "USB_DRD_BASE", "USB_BASE_NS", "USB_DRD_BASE_NS"]),
             (


### PR DESCRIPTION
Fix FMC base address and update `stm32-data-sources` revision in windows build script to match the linux one.

FMC base address was pointing to the wrong address (`0x6000_0000` instead of `0x4700_0400`). See related issue here - #462 .
Tested by building the project on Windows according to the README and utilizing the FMC with supported board (STM32H573).