### PR TITLE
Convert HRTIM boolean-like enums to bool

### DIFF
--- a/data/registers/hrtim_v1.yaml
+++ b/data/registers/hrtim_v1.yaml
@@ -1191,12 +1191,10 @@ fieldset/TIMXCCR:
     description: Software Capture
     bit_offset: 0
     bit_size: 1
-    enum: CAPTUREEFFECT
   - name: UPDCPT
     description: Update Capture
     bit_offset: 1
     bit_size: 1
-    enum: CAPTUREEFFECT
   - name: EXEVCPT
     description: External Event X Capture
     bit_offset: 2
@@ -1204,17 +1202,14 @@ fieldset/TIMXCCR:
     array:
       len: 10
       stride: 1
-    enum: CAPTUREEFFECT
   - name: TXSET
     description: Timer X output Set
     bit_offset: 16
     bit_size: 1
-    enum: CAPTUREEFFECT
   - name: TXRST
     description: Timer X output Reset
     bit_offset: 17
     bit_size: 1
-    enum: CAPTUREEFFECT
   - name: TXCMP
     description: Timer X Compare X
     bit_offset: 18
@@ -1222,17 +1217,14 @@ fieldset/TIMXCCR:
     array:
       len: 2
       stride: 1
-    enum: CAPTUREEFFECT
   - name: TYSET
     description: Timer Y output Set
     bit_offset: 20
     bit_size: 1
-    enum: CAPTUREEFFECT
   - name: TYRST
     description: Timer Y output Reset
     bit_offset: 21
     bit_size: 1
-    enum: CAPTUREEFFECT
   - name: TYCMP
     description: Timer Y Compare X
     bit_offset: 22
@@ -1240,17 +1232,14 @@ fieldset/TIMXCCR:
     array:
       len: 2
       stride: 1
-    enum: CAPTUREEFFECT
   - name: TZSET
     description: Timer Z output Set
     bit_offset: 24
     bit_size: 1
-    enum: CAPTUREEFFECT
   - name: TZRST
     description: Timer Z output Reset
     bit_offset: 25
     bit_size: 1
-    enum: CAPTUREEFFECT
   - name: TZCMP
     description: Timer Z Compare X
     bit_offset: 26
@@ -1258,17 +1247,14 @@ fieldset/TIMXCCR:
     array:
       len: 2
       stride: 1
-    enum: CAPTUREEFFECT
   - name: TTSET
     description: Timer T output Set
     bit_offset: 28
     bit_size: 1
-    enum: CAPTUREEFFECT
   - name: TTRST
     description: Timer T output Reset
     bit_offset: 29
     bit_size: 1
-    enum: CAPTUREEFFECT
   - name: TTCMP
     description: Timer T Compare X
     bit_offset: 30
@@ -1276,7 +1262,6 @@ fieldset/TIMXCCR:
     array:
       len: 2
       stride: 1
-    enum: CAPTUREEFFECT
 fieldset/TIMXCHP:
   description: Timerx Chopper Register
   fields:
@@ -1351,12 +1336,10 @@ fieldset/TIMXCR:
     description: Synchronization Resets Timer X
     bit_offset: 10
     bit_size: 1
-    enum: SYNCRST
   - name: SYNCSTRT
     description: Synchronization Starts Timer X
     bit_offset: 11
     bit_size: 1
-    enum: SYNCSTRT
   - name: DELCMP2
     description: Delayed CMP2 mode
     bit_offset: 12
@@ -1577,7 +1560,6 @@ fieldset/TIMXFLT:
     array:
       len: 5
       stride: 1
-    enum: FLTEN
   - name: FLTLCK
     description: Fault sources Lock
     bit_offset: 31
@@ -1680,7 +1662,6 @@ fieldset/TIMXISR:
     description: Delayed Protection Flag
     bit_offset: 14
     bit_size: 1
-    enum: TIMAISR_DLYPRT
   - name: CPPSTAT
     description: Current Push Pull Status
     bit_offset: 16
