### PR TITLE
Rename HRTIM FAULTX bits to FAULT

### DIFF
--- a/data/registers/hrtim_v1.yaml
+++ b/data/registers/hrtim_v1.yaml
@@ -1735,7 +1735,7 @@ fieldset/TIMXOUTR:
       offsets:
       - 0
       - 16
-  - name: FAULTX
+  - name: FAULT
     description: Output X Fault state
     bit_offset: 4
     bit_size: 2

--- a/data/registers/hrtim_v2.yaml
+++ b/data/registers/hrtim_v2.yaml
@@ -1732,7 +1732,7 @@ fieldset/TIMXOUTR:
       offsets:
       - 0
       - 16
-  - name: FAULTX
+  - name: FAULT
     description: Output X Fault state
     bit_offset: 4
     bit_size: 2


### PR DESCRIPTION
This is consistent with the STM32 datasheet as well as all the other bitfields in the HRTIM_OUTxR register.

STM32H743 reference manual (HRTIMv2):

![2024-12-04-101132_733x997_scrot](https://github.com/user-attachments/assets/8ec9108a-3ce5-4548-a5e9-4366b815978a)
