### PR TITLE
Oversampling ratio register is OVSR, not OSVR

### DIFF
--- a/data/registers/adc_u5.yaml
+++ b/data/registers/adc_u5.yaml
@@ -659,8 +659,8 @@ fieldset/CFGR2:
     description: SMPTRIG.
     bit_offset: 15
     bit_size: 1
-  - name: OSVR
-    description: OSVR.
+  - name: OVSR
+    description: OVSR.
     bit_offset: 16
     bit_size: 10
   - name: LFTRIG

--- a/data/registers/adc_v4.yaml
+++ b/data/registers/adc_v4.yaml
@@ -272,7 +272,7 @@ fieldset/CFGR2:
     description: Right-shift data after Offset 4 correction
     bit_offset: 14
     bit_size: 1
-  - name: OSVR
+  - name: OVSR
     description: Oversampling ratio
     bit_offset: 16
     bit_size: 10


### PR DESCRIPTION
This typo was inherited from the source SVDs. The typo is also present in the reference manual for the STM32H743 (!) but I think it's best to apply the correct name for consistency with all the other ADC versions that correctly name this field OSVR.

STM32H743 reference manual:
![2025-04-25-123653_772x368_scrot](https://github.com/user-attachments/assets/682f2d9c-21f7-4bdb-8b80-4142f35be0fb)


