### PR TITLE
Switch stm32u5 to dma2d-v2 and manually corrected yaml

### DIFF
--- a/data/registers/dma2d_v2.yaml
+++ b/data/registers/dma2d_v2.yaml
@@ -6,7 +6,7 @@ block/DMA2D:
     byte_offset: 0
     fieldset: CR
   - name: ISR
-    description: DMA2D Interrupt Status Register
+    description: DMA2D interrupt status register
     byte_offset: 4
     access: Read
     fieldset: ISR
@@ -31,7 +31,7 @@ block/DMA2D:
     byte_offset: 24
     fieldset: BGOR
   - name: FGPFCCR
-    description: DMA2D foreground PFC control register
+    description: DMA2D foreground PFC (pixel format converter) control register
     byte_offset: 28
     fieldset: FGPFCCR
   - name: FGCOLR
@@ -39,7 +39,7 @@ block/DMA2D:
     byte_offset: 32
     fieldset: FGCOLR
   - name: BGPFCCR
-    description: DMA2D background PFC control register
+    description: DMA2D background PFC (pixel format converter) control register
     byte_offset: 36
     fieldset: BGPFCCR
   - name: BGCOLR
@@ -55,7 +55,7 @@ block/DMA2D:
     byte_offset: 48
     fieldset: BGCMAR
   - name: OPFCCR
-    description: DMA2D output PFC control register
+    description: DMA2D output PFC (pixel format converter) control register
     byte_offset: 52
     fieldset: OPFCCR
   - name: OCOLR
@@ -86,247 +86,252 @@ fieldset/AMTCR:
   description: DMA2D AXI master timer configuration register
   fields:
   - name: EN
-    description: Enable Enables the dead time functionality.
+    description: Enable. Enables the dead time functionality.
     bit_offset: 0
     bit_size: 1
   - name: DT
-    description: Dead Time Dead time value in the AXI clock cycle inserted between two consecutive accesses on the AXI master port. These bits represent the minimum guaranteed number of cycles between two consecutive AXI accesses.
+    description: Dead time. Dead time value in the AXI clock cycle inserted between two consecutive accesses on the AXI master port. These bits represent the minimum guaranteed number of cycles between two consecutive AXI accesses.
     bit_offset: 8
     bit_size: 8
 fieldset/BGCMAR:
   description: DMA2D background CLUT memory address register
   fields:
   - name: MA
-    description: Memory address Address of the data used for the CLUT address dedicated to the background image. This register can only be written when no transfer is on going. Once the CLUT transfer has started, this register is read-only. If the background CLUT format is 32-bit, the address must be 32-bit aligned.
+    description: Memory address. Address of the data used for the CLUT address dedicated to the background image. This register can only be written when no transfer is on going. Once the CLUT transfer has started, this register is read-only. If the background CLUT format is 32-bit, the address must be 32-bit aligned.
     bit_offset: 0
     bit_size: 32
 fieldset/BGCOLR:
   description: DMA2D background color register
   fields:
   - name: BLUE
-    description: Blue Value These bits define the blue value for the A4 or A8 mode of the background. These bits can only be written when data transfers are disabled. Once the transfer has started, they are read-only.
+    description: Blue value. These bits define the blue value for the A4 or A8 mode of the background. These bits can only be written when data transfers are disabled. Once the transfer has started, they are read-only.
     bit_offset: 0
     bit_size: 8
   - name: GREEN
-    description: Green Value These bits define the green value for the A4 or A8 mode of the background. These bits can only be written when data transfers are disabled. Once the transfer has started, they are read-only.
+    description: Green value. These bits define the green value for the A4 or A8 mode of the background. These bits can only be written when data transfers are disabled. Once the transfer has started, they are read-only.
     bit_offset: 8
     bit_size: 8
   - name: RED
-    description: Red Value These bits define the red value for the A4 or A8 mode of the background. These bits can only be written when data transfers are disabled. Once the transfer has started, they are read-only.
+    description: Red value. These bits define the red value for the A4 or A8 mode of the background. These bits can only be written when data transfers are disabled. Once the transfer has started, they are read-only.
     bit_offset: 16
     bit_size: 8
 fieldset/BGMAR:
   description: DMA2D background memory address register
   fields:
   - name: MA
