### PR TITLE
Support STM32H23x and STM32H33x ADCs

### DIFF
--- a/stm32-data-gen/src/perimap.rs
+++ b/stm32-data-gen/src/perimap.rs
@@ -100,6 +100,7 @@ pub static PERIMAP: RegexMap<(&str, &str, &str)> = RegexMap::new(&[
     (".*:ADC:aditf5_v2_2", ("adc", "v3", "ADC")),
     (".*:ADC:aditf5_v3_0", ("adc", "v4", "ADC")),
     (".*:ADC:aditf5_v3_0_H5", ("adc", "h5", "ADC")),
+    (".*:ADC:aditf512_v3_0_H5", ("adc", "h5", "ADC")),
     (".*:ADC:aditf5_v3_1", ("adc", "v4", "ADC")),
     ("STM32WL5.*:ADC:.*", ("adc", "g0", "ADC")),
     ("STM32WLE.*:ADC:.*", ("adc", "g0", "ADC")),


### PR DESCRIPTION
The aditf512_v3_0_H5 peripheral definition seems to be the same as the aditf5_v3_0_H5, just cleaned up.

Fixes #477