@@ -1698,7 +1679,6 @@ fieldset/TIMXISR:
     array:
       len: 2
       stride: 1
-    enum: OUTPUTSTATE
   - name: OCPY
     description: Output X Copy
     bit_offset: 20
@@ -1706,7 +1686,6 @@ fieldset/TIMXISR:
     array:
       len: 2
       stride: 1
-    enum: OUTPUTSTATE
 fieldset/TIMXOUTR:
   description: Timerx Output Register
   fields:
@@ -1794,7 +1773,6 @@ fieldset/TIMXRST:
     description: Timer X Update reset
     bit_offset: 1
     bit_size: 1
-    enum: RESETEFFECT
   - name: CMP
     description: Timer X compare X reset
     bit_offset: 2
@@ -1802,12 +1780,10 @@ fieldset/TIMXRST:
     array:
       len: 2
       stride: 1
-    enum: RESETEFFECT
   - name: MSTPER
     description: Master timer Period
     bit_offset: 4
     bit_size: 1
-    enum: RESETEFFECT
   - name: MSTCMP
     description: Master compare X
     bit_offset: 5
@@ -1815,7 +1791,6 @@ fieldset/TIMXRST:
     array:
       len: 4
       stride: 1
-    enum: RESETEFFECT
   - name: EXTEVNT
     description: External Event X
     bit_offset: 9
@@ -1823,7 +1798,6 @@ fieldset/TIMXRST:
     array:
       len: 10
       stride: 1
-    enum: RESETEFFECT
   - name: TCMP1
     description: Timer X compare 1 event
     bit_offset: 19
@@ -1834,7 +1808,6 @@ fieldset/TIMXRST:
       - 3
       - 6
       - 9
-    enum: RESETEFFECT
   - name: TCMP2
     description: Timer X compare 2 event
     bit_offset: 20
@@ -1845,7 +1818,6 @@ fieldset/TIMXRST:
       - 3
       - 6
       - 9
-    enum: RESETEFFECT
   - name: TCMP4
     description: Timer X compare 4 event
     bit_offset: 21
@@ -1856,7 +1828,6 @@ fieldset/TIMXRST:
       - 3
       - 6
       - 9
-    enum: RESETEFFECT
 fieldset/TIMXRSTR:
   description: Timerx OutputX Reset Register
   fields:
@@ -1864,17 +1835,14 @@ fieldset/TIMXRSTR:
     description: Software Reset trigger
     bit_offset: 0
     bit_size: 1
-    enum: INACTIVEEFFECT
   - name: RESYNC
     description: Timer X resynchronizaton
     bit_offset: 1
     bit_size: 1
-    enum: INACTIVEEFFECT
   - name: PER
     description: Timer X Period
     bit_offset: 2
     bit_size: 1
-    enum: INACTIVEEFFECT
   - name: CMP
     description: Timer X compare X
     bit_offset: 3
@@ -1882,12 +1850,10 @@ fieldset/TIMXRSTR:
     array:
       len: 4
       stride: 1
-    enum: INACTIVEEFFECT
   - name: MSTPER
     description: Master Period
     bit_offset: 7
     bit_size: 1
-    enum: INACTIVEEFFECT
   - name: MSTCMP
     description: Master Compare X
     bit_offset: 8
@@ -1895,7 +1861,6 @@ fieldset/TIMXRSTR:
     array:
       len: 4
       stride: 1
-    enum: INACTIVEEFFECT
   - name: TIMEVNT
     description: Timer Event X
     bit_offset: 12
@@ -1903,7 +1868,6 @@ fieldset/TIMXRSTR:
     array:
       len: 9
       stride: 1
-    enum: INACTIVEEFFECT
   - name: EXTEVNT
     description: External Event X
     bit_offset: 21
@@ -1911,12 +1875,10 @@ fieldset/TIMXRSTR:
     array:
       len: 10
       stride: 1
-    enum: INACTIVEEFFECT
   - name: UPDATE
     description: Registers update (transfer preload to active)
     bit_offset: 31
     bit_size: 1
