### PR TITLE
Map h7rs TMPSENS* RCC fields to the DTS peripheral

### DIFF
--- a/stm32-data-gen/src/rcc.rs
+++ b/stm32-data-gen/src/rcc.rs
@@ -306,6 +306,7 @@ impl ParsedRccs {
             ("USB", &["USB", "CLK48", "ICLK"]),
             ("USB_OTG_FS", &["USB", "CLK48", "ICLK"]),
             ("USB_OTG_HS", &["USB", "USBPHYC", "OTGHS", "CLK48", "ICLK"]),
+            ("DTS", &["TMPSENS"]),
         ];
 
         let rcc = self.rccs.get(rcc_version)?;


### PR DESCRIPTION
Despite the reference manual and header files referring to these fields in terms of DTS, the SVD files insist on using TMPSENS.

I opted to do the mapping at lookup time rather than renaming all of the fields.