-    description: Memory address Address of the data used for the background image. This register can only be written when data transfers are disabled. Once a data transfer has started, this register is read-only. The address alignment must match the image format selected e.g. a 32-bit per pixel format must be 32-bit aligned, a 16-bit per pixel format must be 16-bit aligned and a 4-bit per pixel format must be 8-bit aligned.
+    description: Memory address. Address of the data used for the background image. This register can only be written when data transfers are disabled. Once a data transfer has started, this register is read-only. The address alignment must match the image format selected e.g. a 32-bit per pixel format must be 32-bit aligned, a 16-bit per pixel format must be 16-bit aligned and a 4-bit per pixel format must be 8-bit aligned.
     bit_offset: 0
     bit_size: 32
 fieldset/BGOR:
   description: DMA2D background offset register
   fields:
   - name: LO
-    description: Line offset Line offset used for the background image (expressed in pixel). This value is used for the address generation. It is added at the end of each line to determine the starting address of the next line. These bits can only be written when data transfers are disabled. Once data transfer has started, they become read-only. If the image format is 4-bit per pixel, the line offset must be even.
+    description: Line offset used for the background image (expressed in pixels (default) or bytes as per LOM in CR). This value is used for the address generation. It is added at the end of each line to determine the starting address of the next line. These bits can only be written when data transfers are disabled. Once data transfer has started, they become read-only. If the image format is 4-bit per pixel, the line offset must be even.
     bit_offset: 0
     bit_size: 16
 fieldset/BGPFCCR:
-  description: DMA2D background PFC control register
+  description: DMA2D background PFC (pixel format converter) control register
   fields:
   - name: CM
-    description: 'Color mode These bits define the color format of the foreground image. These bits can only be written when data transfers are disabled. Once the transfer has started, they are read-only. others: meaningless'
+    description: 'Color mode. These bits define the color format of the foreground image. These bits can only be written when data transfers are disabled. Once the transfer has started, they are read-only. others: meaningless'
     bit_offset: 0
     bit_size: 4
     enum: BGPFCCR_CM
   - name: CCM
-    description: CLUT Color mode These bits define the color format of the CLUT. This register can only be written when the transfer is disabled. Once the CLUT transfer has started, this bit is read-only.
+    description: CLUT (color lookup table) color mode. These bits define the color format of the CLUT. This register can only be written when the transfer is disabled. Once the CLUT transfer has started, this bit is read-only.
     bit_offset: 4
     bit_size: 1
     enum: BGPFCCR_CCM
   - name: START
-    description: 'Start This bit is set to start the automatic loading of the CLUT. This bit is automatically reset: ** at the end of the transfer ** when the transfer is aborted by the user application by setting the ABORT bit in the DMA2D_CR ** when a transfer error occurs ** when the transfer has not started due to a configuration error or another transfer operation already on going (data transfer or automatic BackGround CLUT transfer).'
+    description: 'Start. This bit is set to start the automatic loading of the CLUT. This bit is automatically reset: ** at the end of the transfer ** when the transfer is aborted by the user application by setting the ABORT bit in the DMA2D_CR ** when a transfer error occurs ** when the transfer has not started due to a configuration error or another transfer operation already on going (data transfer or automatic BackGround CLUT transfer).'
     bit_offset: 5
     bit_size: 1
     enum: BGPFCCR_START
   - name: CS
-    description: CLUT size These bits define the size of the CLUT used for the BG. Once the CLUT transfer has started, this field is read-only. The number of CLUT entries is equal to CS[7:0] + 1.
+    description: CLUT size. These bits define the size of the CLUT used for the BG. Once the CLUT transfer has started, this field is read-only. The number of CLUT entries is equal to CS[7:0] + 1.
     bit_offset: 8
     bit_size: 8
   - name: AM
-    description: 'Alpha mode These bits define which alpha channel value to be used for the background image. These bits can only be written when data transfers are disabled. Once the transfer has started, they are read-only. others: meaningless'
+    description: 'Alpha mode. These bits define which alpha channel value to be used for the background image. These bits can only be written when data transfers are disabled. Once the transfer has started, they are read-only. others: meaningless'
     bit_offset: 16
     bit_size: 2
     enum: BGPFCCR_AM
   - name: AI
-    description: Alpha Inverted This bit inverts the alpha value. Once the transfer has started, this bit is read-only.
+    description: Alpha inverted. This bit inverts the alpha value. Once the transfer has started, this bit is read-only.
     bit_offset: 20
     bit_size: 1
     enum: BGPFCCR_AI
   - name: RBS
