### PR TITLE
Move pin cleanup from code to YAML, before adding more clean-up rules

### DIFF
--- a/data/extra/family/STM32H7.yaml
+++ b/data/extra/family/STM32H7.yaml
@@ -1,0 +1,10 @@
+---
+pin_cleanup:
+  # H7 has some _C pin variants (e.g. PC2 and PC2_C). Digital stuff should always be in the non-C pin.
+  # cubedb puts it either in both, or in the -C pin only! (in chips where the package has only the -C pin)
+  # so we fix that up here.
+  strip_suffix: "_C"
+  exclude_peripherals:
+    - ADC
+    - DAC
+    - COMP


### PR DESCRIPTION
This commit does not introduce any PAC changes, the results are identical except that now all pins are sorted, also the ones read from data/extras. I wanted to do this in an extra commit to make reviewing easier, although it doesn't add value at the moment and is just a first step.