### PR TITLE
Add support for RTC3 v4

### DIFF
--- a/stm32-data-gen/src/perimap.rs
+++ b/stm32-data-gen/src/perimap.rs
@@ -198,6 +198,7 @@ pub static PERIMAP: RegexMap<(&str, &str, &str)> = RegexMap::new(&[
     (".*:RTC:rtc3_v2_0", ("rtc", "v3", "RTC")),
     (".*:RTC:rtc3_v3_0", ("rtc", "v3", "RTC")),
     (".*:RTC:rtc3_v3_5", ("rtc", "v3", "RTC")),
+    (".*:RTC:rtc3_v4_0", ("rtc", "v3", "RTC")),
     (".*:SAI:sai1_v1_0", ("sai", "v1", "SAI")),
     (".*:SAI:sai1_v1_1", ("sai", "v2", "SAI")),
     (".*:SAI:sai1_v1_2", ("sai", "v2", "SAI")),


### PR DESCRIPTION
This impacts the STM32C0 line, specifically:
* STM32C011F(4-6)Px
* STM32C031F(4-6)Px
* STM32C011F(4-6)Ux
* STM32C011D6Yx
* STM32C011J(4-6)Mx
* STM32C031K(4-6)Tx
* STM32C031C(4-6)Tx
* STM32C031C(4-6)Ux
* STM32C031G(4-6)Ux
* STM32C031K(4-6)Ux

Tested on STM32C0116F6