### PR TITLE
Unify and clean up OpAmp descriptions and identifiers

### DIFF
--- a/data/registers/opamp_f3.yaml
+++ b/data/registers/opamp_f3.yaml
@@ -1,29 +1,28 @@
 block/OPAMP:
-  description: Operational Amplifier
+  description: Operational amplifier
   items:
   - name: CSR
-    description: OPAMP control/status register
+    description: Control/status register
     byte_offset: 0
     fieldset: CSR
 fieldset/CSR:
-  description: OPAMP control/status register
+  description: Control/status register
   fields:
   - name: OPAMPEN
-    description: OPAMP enable
+    description: Enable
     bit_offset: 0
     bit_size: 1
   - name: FORCE_VP
-    description: Forces a calibration reference voltage on non-inverting input and disables external connections.
+    description: Force internal reference on VP (reserved for test)
     bit_offset: 1
     bit_size: 1
-    enum: FORCE_VP
   - name: VP_SEL
-    description: OPAMP Non inverting input selection
+    description: Non-inverting input selection
     bit_offset: 2
     bit_size: 2
     enum: VP_SEL
   - name: VM_SEL
-    description: OPAMP inverting input selection
+    description: Inverting input selection
     bit_offset: 5
     bit_size: 2
     enum: VM_SEL
@@ -32,12 +31,12 @@ fieldset/CSR:
     bit_offset: 7
     bit_size: 1
   - name: VMS_SEL
-    description: OPAMP inverting input secondary selection
+    description: Inverting input secondary selection
     bit_offset: 8
     bit_size: 1
     enum: VMS_SEL
   - name: VPS_SEL
-    description: OPAMP Non inverting input secondary selection
+    description: Non-inverting input secondary selection
     bit_offset: 9
     bit_size: 2
     enum: VPS_SEL
@@ -55,7 +54,7 @@ fieldset/CSR:
     bit_offset: 14
     bit_size: 4
     enum: PGA_GAIN
-  - name: USER_TRIM
+  - name: USERTRIM
     description: User trimming enable
     bit_offset: 18
     bit_size: 1
@@ -71,11 +70,10 @@ fieldset/CSR:
     description: Output the internal reference voltage
     bit_offset: 29
     bit_size: 1
-  - name: OUTCAL
-    description: OPAMP ouput status flag
+  - name: CALOUT
+    description: Calibration output
     bit_offset: 30
     bit_size: 1
-    enum: OUTCAL
   - name: LOCK
     description: OPAMP lock
     bit_offset: 31
@@ -84,35 +82,17 @@ enum/CALSEL:
   bit_size: 2
   variants:
   - name: Percent3_3
-    description: VREFOPAMP=3.3% VDDA
+    description: VREFOPAMP = 3.3% VDDA
     value: 0
   - name: Percent10
-    description: VREFOPAMP=10% VDDA
+    description: VREFOPAMP = 10% VDDA
     value: 1
   - name: Percent50
-    description: VREFOPAMP=50% VDDA
+    description: VREFOPAMP = 50% VDDA
     value: 2
   - name: Percent90
-    description: VREFOPAMP=90% VDDA
+    description: VREFOPAMP = 90% VDDA
     value: 3
-enum/FORCE_VP:
-  bit_size: 1
-  variants:
-  - name: Normal
-    description: Normal operating mode
-    value: 0
-  - name: Calibration
-    description: Calibration mode. Non-inverting input connected to calibration reference
-    value: 1
-enum/OUTCAL:
-  bit_size: 1
-  variants:
-  - name: Low
-    description: Non-inverting < inverting
-    value: 0
-  - name: High
-    description: Non-inverting > inverting
-    value: 1
 enum/PGA_GAIN:
   bit_size: 4
   variants:
@@ -156,10 +136,10 @@ enum/VMS_SEL:
   bit_size: 1
   variants:
   - name: PC5
-    description: PC5 (VM0) used as OPAMP2 inverting input when TCM_EN=1
+    description: PC5 (VM0) used as OPAMP2 inverting input when TCM_EN = 1
     value: 0
   - name: PA5
-    description: PA5 (VM1) used as OPAMP2 inverting input when TCM_EN=1
+    description: PA5 (VM1) used as OPAMP2 inverting input when TCM_EN = 1
     value: 1
 enum/VM_SEL:
   bit_size: 2

--- a/data/registers/opamp_g4.yaml
+++ b/data/registers/opamp_g4.yaml
@@ -1,51 +1,47 @@
 block/OPAMP:
-  description: Operational Amplifier
+  description: Operational amplifier
   items:
   - name: CSR
-    description: OPAMP control/status register
+    description: Control/status register
     byte_offset: 0
     fieldset: CSR
   - name: TCMR
-    description: OPAMP control/status register
+    description: Control/status register
     byte_offset: 24
     fieldset: TCMR
 fieldset/CSR:
-  description: OPAMP control/status register
+  description: Control/status register
   fields:
   - name: OPAMPEN
-    description: OPAMP enable
+    description: Enable
     bit_offset: 0
     bit_size: 1
   - name: FORCE_VP
-    description: Forces a calibration reference voltage on non-inverting input and disables external connections.
+    description: Force internal reference on VP (reserved for test)
     bit_offset: 1
     bit_size: 1
