### PR TITLE
Add xspi_v1 and xspim_v1 from h7s svd

### DIFF
--- a/data/registers/xspi_v1.yaml
+++ b/data/registers/xspi_v1.yaml
@@ -1,0 +1,1218 @@
+block/XSPI:
+  description: XSPI register block
+  items:
+  - name: CR
+    description: XSPI control register
+    byte_offset: 0
+    fieldset: CR
+  - name: DCR1
+    description: XSPI device configuration register 1
+    byte_offset: 8
+    fieldset: DCR1
+  - name: DCR2
+    description: XSPI device configuration register 2
+    byte_offset: 12
+    fieldset: DCR2
+  - name: DCR3
+    description: XSPI device configuration register 3
+    byte_offset: 16
+    fieldset: DCR3
+  - name: DCR4
+    description: XSPI device configuration register 4
+    byte_offset: 20
+    fieldset: DCR4
+  - name: SR
+    description: XSPI status register
+    byte_offset: 32
+    fieldset: SR
+  - name: FCR
+    description: XSPI flag clear register
+    byte_offset: 36
+    fieldset: FCR
+  - name: DLR
+    description: XSPI data length register
+    byte_offset: 64
+    fieldset: DLR
+  - name: AR
+    description: XSPIaddress register
+    byte_offset: 72
+    fieldset: AR
+  - name: DR
+    description: XSPI data register
+    byte_offset: 80
+    fieldset: DR
+  - name: PSMKR
+    description: XSPI polling status mask register
+    byte_offset: 128
+    fieldset: PSMKR
+  - name: PSMAR
+    description: XSPI polling status match register
+    byte_offset: 136
+    fieldset: PSMAR
+  - name: PIR
+    description: XSPI polling interval register
+    byte_offset: 144
+    fieldset: PIR
+  - name: CCR
+    description: XSPI communication configuration register
+    byte_offset: 256
+    fieldset: CCR
+  - name: TCR
+    description: XSPI timing configuration register
+    byte_offset: 264
+    fieldset: TCR
+  - name: IR
+    description: XSPI instruction register
+    byte_offset: 272
+    fieldset: IR
+  - name: ABR
+    description: XSPI alternate bytes register
+    byte_offset: 288
+    fieldset: ABR
+  - name: LPTR
+    description: XSPI low-power timeout register
+    byte_offset: 304
+    fieldset: LPTR
+  - name: WPCCR
+    description: XSPI wrap communication configuration register
+    byte_offset: 320
+    fieldset: WPCCR
+  - name: WPTCR
+    description: XSPI wrap timing configuration register
+    byte_offset: 328
+    fieldset: WPTCR
+  - name: WPIR
+    description: XSPI wrap instruction register
+    byte_offset: 336
+    fieldset: WPIR
+  - name: WPABR
+    description: XSPI wrap alternate byte register
+    byte_offset: 352
+    fieldset: WPABR
+  - name: WCCR
+    description: XSPI write communication configuration register
+    byte_offset: 384
+    fieldset: WCCR
+  - name: WTCR
+    description: XSPI write timing configuration register
+    byte_offset: 392
+    fieldset: WTCR
+  - name: WIR
+    description: XSPI write instruction register
+    byte_offset: 400
+    fieldset: WIR
+  - name: WABR
+    description: XSPI write alternate byte register
+    byte_offset: 416
+    fieldset: WABR
+  - name: HLCR
+    description: XSPI HyperBus latency configuration register
+    byte_offset: 512
+    fieldset: HLCR
+  - name: CALFCR
+    description: XSPI full-cycle calibration configuration
+    byte_offset: 528
+    fieldset: CALFCR
+  - name: CALMR
+    description: XSPI DLL master calibration configuration
+    byte_offset: 536
+    fieldset: CALMR
+  - name: CALSOR
+    description: XSPI DLL slave output calibration configuration
+    byte_offset: 544
+    fieldset: CALSOR
+  - name: CALSIR
+    description: XSPI DLL slave input calibration configuration
+    byte_offset: 552
+    fieldset: CALSIR
+fieldset/ABR:
+  description: XSPI alternate bytes register
+  fields:
+  - name: ALTERNATE
+    description: "Alternate bytes\r Optional data to be sent to the external SPI device right after the address."
+    bit_offset: 0
+    bit_size: 32
+fieldset/AR:
+  description: XSPIaddress register
+  fields:
+  - name: ADDRESS
+    description: "Address\r Address to be sent to the external device. In HyperBus protocol, this field must be even as this protocol is 16-bit word oriented. In dual-memory configuration, AR[0] is forced to 0. \r Writes to this field are ignored when BUSY = 1 or when FMODE = 11 (memory-mapped mode).\r Some memory specifications consider that each address corresponds to a 16-bit value. XSPI considers that each address corresponds to an 8-bit value. So the software needs to multiple the address by two when accessing the memory registers."
+    bit_offset: 0
+    bit_size: 32
+fieldset/CALFCR:
+  description: XSPI full-cycle calibration configuration
+  fields:
+  - name: FINE
+    description: "Fine calibration\r The unitary value of delay for this field depends on product technology (refer to the product datasheet)."
+    bit_offset: 0
+    bit_size: 7
+  - name: COARSE
+    description: "Coarse calibration\r The unitary value of delay for this field depends on product technology (refer to the product datasheet)."
+    bit_offset: 16
+    bit_size: 5
+  - name: CALMAX
+    description: "Max value\r This bit gets set when the memory-clock period is outside the range of DLL master, in which case XSPI_CALFCR and XSPI_CALSR are updated with the values for the maximum delay."
+    bit_offset: 31
+    bit_size: 1
+fieldset/CALMR:
+  description: XSPI DLL master calibration configuration
+  fields:
+  - name: FINE
+    description: "Fine calibration\r The unitary value of delay for this field depends on product technology (refer to the product datasheet)."
+    bit_offset: 0
+    bit_size: 7
+  - name: COARSE
+    description: "Coarse calibration\r The unitary value of delay for this field depends on product technology (refer to the product datasheet)."
+    bit_offset: 16
+    bit_size: 5
+fieldset/CALSIR:
+  description: XSPI DLL slave input calibration configuration
+  fields:
+  - name: FINE
+    description: "Fine calibration\r The unitary value of delay for this field depends on product technology (refer to the product datasheet)."
+    bit_offset: 0
+    bit_size: 7
+  - name: COARSE
+    description: "Coarse calibration\r The unitary value of delay for this field depends on product technology (refer to the product datasheet)."
+    bit_offset: 16
+    bit_size: 5
+fieldset/CALSOR:
+  description: XSPI DLL slave output calibration configuration
+  fields:
+  - name: FINE
+    description: "Fine calibration\r The unitary value of delay for this field depends on product technology (refer to the product datasheet)."
+    bit_offset: 0
+    bit_size: 7
+  - name: COARSE
+    description: "Coarse calibration\r The unitary value of delay for this field depends on product technology (refer to the product datasheet)."
+    bit_offset: 16
+    bit_size: 5
+fieldset/CCR:
+  description: XSPI communication configuration register
+  fields:
+  - name: IMODE
+    description: "Instruction mode\r This field defines the instruction phase mode of operation.\r Others: reserved"
+    bit_offset: 0
+    bit_size: 3
+    enum: CCR_IMODE
+  - name: IDTR
+    description: "Instruction double transfer rate\r This bit sets the DTR mode for the instruction phase."
+    bit_offset: 3
+    bit_size: 1
+  - name: ISIZE
+    description: "Instruction size\r This bit defines instruction size."
+    bit_offset: 4
+    bit_size: 2
+    enum: CCR_ISIZE
+  - name: ADMODE
+    description: "Address mode\r This field defines the address phase mode of operation.\r Others: reserved"
+    bit_offset: 8
+    bit_size: 3
+    enum: CCR_ADMODE
+  - name: ADDTR
+    description: "Address double transfer rate\r This bit sets the DTR mode for the address phase."
+    bit_offset: 11
+    bit_size: 1
+  - name: ADSIZE
+    description: "Address size\r This field defines address size."
+    bit_offset: 12
+    bit_size: 2
+    enum: CCR_ADSIZE
+  - name: ABMODE
+    description: "Alternate-byte mode\r This field defines the alternate byte phase mode of operation.\r Others: reserved"
+    bit_offset: 16
+    bit_size: 3
+    enum: CCR_ABMODE
+  - name: ABDTR
+    description: "Alternate bytes double transfer rate\r This bit sets the DTR mode for the alternate bytes phase.\r Note: This field can be written only when BUSY = 0."
+    bit_offset: 19
+    bit_size: 1
+  - name: ABSIZE
+    description: "Alternate bytes size\r This bit defines alternate bytes size."
+    bit_offset: 20
+    bit_size: 2
+    enum: CCR_ABSIZE
+  - name: DMODE
+    description: "Data mode\r This field defines the data phase mode of operation.\r Others: reserved"
+    bit_offset: 24
+    bit_size: 3
+    enum: CCR_DMODE
+  - name: DDTR
+    description: "Data double transfer rate\r This bit sets the DTR mode for the data phase."
+    bit_offset: 27
+    bit_size: 1
+  - name: DQSE
+    description: "DQS enable\r This bit enables the data strobe management."
+    bit_offset: 29
+    bit_size: 1
+fieldset/CR:
+  description: XSPI control register
+  fields:
+  - name: EN
+    description: "Enable\r This bit enables the XSPI.\r The DMA request can be aborted without having received the ACK in case this EN bit is cleared during the operation.\r Note: In case this bit is set to 0 during a DMA transfer, the REQ signal to DMA returns to inactive state without waiting for the ACK signal from DMA to be active."
+    bit_offset: 0
+    bit_size: 1
+  - name: ABORT
+    description: "Abort request\r This bit aborts the on-going command sequence. It is automatically reset once the abort is completed. This bit stops the current transfer.\r Note: This bit is always read as 0."
+    bit_offset: 1
+    bit_size: 1
+  - name: DMAEN
+    description: "DMA enable\r In indirect mode, the DMA can be used to input or output data via XSPI_DR. DMA transfers are initiated when FTF is set. \r Note: Resetting the DMAEN bit while a DMA transfer is ongoing, breaks the handshake with the DMA. Do not write this bit during DMA operation."
+    bit_offset: 2
+    bit_size: 1
+  - name: TCEN
+    description: "Timeout counter enable\r This bit is valid only when the memory-mapped mode (FMODE[1:0] = 11) is selected. This bit enables the timeout counter.\r Note: This bit can be modified only when BUSY = 0."
+    bit_offset: 3
+    bit_size: 1
+  - name: DMM
+    description: "Dual-memory configuration\r This bit activates the dual-memory configuration, where two external devices are used simultaneously to double the throughput and the capacity\r Note: This bit can be modified only when BUSY = 0."
+    bit_offset: 6
+    bit_size: 1
+  - name: FTHRES
+    description: "FIFO threshold level\r This field defines, in indirect mode, the threshold number of bytes in the FIFO that causes the FIFO threshold flag FTF in XSPI_SR, to be set.\r ...\r Note: If DMAEN = 1, the DMA controller for the corresponding channel must be disabled before changing the FTHRES[5:0] value."
+    bit_offset: 8
+    bit_size: 6
+    enum: FTHRES
+  - name: TEIE
+    description: "Transfer error interrupt enable\r This bit enables the transfer error interrupt."
+    bit_offset: 16
+    bit_size: 1
+  - name: TCIE
+    description: "Transfer complete interrupt enable\r This bit enables the transfer complete interrupt."
+    bit_offset: 17
+    bit_size: 1
+  - name: FTIE
+    description: "FIFO threshold interrupt enable\r This bit enables the FIFO threshold interrupt."
+    bit_offset: 18
+    bit_size: 1
+  - name: SMIE
+    description: "Status match interrupt enable\r This bit enables the status match interrupt."
+    bit_offset: 19
+    bit_size: 1
+  - name: TOIE
+    description: "Timeout interrupt enable\r This bit enables the timeout interrupt."
+    bit_offset: 20
+    bit_size: 1
+  - name: APMS
+    description: "Automatic status-polling mode stop\r This bit determines if the automatic status-polling is stopped after a match.\r Note: This bit can be modified only when BUSY = 0."
+    bit_offset: 22
+    bit_size: 1
+    enum: APMS
+  - name: PMM
+    description: "Polling match mode\r This bit indicates which method must be used to determine a match during the automatic status-polling mode.\r Note: This bit can be modified only when BUSY = 0."
+    bit_offset: 23
+    bit_size: 1
+    enum: PMM
+  - name: CSSEL
+    description: "chip select selection\r This bit indicates if the XSPI must activate NCS1 or NCS2.\r Note: This bit can be modified only when BUSY = 0."
+    bit_offset: 24
+    bit_size: 1
+    enum: CSSEL
+  - name: FMODE
+    description: "Functional mode\r This field defines the XSPI functional mode of operation.\r If DMAEN = 1 already, then the DMA controller for the corresponding channel must be disabled before changing the FMODE[1:0] value. If FMODE[1:0] and FTHRES[4:0] are wrongly updated while DMAEN = 1, the DMA request signal automatically goes to inactive state.\r Note: This bitfield can be modified only when BUSY = 0."
+    bit_offset: 28
+    bit_size: 2
+    enum: FMODE
+  - name: MSEL
+    description: Flash select
+    bit_offset: 30
+    bit_size: 2
+    enum: MSEL
+fieldset/DCR1:
+  description: XSPI device configuration register 1
+  fields:
+  - name: CKMODE
+    description: "clock mode 0/mode 3\r This bit indicates the level taken by the CLK between commands (when NCS = 1)."
+    bit_offset: 0
+    bit_size: 1
+    enum: CKMODE
+  - name: FRCK
+    description: "Free running clock\r This bit configures the free running clock."
+    bit_offset: 1
+    bit_size: 1
+  - name: CSHT
+    description: "Chip-select high time\r CSHT + 1 defines the minimum number of CLK cycles where the chip-select (NCS) must remain high between commands issued to the external device.\r ..."
+    bit_offset: 8
+    bit_size: 6
+    enum: CSHT
+  - name: DEVSIZE
+    description: "Device size\r This field defines the size of the external device using the following formula:\r Number of bytes in device = 2<sup>[DEVSIZE+1]</sup>.\r DEVSIZE+1 is effectively the number of address bits required to address the external device. The device capacity can be up to 4 Gbytes (addressed using 32-bits) in indirect mode, but the addressable space in memory-mapped mode is limited to 256 Mbytes.\r In regular-command protocol, if DMM = 1, DEVSIZE[4:0] indicates the total capacity of the two devices together."
+    bit_offset: 16
+    bit_size: 5
+  - name: MTYP
+    description: "Memory type\r This bit indicates the type of memory to be supported.\r Note: In this mode, DQS signal polarity is inverted with respect to the memory clock signal. This is the default value and care must be taken to change MTYP[2:0] for memories different from Micron.\r Others: Reserved"
+    bit_offset: 24
+    bit_size: 3
+    enum: MTYP
+fieldset/DCR2:
+  description: XSPI device configuration register 2
+  fields:
+  - name: PRESCALER
+    description: "Clock prescaler\r This field defines the scaler factor for generating the CLK based on the kernel clock (value + 1). \r ...\r For odd clock division factors, the CLK duty cycle is not 50 %. The clock signal remains low one cycle longer than it stays high.\r Writing this field automatically starts a new calibration of high-speed interface DLL at the start of next transfer, except in case XSPI_CALOSR or XSPI_CALISR have been written in the meantime. BUSY stays high during the whole calibration execution."
+    bit_offset: 0
+    bit_size: 8
+  - name: WRAPSIZE
+    description: "Wrap size\r This field indicates the wrap size to which the memory is configured. For memories which have a separate command for wrapped instructions, this field indicates the wrap-size associated with the command held in XSPI_WPIR.\r Others: reserved"
+    bit_offset: 16
+    bit_size: 3
+    enum: WRAPSIZE
+fieldset/DCR3:
+  description: XSPI device configuration register 3
+  fields:
+  - name: MAXTRAN
+    description: "Maximum transfer\r This field enables the communication regulation feature.\r The NCS is released every MAXTRAN+1 clock cycles when the other XSPI request the access to the bus.\r Others: maximum communication is set to MAXTRAN + 1 bytes."
+    bit_offset: 0
+    bit_size: 8
+    enum: MAXTRAN
+  - name: CSBOUND
+    description: "NCS boundary\r This field enables the transaction boundary feature. When active, a minimum value of 3 is recommended.\r The NCS is released on each boundary of 2<sup>CSBOUND</sup> bytes.\r Others: NCS boundary set to 2<sup>CSBOUND</sup> bytes"
+    bit_offset: 16
+    bit_size: 5
+    enum: CSBOUND
+fieldset/DCR4:
+  description: XSPI device configuration register 4
+  fields:
+  - name: REFRESH
+    description: "Refresh rate\r This field enables the refresh rate feature.\r The NCS is released every REFRESH + 1 clock cycles for writes, and REFRESH + 4 clock cycles for reads. \r Note: These two values can be extended with few clock cycles when refresh occurs during a byte transmission in single-, dual- or quad-SPI mode, because the byte transmission must be completed.\r Others: maximum communication length is set to REFRESH + 1 clock cycles."
+    bit_offset: 0
+    bit_size: 32
+    enum: REFRESH
+fieldset/DLR:
+  description: XSPI data length register
+  fields:
+  - name: DL
+    description: Data length
+    bit_offset: 0
+    bit_size: 32
+fieldset/DR:
+  description: XSPI data register
+  fields:
+  - name: DATA
+    description: "Data\r Data to be sent/received to/from the external SPI device\r In indirect-write mode, data written to this register is stored on the FIFO before it is sent to the external device during the data phase. If the FIFO is too full, a write operation is stalled until the FIFO has enough space to accept the amount of data being written.\r In indirect-read mode, reading this register gives (via the FIFO) the data that was received from the external device. If the FIFO does not have as many bytes as requested by the read operation and if BUSY = 1, the read operation is stalled until enough data is present or until the transfer is complete, whichever happens first.\r In automatic status-polling mode, this register contains the last data read from the external device (without masking).\r Word, half-word, and byte accesses to this register are supported. In indirect-write mode, a byte write adds 1 byte to the FIFO, a half-word write 2 bytes, and a word write 4 bytes.\r Similarly, in indirect-read mode, a byte read removes 1 byte from the FIFO, a halfword read 2 bytes, and a word read 4 bytes. Accesses in indirect mode must be aligned to the bottom of this register: A byte read must read DATA[7:0] and a half-word read must read DATA[15:0]."
+    bit_offset: 0
+    bit_size: 32
+fieldset/FCR:
+  description: XSPI flag clear register
+  fields:
+  - name: CTEF
+    description: "Clear transfer error flag\r Writing 1 clears the TEF flag in the XSPI_SR register."
+    bit_offset: 0
+    bit_size: 1
+  - name: CTCF
+    description: "Clear transfer complete flag\r Writing 1 clears the TCF flag in the XSPI_SR register."
+    bit_offset: 1
+    bit_size: 1
+  - name: CSMF
+    description: "Clear status match flag\r Writing 1 clears the SMF flag in the XSPI_SR register."
+    bit_offset: 3
+    bit_size: 1
+  - name: CTOF
+    description: "Clear timeout flag\r Writing 1 clears the TOF flag in the XSPI_SR register."
+    bit_offset: 4
+    bit_size: 1
+fieldset/HLCR:
+  description: XSPI HyperBus latency configuration register
+  fields:
+  - name: LM
+    description: "Latency mode\r This bit selects the Latency mode.\r Note: This bit must be set when using the dual-octal HyperBus configuration."
+    bit_offset: 0
+    bit_size: 1
+    enum: LM
+  - name: WZL
+    description: "Write zero latency\r This bit enables zero latency on write operations."
+    bit_offset: 1
+    bit_size: 1
+    enum: WZL
+  - name: TACC
+    description: "Access time\r Device access time expressed in number of communication clock cycles"
+    bit_offset: 8
+    bit_size: 8
+  - name: TRWR
+    description: "Read write recovery time\r Device read write recovery time expressed in number of communication clock cycles"
+    bit_offset: 16
+    bit_size: 8
+fieldset/IR:
+  description: XSPI instruction register
+  fields:
+  - name: INSTRUCTION
+    description: "Instruction\r Instruction to be sent to the external SPI device"
+    bit_offset: 0
+    bit_size: 32
+fieldset/LPTR:
+  description: XSPI low-power timeout register
+  fields:
+  - name: TIMEOUT
+    description: "Timeout period\r After each access in memory-mapped mode, the XSPI prefetches the subsequent bytes and hold them in the FIFO.\r This field indicates how many CLK cycles the XSPI waits after the clock becomes inactive and until it raises the NCS, putting the external device in a lower-consumption state."
+    bit_offset: 0
+    bit_size: 16
+fieldset/PIR:
+  description: XSPI polling interval register
+  fields:
+  - name: INTERVAL
+    description: "Polling interval\r Number of CLK cycle between a read during the automatic status-polling phases"
+    bit_offset: 0
+    bit_size: 16
+fieldset/PSMAR:
+  description: XSPI polling status match register
+  fields:
+  - name: MATCH
+    description: "Status match\r Value to be compared with the masked status register to get a match"
+    bit_offset: 0
+    bit_size: 32
+fieldset/PSMKR:
+  description: XSPI polling status mask register
+  fields:
+  - name: MASK
+    description: "Status mask\r Mask to be applied to the status bytes received in automatic status-polling mode\r For bit n:"
+    bit_offset: 0
+    bit_size: 32
+    enum: MASK
+fieldset/SR:
+  description: XSPI status register
+  fields:
+  - name: TEF
+    description: "Transfer error flag\r This bit is set in indirect mode when an invalid address is being accessed in indirect mode.\r It is cleared by writing 1 to CTEF."
+    bit_offset: 0
+    bit_size: 1
+  - name: TCF
+    description: "Transfer complete flag\r This bit is set in indirect mode when the programmed number of data has been transferred or in any mode when the transfer has been aborted.It is cleared by writing 1 to CTCF."
+    bit_offset: 1
+    bit_size: 1
+  - name: FTF
+    description: "FIFO threshold flag\r In indirect mode, this bit is set when the FIFO threshold has been reached, or if there is any data left in the FIFO after the reads from the external device are complete.\r It is cleared automatically as soon as the threshold condition is no longer true.\r In automatic status-polling mode this bit is set every time the status register is read, and the bit is cleared when the data register is read."
+    bit_offset: 2
+    bit_size: 1
+  - name: SMF
+    description: "Status match flag\r This bit is set in automatic status-polling mode when the unmasked received data matches the corresponding bits in the match register (XSPI_PSMAR). \r It is cleared by writing 1 to CSMF."
+    bit_offset: 3
+    bit_size: 1
+  - name: TOF
+    description: "Timeout flag\r This bit is set when timeout occurs. It is cleared by writing 1 to CTOF."
+    bit_offset: 4
+    bit_size: 1
+  - name: BUSY
+    description: "Busy\r This bit is set when an operation is ongoing. It is cleared automatically when the operation with the external device is finished and the FIFO is empty."
+    bit_offset: 5
+    bit_size: 1
+  - name: FLEVEL
+    description: "FIFO level\r This field gives the number of valid bytes that are being held in the FIFO. FLEVEL = 0 when the FIFO is empty, and 64 when it is full.\r In automatic-status polling mode, FLEVEL is zero."
+    bit_offset: 8
+    bit_size: 7
+fieldset/TCR:
+  description: XSPI timing configuration register
+  fields:
+  - name: DCYC
+    description: "Number of dummy cycles\r This field defines the duration of the dummy phase.\r In both SDR and DTR modes, it specifies a number of CLK cycles (0-31)."
+    bit_offset: 0
+    bit_size: 5
+  - name: DHQC
+    description: Delay hold quarter cycle
+    bit_offset: 28
+    bit_size: 1
+  - name: SSHIFT
+    description: "Sample shift\r By default, the XSPI samples data 1/2 of a CLK cycle after the data is driven by the external device.\r This bit allows the data to be sampled later in order to consider the external signal delays.\r The software must ensure that SSHIFT = 0 when the data phase is configured in DTR mode (when DDTR = 1.)"
+    bit_offset: 30
+    bit_size: 1
+fieldset/WABR:
+  description: XSPI write alternate byte register
+  fields:
+  - name: ALTERNATE
+    description: "Alternate bytes\r Optional data to be sent to the external SPI device right after the address"
+    bit_offset: 0
+    bit_size: 32
+fieldset/WCCR:
+  description: XSPI write communication configuration register
+  fields:
+  - name: IMODE
+    description: "Instruction mode\r This field defines the instruction phase mode of operation.\r Others: reserved"
+    bit_offset: 0
+    bit_size: 3
+    enum: WCCR_IMODE
+  - name: IDTR
+    description: "Instruction double transfer rate\r This bit sets the DTR mode for the instruction phase."
+    bit_offset: 3
+    bit_size: 1
+  - name: ISIZE
+    description: "Instruction size\r This bit defines instruction size:"
+    bit_offset: 4
+    bit_size: 2
+    enum: WCCR_ISIZE
+  - name: ADMODE
+    description: "Address mode\r This field defines the address phase mode of operation.\r Others: reserved"
+    bit_offset: 8
+    bit_size: 3
+    enum: WCCR_ADMODE
+  - name: ADDTR
+    description: "Address double transfer rate\r This bit sets the DTR mode for the address phase."
+    bit_offset: 11
+    bit_size: 1
+  - name: ADSIZE
+    description: "Address size\r This field defines address size."
+    bit_offset: 12
+    bit_size: 2
+    enum: WCCR_ADSIZE
+  - name: ABMODE
+    description: "Alternate-byte mode\r This field defines the alternate-byte phase mode of operation.\r Others: reserved"
+    bit_offset: 16
+    bit_size: 3
+    enum: WCCR_ABMODE
+  - name: ABDTR
+    description: "Alternate bytes double-transfer rate\r This bit sets the DTR mode for the alternate-bytes phase."
+    bit_offset: 19
+    bit_size: 1
+  - name: ABSIZE
+    description: "Alternate bytes size\r This field defines alternate bytes size:"
+    bit_offset: 20
+    bit_size: 2
+    enum: WCCR_ABSIZE
+  - name: DMODE
+    description: "Data mode\r This field defines the data phase mode of operation."
+    bit_offset: 24
+    bit_size: 3
+    enum: WCCR_DMODE
+  - name: DDTR
+    description: "data double transfer rate\r This bit sets the DTR mode for the data phase."
+    bit_offset: 27
+    bit_size: 1
+  - name: DQSE
+    description: "DQS enable\r This bit enables the data strobe management."
+    bit_offset: 29
+    bit_size: 1
+fieldset/WIR:
+  description: XSPI write instruction register
+  fields:
+  - name: INSTRUCTION
+    description: "Instruction\r Instruction to be sent to the external SPI device"
+    bit_offset: 0
+    bit_size: 32
+fieldset/WPABR:
+  description: XSPI wrap alternate byte register
+  fields:
+  - name: ALTERNATE
+    description: "Alternate bytes\r Optional data to be sent to the external SPI device right after the address"
+    bit_offset: 0
+    bit_size: 32
+fieldset/WPCCR:
+  description: XSPI wrap communication configuration register
+  fields:
+  - name: IMODE
+    description: "Instruction mode\r This field defines the instruction phase mode of operation.\r Others: reserved"
+    bit_offset: 0
+    bit_size: 3
+    enum: WPCCR_IMODE
+  - name: IDTR
+    description: "Instruction double transfer rate\r This bit sets the DTR mode for the instruction phase."
+    bit_offset: 3
+    bit_size: 1
+  - name: ISIZE
+    description: "Instruction size\r This field defines instruction size."
+    bit_offset: 4
+    bit_size: 2
+    enum: WPCCR_ISIZE
+  - name: ADMODE
+    description: "Address mode\r This field defines the address phase mode of operation.\r Others: reserved"
+    bit_offset: 8
+    bit_size: 3
+    enum: WPCCR_ADMODE
+  - name: ADDTR
+    description: "Address double transfer rate\r This bit sets the DTR mode for the address phase."
+    bit_offset: 11
+    bit_size: 1
+  - name: ADSIZE
+    description: "Address size\r This field defines address size."
+    bit_offset: 12
+    bit_size: 2
+    enum: WPCCR_ADSIZE
+  - name: ABMODE
+    description: "Alternate-byte mode\r This field defines the alternate byte phase mode of operation."
+    bit_offset: 16
+    bit_size: 3
+    enum: WPCCR_ABMODE
+  - name: ABDTR
+    description: "Alternate bytes double transfer rate\r This bit sets the DTR mode for the alternate bytes phase."
+    bit_offset: 19
+    bit_size: 1
+  - name: ABSIZE
+    description: "Alternate bytes size\r This bit defines alternate bytes size."
+    bit_offset: 20
+    bit_size: 2
+    enum: WPCCR_ABSIZE
+  - name: DMODE
+    description: "Data mode\r This field defines the data phase mode of operation.\r 101; data on 16 lines\r Others: reserved"
+    bit_offset: 24
+    bit_size: 3
+    enum: WPCCR_DMODE
+  - name: DDTR
+    description: "Data double transfer rate\r This bit sets the DTR mode for the data phase."
+    bit_offset: 27
+    bit_size: 1
+  - name: DQSE
+    description: "DQS enable\r This bit enables the data strobe management."
+    bit_offset: 29
+    bit_size: 1
+fieldset/WPIR:
+  description: XSPI wrap instruction register
+  fields:
+  - name: INSTRUCTION
+    description: "Instruction\r Instruction to be sent to the external SPI device"
+    bit_offset: 0
+    bit_size: 32
+fieldset/WPTCR:
+  description: XSPI wrap timing configuration register
+  fields:
+  - name: DCYC
+    description: "Number of dummy cycles\r This field defines the duration of the dummy phase.\r In both SDR and DTR modes, it specifies a number of CLK cycles (0-31)."
+    bit_offset: 0
+    bit_size: 5
+  - name: DHQC
+    description: "Delay hold quarter cycle\r Add a quarter cycle delay on the outputs in DTR communication to match hold requirement."
+    bit_offset: 28
+    bit_size: 1
+  - name: SSHIFT
+    description: "Sample shift\r By default, the XSPI samples data 1/2 of a CLK cycle after the data is driven by the external device.\r This bit allows the data to be sampled later in order to consider the external signal delays.\r The firmware must assure that SSHIFT=0 when the data phase is configured in DTR mode (when DDTR = 1)."
+    bit_offset: 30
+    bit_size: 1
+fieldset/WTCR:
+  description: XSPI write timing configuration register
+  fields:
+  - name: DCYC
+    description: "Number of dummy cycles\r This field defines the duration of the dummy phase.\r In both SDR and DTR modes, it specifies a number of CLK cycles (0-31). It is recommended to have at least 5 dummy cycles when using memories with DQS activated."
+    bit_offset: 0
+    bit_size: 5
+enum/APMS:
+  bit_size: 1
+  variants:
+  - name: B_0x0
+    description: Automatic status-polling mode is stopped only by abort or by disabling the XSPI.
+    value: 0
+  - name: B_0x1
+    description: Automatic status-polling mode stops as soon as there is a match.
+    value: 1
+enum/CCR_ABMODE:
+  bit_size: 3
+  variants:
+  - name: B_0x0
+    description: no alternate bytes
+    value: 0
+  - name: B_0x1
+    description: alternate bytes on a single line
+    value: 1
+  - name: B_0x2
+    description: alternate bytes on two lines
+    value: 2
+  - name: B_0x3
+    description: alternate bytes on four lines
+    value: 3
+enum/CCR_ABSIZE:
+  bit_size: 2
+  variants:
+  - name: B_0x0
+    description: 8-bit alternate bytes
+    value: 0
+  - name: B_0x1
+    description: 16-bit alternate bytes
+    value: 1
+  - name: B_0x2
+    description: 24-bit alternate bytes
+    value: 2
+  - name: B_0x3
+    description: 32-bit alternate bytes
+    value: 3
+enum/CCR_ADMODE:
+  bit_size: 3
+  variants:
+  - name: B_0x0
+    description: no address
+    value: 0
+  - name: B_0x1
+    description: address on a single line
+    value: 1
+  - name: B_0x2
+    description: address on two lines
+    value: 2
+  - name: B_0x3
+    description: address on four lines
+    value: 3
+  - name: B_0x4
+    description: address on eight lines
+    value: 4
+enum/CCR_ADSIZE:
+  bit_size: 2
+  variants:
+  - name: B_0x0
+    description: 8-bit address
+    value: 0
+  - name: B_0x1
+    description: 16-bit address
+    value: 1
+  - name: B_0x2
+    description: 24-bit address
+    value: 2
+  - name: B_0x3
+    description: 32-bit address
+    value: 3
+enum/CCR_DMODE:
+  bit_size: 3
+  variants:
+  - name: B_0x0
+    description: no data
+    value: 0
+  - name: B_0x1
+    description: data on a single line
+    value: 1
+  - name: B_0x2
+    description: data on two lines
+    value: 2
+  - name: B_0x3
+    description: data on four lines
+    value: 3
+  - name: B_0x4
+    description: data on eight lines
+    value: 4
+  - name: B_0x5
+    description: data on 16 lines
+    value: 5
+enum/CCR_IMODE:
+  bit_size: 3
+  variants:
+  - name: B_0x0
+    description: no instruction
+    value: 0
+  - name: B_0x1
+    description: instruction on a single line
+    value: 1
+  - name: B_0x2
+    description: instruction on two lines
+    value: 2
+  - name: B_0x3
+    description: instruction on four lines
+    value: 3
+  - name: B_0x4
+    description: instruction on eight lines
+    value: 4
+enum/CCR_ISIZE:
+  bit_size: 2
+  variants:
+  - name: B_0x0
+    description: 8-bit instruction
+    value: 0
+  - name: B_0x1
+    description: 16-bit instruction
+    value: 1
+  - name: B_0x2
+    description: 24-bit instruction
+    value: 2
+  - name: B_0x3
+    description: 32-bit instruction
+    value: 3
+enum/CKMODE:
+  bit_size: 1
+  variants:
+  - name: B_0x0
+    description: CLK must stay low while NCS is high (chip-select released), referred to as clock mode 0.
+    value: 0
+  - name: B_0x1
+    description: CLK must stay high while NCS is high (chip-select released), referred to as clock mode 3.
+    value: 1
+enum/CSBOUND:
+  bit_size: 5
+  variants:
+  - name: B_0x0
+    description: NCS boundary disabled
+    value: 0
+enum/CSHT:
+  bit_size: 6
+  variants:
+  - name: B_0x0
+    description: NCS stays high for at least 1 cycle between external device commands.
+    value: 0
+  - name: B_0x1
+    description: NCS stays high for at least 2 cycles between external device commands.
+    value: 1
+  - name: B_0x3F
+    description: NCS stays high for at least 64 cycles between external device commands.
+    value: 63
+enum/CSSEL:
+  bit_size: 1
+  variants:
+  - name: B_0x0
+    description: NCS1 active
+    value: 0
+  - name: B_0x1
+    description: NCS2 active
+    value: 1
+enum/FMODE:
+  bit_size: 2
+  variants:
+  - name: B_0x0
+    description: indirect-write mode
+    value: 0
+  - name: B_0x1
+    description: indirect-read mode
+    value: 1
+  - name: B_0x2
+    description: automatic status-polling mode
+    value: 2
+  - name: B_0x3
+    description: memory-mapped mode
+    value: 3
+enum/FTHRES:
+  bit_size: 6
+  variants:
+  - name: B_0x0
+    description: FTF is set if there are one or more free bytes available to be written to in the FIFO
+    value: 0
+  - name: B_0x1
+    description: FTF is set if there are two or more free bytes available to be written to in the FIFO
+    value: 1
+  - name: B_0x3F
+    description: FTF is set if there are 64 free bytes available to be written to in the FIFO
+    value: 63
+enum/LM:
+  bit_size: 1
+  variants:
+  - name: B_0x0
+    description: Variable initial latency
+    value: 0
+  - name: B_0x1
+    description: Fixed latency
+    value: 1
+enum/MASK:
+  bit_size: 32
+  variants:
+  - name: B_0x0
+    description: bit n of the data received in automatic status-polling mode is masked and its value is not considered in the matching logic.
+    value: 0
+  - name: B_0x1
+    description: bit n of the data received in automatic status-polling mode is unmasked and its value is considered in the matching logic.
+    value: 1
+enum/MAXTRAN:
+  bit_size: 8
+  variants:
+  - name: B_0x0
+    description: maximum communication disabled
+    value: 0
+enum/MSEL:
+  bit_size: 2
+  variants:
+  - name: B_0x0
+    description: data exchanged over IO[3:0]
+    value: 0
+  - name: B_0x1
+    description: data exchanged over IO[7:4]
+    value: 1
+  - name: B_0x2
+    description: data exchanged over IO[11:8]
+    value: 2
+  - name: B_0x3
+    description: data exchanged over IO[15:12]
+    value: 3
+enum/MTYP:
+  bit_size: 3
+  variants:
+  - name: B_0x0
+    description: Micron mode, D0/D1 ordering in DTR 8-data-bit mode. Regular-command protocol in single-, dual-, quad-, and octal-SPI modes.
+    value: 0
+  - name: B_0x1
+    description: Macronix mode, D1/D0 ordering in DTR 8-data-bit mode. Regular-command protocol in single-, dual-, quad-, and octal-SPI modes.
+    value: 1
+  - name: B_0x2
+    description: Standard mode
+    value: 2
+  - name: B_0x3
+    description: Macronix RAM mode, D1/D0 ordering in DTR 8-data-bit mode. Regular-command protocol in single-, dual-, quad-, and octal-SPI modes with dedicated address mapping.
+    value: 3
+  - name: B_0x4
+    description: HyperBus memory mode, the protocol follows the HyperBus<sup> </sup>specification. 8-data-bit DTR mode must be selected.
+    value: 4
+  - name: B_0x5
+    description: HyperBus register mode, addressing register space. The memory-mapped accesses in this mode must be non-cacheable, or indirect read/write modes must be used.
+    value: 5
+enum/PMM:
+  bit_size: 1
+  variants:
+  - name: B_0x0
+    description: AND-match mode, SMF is set if all the unmasked bits received from the device match the corresponding bits in the match register.
+    value: 0
+  - name: B_0x1
+    description: OR-match mode, SMF is set if any of the unmasked bits received from the device matches its corresponding bit in the match register.
+    value: 1
+enum/REFRESH:
+  bit_size: 32
+  variants:
+  - name: B_0x0
+    description: refresh disabled
+    value: 0
+enum/WCCR_ABMODE:
+  bit_size: 3
+  variants:
+  - name: B_0x0
+    description: no alternate bytes
+    value: 0
+  - name: B_0x1
+    description: alternate bytes on a single line
+    value: 1
+  - name: B_0x2
+    description: alternate bytes on two lines
+    value: 2
+  - name: B_0x3
+    description: alternate bytes on four lines
+    value: 3
+  - name: B_0x4
+    description: alternate bytes on eight lines
+    value: 4
+enum/WCCR_ABSIZE:
+  bit_size: 2
+  variants:
+  - name: B_0x0
+    description: 8-bit alternate bytes
+    value: 0
+  - name: B_0x1
+    description: 16-bit alternate bytes
+    value: 1
+  - name: B_0x2
+    description: 24-bit alternate bytes
+    value: 2
+  - name: B_0x3
+    description: 32-bit alternate bytes
+    value: 3
+enum/WCCR_ADMODE:
+  bit_size: 3
+  variants:
+  - name: B_0x0
+    description: no address
+    value: 0
+  - name: B_0x1
+    description: address on a single line
+    value: 1
+  - name: B_0x2
+    description: address on two lines
+    value: 2
+  - name: B_0x3
+    description: address on four lines
+    value: 3
+  - name: B_0x4
+    description: address on eight lines
+    value: 4
+enum/WCCR_ADSIZE:
+  bit_size: 2
+  variants:
+  - name: B_0x0
+    description: 8-bit address
+    value: 0
+  - name: B_0x1
+    description: 16-bit address
+    value: 1
+  - name: B_0x2
+    description: 24-bit address
+    value: 2
+  - name: B_0x3
+    description: 32-bit address
+    value: 3
+enum/WCCR_DMODE:
+  bit_size: 3
+  variants:
+  - name: B_0x0
+    description: no data
+    value: 0
+  - name: B_0x1
+    description: data on a single line
+    value: 1
+  - name: B_0x2
+    description: data on two lines
+    value: 2
+  - name: B_0x3
+    description: data on four lines
+    value: 3
+  - name: B_0x4
+    description: data on eight lines
+    value: 4
+  - name: B_0x5
+    description: Data on 16 lines
+    value: 5
+  - name: B_0x7
+    description: DATA reserved
+    value: 7
+enum/WCCR_IMODE:
+  bit_size: 3
+  variants:
+  - name: B_0x0
+    description: no instruction
+    value: 0
+  - name: B_0x1
+    description: instruction on a single line
+    value: 1
+  - name: B_0x2
+    description: instruction on two lines
+    value: 2
+  - name: B_0x3
+    description: instruction on four lines
+    value: 3
+  - name: B_0x4
+    description: instruction on eight lines
+    value: 4
+enum/WCCR_ISIZE:
+  bit_size: 2
+  variants:
+  - name: B_0x0
+    description: 8-bit instruction
+    value: 0
+  - name: B_0x1
+    description: 16-bit instruction
+    value: 1
+  - name: B_0x2
+    description: 24-bit instruction
+    value: 2
+  - name: B_0x3
+    description: 32-bit instruction
+    value: 3
+enum/WPCCR_ABMODE:
+  bit_size: 3
+  variants:
+  - name: B_0x0
+    description: no alternate bytes
+    value: 0
+  - name: B_0x1
+    description: alternate bytes on a single line
+    value: 1
+  - name: B_0x2
+    description: alternate bytes on two lines
+    value: 2
+  - name: B_0x3
+    description: alternate bytes on four lines
+    value: 3
+  - name: B_0x4
+    description: alternate bytes on eight lines
+    value: 4
+  - name: B_0x5
+    description: alternate bytes on 16 lines
+    value: 5
+  - name: B_0x7
+    description: DATA reserved
+    value: 7
+enum/WPCCR_ABSIZE:
+  bit_size: 2
+  variants:
+  - name: B_0x0
+    description: 8-bit alternate bytes
+    value: 0
+  - name: B_0x1
+    description: 16-bit alternate bytes
+    value: 1
+  - name: B_0x2
+    description: 24-bit alternate bytes
+    value: 2
+  - name: B_0x3
+    description: 32-bit alternate bytes
+    value: 3
+enum/WPCCR_ADMODE:
+  bit_size: 3
+  variants:
+  - name: B_0x0
+    description: no address
+    value: 0
+  - name: B_0x1
+    description: address on a single line
+    value: 1
+  - name: B_0x2
+    description: address on two lines
+    value: 2
+  - name: B_0x3
+    description: address on four lines
+    value: 3
+  - name: B_0x4
+    description: address on eight lines
+    value: 4
+enum/WPCCR_ADSIZE:
+  bit_size: 2
+  variants:
+  - name: B_0x0
+    description: 8-bit address
+    value: 0
+  - name: B_0x1
+    description: 16-bit address
+    value: 1
+  - name: B_0x2
+    description: 24-bit address
+    value: 2
+  - name: B_0x3
+    description: 32-bit address
+    value: 3
+enum/WPCCR_DMODE:
+  bit_size: 3
+  variants:
+  - name: B_0x0
+    description: no data
+    value: 0
+  - name: B_0x1
+    description: data on a single line
+    value: 1
+  - name: B_0x2
+    description: data on two lines
+    value: 2
+  - name: B_0x3
+    description: data on four lines
+    value: 3
+  - name: B_0x4
+    description: data on eight lines
+    value: 4
+enum/WPCCR_IMODE:
+  bit_size: 3
+  variants:
+  - name: B_0x0
+    description: no instruction
+    value: 0
+  - name: B_0x1
+    description: instruction on a single line
+    value: 1
+  - name: B_0x2
+    description: instruction on two lines
+    value: 2
+  - name: B_0x3
+    description: instruction on four lines
+    value: 3
+  - name: B_0x4
+    description: instruction on eight lines
+    value: 4
+enum/WPCCR_ISIZE:
+  bit_size: 2
+  variants:
+  - name: B_0x0
+    description: 8-bit instruction
+    value: 0
+  - name: B_0x1
+    description: 16-bit instruction
+    value: 1
+  - name: B_0x2
+    description: 24-bit instruction
+    value: 2
+  - name: B_0x3
+    description: 32-bit instruction
+    value: 3
+enum/WRAPSIZE:
+  bit_size: 3
+  variants:
+  - name: B_0x0
+    description: wrapped reads are not supported by the memory.
+    value: 0
+  - name: B_0x2
+    description: external memory supports wrap size of 16 bytes.
+    value: 2
+  - name: B_0x3
+    description: external memory supports wrap size of 32 bytes.
+    value: 3
+  - name: B_0x4
+    description: external memory supports wrap size of 64 bytes.
+    value: 4
+  - name: B_0x5
+    description: external memory supports wrap size of 128 bytes.
+    value: 5
+enum/WZL:
+  bit_size: 1
+  variants:
+  - name: B_0x0
+    description: latency on write accesses
+    value: 0
+  - name: B_0x1
+    description: no latency on write accesses
+    value: 1