-    enum: INACTIVEEFFECT
 fieldset/TIMXSETR:
   description: Timerx OutputX Set Register
   fields:
@@ -1924,17 +1886,14 @@ fieldset/TIMXSETR:
     description: Software Set trigger
     bit_offset: 0
     bit_size: 1
-    enum: ACTIVEEFFECT
   - name: RESYNC
     description: Timer X resynchronizaton
     bit_offset: 1
     bit_size: 1
-    enum: ACTIVEEFFECT
   - name: PER
     description: Timer X Period
     bit_offset: 2
     bit_size: 1
-    enum: ACTIVEEFFECT
   - name: CMP
     description: Timer X compare X
     bit_offset: 3
@@ -1942,12 +1901,10 @@ fieldset/TIMXSETR:
     array:
       len: 4
       stride: 1
-    enum: ACTIVEEFFECT
   - name: MSTPER
     description: Master Period
     bit_offset: 7
     bit_size: 1
-    enum: ACTIVEEFFECT
   - name: MSTCMPX
     description: Master Compare X
     bit_offset: 8
@@ -1955,7 +1912,6 @@ fieldset/TIMXSETR:
     array:
       len: 4
       stride: 1
-    enum: ACTIVEEFFECT
   - name: TIMEVNT
     description: Timer Event X
     bit_offset: 12
@@ -1963,7 +1919,6 @@ fieldset/TIMXSETR:
     array:
       len: 9
       stride: 1
-    enum: ACTIVEEFFECT
   - name: EXTEVNT
     description: External Event X
     bit_offset: 21
@@ -1971,21 +1926,10 @@ fieldset/TIMXSETR:
     array:
       len: 10
       stride: 1
-    enum: ACTIVEEFFECT
   - name: UPDATE
     description: Registers update (transfer preload to active)
     bit_offset: 31
     bit_size: 1
-    enum: ACTIVEEFFECT
-enum/ACTIVEEFFECT:
-  bit_size: 1
-  variants:
-  - name: NoEffect
-    description: Timer event has no effect
-    value: 0
-  - name: SetActive
-    description: Timer event forces the output to its active state
-    value: 1
 enum/BRSTDMA:
   bit_size: 2
   variants:
@@ -1998,15 +1942,6 @@ enum/BRSTDMA:
   - name: Rollover
     description: Update done on master timer roll-over following a DMA burst transfer completion
     value: 2
-enum/CAPTUREEFFECT:
-  bit_size: 1
-  variants:
-  - name: NoEffect
-    description: Timer event has no effect
-    value: 0
-  - name: TriggerCapture
-    description: Timer event triggers capture
-    value: 1
 enum/CPPSTAT:
   bit_size: 1
   variants:
@@ -2139,24 +2074,6 @@ enum/FAULT:
   - name: SetHighZ
     description: Output goes to high-z state after a fault event
     value: 3
-enum/FLTEN:
-  bit_size: 1
-  variants:
-  - name: Ignored
-    description: Fault input ignored
-    value: 0
-  - name: Active
-    description: Fault input is active and can disable HRTIM outputs
-    value: 1
-enum/INACTIVEEFFECT:
-  bit_size: 1
-  variants:
-  - name: NoEffect
-    description: Timer event has no effect
-    value: 0
-  - name: SetInactive
-    description: Timer event forces the output to its inactive state
-    value: 1
 enum/IPPSTAT:
   bit_size: 1
   variants:
@@ -2166,15 +2083,6 @@ enum/IPPSTAT:
   - name: Output2Active
     description: Protection occurred when the output 2 was active and output 1 forced inactive
     value: 1
-enum/OUTPUTSTATE:
-  bit_size: 1
-  variants:
-  - name: Inactive
-    description: Output is or was inactive
-    value: 0
-  - name: Active
-    description: Output is or was active
-    value: 1
 enum/POL:
   bit_size: 1
   variants:
@@ -2183,15 +2091,6 @@ enum/POL:
     value: 0
   - name: ActiveLow
     description: Negative polarity (output active low)
