### PR TITLE
Fix SMPSEL channel bit offset

### DIFF
--- a/data/registers/adc_g0.yaml
+++ b/data/registers/adc_g0.yaml
@@ -603,7 +603,7 @@ fieldset/SMPR:
     bit_size: 1
     array:
       len: 19
-      stride: 0
+      stride: 1
 fieldset/VERR:
   description: EXTI IP Version register
   fields:

--- a/data/registers/adc_u0.yaml
+++ b/data/registers/adc_u0.yaml
@@ -416,7 +416,7 @@ fieldset/SMPR:
     bit_size: 1
     array:
       len: 19
-      stride: 0
+      stride: 1
 enum/DMACFG:
   bit_size: 1
   variants:

--- a/data/registers/adc_u5.yaml
+++ b/data/registers/adc_u5.yaml
@@ -502,7 +502,7 @@ fieldset/ADC4_SMPR:
       stride: 4
     enum: ADC4_SAMPLE_TIME
   - name: SMPSEL
-    description: SMPSEL0.
+    description: Channel sampling time selection
     bit_offset: 8
     bit_size: 1
     array:


### PR DESCRIPTION
Channel offsets were previously calculated incorrectly:

```rust   
#[doc = "Channel sampling time selection"]
#[inline(always)]
pub fn set_smpsel(&mut self, n: usize, val: bool) {
    assert!(n < 19usize);
    let offs = 8usize + n * 0usize;
    self.0 = (self.0 & !(0x01 << offs)) | (((val as u32) & 0x01) << offs);
}
```