### PR TITLE
Fix naming of ALRIE flag in rtc_v3

### DIFF
--- a/data/registers/rtc_v3.yaml
+++ b/data/registers/rtc_v3.yaml
@@ -255,7 +255,7 @@ fieldset/CR:
     description: Timestamp enable
     bit_offset: 11
     bit_size: 1
-  - name: ALRAIE
+  - name: ALRIE
     description: Alarm interrupt enable
     bit_offset: 12
     bit_size: 1


### PR DESCRIPTION
All other variants name this flag ALRIE, but was named ALRAIE for v3. Probably a copy/paste error or missed rename.