-    value: 1
-enum/RESETEFFECT:
-  bit_size: 1
-  variants:
-  - name: NoEffect
-    description: Timer Y compare Z event has no effect
-    value: 0
-  - name: ResetCounter
-    description: Timer X counter is reset upon timer Y compare Z event
     value: 1
 enum/SDTF:
   bit_size: 1
@@ -2235,15 +2134,6 @@ enum/SYNCOUT:
   - name: NegativePulse
     description: Negative pulse on SCOUT output (16x f_HRTIM clock cycles)
     value: 3
-enum/SYNCRST:
-  bit_size: 1
-  variants:
-  - name: Disabled
-    description: Synchronization event has no effect on Timer x
-    value: 0
-  - name: Reset
-    description: Synchronization event resets Timer x
-    value: 1
 enum/SYNCSRC:
   bit_size: 2
   variants:
@@ -2259,24 +2149,6 @@ enum/SYNCSRC:
   - name: TimerACompare1
     description: Timer A Compare 1 event
     value: 3
-enum/SYNCSTRT:
-  bit_size: 1
-  variants:
-  - name: Disabled
-    description: Synchronization event has no effect on Timer x
-    value: 0
-  - name: Start
-    description: Synchronization event starts Timer x
-    value: 1
-enum/TIMAISR_DLYPRT:
-  bit_size: 1
-  variants:
-  - name: Inactive
-    description: Not in delayed idle or balanced idle mode
-    value: 0
-  - name: Active
-    description: Delayed idle or balanced idle mode entry
-    value: 1
 enum/UPDGAT:
   bit_size: 4
   variants:

--- a/data/registers/hrtim_v2.yaml
+++ b/data/registers/hrtim_v2.yaml
@@ -1188,12 +1188,10 @@ fieldset/TIMXCCR:
     description: Software Capture
     bit_offset: 0
     bit_size: 1
-    enum: CAPTUREEFFECT
   - name: UPDCPT
     description: Update Capture
     bit_offset: 1
     bit_size: 1
-    enum: CAPTUREEFFECT
   - name: EXEVCPT
     description: External Event X Capture
     bit_offset: 2
@@ -1201,17 +1199,14 @@ fieldset/TIMXCCR:
     array:
       len: 10
       stride: 1
-    enum: CAPTUREEFFECT
   - name: TXSET
     description: Timer X output Set
     bit_offset: 16
     bit_size: 1
-    enum: CAPTUREEFFECT
   - name: TXRST
     description: Timer X output Reset
     bit_offset: 17
     bit_size: 1
-    enum: CAPTUREEFFECT
   - name: TXCMP
     description: Timer X Compare X
     bit_offset: 18
@@ -1219,17 +1214,14 @@ fieldset/TIMXCCR:
     array:
       len: 2
       stride: 1
-    enum: CAPTUREEFFECT
   - name: TYSET
     description: Timer Y output Set
     bit_offset: 20
     bit_size: 1
-    enum: CAPTUREEFFECT
   - name: TYRST
     description: Timer Y output Reset
     bit_offset: 21
     bit_size: 1
-    enum: CAPTUREEFFECT
   - name: TYCMP
     description: Timer Y Compare X
     bit_offset: 22
@@ -1237,17 +1229,14 @@ fieldset/TIMXCCR:
     array:
       len: 2
       stride: 1
-    enum: CAPTUREEFFECT
   - name: TZSET
     description: Timer Z output Set
     bit_offset: 24
     bit_size: 1
-    enum: CAPTUREEFFECT
   - name: TZRST
     description: Timer Z output Reset
     bit_offset: 25
     bit_size: 1
-    enum: CAPTUREEFFECT
   - name: TZCMP
     description: Timer Z Compare X
     bit_offset: 26
@@ -1255,17 +1244,14 @@ fieldset/TIMXCCR:
     array:
       len: 2
       stride: 1