--- a/data/registers/xspim_v1.yaml
+++ b/data/registers/xspim_v1.yaml
@@ -1,0 +1,34 @@
+block/XSPIM:
+  description: XSPIM1 register block.
+  items:
+  - name: CR
+    description: XSPIM control register.
+    byte_offset: 0
+    fieldset: CR
+fieldset/CR:
+  description: XSPIM control register.
+  fields:
+  - name: MUXEN
+    description: Multiplexed mode enable This bit enables the multiplexing of the two XSPIs.
+    bit_offset: 0
+    bit_size: 1
+  - name: MODE
+    description: XSPI multiplexing mode.
+    bit_offset: 1
+    bit_size: 1
+  - name: CSSEL_OVR_EN
+    description: Chip select selector override enable.
+    bit_offset: 4
+    bit_size: 1
+  - name: CSSEL_OVR_O1
+    description: Chip select selector override setting for XSPI1.
+    bit_offset: 5
+    bit_size: 1
+  - name: CSSEL_OVR_O2
+    description: Chip select selector override setting for XSPI2.
+    bit_offset: 6
+    bit_size: 1
+  - name: REQ2ACK_TIME
+    description: REQ to ACK time In Multiplexed mode (MUXEN = 1), this field defines the time between two transactions.
+    bit_offset: 16
+    bit_size: 8

