### PR TITLE
Incorrect bit size for FLASH_CR PNB for g4c4

### DIFF
--- a/data/registers/flash_g4c4.yaml
+++ b/data/registers/flash_g4c4.yaml
@@ -111,7 +111,7 @@ fieldset/CR:
   - name: PNB
     description: Page number
     bit_offset: 3
-    bit_size: 7
+    bit_size: 8
   - name: STRT
     description: Start
     bit_offset: 16


### PR DESCRIPTION
The bitsize for the number of flash pages (`PNB`) in the `FLASH_CR` is incorrect for category 4 devices (STM32G491, STM32G4A1).

As a result, erasing a page in bank 2 in single-bank mode will incorrectly erase the corresponding bank 1 page.  

![image](https://github.com/user-attachments/assets/c7372fb3-491d-4eca-bd89-fd1da383a3ff)