-    enum: CAPTUREEFFECT
   - name: TTSET
     description: Timer T output Set
     bit_offset: 28
     bit_size: 1
-    enum: CAPTUREEFFECT
   - name: TTRST
     description: Timer T output Reset
     bit_offset: 29
     bit_size: 1
-    enum: CAPTUREEFFECT
   - name: TTCMP
     description: Timer T Compare X
     bit_offset: 30
@@ -1273,7 +1259,6 @@ fieldset/TIMXCCR:
     array:
       len: 2
       stride: 1
-    enum: CAPTUREEFFECT
 fieldset/TIMXCHP:
   description: Timerx Chopper Register
   fields:
@@ -1348,12 +1333,10 @@ fieldset/TIMXCR:
     description: Synchronization Resets Timer X
     bit_offset: 10
     bit_size: 1
-    enum: SYNCRST
   - name: SYNCSTRT
     description: Synchronization Starts Timer X
     bit_offset: 11
     bit_size: 1
-    enum: SYNCSTRT
   - name: DELCMP2
     description: Delayed CMP2 mode
     bit_offset: 12
@@ -1574,7 +1557,6 @@ fieldset/TIMXFLT:
     array:
       len: 5
       stride: 1
-    enum: FLTEN
   - name: FLTLCK
     description: Fault sources Lock
     bit_offset: 31
@@ -1677,7 +1659,6 @@ fieldset/TIMXISR:
     description: Delayed Protection Flag
     bit_offset: 14
     bit_size: 1
-    enum: TIMAISR_DLYPRT
   - name: CPPSTAT
     description: Current Push Pull Status
     bit_offset: 16
@@ -1695,7 +1676,6 @@ fieldset/TIMXISR:
     array:
       len: 2
       stride: 1
-    enum: OUTPUTSTATE
   - name: OCPY
     description: Output X Copy
     bit_offset: 20
@@ -1703,7 +1683,6 @@ fieldset/TIMXISR:
     array:
       len: 2
       stride: 1
-    enum: OUTPUTSTATE
 fieldset/TIMXOUTR:
   description: Timerx Output Register
   fields:
@@ -1798,12 +1777,10 @@ fieldset/TIMXRST:
       - 25
       - 28
       - 0
-    enum: RESETEFFECT
   - name: UPDT
     description: Timer X Update reset
     bit_offset: 1
     bit_size: 1
-    enum: RESETEFFECT
   - name: CMP
     description: Timer X compare X reset
     bit_offset: 2
@@ -1811,12 +1788,10 @@ fieldset/TIMXRST:
     array:
       len: 2
       stride: 1
-    enum: RESETEFFECT
   - name: MSTPER
     description: Master timer Period
     bit_offset: 4
     bit_size: 1
-    enum: RESETEFFECT
   - name: MSTCMP
     description: Master compare X
     bit_offset: 5
@@ -1824,7 +1799,6 @@ fieldset/TIMXRST:
     array:
       len: 4
       stride: 1
-    enum: RESETEFFECT
   - name: EXTEVNT
     description: External Event X
     bit_offset: 9
@@ -1832,7 +1806,6 @@ fieldset/TIMXRST:
     array:
       len: 10
       stride: 1
-    enum: RESETEFFECT
   - name: TCMP2
     description: Timer X compare 2 event
     bit_offset: 20
@@ -1844,7 +1817,6 @@ fieldset/TIMXRST:
       - 6
       - 9
       - 11
-    enum: RESETEFFECT
   - name: TCMP4
     description: Timer X compare 4 event
     bit_offset: 21
@@ -1855,7 +1827,6 @@ fieldset/TIMXRST:
       - 3
       - 6
       - 9
-    enum: RESETEFFECT
 fieldset/TIMXRSTR:
   description: Timerx OutputX Reset Register
   fields:
@@ -1863,17 +1834,14 @@ fieldset/TIMXRSTR:
     description: Software Reset trigger
     bit_offset: 0
     bit_size: 1
-    enum: INACTIVEEFFECT
   - name: RESYNC
     description: Timer X resynchronizaton
     bit_offset: 1
     bit_size: 1