-    description: Red Blue Swap This bit allows to swap the R &amp; B to support BGR or ABGR color formats. Once the transfer has started, this bit is read-only.
+    description: Red blue swap. This bit allows to swap the R and B to support BGR or ABGR color formats. Once the transfer has started, this bit is read-only.
     bit_offset: 21
     bit_size: 1
     enum: BGPFCCR_RBS
   - name: ALPHA
-    description: 'Alpha value These bits define a fixed alpha channel value which can replace the original alpha value or be multiplied with the original alpha value according to the alpha mode selected with bits AM[1: 0]. These bits can only be written when data transfers are disabled. Once the transfer has started, they are read-only.'
+    description: 'Alpha value. These bits define a fixed alpha channel value which can replace the original alpha value or be multiplied with the original alpha value according to the alpha mode selected with bits AM[1: 0]. These bits can only be written when data transfers are disabled. Once the transfer has started, they are read-only.'
     bit_offset: 24
     bit_size: 8
 fieldset/CR:
   description: DMA2D control register
   fields:
   - name: START
-    description: Start This bit can be used to launch the DMA2D according to the parameters loaded in the various configuration registers
+    description: Start. This bit can be used to launch the DMA2D according to the parameters loaded in the various configuration registers
     bit_offset: 0
     bit_size: 1
     enum: CR_START
   - name: SUSP
-    description: Suspend This bit can be used to suspend the current transfer. This bit is set and reset by software. It is automatically reset by hardware when the START bit is reset.
+    description: Suspend. This bit can be used to suspend the current transfer. This bit is set and reset by software. It is automatically reset by hardware when the START bit is reset.
     bit_offset: 1
     bit_size: 1
   - name: ABORT
-    description: Abort This bit can be used to abort the current transfer. This bit is set by software and is automatically reset by hardware when the START bit is reset.
+    description: Abort. This bit can be used to abort the current transfer. This bit is set by software and is automatically reset by hardware when the START bit is reset.
     bit_offset: 2
     bit_size: 1
     enum: ABORT
+  - name: LOM
+    description: Line offset mode. This bit configures how the line offset is expressed (in pixels or bytes) for the foreground, background and output. This bit is set and cleared by software. It can not be modified while a transfer is ongoing.
+    bit_offset: 6
+    bit_size: 1
+    enum: LOM
   - name: TEIE
-    description: Transfer error interrupt enable This bit is set and cleared by software.
+    description: Transfer error interrupt enable. This bit is set and cleared by software.
     bit_offset: 8
     bit_size: 1
   - name: TCIE
-    description: Transfer complete interrupt enable This bit is set and cleared by software.
+    description: Transfer complete interrupt enable. This bit is set and cleared by software.
     bit_offset: 9
     bit_size: 1
   - name: TWIE
-    description: Transfer watermark interrupt enable This bit is set and cleared by software.
+    description: Transfer watermark interrupt enable. This bit is set and cleared by software.
     bit_offset: 10
     bit_size: 1
   - name: CAEIE
-    description: CLUT access error interrupt enable This bit is set and cleared by software.
+    description: CLUT access error interrupt enable. This bit is set and cleared by software.
     bit_offset: 11
     bit_size: 1
   - name: CTCIE
-    description: CLUT transfer complete interrupt enable This bit is set and cleared by software.
+    description: CLUT transfer complete interrupt enable. This bit is set and cleared by software.
     bit_offset: 12
     bit_size: 1
   - name: CEIE
-    description: Configuration Error Interrupt Enable This bit is set and cleared by software.
+    description: Configuration error interrupt enable. This bit is set and cleared by software.
     bit_offset: 13
     bit_size: 1
   - name: MODE
     description: DMA2D mode This bit is set and cleared by software. It cannot be modified while a transfer is ongoing.
     bit_offset: 16
-    bit_size: 2
+    bit_size: 3
     enum: MODE
 fieldset/FGCMAR:
   description: DMA2D foreground CLUT memory address register
   fields:
   - name: MA
-    description: Memory Address Address of the data used for the CLUT address dedicated to the foreground image. This register can only be written when no transfer is ongoing. Once the CLUT transfer has started, this register is read-only. If the foreground CLUT format is 32-bit, the address must be 32-bit aligned.
+    description: Memory Address. Address of the data used for the CLUT address dedicated to the foreground image. This register can only be written when no transfer is ongoing. Once the CLUT transfer has started, this register is read-only. If the foreground CLUT format is 32-bit, the address must be 32-bit aligned.
     bit_offset: 0
     bit_size: 32
 fieldset/FGCOLR:
   description: DMA2D foreground color register
   fields:
   - name: BLUE
