### PR TITLE
Correction to JEXTEN field name in JSQR

### DIFF
--- a/data/registers/adc_v4.yaml
+++ b/data/registers/adc_v4.yaml
@@ -514,7 +514,7 @@ fieldset/JSQR:
     description: group injected external trigger source
     bit_offset: 2
     bit_size: 5
-  - name: EXTEN
+  - name: JEXTEN
     description: group injected external trigger polarity
     bit_offset: 7
     bit_size: 2


### PR DESCRIPTION
This change was erroneously introduced (by me) in c039709968dae10e83bb7903731c27c3b49c9ebf, and only on the adc_v4. Whoops!