-    enum: INACTIVEEFFECT
   - name: PER
     description: Timer X Period
     bit_offset: 2
     bit_size: 1
-    enum: INACTIVEEFFECT
   - name: CMP
     description: Timer X compare X
     bit_offset: 3
@@ -1881,12 +1849,10 @@ fieldset/TIMXRSTR:
     array:
       len: 4
       stride: 1
-    enum: INACTIVEEFFECT
   - name: MSTPER
     description: Master Period
     bit_offset: 7
     bit_size: 1
-    enum: INACTIVEEFFECT
   - name: MSTCMP
     description: Master Compare X
     bit_offset: 8
@@ -1894,7 +1860,6 @@ fieldset/TIMXRSTR:
     array:
       len: 4
       stride: 1
-    enum: INACTIVEEFFECT
   - name: TIMEVNT
     description: Timer Event X
     bit_offset: 12
@@ -1902,7 +1867,6 @@ fieldset/TIMXRSTR:
     array:
       len: 9
       stride: 1
-    enum: INACTIVEEFFECT
   - name: EXTEVNT
     description: External Event X
     bit_offset: 21
@@ -1910,12 +1874,10 @@ fieldset/TIMXRSTR:
     array:
       len: 10
       stride: 1
-    enum: INACTIVEEFFECT
   - name: UPDATE
     description: Registers update (transfer preload to active)
     bit_offset: 31
     bit_size: 1
-    enum: INACTIVEEFFECT
 fieldset/TIMXSETR:
   description: Timerx OutputX Set Register
   fields:
@@ -1923,17 +1885,14 @@ fieldset/TIMXSETR:
     description: Software Set trigger
     bit_offset: 0
     bit_size: 1
-    enum: ACTIVEEFFECT
   - name: RESYNC
     description: Timer X resynchronizaton
     bit_offset: 1
     bit_size: 1
-    enum: ACTIVEEFFECT
   - name: PER
     description: Timer X Period
     bit_offset: 2
     bit_size: 1
-    enum: ACTIVEEFFECT
   - name: CMP
     description: Timer X compare X
     bit_offset: 3
@@ -1941,12 +1900,10 @@ fieldset/TIMXSETR:
     array:
       len: 4
       stride: 1
-    enum: ACTIVEEFFECT
   - name: MSTPER
     description: Master Period
     bit_offset: 7
     bit_size: 1
-    enum: ACTIVEEFFECT
   - name: MSTCMPX
     description: Master Compare X
     bit_offset: 8
@@ -1954,7 +1911,6 @@ fieldset/TIMXSETR:
     array:
       len: 4
       stride: 1
-    enum: ACTIVEEFFECT
   - name: TIMEVNT
     description: Timer Event X
     bit_offset: 12
@@ -1962,7 +1918,6 @@ fieldset/TIMXSETR:
     array:
       len: 9
       stride: 1
-    enum: ACTIVEEFFECT
   - name: EXTEVNT
     description: External Event X
     bit_offset: 21
@@ -1970,21 +1925,10 @@ fieldset/TIMXSETR:
     array:
       len: 10
       stride: 1
-    enum: ACTIVEEFFECT
   - name: UPDATE
     description: Registers update (transfer preload to active)
     bit_offset: 31
     bit_size: 1
-    enum: ACTIVEEFFECT
-enum/ACTIVEEFFECT:
-  bit_size: 1
-  variants:
-  - name: NoEffect
-    description: Timer event has no effect
-    value: 0
-  - name: SetActive
-    description: Timer event forces the output to its active state
-    value: 1
 enum/BRSTDMA:
   bit_size: 2
   variants:
@@ -1997,15 +1941,6 @@ enum/BRSTDMA:
   - name: Rollover
     description: Update done on master timer roll-over following a DMA burst transfer completion
     value: 2