-    enum: FORCE_VP
   - name: VP_SEL
-    description: VP_SEL
+    description: Non-inverting input selection
     bit_offset: 2
     bit_size: 2
     enum: VP_SEL
   - name: USERTRIM
-    description: USERTRIM
+    description: User trimming enable
     bit_offset: 4
     bit_size: 1
-    enum: USERTRIM
   - name: VM_SEL
-    description: OPAMP inverting input selection
+    description: Inverting input selection
     bit_offset: 5
     bit_size: 2
     enum: VM_SEL
   - name: OPAHSM
-    description: OPAHSM
+    description: High-speed mode enable
     bit_offset: 7
     bit_size: 1
-    enum: OPAHSM
   - name: OPAINTOEN
-    description: OPAINTOEN
+    description: Internal output enable
     bit_offset: 8
     bit_size: 1
-    enum: OPAINTOEN
   - name: CALON
     description: Calibration mode enable
     bit_offset: 11
@@ -68,11 +64,10 @@ fieldset/CSR:
     description: Offset trimming value (NMOS)
     bit_offset: 24
     bit_size: 5
-  - name: OUTCAL
+  - name: CALOUT
     description: OPAMP ouput status flag
     bit_offset: 30
     bit_size: 1
-    enum: OUTCAL
   - name: LOCK
     description: LOCK
     bit_offset: 31
@@ -81,81 +76,45 @@ fieldset/TCMR:
   description: OPAMP timer controlled mode register
   fields:
   - name: VMS_SEL
-    description: VMS_SEL
+    description: Inverting input secondary selection
     bit_offset: 0
     bit_size: 1
   - name: VPS_SEL
-    description: VPS_SEL
+    description: Non-inverting input secondary selection
     bit_offset: 1
     bit_size: 2
     enum: VPS_SEL
   - name: T1CM_EN
-    description: T1CM_EN
+    description: TIM1 controlled mux mode enable
     bit_offset: 3
     bit_size: 1
   - name: T8CM_EN
-    description: T8CM_EN
+    description: TIM8 controlled mux mode enable
     bit_offset: 4
     bit_size: 1
   - name: T20CM_EN
-    description: T20CM_EN
+    description: TIM20 controlled mux mode enable
     bit_offset: 5
     bit_size: 1
   - name: LOCK
-    description: TCMR LOCK
+    description: Configure this register as read-only
     bit_offset: 31
     bit_size: 1
 enum/CALSEL:
   bit_size: 2
   variants:
   - name: Percent3_3
-    description: VREFOPAMP=3.3% VDDA
+    description: VREFOPAMP = 3.3% VDDA
     value: 0
   - name: Percent10
-    description: VREFOPAMP=10% VDDA
+    description: VREFOPAMP = 10% VDDA
     value: 1
   - name: Percent50
-    description: VREFOPAMP=50% VDDA
+    description: VREFOPAMP = 50% VDDA
     value: 2
   - name: Percent90
-    description: VREFOPAMP=90% VDDA
+    description: VREFOPAMP = 90% VDDA
     value: 3
-enum/FORCE_VP:
-  bit_size: 1
-  variants:
-  - name: Normal
-    description: Normal operating mode
-    value: 0
-  - name: Calibration
-    description: Calibration mode. Non-inverting input connected to calibration reference
-    value: 1
-enum/OPAHSM:
-  bit_size: 1
-  variants:
-  - name: Normal
-    description: OpAmp in normal mode
-    value: 0
-  - name: HighSpeed
-    description: OpAmp in high speed mode
-    value: 1
-enum/OPAINTOEN:
-  bit_size: 1
-  variants:
-  - name: OutputPin
-    description: Output is connected to the output Pin
-    value: 0
-  - name: ADCChannel
-    description: Output is connected internally to ADC channel
-    value: 1
-enum/OUTCAL:
-  bit_size: 1
-  variants:
-  - name: Low
-    description: Non-inverting < inverting
-    value: 0
-  - name: High
-    description: Non-inverting > inverting
-    value: 1
 enum/PGA_GAIN:
   bit_size: 5
   variants:
@@ -231,15 +190,6 @@ enum/PGA_GAIN:
   - name: Gain64_InputVINM0FilteringVINM1
     description: Gain 64, input/bias connected to VINM0 with filtering on VINM1 or inverting gain
     value: 29
-enum/USERTRIM:
-  bit_size: 1
-  variants:
-  - name: Factory
-    description: Factory trim used
-    value: 0
-  - name: User
-    description: User trim used
-    value: 1
 enum/VM_SEL:
   bit_size: 2
   variants:

--- a/data/registers/opamp_h_v1.yaml
+++ b/data/registers/opamp_h_v1.yaml
@@ -1,173 +1,132 @@
 block/OPAMP:
-  description: Operational amplifiers.
+  description: Operational amplifier
   items:
   - name: CSR
-    description: OPAMP1 control/status register.
+    description: Control/status register
     byte_offset: 0
     fieldset: CSR
   - name: OTR
-    description: OPAMP1 offset trimming register in normal mode.
+    description: Offset trimming register in normal mode
     byte_offset: 4
     fieldset: OTR
   - name: HSOTR
