### PR TITLE
Add missing STM32U5 SYSCFG and PWR registers

### DIFF
--- a/data/registers/pwr_u5.yaml
+++ b/data/registers/pwr_u5.yaml
@@ -467,6 +467,10 @@ fieldset/UCPDR:
 fieldset/VOSR:
   description: voltage scaling register
   fields:
+  - name: USBBOOSTRDY
+    description: "OTG_HS EPOD booster ready\r This bit is set to one by hardware when the power booster startup time is reached. The OTG_HS clock can be provided only after this bit is set."
+    bit_offset: 13
+    bit_size: 1
   - name: BOOSTRDY
     description: "EPOD booster ready\r This bit is set to 1 by hardware when the power booster startup time is reached. The system clock frequency can be switched higher than 50 MHz only after this bit is set."
     bit_offset: 14
@@ -483,6 +487,18 @@ fieldset/VOSR:
   - name: BOOSTEN
     description: EPOD booster enable
     bit_offset: 18
+    bit_size: 1
+  - name: USBPWREN
+    description: OTG_HS power enable
+    bit_offset: 19
+    bit_size: 1
+  - name: USBBOOSTEN
+    description: OTG_HS EPOD booster enable
+    bit_offset: 20
+    bit_size: 1
+  - name: VDD11USBDIS
+    description: OTG_HS VDD11USB disable
+    bit_offset: 21
     bit_size: 1
 fieldset/WUCR1:
   description: wakeup control register 1

--- a/data/registers/syscfg_u5.yaml
+++ b/data/registers/syscfg_u5.yaml
@@ -50,6 +50,14 @@ block/SYSCFG:
     description: USB Type C and Power Delivery register
     byte_offset: 112
     fieldset: UCPDR
+  - name: OTGHSPHYCR
+    description: OTG_HS PHY register
+    byte_offset: 116
+    fieldset: OTGHSPHYCR
+  - name: OTGHSPHYTUNER2
+    description: OTG_HS PHY tune register 2
+    byte_offset: 124
+    fieldset: OTGHSPHYTUNER2
 fieldset/CCCR:
   description: compensation cell code register
   fields:
@@ -238,3 +246,33 @@ fieldset/UCPDR:
     description: CC2ENRXFILTER
     bit_offset: 1
     bit_size: 1
+fieldset/OTGHSPHYCR:
+  description: OTG_HS PHY register
+  fields:
+  - name: EN
+    description: PHY Enable
+    bit_offset: 0
+    bit_size: 1
+  - name: PDCTRL
+    description: Common block power-down control
+    bit_offset: 1
+    bit_size: 1
+  - name: CLKSEL
+    description: Reference clock frequency selection
+    bit_offset: 2
+    bit_size: 4
+fieldset/OTGHSPHYTUNER2:
+  description: OTG_HS tune register 2
+  fields:
+  - name: COMPDISTUNE
+    description: Disconnect threshold adjustment
+    bit_offset: 0
+    bit_size: 3
+  - name: SQRXTUNE
+    description: Squelch threshold adjustment
+    bit_offset: 4
+    bit_size: 3
+  - name: TXPREEMPAMPTUNE
+    description: HS transmitter preemphasis current control
+    bit_offset: 13
+    bit_size: 2


### PR DESCRIPTION
This adds some missing register definitions as noted in #519 to enable the USB OTG_HS PHY on some STM32U5 platforms.