-enum/CAPTUREEFFECT:
-  bit_size: 1
-  variants:
-  - name: NoEffect
-    description: Timer event has no effect
-    value: 0
-  - name: TriggerCapture
-    description: Timer event triggers capture
-    value: 1
 enum/CPPSTAT:
   bit_size: 1
   variants:
@@ -2138,24 +2073,6 @@ enum/FAULT:
   - name: SetHighZ
     description: Output goes to high-z state after a fault event
     value: 3
-enum/FLTEN:
-  bit_size: 1
-  variants:
-  - name: Ignored
-    description: Fault input ignored
-    value: 0
-  - name: Active
-    description: Fault input is active and can disable HRTIM outputs
-    value: 1
-enum/INACTIVEEFFECT:
-  bit_size: 1
-  variants:
-  - name: NoEffect
-    description: Timer event has no effect
-    value: 0
-  - name: SetInactive
-    description: Timer event forces the output to its inactive state
-    value: 1
 enum/IPPSTAT:
   bit_size: 1
   variants:
@@ -2165,15 +2082,6 @@ enum/IPPSTAT:
   - name: Output2Active
     description: Protection occurred when the output 2 was active and output 1 forced inactive
     value: 1
-enum/OUTPUTSTATE:
-  bit_size: 1
-  variants:
-  - name: Inactive
-    description: Output is or was inactive
-    value: 0
-  - name: Active
-    description: Output is or was active
-    value: 1
 enum/POL:
   bit_size: 1
   variants:
@@ -2182,15 +2090,6 @@ enum/POL:
     value: 0
   - name: ActiveLow
     description: Negative polarity (output active low)
-    value: 1
-enum/RESETEFFECT:
-  bit_size: 1
-  variants:
-  - name: NoEffect
-    description: Timer Y compare Z event has no effect
-    value: 0
-  - name: ResetCounter
-    description: Timer X counter is reset upon timer Y compare Z event
     value: 1
 enum/SDTF:
   bit_size: 1
@@ -2234,15 +2133,6 @@ enum/SYNCOUT:
   - name: NegativePulse
     description: Negative pulse on SCOUT output (16x f_HRTIM clock cycles)
     value: 3
-enum/SYNCRST:
-  bit_size: 1
-  variants:
-  - name: Disabled
-    description: Synchronization event has no effect on Timer x
-    value: 0
-  - name: Reset
-    description: Synchronization event resets Timer x
-    value: 1
 enum/SYNCSRC:
   bit_size: 2
   variants:
@@ -2258,24 +2148,6 @@ enum/SYNCSRC:
   - name: TimerACompare1
     description: Timer A Compare 1 event
     value: 3
-enum/SYNCSTRT:
-  bit_size: 1
-  variants:
-  - name: Disabled
-    description: Synchronization event has no effect on Timer x
-    value: 0
-  - name: Start
-    description: Synchronization event starts Timer x
-    value: 1
-enum/TIMAISR_DLYPRT:
-  bit_size: 1
-  variants:
-  - name: Inactive
-    description: Not in delayed idle or balanced idle mode
-    value: 0
-  - name: Active
-    description: Delayed idle or balanced idle mode entry
-    value: 1
 enum/UPDGAT:
   bit_size: 4
   variants:


### PR DESCRIPTION
The following enums are removed from HRTIM register definitions, since they represent 1-bit values with unambiguous boolean interpretations:
* ACTIVEEFFECT (from Output Set register HRTIM_SETx?R)
* INACTIVEEFFECT (from Output Reset register HRTIM_RSTx?R)
* RESETEFFECT (from Reset register HRTIM_RSTxR)
* CAPTUREEFFECT (from Capture register HRTIM_CPT?xR)
* FLTEN (from Fault register HRTIM_FLTxR)
* OUTPUTSTATE and TIMAISR_DLYPRT (from Interrupt Status register HRTIM_TIMxISR)
* SYNCSTRT and SYNCRST (from Control register HRTIM_TIMxCR)

Happy to make changes if you disagree with the assessment of any of these as sufficiently boolean-like. Thanks!

We :heart: stm32-metapac