### PR TITLE
Add missing ALRWF bit to ICSR register in RTC v3 yamls

### DIFF
--- a/data/registers/rtc_v3.yaml
+++ b/data/registers/rtc_v3.yaml
@@ -360,6 +360,13 @@ fieldset/DR:
 fieldset/ICSR:
   description: Initialization control and status register
   fields:
+  - name: ALRWF
+    description: Alarm write enabled
+    bit_offset: 0
+    bit_size: 1
+    array:
+      len: 2
+      stride: 1
   - name: WUTWF
     description: Wakeup timer write enabled
     bit_offset: 2

--- a/data/registers/rtc_v3l5.yaml
+++ b/data/registers/rtc_v3l5.yaml
@@ -349,6 +349,13 @@ fieldset/DR:
 fieldset/ICSR:
   description: Initialization control and status register
   fields:
+  - name: ALRWF
+    description: Alarm write enabled
+    bit_offset: 0
+    bit_size: 1
+    array:
+      len: 2
+      stride: 1
   - name: WUTWF
     description: Wakeup timer write flag
     bit_offset: 2

--- a/data/registers/rtc_v3u5.yaml
+++ b/data/registers/rtc_v3u5.yaml
@@ -380,6 +380,13 @@ fieldset/DR:
 fieldset/ICSR:
   description: Initialization control and status register
   fields:
+  - name: ALRWF
+    description: Alarm write enabled
+    bit_offset: 0
+    bit_size: 1
+    array:
+      len: 2
+      stride: 1
   - name: WUTWF
     description: Wakeup timer write enabled
     bit_offset: 2


### PR DESCRIPTION
I'm currently working on implementing RTC alarms in `embassy-stm32` and noticed the `ALRWF` bit in the `ICSR` was missing in `stm32-metapac` for v3. So this PR adds the definition to the the RTC v3 definitions.