### PR TITLE
Add gen-all command to helper script and update README

### DIFF
--- a/d
+++ b/d
@@ -46,17 +46,20 @@ case "$CMD" in
         rm -rf build/data
         cargo run --release --bin stm32-data-gen
     ;;
+    gen-all)
+        rm -rf build/{data,stm32-metapac}
+        cargo run --release --bin stm32-data-gen
+        cargo run --release --bin stm32-metapac-gen
+        cd build/stm32-metapac
+        find . -name '*.rs' -not -path '*target*' | xargs rustfmt --skip-children --unstable-features --edition 2021
+    ;;
     ci)
         [ -d sources ] || ./d download-all
         cd ./sources/
         git fetch origin $REV
         git checkout $REV
         cd ..
-        rm -rf build/{data,stm32-metapac}
-        cargo run --release --bin stm32-data-gen
-        cargo run --release --bin stm32-metapac-gen
-        cd build/stm32-metapac
-        find . -name '*.rs' -not -path '*target*' | xargs rustfmt --skip-children --unstable-features --edition 2021
+        ./d gen-all
     ;;
     check)
         cargo batch \


### PR DESCRIPTION
- Introduce a new `gen-all` target in `d` to run JSON, PAC generation, and formatting in one step
- Slightly restructure README to ease getting started
- Add an overview of files and functionality
- Update Quick Guide in README to reference `./d gen-all`
- Remove outdated `parse.py` reference and point to `stm32-data-gen/src/perimap.rs` instead