-    description: Blue Value These bits defines the blue value for the A4 or A8 mode of the foreground image. They can only be written when data transfers are disabled. Once the transfer has started, They are read-only.
+    description: Blue Value. These bits define the blue value for the A4 or A8 mode of the foreground image. They can only be written when data transfers are disabled. Once the transfer has started, They are read-only.
     bit_offset: 0
     bit_size: 8
   - name: GREEN
-    description: Green Value These bits defines the green value for the A4 or A8 mode of the foreground image. They can only be written when data transfers are disabled. Once the transfer has started, They are read-only.
+    description: Green Value. These bits define the green value for the A4 or A8 mode of the foreground image. They can only be written when data transfers are disabled. Once the transfer has started, They are read-only.
     bit_offset: 8
     bit_size: 8
   - name: RED
-    description: Red Value These bits defines the red value for the A4 or A8 mode of the foreground image. They can only be written when data transfers are disabled. Once the transfer has started, they are read-only.
+    description: Red Value. These bits define the red value for the A4 or A8 mode of the foreground image. They can only be written when data transfers are disabled. Once the transfer has started, they are read-only.
     bit_offset: 16
     bit_size: 8
 fieldset/FGMAR:
   description: DMA2D foreground memory address register
   fields:
   - name: MA
-    description: Memory address Address of the data used for the foreground image. This register can only be written when data transfers are disabled. Once the data transfer has started, this register is read-only. The address alignment must match the image format selected e.g. a 32-bit per pixel format must be 32-bit aligned, a 16-bit per pixel format must be 16-bit aligned and a 4-bit per pixel format must be 8-bit aligned.
+    description: Memory address. Address of the data used for the foreground image. This register can only be written when data transfers are disabled. Once the data transfer has started, this register is read-only. The address alignment must match the image format selected e.g. a 32-bit per pixel format must be 32-bit aligned, a 16-bit per pixel format must be 16-bit aligned and a 4-bit per pixel format must be 8-bit aligned.
     bit_offset: 0
     bit_size: 32
 fieldset/FGOR:
   description: DMA2D foreground offset register
   fields:
   - name: LO
-    description: Line offset Line offset used for the foreground expressed in pixel. This value is used to generate the address. It is added at the end of each line to determine the starting address of the next line. These bits can only be written when data transfers are disabled. Once a data transfer has started, they become read-only. If the image format is 4-bit per pixel, the line offset must be even.
+    description: Line offset. Line offset used for the foreground expressed in pixel. This value is used to generate the address. It is added at the end of each line to determine the starting address of the next line. These bits can only be written when data transfers are disabled. Once a data transfer has started, they become read-only. If the image format is 4-bit per pixel, the line offset must be even.
     bit_offset: 0
     bit_size: 16
 fieldset/FGPFCCR:
-  description: DMA2D foreground PFC control register
+  description: DMA2D foreground PFC (pixel format converter) control register
   fields:
   - name: CM
-    description: 'Color mode These bits defines the color format of the foreground image. They can only be written when data transfers are disabled. Once the transfer has started, they are read-only. others: meaningless'
+    description: 'Color mode. These bits define the color format of the foreground image. They can only be written when data transfers are disabled. Once the transfer has started, they are read-only. others: meaningless'
     bit_offset: 0
     bit_size: 4
     enum: FGPFCCR_CM
   - name: CCM
-    description: CLUT color mode This bit defines the color format of the CLUT. It can only be written when the transfer is disabled. Once the CLUT transfer has started, this bit is read-only.
+    description: CLUT color mode. This bit defines the color format of the CLUT. It can only be written when the transfer is disabled. Once the CLUT transfer has started, this bit is read-only.
     bit_offset: 4
     bit_size: 1
     enum: FGPFCCR_CCM
   - name: START
-    description: 'Start This bit can be set to start the automatic loading of the CLUT. It is automatically reset: ** at the end of the transfer ** when the transfer is aborted by the user application by setting the ABORT bit in DMA2D_CR ** when a transfer error occurs ** when the transfer has not started due to a configuration error or another transfer operation already ongoing (data transfer or automatic background CLUT transfer).'
+    description: 'Start. This bit can be set to start the automatic loading of the CLUT. It is automatically reset: ** at the end of the transfer ** when the transfer is aborted by the user application by setting the ABORT bit in DMA2D_CR ** when a transfer error occurs ** when the transfer has not started due to a configuration error or another transfer operation already ongoing (data transfer or automatic background CLUT transfer).'
     bit_offset: 5
     bit_size: 1
     enum: FGPFCCR_START
   - name: CS