-    description: OPAMP1 offset trimming register in low-power mode.
+    description: Offset trimming register in low-power mode
     byte_offset: 8
     fieldset: HSOTR
 fieldset/CSR:
-  description: OPAMP1 control/status register.
+  description: Control/status register
   fields:
   - name: OPAMPEN
-    description: Operational amplifier Enable.
+    description: Enable
     bit_offset: 0
     bit_size: 1
   - name: FORCE_VP
-    description: Force internal reference on VP (reserved for test.
+    description: Force internal reference on VP (reserved for test)
     bit_offset: 1
     bit_size: 1
-    enum: FORCE_VP
   - name: VP_SEL
-    description: Operational amplifier PGA mode.
+    description: Non-inverting input selection
     bit_offset: 2
     bit_size: 2
     enum: VP_SEL
   - name: VM_SEL
-    description: Inverting input selection.
+    description: Inverting input selection
     bit_offset: 5
     bit_size: 2
     enum: VM_SEL
   - name: OPAHSM
-    description: Operational amplifier high-speed mode.
+    description: High-speed mode enable
     bit_offset: 8
     bit_size: 1
-    enum: OPAHSM
   - name: CALON
-    description: Calibration mode enabled.
+    description: Calibration mode enable
     bit_offset: 11
     bit_size: 1
-    enum: CALON
   - name: CALSEL
-    description: Calibration selection.
+    description: Calibration selection
     bit_offset: 12
     bit_size: 2
     enum: CALSEL
   - name: PGA_GAIN
-    description: allows to switch from AOP offset trimmed values to AOP offset.
+    description: Gain in PGA mode
     bit_offset: 14
     bit_size: 4
     enum: PGA_GAIN
   - name: USERTRIM
-    description: User trimming enable.
+    description: User trimming enable
     bit_offset: 18
     bit_size: 1
-    enum: USERTRIM
   - name: TSTREF
-    description: OPAMP calibration reference voltage output control (reserved for test).
+    description: Output the internal reference voltage
     bit_offset: 29
     bit_size: 1
   - name: CALOUT
-    description: Operational amplifier calibration output.
+    description: Calibration output
     bit_offset: 30
     bit_size: 1
-    enum: CALOUT
 fieldset/HSOTR:
-  description: OPAMP1 offset trimming register in low-power mode.
+  description: Offset trimming register in low-power mode
   fields:
   - name: TRIMLPOFFSETN
-    description: Trim for NMOS differential pairs.
+    description: Offset trimming value (NMOS)
     bit_offset: 0
     bit_size: 5
   - name: TRIMLPOFFSETP
-    description: Trim for PMOS differential pairs.
+    description: Offset trimming value (PMOS)
     bit_offset: 8
     bit_size: 5
 fieldset/OTR:
-  description: OPAMP1 offset trimming register in normal mode.
+  description: Offset trimming register in normal mode
   fields:
   - name: TRIMOFFSETN
-    description: Trim for NMOS differential pairs.
+    description: Offset trimming value (NMOS)
     bit_offset: 0
     bit_size: 5
   - name: TRIMOFFSETP
-    description: Trim for PMOS differential pairs.
+    description: Offset trimming value (PMOS)
     bit_offset: 8
     bit_size: 5
-enum/CALON:
-  bit_size: 1
-  variants:
-  - name: Normal
-    description: Normal mode
-    value: 0
-  - name: Calibration
-    description: Calibration mode (all switches opened by HW)
-    value: 1
-enum/CALOUT:
-  bit_size: 1
-  variants:
-  - name: Less
-    description: Non-inverting < inverting
-    value: 0
-  - name: Greater
-    description: Non-inverting > inverting
-    value: 1
 enum/CALSEL:
   bit_size: 2
   variants:
   - name: Percent3_3
-    description: VREFOPAMP=3.3% VDDA.
+    description: VREFOPAMP = 3.3% VDDA
     value: 0
   - name: Percent10
-    description: VREFOPAMP=10% VDDA.
+    description: VREFOPAMP = 10% VDDA
     value: 1
   - name: Percent50
-    description: VREFOPAMP=50% VDDA.
+    description: VREFOPAMP = 50% VDDA
     value: 2
   - name: Percent90
-    description: VREFOPAMP=90% VDDA.
+    description: VREFOPAMP = 90% VDDA
     value: 3
-enum/FORCE_VP:
-  bit_size: 1
-  variants:
-  - name: NormalOperating
-    description: Normal operating mode. Non-inverting input connected to inputs.
-    value: 0
-  - name: CalibrationVerification
-    description: Calibration verification mode. Non-inverting input connected to calibration reference voltage.
-    value: 1
-enum/OPAHSM:
-  bit_size: 1
-  variants:
-  - name: Normal
-    description: operational amplifier in normal mode
-    value: 0
-  - name: HighSpeed
-    description: operational amplifier in high-speed mode
-    value: 1
 enum/PGA_GAIN:
   bit_size: 4
   variants:
   - name: Gain2
-    description: Non-inverting internal Gain 2, VREF- referenced
+    description: Non-inverting internal gain 2, VREF- referenced
     value: 0
   - name: Gain4
-    description: Non-inverting internal Gain 4, VREF- referenced
+    description: Non-inverting internal gain 4, VREF- referenced
     value: 1
   - name: Gain8
-    description: Non-inverting internal Gain 8, VREF- referenced
+    description: Non-inverting internal gain 8, VREF- referenced
     value: 2
   - name: Gain16
-    description: Non-inverting internal Gain 16, VREF- referenced
+    description: Non-inverting internal gain 16, VREF- referenced
     value: 3
   - name: Gain2_FilteringVINM0
-    description: Non-inverting internal Gain 2 with filtering on INM0, VREF- referenced
+    description: Non-inverting internal gain 2 with filtering on INM0, VREF- referenced
     value: 4
   - name: Gain4_FilteringVINM0
-    description: Non-inverting internal Gain 4 with filtering on INM0, VREF- referenced
+    description: Non-inverting internal gain 4 with filtering on INM0, VREF- referenced
     value: 5
   - name: Gain8_FilteringVINM0
-    description: Non-inverting internal Gain 8 with filtering on INM0, VREF- referenced
+    description: Non-inverting internal gain 8 with filtering on INM0, VREF- referenced
     value: 6
   - name: Gain16_FilteringVINM0
-    description: Non-inverting internal Gain 8 with filtering on INM0, VREF- referenced
+    description: Non-inverting internal gain 8 with filtering on INM0, VREF- referenced
     value: 7
   - name: Gain2InvGainNeg1_InputVINM0
     description: Inverting gain=-1/ Non-inverting gain =2 with INM0 node for input or bias
@@ -193,15 +152,6 @@ enum/PGA_GAIN:
   - name: Gain16InvGainNeg15_InputVINM0FilteringVINM1
     description: Inverting gain=-15/ Non-inverting gain =16 with INM0 node for input or bias, INM1 node for filtering
     value: 15
-enum/USERTRIM:
-  bit_size: 1
-  variants:
-  - name: Factory
-    description: \'factory\' trim code used
-    value: 0
-  - name: User
-    description: \'user\' trim code used
-    value: 1
 enum/VM_SEL:
   bit_size: 2
   variants:
@@ -221,8 +171,8 @@ enum/VP_SEL:
   bit_size: 2
   variants:
   - name: Gpio
-    description: GPIO connected to OPAMPx_VINP
+    description: GPIO connected to VINP
     value: 0
   - name: DacOut
-    description: dac_outx connected to OPAMPx_VINP
+    description: DAC connected to VINP
     value: 1

--- a/data/registers/opamp_h_v2.yaml
+++ b/data/registers/opamp_h_v2.yaml
@@ -1,173 +1,132 @@
 block/OPAMP:
-  description: Operational amplifiers.
+  description: Operational amplifier
   items:
   - name: CSR
-    description: OPAMP1 control/status register.
+    description: Control/status register
     byte_offset: 0
     fieldset: CSR
   - name: OTR
-    description: OPAMP1 offset trimming register in normal mode.
+    description: Offset trimming register in normal mode
     byte_offset: 4
     fieldset: OTR
   - name: HSOTR
-    description: OPAMP1 offset trimming register in low-power mode.
+    description: Offset trimming register in low-power mode
     byte_offset: 8
     fieldset: HSOTR
 fieldset/CSR:
-  description: OPAMP1 control/status register.
+  description: Control/status register
   fields:
   - name: OPAMPEN
-    description: Operational amplifier Enable.
+    description: Enable
     bit_offset: 0
     bit_size: 1
   - name: FORCE_VP
-    description: Force internal reference on VP (reserved for test.
+    description: Force internal reference on VP (reserved for test)
     bit_offset: 1
     bit_size: 1
-    enum: FORCE_VP
   - name: VP_SEL
-    description: Operational amplifier PGA mode.
+    description: Non-inverting input selection
     bit_offset: 2
     bit_size: 2
     enum: VP_SEL
   - name: VM_SEL
-    description: Inverting input selection.
+    description: Inverting input selection
     bit_offset: 5
     bit_size: 2
     enum: VM_SEL
   - name: OPAHSM
-    description: Operational amplifier high-speed mode.
+    description: High-speed mode enable
     bit_offset: 8
     bit_size: 1
-    enum: OPAHSM
   - name: CALON
-    description: Calibration mode enabled.
+    description: Calibration mode enable
     bit_offset: 11
     bit_size: 1
-    enum: CALON
   - name: CALSEL
-    description: Calibration selection.
+    description: Calibration selection
     bit_offset: 12
     bit_size: 2
     enum: CALSEL
   - name: PGA_GAIN
-    description: allows to switch from AOP offset trimmed values to AOP offset.
+    description: Gain in PGA mode
     bit_offset: 14
     bit_size: 4
     enum: PGA_GAIN
   - name: USERTRIM
-    description: User trimming enable.
+    description: User trimming enable
     bit_offset: 18
     bit_size: 1
-    enum: USERTRIM
   - name: TSTREF
-    description: OPAMP calibration reference voltage output control (reserved for test).
+    description: Output the internal reference voltage
     bit_offset: 29
     bit_size: 1
   - name: CALOUT
-    description: Operational amplifier calibration output.
+    description: Calibration output
     bit_offset: 30
     bit_size: 1
-    enum: CALOUT
 fieldset/HSOTR:
-  description: OPAMP1 offset trimming register in low-power mode.
+  description: Offset trimming register in low-power mode
   fields:
   - name: TRIMLPOFFSETN
-    description: Trim for NMOS differential pairs.
+    description: Offset trimming value (NMOS)
     bit_offset: 0
     bit_size: 5
   - name: TRIMLPOFFSETP
-    description: Trim for PMOS differential pairs.
+    description: Offset trimming value (PMOS)
     bit_offset: 8
     bit_size: 5
 fieldset/OTR:
-  description: OPAMP1 offset trimming register in normal mode.
+  description: Offset trimming register in normal mode
   fields:
   - name: TRIMOFFSETN
-    description: Trim for NMOS differential pairs.
+    description: Offset trimming value (NMOS)
     bit_offset: 0
     bit_size: 5
   - name: TRIMOFFSETP
-    description: Trim for PMOS differential pairs.
+    description: Offset trimming value (PMOS)
     bit_offset: 8
     bit_size: 5
-enum/CALON:
-  bit_size: 1
-  variants:
-  - name: Normal
-    description: Normal mode
-    value: 0
-  - name: Calibration
-    description: Calibration mode (all switches opened by HW)
-    value: 1
-enum/CALOUT:
-  bit_size: 1
-  variants:
-  - name: Less
-    description: Non-inverting < inverting
-    value: 0
-  - name: Greater
-    description: Non-inverting > inverting
-    value: 1
 enum/CALSEL:
   bit_size: 2
   variants:
   - name: Percent3_3
-    description: VREFOPAMP=3.3% VDDA.
+    description: VREFOPAMP = 3.3% VDDA
     value: 0
   - name: Percent10
-    description: VREFOPAMP=10% VDDA.
+    description: VREFOPAMP = 10% VDDA
     value: 1
   - name: Percent50
-    description: VREFOPAMP=50% VDDA.
+    description: VREFOPAMP = 50% VDDA
     value: 2
   - name: Percent90
-    description: VREFOPAMP=90% VDDA.
+    description: VREFOPAMP = 90% VDDA
     value: 3
-enum/FORCE_VP:
-  bit_size: 1
-  variants:
-  - name: NormalOperating
-    description: Normal operating mode. Non-inverting input connected to inputs.
-    value: 0
-  - name: CalibrationVerification
-    description: Calibration verification mode. Non-inverting input connected to calibration reference voltage.
-    value: 1
-enum/OPAHSM:
-  bit_size: 1
-  variants:
-  - name: Normal
-    description: operational amplifier in normal mode
-    value: 0
-  - name: HighSpeed
-    description: operational amplifier in high-speed mode
-    value: 1
 enum/PGA_GAIN:
   bit_size: 4
   variants:
   - name: Gain2
-    description: Non-inverting internal Gain 2, VREF- referenced
+    description: Non-inverting internal gain 2, VREF- referenced
     value: 0
   - name: Gain4
-    description: Non-inverting internal Gain 4, VREF- referenced
+    description: Non-inverting internal gain 4, VREF- referenced
     value: 1
   - name: Gain8
-    description: Non-inverting internal Gain 8, VREF- referenced
+    description: Non-inverting internal gain 8, VREF- referenced
     value: 2
   - name: Gain16
-    description: Non-inverting internal Gain 16, VREF- referenced
+    description: Non-inverting internal gain 16, VREF- referenced
     value: 3
   - name: Gain2_FilteringVINM0
-    description: Non-inverting internal Gain 2 with filtering on INM0, VREF- referenced
+    description: Non-inverting internal gain 2 with filtering on INM0, VREF- referenced
     value: 4
   - name: Gain4_FilteringVINM0
-    description: Non-inverting internal Gain 4 with filtering on INM0, VREF- referenced
+    description: Non-inverting internal gain 4 with filtering on INM0, VREF- referenced
     value: 5
   - name: Gain8_FilteringVINM0
-    description: Non-inverting internal Gain 8 with filtering on INM0, VREF- referenced
+    description: Non-inverting internal gain 8 with filtering on INM0, VREF- referenced
     value: 6
   - name: Gain16_FilteringVINM0
-    description: Non-inverting internal Gain 8 with filtering on INM0, VREF- referenced
+    description: Non-inverting internal gain 8 with filtering on INM0, VREF- referenced
     value: 7
   - name: Gain2InvGainNeg1_InputVINM0
     description: Inverting gain=-1/ Non-inverting gain =2 with INM0 node for input or bias
@@ -193,15 +152,6 @@ enum/PGA_GAIN:
   - name: Gain16InvGainNeg15_InputVINM0FilteringVINM1
     description: Inverting gain=-15/ Non-inverting gain =16 with INM0 node for input or bias, INM1 node for filtering
     value: 15
-enum/USERTRIM:
-  bit_size: 1
-  variants:
-  - name: Factory
-    description: \'factory\' trim code used
-    value: 0
-  - name: User
-    description: \'user\' trim code used
-    value: 1
 enum/VM_SEL:
   bit_size: 2
   variants:
@@ -221,10 +171,10 @@ enum/VP_SEL:
   bit_size: 2
   variants:
   - name: GpioInp0
-    description: GPIO INP0 connected to OPAMP_VINP
+    description: GPIO INP0 connected to VINP
     value: 0
   - name: DacOut
-    description: dac_outx connected to OPAMPx_VINP
+    description: DAC connected to VINP
     value: 1
   - name: GpioInp2
     description: GPIO INP2 is connected to OPAMP_VINP

--- a/data/registers/opamp_l4.yaml
+++ b/data/registers/opamp_l4.yaml
@@ -1,176 +1,159 @@
 block/OPAMP:
-  description: Operational amplifiers.
+  description: Operational amplifier
   items:
   - name: CSR
-    description: OPAMP control/status register.
+    description: Control/status register
     byte_offset: 0
     fieldset: CSR
   - name: OTR
-    description: OPAMP offset trimming register in normal mode.
+    description: Offset trimming register in normal mode
     byte_offset: 4
     fieldset: OTR
   - name: LPOTR
-    description: OPAMP offset trimming register in low-power mode.
+    description: Offset trimming register in low-power mode
     byte_offset: 8
     fieldset: LPOTR
 fieldset/CSR:
-  description: OPAMP control/status register.
+  description: Control/status register
   fields:
   - name: OPAMPEN
-    description: Operational amplifier Enable.
+    description: Enable
     bit_offset: 0
     bit_size: 1
   - name: OPALPM
-    description: Operational amplifier Low Power Mode.
+    description: Low-power mode enable. The operational amplifier must be disabled to change this configuration.
     bit_offset: 1
     bit_size: 1
-    enum: OPALPM
   - name: OPAMODE
-    description: Operational amplifier PGA mode.
+    description: PGA mode
     bit_offset: 2
     bit_size: 2
     enum: OPAMODE
   - name: PGA_GAIN
-    description: Operational amplifier Programmable amplifier gain value.
+    description: Gain in PGA mode
     bit_offset: 4
     bit_size: 2
     enum: PGA_GAIN
   - name: VM_SEL
-    description: Inverting input selection.
+    description: Inverting input selection
     bit_offset: 8
     bit_size: 2
     enum: VM_SEL
   - name: VP_SEL
-    description: Non inverted input selection.
+    description: Non inverted input selection
     bit_offset: 10
     bit_size: 1
     enum: VP_SEL
   - name: CALON
-    description: Calibration mode enabled.
+    description: Calibration mode enable
     bit_offset: 12
     bit_size: 1
   - name: CALSEL
-    description: Calibration selection.
+    description: Calibration selection
     bit_offset: 13
     bit_size: 1
     enum: CALSEL
   - name: USERTRIM
-    description: allows to switch from AOP offset trimmed values to AOP offset.
+    description: User trimming enable
     bit_offset: 14
     bit_size: 1
-    enum: USERTRIM
   - name: CALOUT
-    description: Operational amplifier calibration output.
+    description: Calibration output
     bit_offset: 15
     bit_size: 1
   - name: OPA_RANGE
-    description: Operational amplifier power supply range for stability.
+    description: Power supply range for stability
     bit_offset: 31
     bit_size: 1
     enum: OPA_RANGE
 fieldset/LPOTR:
-  description: OPAMP offset trimming register in low-power mode.
+  description: Offset trimming register in low-power mode
   fields:
   - name: TRIMLPOFFSETN
-    description: Trim for NMOS differential pairs.
+    description: Offset trimming value (NMOS)
     bit_offset: 0
     bit_size: 5
   - name: TRIMLPOFFSETP
-    description: Trim for PMOS differential pairs.
+    description: Offset trimming value (PMOS)
     bit_offset: 8
     bit_size: 5
 fieldset/OTR:
-  description: OPAMP offset trimming register in normal mode.
+  description: Offset trimming register in normal mode
   fields:
   - name: TRIMOFFSETN
-    description: Trim for NMOS differential pairs.
+    description: Offset trimming value (NMOS)
     bit_offset: 0
     bit_size: 5
   - name: TRIMOFFSETP
-    description: Trim for PMOS differential pairs.
+    description: Offset trimming value (PMOS)
     bit_offset: 8
     bit_size: 5
 enum/CALSEL:
   bit_size: 1
   variants:
   - name: NMOS
-    description: 0.2V applied to OPAMP inputs during calibration.
+    description: NMOS calibration, 0.2 V applied to OPAMP inputs during calibration
     value: 0
   - name: PMOS
-    description: VDDA-0.2V applied to OPAMP inputs during calibration".
-    value: 1
-enum/OPALPM:
-  bit_size: 1
-  variants:
-  - name: NORMAL
-    description: OpAmp in normal mode.
-    value: 0
-  - name: LOW
-    description: OpAmp in low power mode.
+    description: PMOS calibration, VDDA - 0.2 V applied to OPAMP inputs during calibration
     value: 1
 enum/OPAMODE:
   bit_size: 2
   variants:
-  - name: PGA_DISABLED
-    description: internal PGA diabled.
+  - name: Disable
+    description: Internal PGA disable
     value: 0
-  - name: PGA_ENABLED
-    description: internal PGA enabled, gain programmed in PGA_GAIN.
+  - name: Disable2
+    description: Internal PGA disable (duplicate)
+    value: 1
+  - name: Enable
+    description: Internal PGA enable, gain programmed in PGA_GAIN
     value: 2
-  - name: FOLLOWER
-    description: internal follower.
+  - name: Follower
+    description: Internal follower
     value: 3
 enum/OPA_RANGE:
   bit_size: 1
   variants:
-  - name: LOW
-    description: low range (VDDA < 2.4V.
+  - name: Low
+    description: Low range (VDDA < 2.4 V)
     value: 0
-  - name: HIGH
-    description: low range (VDDA >2.4V.
+  - name: High
+    description: High range (VDDA > 2.4 V)
     value: 1
 enum/PGA_GAIN:
   bit_size: 2
   variants:
   - name: Gain2
-    description: Gain 2.
+    description: Gain 2
     value: 0
   - name: Gain4
-    description: Gain 4.
+    description: Gain 4
     value: 1
   - name: Gain8
-    description: Gain 8.
+    description: Gain 8
     value: 2
   - name: Gain16
-    description: Gain 16.
+    description: Gain 16
     value: 3
-enum/USERTRIM:
-  bit_size: 1
-  variants:
-  - name: Factory
-    description: Factory trim used.
-    value: 0
-  - name: User
-    description: User trim used.
-    value: 1
 enum/VM_SEL:
   bit_size: 2
   variants:
   - name: GPIO
-    description: GPIO connectet to VINM.
+    description: GPIO connected to VINM (valid also in PGA mode for filtering)
     value: 0
   - name: LOW_LEAKAGE
-    description: Low leakage inputs connecte (only available in certen BGA cases.
+    description: Low leakage inputs connected (only available in certain packages)
     value: 1
-  - name: PGA_MODE
-    description: OPAMP in PGA mode.
+  - name: NOT_CONNECTED
+    description: VINM not externally connected, valid only in PGA mode
     value: 2
 enum/VP_SEL:
   bit_size: 1
   variants:
   - name: GPIO
-    description: GPIO connectet to VINP.
+    description: GPIO connected to VINP
     value: 0
   - name: DAC
-    description: DAC connected to VPINP.
+    description: DAC connected to VINP
     value: 1

--- a/data/registers/opamp_u0.yaml
+++ b/data/registers/opamp_u0.yaml
@@ -1,186 +1,156 @@
 block/OPAMP:
-  description: OPAMP address block description.
+  description: Operational amplifier
   items:
   - name: CSR
-    description: OPAMP control/status register.
+    description: Control/status register
     byte_offset: 0
     fieldset: CSR
   - name: OTR
-    description: OPAMP offset trimming register in normal mode.
+    description: Offset trimming register in normal mode
     byte_offset: 4
     fieldset: OTR
   - name: LPOTR
-    description: OPAMP offset trimming register in low-power mode.
+    description: Offset trimming register in low-power mode
     byte_offset: 8
     fieldset: LPOTR
 fieldset/CSR:
-  description: OPAMP control/status register.
+  description: Control/status register
   fields:
   - name: OPAMPEN
-    description: Operational amplifier Enable.
+    description: Enable
     bit_offset: 0
     bit_size: 1
   - name: OPALPM
-    description: Operational amplifier Low Power Mode. The operational amplifier must be disable to change this configuration.
+    description: Low-power mode enable. The operational amplifier must be disabled to change this configuration.
     bit_offset: 1
     bit_size: 1
-    enum: OPALPM
   - name: OPAMODE
-    description: Operational amplifier PGA mode.
+    description: PGA mode
     bit_offset: 2
     bit_size: 2
     enum: OPAMODE
   - name: PGA_GAIN
-    description: Operational amplifier Programmable amplifier gain value.
+    description: Gain in PGA mode
     bit_offset: 4
     bit_size: 2
     enum: PGA_GAIN
   - name: VM_SEL
-    description: 'Inverting input selection. These bits are used only when OPAMODE = 00, 01 or 10. 1x: Inverting input not externally connected. These configurations are valid only when OPAMODE = 10 (PGA mode).'
+    description: Inverting input selection
     bit_offset: 8
     bit_size: 2
     enum: VM_SEL
   - name: VP_SEL
-    description: Non inverted input selection.
+    description: Non inverted input selection
     bit_offset: 10
     bit_size: 1
     enum: VP_SEL
   - name: CALON
-    description: Calibration mode enabled.
+    description: Calibration mode enable
     bit_offset: 12
     bit_size: 1
-    enum: CALON
   - name: CALSEL
-    description: Calibration selection.
+    description: Calibration selection
     bit_offset: 13
     bit_size: 1
     enum: CALSEL
   - name: USERTRIM
-    description: allows to switch from factory AOP offset trimmed values to AOP offset user trimmed values This bit is active for both mode normal and low-power.
+    description: User trimming enable
     bit_offset: 14
     bit_size: 1
-    enum: USERTRIM
   - name: CALOUT
-    description: Operational amplifier calibration output During calibration mode offset is trimmed when this signal toggle.
+    description: Calibration output
     bit_offset: 15
     bit_size: 1
   - name: OPA_RANGE
-    description: Operational amplifier power supply range for stability All AOP must be in power down to allow AOP-RANGE bit write. It applies to all AOP embedded in the product.
+    description: Power supply range for stability
     bit_offset: 31
     bit_size: 1
     enum: OPA_RANGE
 fieldset/LPOTR:
-  description: OPAMP offset trimming register in low-power mode.
+  description: Offset trimming register in low-power mode
   fields:
   - name: TRIMLPOFFSETN
-    description: Low-power mode trim for NMOS differential pairs.
+    description: Offset trimming value (NMOS)
     bit_offset: 0
     bit_size: 5
   - name: TRIMLPOFFSETP
-    description: Low-power mode trim for PMOS differential pairs.
+    description: Offset trimming value (PMOS)
     bit_offset: 8
     bit_size: 5
 fieldset/OTR:
-  description: OPAMP offset trimming register in normal mode.
+  description: Offset trimming register in normal mode
   fields:
   - name: TRIMOFFSETN
-    description: Trim for NMOS differential pairs.
+    description: Offset trimming value (NMOS)
     bit_offset: 0
     bit_size: 5
   - name: TRIMOFFSETP
-    description: Trim for PMOS differential pairs.
+    description: Offset trimming value (PMOS)
     bit_offset: 8
     bit_size: 5
-enum/CALON:
-  bit_size: 1
-  variants:
-  - name: Normal
-    description: Normal mode.
-    value: 0
-  - name: Calibration
-    description: Calibration mode (all switches opened by HW).
-    value: 1
 enum/CALSEL:
   bit_size: 1
   variants:
   - name: NMOS
-    description: NMOS calibration (200mV applied on OPAMP inputs).
+    description: NMOS calibration, 0.2 V applied to OPAMP inputs during calibration
     value: 0
   - name: PMOS
-    description: PMOS calibration (VDDA-200mV applied on OPAMP inputs).
-    value: 1
-enum/OPALPM:
-  bit_size: 1
-  variants:
-  - name: Normal
-    description: operational amplifier in normal mode.
-    value: 0
-  - name: LowPower
-    description: operational amplifier in low-power mode.
+    description: PMOS calibration, VDDA - 0.2 V applied to OPAMP inputs during calibration
     value: 1
 enum/OPAMODE:
   bit_size: 2
   variants:
   - name: Disable
-    description: internal PGA disable.
+    description: Internal PGA disable
     value: 0
   - name: Disable2
-    description: internal PGA disable. (Duplicate)
+    description: Internal PGA disable (duplicate)
     value: 1
   - name: Enable
-    description: internal PGA enable, gain programmed in PGA_GAIN.
+    description: Internal PGA enable, gain programmed in PGA_GAIN
     value: 2
   - name: Follower
-    description: internal follower.
+    description: Internal follower
     value: 3
 enum/OPA_RANGE:
   bit_size: 1
   variants:
   - name: Low
-    description: Low range (VDDA < 2.4V).
+    description: Low range (VDDA < 2.4 V)
     value: 0
   - name: High
-    description: High range (VDDA > 2.4V).
+    description: High range (VDDA > 2.4 V)
     value: 1
 enum/PGA_GAIN:
   bit_size: 2
   variants:
   - name: Gain2
-    description: internal PGA Gain 2.
+    description: Gain 2
     value: 0
   - name: Gain4
-    description: internal PGA Gain 4.
+    description: Gain 4
     value: 1
   - name: Gain8
-    description: internal PGA Gain 8.
+    description: Gain 8
     value: 2
   - name: Gain16
-    description: internal PGA Gain 16.
+    description: Gain 16
     value: 3
-enum/USERTRIM:
-  bit_size: 1
-  variants:
-  - name: Factory
-    description: Factory trim code used.
-    value: 0
-  - name: User
-    description: User trim code used.
-    value: 1
 enum/VM_SEL:
   bit_size: 2
   variants:
-  - name: VINM
-    description: GPIO connected to VINM (valid also in PGA mode for filtering).
+  - name: GPIO
+    description: GPIO connected to VINM (valid also in PGA mode for filtering)
     value: 0
-  - name: NotConnected
-    description: Inverting input not externally connected. These configurations are valid only when OPAMODE = 10 (PGA mode)
+  - name: NOT_CONNECTED
+    description: VINM not externally connected, valid only in PGA mode
     value: 2
 enum/VP_SEL:
   bit_size: 1
   variants:
-  - name: VINP
-    description: GPIO connected to VINP.
+  - name: GPIO
+    description: GPIO connected to VINP
     value: 0
   - name: DAC
-    description: DAC connected to VINP.
+    description: DAC connected to VINP
     value: 1


### PR DESCRIPTION
- Harmonized descriptions across OpAmp versions.
- Improved punctuation consistency: omit the period for fragments; include it for full sentences.
- Fixed various typos and copy/paste errors.
- Removed redundant phrases like “OPAMP” or “Operational amplifier” from register descriptions.
- Standardized enum and field names to reflect majority usage and improve cross-family consistency:
  - USER_TRIM → USERTRIM
  - OUTCAL → CALOUT (used in most families; RM0440 also uses CALOUT)
- Some changes diverge slightly from reference manual naming.

- Removed trivial enums and ensured descriptions are self-explanatory:
  - OPAHSM, USERTRIM, OPAINTOEN, CALON, OPALPM, FORCE_VP, OUTCAL

- Identifier renames for clarity and consistency:
  - U0: VM_SEL variant VINM → GPIO, NotConnected → NOT_CONNECTED
  - L4: PGA_MODE → NOT_CONNECTED (aligned with U0)