### PR TITLE
opamp_l4: align enable register name

### DIFF
--- a/data/registers/opamp_l4.yaml
+++ b/data/registers/opamp_l4.yaml
@@ -16,7 +16,7 @@ block/OPAMP:
 fieldset/CSR:
   description: OPAMP control/status register.
   fields:
-  - name: OPAEN
+  - name: OPAMPEN
     description: Operational amplifier Enable.
     bit_offset: 0
     bit_size: 1


### PR DESCRIPTION
rename OPAEN to OPAMPEN to match the name used by the other OPAMP variants