-    description: CLUT size These bits define the size of the CLUT used for the foreground image. Once the CLUT transfer has started, this field is read-only. The number of CLUT entries is equal to CS[7:0] + 1.
+    description: CLUT size. These bits define the size of the CLUT used for the foreground image. Once the CLUT transfer has started, this field is read-only. The number of CLUT entries is equal to CS[7:0] + 1.
     bit_offset: 8
     bit_size: 8
   - name: AM
-    description: Alpha mode These bits select the alpha channel value to be used for the foreground image. They can only be written data the transfer are disabled. Once the transfer has started, they become read-only. other configurations are meaningless
+    description: Alpha mode. These bits select the alpha channel value to be used for the foreground image. They can only be written data the transfer are disabled. Once the transfer has started, they become read-only. other configurations are meaningless
     bit_offset: 16
     bit_size: 2
     enum: FGPFCCR_AM
   - name: CSS
-    description: 'Chroma Sub-Sampling These bits define the chroma sub-sampling mode for YCbCr color mode. Once the transfer has started, these bits are read-only. others: meaningless'
+    description: 'Chroma Sub-Sampling. These bits define the chroma sub-sampling mode for YCbCr color mode. Once the transfer has started, these bits are read-only. others: meaningless'
     bit_offset: 18
     bit_size: 2
   - name: AI
-    description: Alpha Inverted This bit inverts the alpha value. Once the transfer has started, this bit is read-only.
+    description: Alpha inverted. This bit inverts the alpha value. Once the transfer has started, this bit is read-only.
     bit_offset: 20
     bit_size: 1
     enum: FGPFCCR_AI
   - name: RBS
-    description: Red Blue Swap This bit allows to swap the R &amp; B to support BGR or ABGR color formats. Once the transfer has started, this bit is read-only.
+    description: Red blue swap. This bit allows to swap the R and B to support BGR or ABGR color formats. Once the transfer has started, this bit is read-only.
     bit_offset: 21
     bit_size: 1
     enum: FGPFCCR_RBS
   - name: ALPHA
-    description: Alpha value These bits define a fixed alpha channel value which can replace the original alpha value or be multiplied by the original alpha value according to the alpha mode selected through the AM[1:0] bits. These bits can only be written when data transfers are disabled. Once a transfer has started, they become read-only.
+    description: Alpha value. These bits define a fixed alpha channel value which can replace the original alpha value or be multiplied by the original alpha value according to the alpha mode selected through the AM[1:0] bits. These bits can only be written when data transfers are disabled. Once a transfer has started, they become read-only.
     bit_offset: 24
     bit_size: 8
 fieldset/IFCR:
   description: DMA2D interrupt flag clear register
   fields:
   - name: CTEIF
-    description: Clear Transfer error interrupt flag Programming this bit to 1 clears the TEIF flag in the DMA2D_ISR register
+    description: Clear transfer error interrupt flag. Programming this bit to 1 clears the TEIF flag in the DMA2D_ISR register
     bit_offset: 0
     bit_size: 1
     enum: CTEIF
   - name: CTCIF
-    description: Clear transfer complete interrupt flag Programming this bit to 1 clears the TCIF flag in the DMA2D_ISR register
+    description: Clear transfer complete interrupt flag. Programming this bit to 1 clears the TCIF flag in the DMA2D_ISR register
     bit_offset: 1
     bit_size: 1
     enum: CTCIF
   - name: CTWIF
-    description: Clear transfer watermark interrupt flag Programming this bit to 1 clears the TWIF flag in the DMA2D_ISR register
+    description: Clear transfer watermark interrupt flag. Programming this bit to 1 clears the TWIF flag in the DMA2D_ISR register
     bit_offset: 2
     bit_size: 1
     enum: CTWIF
   - name: CAECIF
-    description: Clear CLUT access error interrupt flag Programming this bit to 1 clears the CAEIF flag in the DMA2D_ISR register
+    description: Clear CLUT access error interrupt flag. Programming this bit to 1 clears the CAEIF flag in the DMA2D_ISR register
     bit_offset: 3
     bit_size: 1
     enum: CAECIF
   - name: CCTCIF
