### PR TITLE
feat: add stop mode rules which override the fallback behavior

### DIFF
--- a/stm32-data-gen/src/chips.rs
+++ b/stm32-data-gen/src/chips.rs
@@ -620,7 +620,11 @@ fn process_core(
             });
         }
 
-        if let Some(rcc_info) = peripheral_to_clock.match_peri_clock(rcc_block.1, &pname) {
+        if let Some(mut rcc_info) = peripheral_to_clock.match_peri_clock(rcc_block.1, &pname) {
+            if let Some(stop_mode_info) = low_power::peripheral_stop_mode_info(chip_name, &pname) {
+                rcc_info.stop_mode = stop_mode_info;
+            }
+
             p.rcc = Some(rcc_info);
         }
         if let Some(pins) = periph_pins.get_mut(&pname) {

--- a/stm32-data-gen/src/low_power.rs
+++ b/stm32-data-gen/src/low_power.rs
@@ -1,0 +1,59 @@
+use stm32_data_serde::chip::core::peripheral::rcc::StopMode;
+
+use crate::util::RegexMap;
+
+/// Get the stop mode limit for a peripheral based on the MCU and peripheral name.
+/// Determines the lowest possible stop mode when a peripheral is enabled.
+///
+/// Parameters:
+/// - mcu_name: the full name of the MCU (e.g., "STM32WB55RG")
+/// - peripheral: the name of the peripheral (e.g., "USART1")
+pub(crate) fn peripheral_stop_mode_info(mcu_name: &str, peripheral: &str) -> Option<StopMode> {
+    /// Regexmap where the key is mcu_name:peripheral and the value is the stop mode.
+    /// Example: STM32WB55RG:USART1 -> StopMode::Stop2
+    #[rustfmt::skip]
+    static STOP_MODE_OVERRIDE_RULES: RegexMap<StopMode> = RegexMap::new(&[
+        (r"^STM32WB55.*:LPTIM1", StopMode::Standby),
+        (r"^STM32WB55.*:USART1", StopMode::Stop2),
+        (r"^STM32WB55.*:LPUART1", StopMode::Standby),
+        (r"^STM32WB55.*:I2C1", StopMode::Stop2),
+        (r"^STM32WB55.*:I2C3", StopMode::Standby),
+        
+
+        // __ATTENTION__: Keep these rules at the bottom to grant precedence to the more specific rules above
+        // Every peripheral with LP prefix is assumed to be able enter up to Stop1 mode
+        (r".*:LP.*", StopMode::Stop2), 
+        // The RTC peripheral is assumed to be able to enter up to Stop2 mode
+        (r".*:RTC", StopMode::Standby),
+    ]);
+
+    STOP_MODE_OVERRIDE_RULES
+        .get(&format!("{mcu_name}:{peripheral}"))
+        .cloned()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_get_peripheral_stop_mode_info() {
+        // MCU independent rule for RTC
+        assert_eq!(peripheral_stop_mode_info("my-test-mcu", "RTC"), Some(StopMode::Standby));
+
+        // No rule for this but starting with LP prefix, so assumed to be Stop2
+        assert_eq!(
+            peripheral_stop_mode_info("my-test-mcu", "LPTIM2"),
+            Some(StopMode::Stop2)
+        );
+
+        // MCU independent rule for RTC. Must match RTC exactly
+        assert_eq!(peripheral_stop_mode_info("my-test-mcu", "RTC1"), None);
+
+        // Rule covering all STM32WB55 for LPTIM1
+        assert_eq!(
+            peripheral_stop_mode_info("STM32WB55RG", "LPTIM1"),
+            Some(StopMode::Standby)
+        );
+    }
+}

--- a/stm32-data-gen/src/main.rs
+++ b/stm32-data-gen/src/main.rs
@@ -5,6 +5,7 @@ mod docs;
 mod gpio_af;
 mod header;
 mod interrupts;
+mod low_power;
 mod memory;
 mod normalize_peris;
 mod perimap;

--- a/stm32-data-gen/src/rcc.rs
+++ b/stm32-data-gen/src/rcc.rs
@@ -37,6 +37,7 @@ struct EnRst {
 }
 
 impl ParsedRccs {
+    /// Parse the RCC information from the `rcc_xx` yaml files in `data/registers`
     pub fn parse(registers: &Registers) -> anyhow::Result<Self> {
         let mut rccs = HashMap::new();
 
@@ -49,6 +50,8 @@ impl ParsedRccs {
         Ok(Self { rccs })
     }
 
+    /// Parse mcu specific RCC information from the IR object
+    /// - Clock source muxes of peripherals
     fn parse_rcc(rcc_version: &str, ir: &IR) -> anyhow::Result<ParsedRcc> {
         let allowed_variants = HashSet::from([
             "DISABLE",
@@ -233,14 +236,6 @@ impl ParsedRccs {
                             }
                         }
 
-                        let stop_mode = if peri == "RTC" {
-                            StopMode::Standby
-                        } else if peri.starts_with("LP") {
-                            StopMode::Stop2
-                        } else {
-                            StopMode::Stop1
-                        };
-
                         let clock = clock.replace("AHB", "HCLK").replace("APB", "PCLK");
 
                         let val = EnRst {
@@ -250,7 +245,8 @@ impl ParsedRccs {
                             },
                             reset,
                             bus_clock: clock,
-                            stop_mode,
+                            // The stop mode info is set in `low_power.rs`
+                            stop_mode: StopMode::default(),
                         };
 
                         if en_rst.insert(peri.to_string(), val).is_some() {

--- a/stm32-data-gen/src/registers.rs
+++ b/stm32-data-gen/src/registers.rs
@@ -5,6 +5,7 @@ use chiptool::ir::IR;
 use chiptool::validate;
 
 pub struct Registers {
+    /// Maps the file name (without the .yaml extension) to the IR object which is parsed from the mcu .svd file
     pub registers: HashMap<String, IR>,
 }
 

--- a/stm32-data-serde/src/lib.rs
+++ b/stm32-data-serde/src/lib.rs
@@ -157,11 +157,16 @@ pub mod chip {
                 }
 
                 #[derive(Clone, Debug, Eq, PartialEq, Hash, PartialOrd, Ord, Serialize, Deserialize, Default)]
+                /// Specifies a limit for the stop mode of the peripheral.
+                /// E.g. if `StopMode::Stop1` is selected, the peripheral prevents the chip from entering Stop1 mode.
                 pub enum StopMode {
                     #[default]
-                    Stop1, // Peripheral prevents chip from entering Stop1
-                    Stop2,   // Peripheral prevents chip from entering Stop2
-                    Standby, // Peripheral does not prevent chip from entering Stop
+                    /// Peripheral prevents chip from entering Stop1
+                    Stop1,
+                    /// Peripheral prevents chip from entering Stop2
+                    Stop2,
+                    /// Peripheral does not prevent chip from entering Stop
+                    Standby,
                 }
             }
 


### PR DESCRIPTION
Allows adding custom rules for the lowest possible stop mode for a peripheral.
This affects the embassy low-power executer, as the peripheral limits the available power modes when it's active.

Supporting information for the rules below:

I went to the `sources/headers` directory and ran `rg` for my MCU.
![{8083D2CE-04CF-4157-8866-F8064F773234}](https://github.com/user-attachments/assets/5c14ddb4-cb44-44d9-be69-b016d0447375)

Checking the manual of the stm32wb55 shows the following:

![{B8E76055-DD32-4DEE-AEE8-B7C87D2CD4F4}](https://github.com/user-attachments/assets/871c5223-31fb-4982-bb36-7f6f4eaacb6b)

![{9B04AC08-117B-42DA-91A5-7B9E9E9C87C6}](https://github.com/user-attachments/assets/2a7f884c-6482-4f98-999e-6e8bc0881f30)

So the header file is not accurate enough to differentiate between stop1 and stop2, but it's an indication at least.
According to the [manual](https://www.st.com/resource/en/reference_manual/rm0434-multiprotocol-wireless-32bit-mcu-armbased-cortexm4-with-fpu-bluetooth-lowenergy-and-802154-radio-solution-stmicroelectronics.pdf), the USART and the I2C should just work in lower power modes as well. At least as far as I understand.