--- a/stm32-data-gen/src/header.rs
+++ b/stm32-data-gen/src/header.rs
@@ -197,6 +197,8 @@ impl Defines {
             ("VREFINTCAL", &["VREFINT_CAL_ADDR_CMSIS"]),
             ("DSIHOST", &["DSI_BASE"]),
             ("SYSCFG", &["SYSCFG_BASE", "SBS_BASE"]),
+            ("XSPI1", &["XSPI1_R_BASE"]),
+            ("XSPI2", &["XSPI2_R_BASE"]),
         ];
         let alt_peri_defines: HashMap<_, _> = ALT_PERI_DEFINES.iter().copied().collect();
 

--- a/stm32-data-gen/src/perimap.rs
+++ b/stm32-data-gen/src/perimap.rs
@@ -607,4 +607,6 @@ pub static PERIMAP: RegexMap<(&str, &str, &str)> = RegexMap::new(&[
     ("STM32(L5|WL|WB).*:PKA:.*", ("pka", "v1c", "PKA")),
     ("STM32(L4Q|L5|WL|WB).*:PKA:.*", ("pka", "v1c", "PKA")),
     (".*:OTFDEC:.*", ("otfdec", "v1", "OTFDEC")),
+    (".*:XSPI[12]:XSPI:xspi_v2_1H7RS*", ("xspi", "v1", "XSPI")),
+    (".*:XSPIM:XSPIM:xspi_v2_1H7RS*", ("xspim", "v1", "XSPIM")),
 ]);