-    description: Clear CLUT transfer complete interrupt flag Programming this bit to 1 clears the CTCIF flag in the DMA2D_ISR register
+    description: Clear CLUT transfer complete interrupt flag. Programming this bit to 1 clears the CTCIF flag in the DMA2D_ISR register
     bit_offset: 4
     bit_size: 1
     enum: CCTCIF
   - name: CCEIF
-    description: Clear configuration error interrupt flag Programming this bit to 1 clears the CEIF flag in the DMA2D_ISR register
+    description: Clear configuration error interrupt flag. Programming this bit to 1 clears the CEIF flag in the DMA2D_ISR register
     bit_offset: 5
     bit_size: 1
     enum: CCEIF
@@ -334,85 +339,73 @@ fieldset/ISR:
   description: DMA2D Interrupt Status Register
   fields:
   - name: TEIF
-    description: Transfer error interrupt flag This bit is set when an error occurs during a DMA transfer (data transfer or automatic CLUT loading).
+    description: Transfer error interrupt flag. This bit is set when an error occurs during a DMA transfer (data transfer or automatic CLUT loading).
     bit_offset: 0
     bit_size: 1
   - name: TCIF
-    description: Transfer complete interrupt flag This bit is set when a DMA2D transfer operation is complete (data transfer only).
+    description: Transfer complete interrupt flag. This bit is set when a DMA2D transfer operation is complete (data transfer only).
     bit_offset: 1
     bit_size: 1
   - name: TWIF
-    description: Transfer watermark interrupt flag This bit is set when the last pixel of the watermarked line has been transferred.
+    description: Transfer watermark interrupt flag. This bit is set when the last pixel of the watermarked line has been transferred.
     bit_offset: 2
     bit_size: 1
   - name: CAEIF
-    description: CLUT access error interrupt flag This bit is set when the CPU accesses the CLUT while the CLUT is being automatically copied from a system memory to the internal DMA2D.
+    description: CLUT access error interrupt flag. This bit is set when the CPU accesses the CLUT while the CLUT is being automatically copied from a system memory to the internal DMA2D.
     bit_offset: 3
     bit_size: 1
   - name: CTCIF
-    description: CLUT transfer complete interrupt flag This bit is set when the CLUT copy from a system memory area to the internal DMA2D memory is complete.
+    description: CLUT transfer complete interrupt flag. This bit is set when the CLUT copy from a system memory area to the internal DMA2D memory is complete.
     bit_offset: 4
     bit_size: 1
   - name: CEIF
-    description: Configuration error interrupt flag This bit is set when the START bit of DMA2D_CR, DMA2DFGPFCCR or DMA2D_BGPFCCR is set and a wrong configuration has been programmed.
+    description: Configuration error interrupt flag. This bit is set when the START bit of DMA2D_CR, DMA2DFGPFCCR or DMA2D_BGPFCCR is set and a wrong configuration has been programmed.
     bit_offset: 5
     bit_size: 1
 fieldset/LWR:
   description: DMA2D line watermark register
   fields:
   - name: LW
-    description: Line watermark These bits allow to configure the line watermark for interrupt generation. An interrupt is raised when the last pixel of the watermarked line has been transferred. These bits can only be written when data transfers are disabled. Once the transfer has started, they are read-only.
+    description: Line watermark. These bits allow to configure the line watermark for interrupt generation. An interrupt is raised when the last pixel of the watermarked line has been transferred. These bits can only be written when data transfers are disabled. Once the transfer has started, they are read-only.
     bit_offset: 0
     bit_size: 16
 fieldset/NLR:
   description: DMA2D number of line register
   fields:
   - name: NL
-    description: Number of lines Number of lines of the area to be transferred. These bits can only be written when data transfers are disabled. Once the transfer has started, they are read-only.
+    description: Number of lines. Number of lines of the area to be transferred. These bits can only be written when data transfers are disabled. Once the transfer has started, they are read-only.
     bit_offset: 0
     bit_size: 16
   - name: PL
-    description: Pixel per lines Number of pixels per lines of the area to be transferred. These bits can only be written when data transfers are disabled. Once the transfer has started, they are read-only. If any of the input image format is 4-bit per pixel, pixel per lines must be even.
+    description: Pixel per lines. Number of pixels per lines of the area to be transferred. These bits can only be written when data transfers are disabled. Once the transfer has started, they are read-only. If any of the input image format is 4-bit per pixel, pixel per lines must be even.
     bit_offset: 16
     bit_size: 14
 fieldset/OCOLR:
   description: DMA2D output color register
   fields:
-  - name: BLUE
-    description: Blue Value These bits define the blue value of the output image. These bits can only be written when data transfers are disabled. Once the transfer has started, they are read-only.
+  - name: COLOR
+    description: Color. Color in the format specified by color mode in OPFCCR (16, 24 or 32 bits). These bits can only be written when data transfers are disabled. Once the transfer has started, they are read-only.
     bit_offset: 0
-    bit_size: 8
-  - name: GREEN
-    description: Green Value These bits define the green value of the output image. These bits can only be written when data transfers are disabled. Once the transfer has started, they are read-only.
-    bit_offset: 8
-    bit_size: 8
-  - name: RED
-    description: Red Value These bits define the red value of the output image. These bits can only be written when data transfers are disabled. Once the transfer has started, they are read-only.
-    bit_offset: 16
-    bit_size: 8
-  - name: ALPHA
-    description: Alpha Channel Value These bits define the alpha channel of the output color. These bits can only be written when data transfers are disabled. Once the transfer has started, they are read-only.
-    bit_offset: 24
-    bit_size: 8
+    bit_size: 32
 fieldset/OMAR:
   description: DMA2D output memory address register
   fields:
   - name: MA
-    description: Memory Address Address of the data used for the output FIFO. These bits can only be written when data transfers are disabled. Once the transfer has started, they are read-only. The address alignment must match the image format selected e.g. a 32-bit per pixel format must be 32-bit aligned and a 16-bit per pixel format must be 16-bit aligned.
+    description: Memory Address. Address of the data used for the output FIFO. These bits can only be written when data transfers are disabled. Once the transfer has started, they are read-only. The address alignment must match the image format selected e.g. a 32-bit per pixel format must be 32-bit aligned and a 16-bit per pixel format must be 16-bit aligned.
     bit_offset: 0
     bit_size: 32
 fieldset/OOR:
   description: DMA2D output offset register
   fields:
   - name: LO
-    description: Line Offset Line offset used for the output (expressed in pixels). This value is used for the address generation. It is added at the end of each line to determine the starting address of the next line. These bits can only be written when data transfers are disabled. Once the transfer has started, they are read-only.
+    description: Line offset. Line offset used for the output (expressed in pixels). This value is used for the address generation. It is added at the end of each line to determine the starting address of the next line. These bits can only be written when data transfers are disabled. Once the transfer has started, they are read-only.
     bit_offset: 0
     bit_size: 16
 fieldset/OPFCCR:
   description: DMA2D output PFC control register
   fields:
   - name: CM
-    description: 'Color mode These bits define the color format of the output image. These bits can only be written when data transfers are disabled. Once the transfer has started, they are read-only. others: meaningless'
+    description: 'Color mode. These bits define the color format of the output image. These bits can only be written when data transfers are disabled. Once the transfer has started, they are read-only. others: meaningless'
     bit_offset: 0
     bit_size: 3
     enum: OPFCCR_CM
@@ -422,12 +415,12 @@ fieldset/OPFCCR:
     bit_size: 1
     enum: SB
   - name: AI
-    description: Alpha Inverted This bit inverts the alpha value. Once the transfer has started, this bit is read-only.
+    description: Alpha inverted. This bit inverts the alpha value. Once the transfer has started, this bit is read-only.
     bit_offset: 20
     bit_size: 1
     enum: OPFCCR_AI
   - name: RBS
-    description: Red Blue Swap This bit allows to swap the R &amp; B to support BGR or ABGR color formats. Once the transfer has started, this bit is read-only.
+    description: Red blue swap. This bit allows to swap the R and B to support BGR or ABGR color formats. Once the transfer has started, this bit is read-only.
     bit_offset: 21
     bit_size: 1
     enum: OPFCCR_RBS
@@ -507,10 +500,10 @@ enum/BGPFCCR_RBS:
   bit_size: 1
   variants:
   - name: Regular
-    description: No Red Blue Swap (RGB or ARGB)
+    description: No red blue swap (RGB or ARGB)
     value: 0
   - name: Swap
-    description: Red Blue Swap (BGR or ABGR)
+    description: Red blue swap (BGR or ABGR)
     value: 1
 enum/BGPFCCR_START:
   bit_size: 1
@@ -541,6 +534,15 @@ enum/CR_START:
   variants:
   - name: Start
     description: Launch the DMA2D
+    value: 1
+enum/LOM:
+  bit_size: 1
+  variants:
+  - name: Pixels
+    description: Line offsets expressed in pixels
+    value: 0
+  - name: Bytes
+    description: Line offsets expressed in bytes
     value: 1
 enum/CTCIF:
   bit_size: 1
