### PR TITLE
Fix BF1 enum

### DIFF
--- a/data/registers/ltdc_v1.yaml
+++ b/data/registers/ltdc_v1.yaml
@@ -480,7 +480,7 @@ enum/BF1:
     value: 4
   - name: Pixel
     description: BF1 = pixel alpha * constant alpha
-    value: 7
+    value: 6
 enum/BF2:
   bit_size: 3
   variants:


### PR DESCRIPTION
See [stm32f75xxx and stm32f74xxx reference manual](https://www.st.com/resource/en/reference_manual/dm00124865-stm32f75xxx-and-stm32f74xxx-advanced-arm-based-32-bit-mcus-stmicroelectronics.pdf) revision 8, section 18.7.21

I do not know with certainty that this change applies to all micros, because, to be quite frankly honest, I don't want to read 30 datasheets. However, I checked the one linked above and two others from different families (u5 and h7) and this change tracks in all of them.