--- a/transforms/XSPI.yaml
+++ b/transforms/XSPI.yaml
@@ -1,0 +1,28 @@
+transforms:
+  - !Rename
+    from: ^XSPI1$
+    to: XSPI
+    type: Block
+
+  - !Rename
+    from: ^XSPI_(.+)
+    to: $1
+    type: All
+
+  - !RenameRegisters
+    block: XSPI
+    from: ^XSPI_(.+)$
+    to: $1
+
+  - !DeleteEnums
+    from: ^(WCCR|WPCCR|TCR|WPTCR|WPDCR|CCR)_(SSHIFT|DHQC|DQSE|(AB|AD|D|I)DTR)$
+
+  - !DeleteEnums
+    from: ^(TCIE|TCEN|SMIE|TEIE|FTIE|TOIE)?$
+
+  - !DeleteEnums
+    from: ^(DMM|DMAEN|EN|ABORT|FRCK)?$
+
+  # prescaler is 0..255, not an enum
+  - !DeleteEnums
+    from: ^(PRESCALER)?$

--- a/transforms/XSPIM.yaml
+++ b/transforms/XSPIM.yaml
@@ -1,0 +1,15 @@
+transforms:
+  - !Rename
+    from: ^XSPIM1$
+    to: XSPIM
+    type: Block
+
+  - !Rename
+    from: ^XSPIM_(.+)
+    to: $1
+    type: All
+
+  - !RenameRegisters
+    block: XSPIM
+    from: ^XSPIM_(.+)$
+    to: $1


### PR DESCRIPTION
I've tested this against a small example in embassy-stm32 [1]. Need to figure why single mode works but quad mode doesn't, but I think the PAC here is OK. 

@rickrogers-ionq 

[1] https://github.com/mkj/embassy/tree/dev/matt/xspi