@@ -633,10 +635,10 @@ enum/FGPFCCR_RBS:
   bit_size: 1
   variants:
   - name: Regular
-    description: No Red Blue Swap (RGB or ARGB)
+    description: No red blue swap (RGB or ARGB)
     value: 0
   - name: Swap
-    description: Red Blue Swap (BGR or ABGR)
+    description: red blue swap (BGR or ABGR)
     value: 1
 enum/FGPFCCR_START:
   bit_size: 1
@@ -645,20 +647,26 @@ enum/FGPFCCR_START:
     description: Start the automatic loading of the CLUT
     value: 1
 enum/MODE:
-  bit_size: 2
+  bit_size: 3
   variants:
   - name: MemoryToMemory
     description: Memory-to-memory (FG fetch only)
     value: 0
   - name: MemoryToMemoryPFC
-    description: Memory-to-memory with PFC (FG fetch only with FG PFC active)
+    description: Memory-to-memory with PFC (pixel format converter) (FG fetch only with FG PFC active)
     value: 1
   - name: MemoryToMemoryPFCBlending
     description: Memory-to-memory with blending (FG and BG fetch with PFC and blending)
     value: 2
   - name: RegisterToMemory
-    description: Register-to-memory
+    description: Register-to-memory (no FG nor BG, only output stage active)
     value: 3
+  - name: MemoryToMemoryPFCBlendingFixedColorFG
+    description: Memory-to-memory with blending and fixed color FG (BG fetch only with FG and BG PFC active)
+    value: 4
+  - name: MemoryToMemoryPFCBlendingFixedColorBG
+    description: Memory-to-memory with blending and fixed color BG (FG fetch only with FG and BG PFC active)
+    value: 5
 enum/OPFCCR_AI:
   bit_size: 1
   variants:
@@ -690,10 +698,10 @@ enum/OPFCCR_RBS:
   bit_size: 1
   variants:
   - name: Regular
-    description: No Red Blue Swap (RGB or ARGB)
+    description: No red blue swap (RGB or ARGB)
     value: 0
   - name: Swap
-    description: Red Blue Swap (BGR or ABGR)
+    description: Red blue swap (BGR or ABGR)
     value: 1
 enum/SB:
   bit_size: 1

--- a/stm32-data-gen/src/perimap.rs
+++ b/stm32-data-gen/src/perimap.rs
@@ -486,6 +486,7 @@ pub static PERIMAP: RegexMap<(&str, &str, &str)> = RegexMap::new(&[
     (r".*:LPDMA\d?:.*", ("lpdma", "v1", "LPDMA")),
     (r".*:BDMA\d?:.*", ("bdma", "v1", "DMA")),
     ("STM32H7.*:DMA2D:DMA2D:dma2d1_v1_0", ("dma2d", "v2", "DMA2D")),
+    ("STM32U5.*:DMA2D:DMA2D:dma2d1_v1_0", ("dma2d", "v2", "DMA2D")),
     (".*:DMA2D:dma2d1_v1_0", ("dma2d", "v1", "DMA2D")),
     ("STM32L4[PQRS].*:DMA.*", ("bdma", "v1", "DMA")), // L4+
     ("STM32L[04].*:DMA.*", ("bdma", "v2", "DMA")),    // L0, L4 non-plus (since plus is handled above)


### PR DESCRIPTION
Hi,

I have been busy building out the DMA2D driver for embassy-stm32 and I noticed some small issues relating to auto-generated config. The DMA2D peripheral is used for graphics applications and has the potential to vastly reduce render times on large displays. I used section 20 of rm0456 to double check everything. The changes are outlined as follows:

- Changed the documentation to make grammatical sense (cosmetic but nice).
- Fixed the `OCOLR` which was incorrectly represented due to an unusual setup in the reference manual (the register is duplicated to demonstrate all possible permutations of color modes). IMO. it is better to expose the raw register value (u32) and handle the permutations in code since as all bit values are valid but mean different things depending on setup in another register.
- Added `LOM` to `CR` register - Line offset mode
- Added 2 more operating modes: MemoryToMemoryPFCBlendingFixedColorFG and MemoryToMemoryPFCBlendingFixedColorBG that were missing. These can be gated in code for mcu's that don't support them but they would simply be reserved on those chips anyway.
- Make the perimap use the `dma2d_v2.yaml` for `stm32u5` chips which, being very recently released chips, I am fairly certain support v2.

