### PR TITLE
Added STM32L4 OPAMP data

### DIFF
--- a/data/registers/opamp_l4.yaml
+++ b/data/registers/opamp_l4.yaml
@@ -1,0 +1,176 @@
+block/OPAMP:
+  description: Operational amplifiers.
+  items:
+  - name: CSR
+    description: OPAMP control/status register.
+    byte_offset: 0
+    fieldset: CSR
+  - name: OTR
+    description: OPAMP offset trimming register in normal mode.
+    byte_offset: 4
+    fieldset: OTR
+  - name: LPOTR
+    description: OPAMP offset trimming register in low-power mode.
+    byte_offset: 8
+    fieldset: LPOTR
+fieldset/CSR:
+  description: OPAMP control/status register.
+  fields:
+  - name: OPAEN
+    description: Operational amplifier Enable.
+    bit_offset: 0
+    bit_size: 1
+  - name: OPALPM
+    description: Operational amplifier Low Power Mode.
+    bit_offset: 1
+    bit_size: 1
+    enum: OPALPM
+  - name: OPAMODE
+    description: Operational amplifier PGA mode.
+    bit_offset: 2
+    bit_size: 2
+    enum: OPAMODE
+  - name: PGA_GAIN
+    description: Operational amplifier Programmable amplifier gain value.
+    bit_offset: 4
+    bit_size: 2
+    enum: PGA_GAIN
+  - name: VM_SEL
+    description: Inverting input selection.
+    bit_offset: 8
+    bit_size: 2
+    enum: VM_SEL
+  - name: VP_SEL
+    description: Non inverted input selection.
+    bit_offset: 10
+    bit_size: 1
+    enum: VP_SEL
+  - name: CALON
+    description: Calibration mode enabled.
+    bit_offset: 12
+    bit_size: 1
+  - name: CALSEL
+    description: Calibration selection.
+    bit_offset: 13
+    bit_size: 1
+    enum: CALSEL
+  - name: USERTRIM
+    description: allows to switch from AOP offset trimmed values to AOP offset.
+    bit_offset: 14
+    bit_size: 1
+    enum: USERTRIM
+  - name: CALOUT
+    description: Operational amplifier calibration output.
+    bit_offset: 15
+    bit_size: 1
+  - name: OPA_RANGE
+    description: Operational amplifier power supply range for stability.
+    bit_offset: 31
+    bit_size: 1
+    enum: OPA_RANGE
+fieldset/LPOTR:
+  description: OPAMP offset trimming register in low-power mode.
+  fields:
+  - name: TRIMLPOFFSETN
+    description: Trim for NMOS differential pairs.
+    bit_offset: 0
+    bit_size: 5
+  - name: TRIMLPOFFSETP
+    description: Trim for PMOS differential pairs.
+    bit_offset: 8
+    bit_size: 5
+fieldset/OTR:
+  description: OPAMP offset trimming register in normal mode.
+  fields:
+  - name: TRIMOFFSETN
+    description: Trim for NMOS differential pairs.
+    bit_offset: 0
+    bit_size: 5
+  - name: TRIMOFFSETP
+    description: Trim for PMOS differential pairs.
+    bit_offset: 8
+    bit_size: 5
+enum/CALSEL:
+  bit_size: 1
+  variants:
+  - name: NMOS
+    description: 0.2V applied to OPAMP inputs during calibration.
+    value: 0
+  - name: PMOS
+    description: VDDA-0.2V applied to OPAMP inputs during calibration".
+    value: 1
+enum/OPALPM:
+  bit_size: 1
+  variants:
+  - name: NORMAL
+    description: OpAmp in normal mode.
+    value: 0
+  - name: LOW
+    description: OpAmp in low power mode.
+    value: 1
+enum/OPAMODE:
+  bit_size: 2
+  variants:
+  - name: PGA_DISABLED
+    description: internal PGA diabled.
+    value: 0
+  - name: PGA_ENABLED
+    description: internal PGA enabled, gain programmed in PGA_GAIN.
+    value: 2
+  - name: FOLLOWER
+    description: internal follower.
+    value: 3
+enum/OPA_RANGE:
+  bit_size: 1
+  variants:
+  - name: LOW
+    description: low range (VDDA < 2.4V.
+    value: 0
+  - name: HIGH
+    description: low range (VDDA >2.4V.
+    value: 1
+enum/PGA_GAIN:
+  bit_size: 2
+  variants:
+  - name: Gain2
+    description: Gain 2.
+    value: 0
+  - name: Gain4
+    description: Gain 4.
+    value: 1
+  - name: Gain8
+    description: Gain 8.
+    value: 2
+  - name: Gain16
+    description: Gain 16.
+    value: 3
+enum/USERTRIM:
+  bit_size: 1
+  variants:
+  - name: Factory
+    description: Factory trim used.
+    value: 0
+  - name: User
+    description: User trim used.
+    value: 1
+enum/VM_SEL:
+  bit_size: 2
+  variants:
+  - name: GPIO
+    description: GPIO connectet to VINM.
+    value: 0
+  - name: LOW_LEAKAGE
+    description: Low leakage inputs connecte (only available in certen BGA cases.
+    value: 1
+  - name: PGA_MODE
+    description: OPAMP in PGA mode.
+    value: 2
+enum/VP_SEL:
+  bit_size: 1
+  variants:
+  - name: GPIO
+    description: GPIO connectet to VINP.
+    value: 0
+  - name: DAC
+    description: DAC connected to VPINP.
+    value: 1

--- a/stm32-data-gen/src/perimap.rs
+++ b/stm32-data-gen/src/perimap.rs
@@ -131,6 +131,7 @@ pub static PERIMAP: RegexMap<(&str, &str, &str)> = RegexMap::new(&[
     ("STM32F3.*:OPAMP:tsmc018_ull_opamp_v1_0", ("opamp", "f3", "OPAMP")),
     ("STM32H7.*:OPAMP:.*", ("opamp", "h_v1", "OPAMP")),
     ("STM32H5.*:OPAMP:.*", ("opamp", "h_v2", "OPAMP")),
+    ("STM32L4.*:OPAMP:.*", ("opamp", "l4", "OPAMP")),
     ("STM32U0.*:OPAMP:.*", ("opamp", "u0", "OPAMP")),
     (".*:DCMI:.*", ("dcmi", "v1", "DCMI")),
     ("STM32C0.*:SYSCFG:.*", ("syscfg", "c0", "SYSCFG")),

--- a/transforms/OPAMP.yaml
+++ b/transforms/OPAMP.yaml
@@ -1,6 +1,6 @@
 transforms:
   - !DeleteEnums
-    from: ^(LOCK)$
+    from: ^(LOCK|OPAMP2_.*)$
 
   - !DeleteFieldsets
     from: OPAMP2_.+
@@ -13,3 +13,12 @@ transforms:
   - !Rename
     from: OPAMP1_(.+)
     to: $1
+    type: All
+
+  - !Rename
+    from: ^CSR_(.+)
+    to: $1
+    type: All
+
+  - !DeleteEnums
+    from: ^(OPAEN|CALON)$


### PR DESCRIPTION
I currently work on an L4 where I need the OpAmp and had to find out the definitions are missing. This is my attempt at extracting the register information following the documentation in the Readme. I extended the existing transformers from other Opamps and used the extracted `l4x1.yaml` as base. All the `l4xx.yaml` are identical, except a description error in the `l4x3.yaml`. The other l4-Variants (`l412`, `l4[pr]x`) appeared to be diffenent.

I do have some questions:
* Some larger variants have two opamps. The existing transformers delete those. The register map for both OpAmps is identical with a different offset. So I think this is fine, but not really sure how this is handled.
* I applied some manual changes to the yaml besides the transformers:
  * For the descriptions I replaced with 's/OPAMP1/OPAMP/'
  * I had to manually delete the `OPAMP2` references in the `block/OPAMP`.