### PR TITLE
Add RTCv3 for the STM32C0

### DIFF
--- a/data/registers/rtc_v3c0.yaml
+++ b/data/registers/rtc_v3c0.yaml
@@ -207,6 +207,9 @@ fieldset/CR:
     description: Alarm enable
     bit_offset: 8
     bit_size: 1
+    array:
+      len: 1
+      stride: 1
   - name: TSE
     description: Timestamp enable
     bit_offset: 11
@@ -331,6 +334,7 @@ fieldset/ICSR:
     description: Recalibration pending Flag
     bit_offset: 16
     bit_size: 1
+    enum: RECALPF
 fieldset/MISR:
   description: Masked interrupt status register
   fields:
@@ -383,6 +387,7 @@ fieldset/SCR:
     description: Clear timestamp overflow flag
     bit_offset: 4
     bit_size: 1
+    enum: CALRF
 fieldset/SHIFTR:
   description: Shift control register
   fields:
@@ -651,6 +656,12 @@ enum/POL:
     value: 0
   - name: Low
     description: The pin is low when ALRAF/ALRBF/WUTF is asserted (depending on OSEL[1:0])
+    value: 1
+enum/RECALPF:
+  bit_size: 1
+  variants:
+  - name: Pending
+    description: The RECALPF status flag is automatically set to 1 when software writes to the RTC_CALR register, indicating that the RTC_CALR register is blocked. When the new calibration settings are taken into account, this bit returns to 0
     value: 1
 enum/TAMPALRM_TYPE:
   bit_size: 1

--- a/data/registers/rtc_v3c0.yaml
+++ b/data/registers/rtc_v3c0.yaml
@@ -1,0 +1,620 @@
+block/RTC:
+  description: Real-time clock
+  items:
+  - name: TR
+    description: Time register
+    byte_offset: 0
+    fieldset: TR
+  - name: DR
+    description: Date register
+    byte_offset: 4
+    fieldset: DR
+  - name: SSR
+    description: Sub second register
+    byte_offset: 8
+    access: Read
+    fieldset: SSR
+  - name: ICSR
+    description: Initialization control and status register
+    byte_offset: 12
+    fieldset: ICSR
+  - name: PRER
+    description: Prescaler register
+    byte_offset: 16
+    fieldset: PRER
+  - name: CR
+    description: Control register
+    byte_offset: 24
+    fieldset: CR
+  - name: WPR
+    description: Write protection register
+    byte_offset: 36
+    access: Write
+    fieldset: WPR
+  - name: CALR
+    description: Calibration register
+    byte_offset: 40
+    fieldset: CALR
+  - name: SHIFTR
+    description: Shift control register
+    byte_offset: 44
+    access: Write
+    fieldset: SHIFTR
+  - name: TSTR
+    description: Timestamp time register
+    byte_offset: 48
+    access: Read
+    fieldset: TSTR
+  - name: TSDR
+    description: Timestamp date register
+    byte_offset: 52
+    access: Read
+    fieldset: TSDR
+  - name: TSSSR
+    description: Timestamp sub second register
+    byte_offset: 56
+    access: Read
+    fieldset: TSSSR
+  - name: ALRMAR
+    description: Alarm A register
+    byte_offset: 64
+    fieldset: ALRMAR
+  - name: ALRMASSR
+    description: Alarm A sub second register
+    byte_offset: 68
+    fieldset: ALRMASSR
+  - name: SR
+    description: Status register
+    byte_offset: 80
+    access: Read
+    fieldset: SR
+  - name: MISR
+    description: Masked interrupt status register
+    byte_offset: 84
+    access: Read
+    fieldset: MISR
+  - name: SCR
+    description: Status clear register
+    byte_offset: 92
+    access: Write
+    fieldset: SCR
+fieldset/ALRMAR:
+  description: RTC alarm A register.
+  fields:
+  - name: SU
+    description: Second units in BCD format.
+    bit_offset: 0
+    bit_size: 4
+  - name: ST
+    description: Second tens in BCD format.
+    bit_offset: 4
+    bit_size: 3
+  - name: MSK1
+    description: Alarm A seconds mask.
+    bit_offset: 7
+    bit_size: 1
+  - name: MNU
+    description: Minute units in BCD format.
+    bit_offset: 8
+    bit_size: 4
+  - name: MNT
+    description: Minute tens in BCD format.
+    bit_offset: 12
+    bit_size: 3
+  - name: MSK2
+    description: Alarm A minutes mask.
+    bit_offset: 15
+    bit_size: 1
+  - name: HU
+    description: Hour units in BCD format.
+    bit_offset: 16
+    bit_size: 4
+  - name: HT
+    description: Hour tens in BCD format.
+    bit_offset: 20
+    bit_size: 2
+  - name: PM
+    description: AM/PM notation.
+    bit_offset: 22
+    bit_size: 1
+  - name: MSK3
+    description: Alarm A hours mask.
+    bit_offset: 23
+    bit_size: 1
+  - name: DU
+    description: Date units or day in BCD format.
+    bit_offset: 24
+    bit_size: 4
+  - name: DT
+    description: Date tens in BCD format.
+    bit_offset: 28
+    bit_size: 2
+  - name: WDSEL
+    description: Week day selection.
+    bit_offset: 30
+    bit_size: 1
+  - name: MSK4
+    description: Alarm A date mask.
+    bit_offset: 31
+    bit_size: 1
+fieldset/ALRMASSR:
+  description: Alarm sub second register
+  fields:
+  - name: SS
+    description: Sub seconds value This value is compared with the contents of the synchronous prescaler counter to determine if alarm A is to be activated. Only bits 0 up MASKSS-1 are compared.
+    bit_offset: 0
+    bit_size: 15
+  - name: MASKSS
+    description: 'Mask the most-significant bits starting at this bit 2: SS[14:2] are don’t care in alarm A comparison. Only SS[1:0] are compared. 3: SS[14:3] are don’t care in alarm A comparison. Only SS[2:0] are compared. ... 12: SS[14:12] are don’t care in alarm A comparison. SS[11:0] are compared. 13: SS[14:13] are don’t care in alarm A comparison. SS[12:0] are compared. 14: SS[14] is don’t care in alarm A comparison. SS[13:0] are compared. 15: All 15 SS bits are compared and must match to activate alarm. The overflow bits of the synchronous counter (bits 15) is never compared. This bit can be different from 0 only after a shift operation. Note: The overflow bits of the synchronous counter (bits 15) is never compared. This bit can be different from 0 only after a shift operation.'
+    bit_offset: 24
+    bit_size: 4
+fieldset/CALR:
+  description: Calibration register
+  fields:
+  - name: CALM
+    description: Calibration minus
+    bit_offset: 0
+    bit_size: 9
+  - name: CALW16
+    description: Use a 16-second calibration cycle period
+    bit_offset: 13
+    bit_size: 1
+    enum: CALW16
+  - name: CALW8
+    description: Use an 8-second calibration cycle period
+    bit_offset: 14
+    bit_size: 1
+    enum: CALW8
+  - name: CALP
+    description: Increase frequency of RTC by 488.5 ppm
+    bit_offset: 15
+    bit_size: 1
+    enum: CALP
+fieldset/CR:
+  description: Control register
+  fields:
+  - name: TSEDGE
+    description: Timestamp event active edge
+    bit_offset: 3
+    bit_size: 1
+    enum: TSEDGE
+  - name: REFCKON
+    description: RTC_REFIN reference clock detection enable (50 or 60 Hz)
+    bit_offset: 4
+    bit_size: 1
+  - name: BYPSHAD
+    description: Bypass the shadow registers
+    bit_offset: 5
+    bit_size: 1
+  - name: FMT
+    description: Hour format
+    bit_offset: 6
+    bit_size: 1
+    enum: FMT
+  - name: ALRAE
+    description: Alarm A enable
+    bit_offset: 8
+    bit_size: 1
+  - name: TSE
+    description: Timestamp enable
+    bit_offset: 11
+    bit_size: 1
+  - name: ALRAIE
+    description: Alarm A interrupt enable
+    bit_offset: 12
+    bit_size: 1
+  - name: TSIE
+    description: Timestamp interrupt enable
+    bit_offset: 15
+    bit_size: 1
+  - name: ADD1H
+    description: Add 1 hour (summer time change)
+    bit_offset: 16
+    bit_size: 1
+  - name: SUB1H
+    description: Subtract 1 hour (winter time change)
+    bit_offset: 17
+    bit_size: 1
+  - name: BKP
+    description: Backup
+    bit_offset: 18
+    bit_size: 1
+  - name: COSEL
+    description: Calibration output selection
+    bit_offset: 19
+    bit_size: 1
+    enum: COSEL
+  - name: POL
+    description: Output polarity
+    bit_offset: 20
+    bit_size: 1
+    enum: POL
+  - name: OSEL
+    description: Output selection
+    bit_offset: 21
+    bit_size: 2
+    enum: OSEL
+  - name: COE
+    description: Calibration output enable
+    bit_offset: 23
+    bit_size: 1
+  - name: TAMPALRM_PU
+    description: TAMPALRM pull-up enable
+    bit_offset: 29
+    bit_size: 1
+  - name: TAMPALRM_TYPE
+    description: TAMPALRM output type
+    bit_offset: 30
+    bit_size: 1
+    enum: TAMPALRM_TYPE
+  - name: OUT2EN
+    description: RTC_OUT2 output enable
+    bit_offset: 31
+    bit_size: 1
+fieldset/DR:
+  description: Date register
+  fields:
+  - name: DU
+    description: Date units in BCD format
+    bit_offset: 0
+    bit_size: 4
+  - name: DT
+    description: Date tens in BCD format
+    bit_offset: 4
+    bit_size: 2
+  - name: MU
+    description: Month units in BCD format
+    bit_offset: 8
+    bit_size: 4
+  - name: MT
+    description: Month tens in BCD format
+    bit_offset: 12
+    bit_size: 1
+  - name: WDU
+    description: Week day units
+    bit_offset: 13
+    bit_size: 3
+  - name: YU
+    description: Year units in BCD format
+    bit_offset: 16
+    bit_size: 4
+  - name: YT
+    description: Year tens in BCD format
+    bit_offset: 20
+    bit_size: 4
+fieldset/ICSR:
+  description: Initialization control and status register
+  fields:
+  - name: ALRAWF
+    description: Alarm A write flag
+    bit_offset: 0
+    bit_size: 1
+  - name: SHPF
+    description: Shift operation pending
+    bit_offset: 3
+    bit_size: 1
+  - name: INITS
+    description: Initialization status flag
+    bit_offset: 4
+    bit_size: 1
+  - name: RSF
+    description: Registers synchronization flag
+    bit_offset: 5
+    bit_size: 1
+  - name: INITF
+    description: Initialization flag
+    bit_offset: 6
+    bit_size: 1
+  - name: INIT
+    description: Enter Initialization mode
+    bit_offset: 7
+    bit_size: 1
+  - name: RECALPF
+    description: Recalibration pending Flag The RECALPF status flag is automatically set to 1 when software writes to the RTC_CALR register, indicating that the RTC_CALR register is blocked. When the new calibration settings are taken into account, this bit returns to 0. Refer to.
+    bit_offset: 16
+    bit_size: 1
+fieldset/MISR:
+  description: RTC masked interrupt status register.
+  fields:
+  - name: ALRAMF
+    description: Alarm A masked flag This flag is set by hardware when the alarm A interrupt occurs.
+    bit_offset: 0
+    bit_size: 1
+  - name: TSMF
+    description: Timestamp masked flag This flag is set by hardware when a timestamp interrupt occurs.
+    bit_offset: 3
+    bit_size: 1
+    enum: TSMF
+  - name: TSOVMF
+    description: Timestamp overflow masked flag This flag is set by hardware when a timestamp interrupt occurs while TSMF is already set. It is recommended to check and then clear TSOVF only after clearing the TSF bit. Otherwise, an overflow might not be noticed if a timestamp event occurs immediately before the TSF bit is cleared.
+    bit_offset: 4
+    bit_size: 1
+    enum: TSOVMF
+fieldset/PRER:
+  description: Prescaler register
+  fields:
+  - name: PREDIV_S
+    description: Synchronous prescaler factor
+    bit_offset: 0
+    bit_size: 15
+  - name: PREDIV_A
+    description: Asynchronous prescaler factor
+    bit_offset: 16
+    bit_size: 7
+fieldset/SCR:
+  description: RTC status clear register.
+  fields:
+  - name: CALRAF
+    description: Clear alarm A flag Writing 1 in this bit clears the ALRAF bit in the RTC_SR register.
+    bit_offset: 0
+    bit_size: 1
+  - name: CTSF
+    description: Clear timestamp flag Writing 1 in this bit clears the TSOVF bit in the RTC_SR register.
+    bit_offset: 3
+    bit_size: 1
+  - name: CTSOVF
+    description: Clear timestamp overflow flag Writing 1 in this bit clears the TSOVF bit in the RTC_SR register. It is recommended to check and then clear TSOVF only after clearing the TSF bit. Otherwise, an overflow might not be noticed if a timestamp event occurs immediately before the TSF bit is cleared.
+    bit_offset: 4
+    bit_size: 1
+fieldset/SHIFTR:
+  description: Shift control register
+  fields:
+  - name: SUBFS
+    description: Subtract a fraction of a second
+    bit_offset: 0
+    bit_size: 15
+  - name: ADD1S
+    description: Add one second
+    bit_offset: 31
+    bit_size: 1
+fieldset/SR:
+  description: Status register
+  fields:
+  - name: ALRAF
+    description: Alarm A flag This flag is set by hardware when the time/date registers (RTC_TR and RTC_DR) match the alarm A register (RTC_ALRMAR).
+    bit_offset: 0
+    bit_size: 1
+  - name: TSF
+    description: Timestamp flag
+    bit_offset: 3
+    bit_size: 1
+    enum: TSF
+  - name: TSOVF
+    description: Timestamp overflow flag
+    bit_offset: 4
+    bit_size: 1
+    enum: TSOVF
+fieldset/SSR:
+  description: Sub second register
+  fields:
+  - name: SS
+    description: Synchronous binary counter
+    bit_offset: 0
+    bit_size: 16
+fieldset/TR:
+  description: Time register
+  fields:
+  - name: SU
+    description: Second units in BCD format
+    bit_offset: 0
+    bit_size: 4
+  - name: ST
+    description: Second tens in BCD format
+    bit_offset: 4
+    bit_size: 3
+  - name: MNU
+    description: Minute units in BCD format
+    bit_offset: 8
+    bit_size: 4
+  - name: MNT
+    description: Minute tens in BCD format
+    bit_offset: 12
+    bit_size: 3
+  - name: HU
+    description: Hour units in BCD format
+    bit_offset: 16
+    bit_size: 4
+  - name: HT
+    description: Hour tens in BCD format
+    bit_offset: 20
+    bit_size: 2
+  - name: PM
+    description: AM/PM notation
+    bit_offset: 22
+    bit_size: 1
+    enum: AMPM
+fieldset/TSDR:
+  description: Timestamp date register
+  fields:
+  - name: DU
+    description: Date units in BCD format
+    bit_offset: 0
+    bit_size: 4
+  - name: DT
+    description: Date tens in BCD format
+    bit_offset: 4
+    bit_size: 2
+  - name: MU
+    description: Month units in BCD format
+    bit_offset: 8
+    bit_size: 4
+  - name: MT
+    description: Month tens in BCD format
+    bit_offset: 12
+    bit_size: 1
+  - name: WDU
+    description: Week day units
+    bit_offset: 13
+    bit_size: 3
+fieldset/TSSSR:
+  description: Timestamp sub second register
+  fields:
+  - name: SS
+    description: Sub second value
+    bit_offset: 0
+    bit_size: 16
+fieldset/TSTR:
+  description: Timestamp time register
+  fields:
+  - name: SU
+    description: Second units in BCD format
+    bit_offset: 0
+    bit_size: 4
+  - name: ST
+    description: Second tens in BCD format
+    bit_offset: 4
+    bit_size: 3
+  - name: MNU
+    description: Minute units in BCD format
+    bit_offset: 8
+    bit_size: 4
+  - name: MNT
+    description: Minute tens in BCD format
+    bit_offset: 12
+    bit_size: 3
+  - name: HU
+    description: Hour units in BCD format
+    bit_offset: 16
+    bit_size: 4
+  - name: HT
+    description: Hour tens in BCD format
+    bit_offset: 20
+    bit_size: 2
+  - name: PM
+    description: AM/PM notation
+    bit_offset: 22
+    bit_size: 1
+fieldset/WPR:
+  description: Write protection register
+  fields:
+  - name: KEY
+    description: Write protection key
+    bit_offset: 0
+    bit_size: 8
+    enum: KEY
+enum/AMPM:
+  bit_size: 1
+  variants:
+  - name: AM
+    description: AM or 24-hour format
+    value: 0
+  - name: PM
+    description: PM
+    value: 1
+enum/CALP:
+  bit_size: 1
+  variants:
+  - name: NoChange
+    description: No RTCCLK pulses are added
+    value: 0
+  - name: IncreaseFreq
+    description: One RTCCLK pulse is effectively inserted every 2^11 pulses (frequency increased by 488.5 ppm)
+    value: 1
+enum/CALW16:
+  bit_size: 1
+  variants:
+  - name: SixteenSeconds
+    description: When CALW16 is set to ‘1’, the 16-second calibration cycle period is selected.This bit must not be set to ‘1’ if CALW8=1
+    value: 1
+enum/CALW8:
+  bit_size: 1
+  variants:
+  - name: EightSeconds
+    description: When CALW8 is set to ‘1’, the 8-second calibration cycle period is selected
+    value: 1
+enum/COSEL:
+  bit_size: 1
+  variants:
+  - name: CalFreq_512Hz
+    description: Calibration output is 512 Hz (with default prescaler setting)
+    value: 0
+  - name: CalFreq_1Hz
+    description: Calibration output is 1 Hz (with default prescaler setting)
+    value: 1
+enum/FMT:
+  bit_size: 1
+  variants:
+  - name: TwentyFourHour
+    description: 24 hour/day format
+    value: 0
+  - name: AmPm
+    description: AM/PM hour format
+    value: 1
+enum/KEY:
+  bit_size: 8
+  variants:
+  - name: Activate
+    description: Activate write protection (any value that is not the keys)
+    value: 0
+  - name: Deactivate2
+    description: Key 2
+    value: 83
+  - name: Deactivate1
+    description: Key 1
+    value: 202
+enum/OSEL:
+  bit_size: 2
+  variants:
+  - name: Disabled
+    description: Output disabled
+    value: 0
+  - name: AlarmA
+    description: Alarm A output enabled
+    value: 1
+  - name: AlarmB
+    description: Alarm B output enabled
+    value: 2
+  - name: Wakeup
+    description: Wakeup output enabled
+    value: 3
+enum/POL:
+  bit_size: 1
+  variants:
+  - name: High
+    description: The pin is high when ALRAF/ALRBF/WUTF is asserted (depending on OSEL[1:0])
+    value: 0
+  - name: Low
+    description: The pin is low when ALRAF/ALRBF/WUTF is asserted (depending on OSEL[1:0])
+    value: 1
+enum/TAMPALRM_TYPE:
+  bit_size: 1
+  variants:
+  - name: PushPull
+    description: TAMPALRM is push-pull output
+    value: 0
+  - name: OpenDrain
+    description: TAMPALRM is open-drain output
+    value: 1
+enum/TSEDGE:
+  bit_size: 1
+  variants:
+  - name: RisingEdge
+    description: RTC_TS input rising edge generates a time-stamp event
+    value: 0
+  - name: FallingEdge
+    description: RTC_TS input falling edge generates a time-stamp event
+    value: 1
+enum/TSF:
+  bit_size: 1
+  variants:
+  - name: TimestampEvent
+    description: This flag is set by hardware when a time-stamp event occurs
+    value: 1
+enum/TSMF:
+  bit_size: 1
+  variants:
+  - name: TimestampEvent
+    description: This flag is set by hardware when a time-stamp event occurs
+    value: 1
+enum/TSOVF:
+  bit_size: 1
+  variants:
+  - name: Overflow
+    description: This flag is set by hardware when a time-stamp event occurs while TSF is already set
+    value: 1
+enum/TSOVMF:
+  bit_size: 1
+  variants:
+  - name: Overflow
+    description: This flag is set by hardware when a time-stamp event occurs while TSF is already set
+    value: 1

--- a/data/registers/rtc_v3c0.yaml
+++ b/data/registers/rtc_v3c0.yaml
@@ -55,14 +55,20 @@ block/RTC:
     byte_offset: 56
     access: Read
     fieldset: TSSSR
-  - name: ALRMAR
-    description: Alarm A register
+  - name: ALRMR
+    description: Alarm register
+    array:
+      len: 1
+      stride: 8
     byte_offset: 64
-    fieldset: ALRMAR
-  - name: ALRMASSR
-    description: Alarm A sub second register
+    fieldset: ALRMR
+  - name: ALRMSSR
+    description: Alarm sub second register
+    array:
+      len: 1
+      stride: 8
     byte_offset: 68
-    fieldset: ALRMASSR
+    fieldset: ALRMSSR
   - name: SR
     description: Status register
     byte_offset: 80
@@ -78,74 +84,80 @@ block/RTC:
     byte_offset: 92
     access: Write
     fieldset: SCR
-fieldset/ALRMAR:
-  description: RTC alarm A register.
+fieldset/ALRMR:
+  description: Alarm register
   fields:
   - name: SU
-    description: Second units in BCD format.
+    description: Second units in BCD format
     bit_offset: 0
     bit_size: 4
   - name: ST
-    description: Second tens in BCD format.
+    description: Second tens in BCD format
     bit_offset: 4
     bit_size: 3
   - name: MSK1
-    description: Alarm A seconds mask.
+    description: Alarm A seconds mask
     bit_offset: 7
     bit_size: 1
+    enum: ALRMR_MSK
   - name: MNU
-    description: Minute units in BCD format.
+    description: Minute units in BCD format
     bit_offset: 8
     bit_size: 4
   - name: MNT
-    description: Minute tens in BCD format.
+    description: Minute tens in BCD format
     bit_offset: 12
     bit_size: 3
   - name: MSK2
-    description: Alarm A minutes mask.
+    description: Alarm A minutes mask
     bit_offset: 15
     bit_size: 1
+    enum: ALRMR_MSK
   - name: HU
-    description: Hour units in BCD format.
+    description: Hour units in BCD format
     bit_offset: 16
     bit_size: 4
   - name: HT
-    description: Hour tens in BCD format.
+    description: Hour tens in BCD format
     bit_offset: 20
     bit_size: 2
   - name: PM
-    description: AM/PM notation.
+    description: AM/PM notation
     bit_offset: 22
     bit_size: 1
+    enum: ALRMR_PM
   - name: MSK3
-    description: Alarm A hours mask.
+    description: Alarm A hours mask
     bit_offset: 23
     bit_size: 1
+    enum: ALRMR_MSK
   - name: DU
-    description: Date units or day in BCD format.
+    description: Date units or day in BCD format
     bit_offset: 24
     bit_size: 4
   - name: DT
-    description: Date tens in BCD format.
+    description: Date tens in BCD format
     bit_offset: 28
     bit_size: 2
   - name: WDSEL
-    description: Week day selection.
+    description: Week day selection
     bit_offset: 30
     bit_size: 1
+    enum: ALRMR_WDSEL
   - name: MSK4
-    description: Alarm A date mask.
+    description: Alarm A date mask
     bit_offset: 31
     bit_size: 1
-fieldset/ALRMASSR:
+    enum: ALRMR_MSK
+fieldset/ALRMSSR:
   description: Alarm sub second register
   fields:
   - name: SS
-    description: Sub seconds value This value is compared with the contents of the synchronous prescaler counter to determine if alarm A is to be activated. Only bits 0 up MASKSS-1 are compared.
+    description: Sub seconds value
     bit_offset: 0
     bit_size: 15
   - name: MASKSS
-    description: 'Mask the most-significant bits starting at this bit 2: SS[14:2] are don’t care in alarm A comparison. Only SS[1:0] are compared. 3: SS[14:3] are don’t care in alarm A comparison. Only SS[2:0] are compared. ... 12: SS[14:12] are don’t care in alarm A comparison. SS[11:0] are compared. 13: SS[14:13] are don’t care in alarm A comparison. SS[12:0] are compared. 14: SS[14] is don’t care in alarm A comparison. SS[13:0] are compared. 15: All 15 SS bits are compared and must match to activate alarm. The overflow bits of the synchronous counter (bits 15) is never compared. This bit can be different from 0 only after a shift operation. Note: The overflow bits of the synchronous counter (bits 15) is never compared. This bit can be different from 0 only after a shift operation.'
+    description: Mask the most-significant bits starting at this bit
     bit_offset: 24
     bit_size: 4
 fieldset/CALR:
@@ -191,18 +203,21 @@ fieldset/CR:
     bit_offset: 6
     bit_size: 1
     enum: FMT
-  - name: ALRAE
-    description: Alarm A enable
+  - name: ALRE
+    description: Alarm enable
     bit_offset: 8
     bit_size: 1
   - name: TSE
     description: Timestamp enable
     bit_offset: 11
     bit_size: 1
-  - name: ALRAIE
-    description: Alarm A interrupt enable
+  - name: ALRIE
+    description: Alarm interrupt enable
     bit_offset: 12
     bit_size: 1
+    array:
+      len: 1
+      stride: 1
   - name: TSIE
     description: Timestamp interrupt enable
     bit_offset: 15
@@ -285,10 +300,13 @@ fieldset/DR:
 fieldset/ICSR:
   description: Initialization control and status register
   fields:
-  - name: ALRAWF
-    description: Alarm A write flag
+  - name: ALRWF
+    description: Alarm write enabled
     bit_offset: 0
     bit_size: 1
+    array:
+      len: 1
+      stride: 1
   - name: SHPF
     description: Shift operation pending
     bit_offset: 3
@@ -310,23 +328,27 @@ fieldset/ICSR:
     bit_offset: 7
     bit_size: 1
   - name: RECALPF
-    description: Recalibration pending Flag The RECALPF status flag is automatically set to 1 when software writes to the RTC_CALR register, indicating that the RTC_CALR register is blocked. When the new calibration settings are taken into account, this bit returns to 0. Refer to.
+    description: Recalibration pending Flag
     bit_offset: 16
     bit_size: 1
 fieldset/MISR:
-  description: RTC masked interrupt status register.
+  description: Masked interrupt status register
   fields:
-  - name: ALRAMF
-    description: Alarm A masked flag This flag is set by hardware when the alarm A interrupt occurs.
+  - name: ALRMF
+    description: Alarm masked flag
     bit_offset: 0
     bit_size: 1
+    array:
+      len: 1
+      stride: 1
+    enum: ALRMF
   - name: TSMF
-    description: Timestamp masked flag This flag is set by hardware when a timestamp interrupt occurs.
+    description: Timestamp masked flag
     bit_offset: 3
     bit_size: 1
     enum: TSMF
   - name: TSOVMF
-    description: Timestamp overflow masked flag This flag is set by hardware when a timestamp interrupt occurs while TSMF is already set. It is recommended to check and then clear TSOVF only after clearing the TSF bit. Otherwise, an overflow might not be noticed if a timestamp event occurs immediately before the TSF bit is cleared.
+    description: Timestamp overflow masked flag
     bit_offset: 4
     bit_size: 1
     enum: TSOVMF
@@ -342,18 +364,23 @@ fieldset/PRER:
     bit_offset: 16
     bit_size: 7
 fieldset/SCR:
-  description: RTC status clear register.
+  description: Status clear register
   fields:
-  - name: CALRAF
-    description: Clear alarm A flag Writing 1 in this bit clears the ALRAF bit in the RTC_SR register.
+  - name: CALRF
+    description: Clear alarm A flag
     bit_offset: 0
     bit_size: 1
+    array:
+      len: 1
+      stride: 1
+    enum: CALRF
   - name: CTSF
-    description: Clear timestamp flag Writing 1 in this bit clears the TSOVF bit in the RTC_SR register.
+    description: Clear timestamp flag
     bit_offset: 3
     bit_size: 1
+    enum: CALRF
   - name: CTSOVF
-    description: Clear timestamp overflow flag Writing 1 in this bit clears the TSOVF bit in the RTC_SR register. It is recommended to check and then clear TSOVF only after clearing the TSF bit. Otherwise, an overflow might not be noticed if a timestamp event occurs immediately before the TSF bit is cleared.
+    description: Clear timestamp overflow flag
     bit_offset: 4
     bit_size: 1
 fieldset/SHIFTR:
@@ -370,10 +397,14 @@ fieldset/SHIFTR:
 fieldset/SR:
   description: Status register
   fields:
-  - name: ALRAF
-    description: Alarm A flag This flag is set by hardware when the time/date registers (RTC_TR and RTC_DR) match the alarm A register (RTC_ALRMAR).
+  - name: ALRF
+    description: Alarm flag
     bit_offset: 0
     bit_size: 1
+    array:
+      len: 1
+      stride: 1
+    enum: ALRF
   - name: TSF
     description: Timestamp flag
     bit_offset: 3
@@ -492,6 +523,45 @@ fieldset/WPR:
     bit_offset: 0
     bit_size: 8
     enum: KEY
+enum/ALRF:
+  bit_size: 1
+  variants:
+  - name: Match
+    description: This flag is set by hardware when the time/date registers (RTC_TR and RTC_DR) match the Alarm A register (RTC_ALRMAR)
+    value: 1
+enum/ALRMF:
+  bit_size: 1
+  variants:
+  - name: Match
+    description: This flag is set by hardware when the time/date registers (RTC_TR and RTC_DR) match the Alarm A register (RTC_ALRMAR)
+    value: 1
+enum/ALRMR_MSK:
+  bit_size: 1
+  variants:
+  - name: ToMatch
+    description: Alarm set if the date/day match
+    value: 0
+  - name: NotMatch
+    description: Date/day don’t care in Alarm comparison
+    value: 1
+enum/ALRMR_PM:
+  bit_size: 1
+  variants:
+  - name: AM
+    description: AM or 24-hour format
+    value: 0
+  - name: PM
+    description: PM
+    value: 1
+enum/ALRMR_WDSEL:
+  bit_size: 1
+  variants:
+  - name: DateUnits
+    description: DU[3:0] represents the date units
+    value: 0
+  - name: WeekDay
+    description: DU[3:0] represents the week day. DT[1:0] is don’t care.
+    value: 1
 enum/AMPM:
   bit_size: 1
   variants:
@@ -509,6 +579,12 @@ enum/CALP:
     value: 0
   - name: IncreaseFreq
     description: One RTCCLK pulse is effectively inserted every 2^11 pulses (frequency increased by 488.5 ppm)
+    value: 1
+enum/CALRF:
+  bit_size: 1
+  variants:
+  - name: Clear
+    description: Clear interrupt flag by writing 1
     value: 1
 enum/CALW16:
   bit_size: 1

--- a/stm32-data-gen/src/perimap.rs
+++ b/stm32-data-gen/src/perimap.rs
@@ -178,6 +178,7 @@ pub static PERIMAP: RegexMap<(&str, &str, &str)> = RegexMap::new(&[
     (".*:QUADSPI:.*", ("quadspi", "v1", "QUADSPI")),
     ("STM32F1.*:BKP.*", ("bkp", "v1", "BKP")),
     (".*:RTC:rtc1_v1_1", ("rtc", "v1", "RTC")),
+    ("STM32C0.*:RTC:rtc3_.*", ("rtc", "v3c0", "RTC")),
     ("STM32F0.*:RTC:rtc2_.*", ("rtc", "v2f0", "RTC")),
     ("STM32F2.*:RTC:rtc2_.*", ("rtc", "v2f2", "RTC")),
     ("STM32F3.*:RTC:rtc2_.*", ("rtc", "v2f3", "RTC")),


### PR DESCRIPTION
The STM32C0 supports v3 of RTC. However it only supports a subset of the features.

Notably the differences are:
* No Wakeup unit / No Wakeup event
* Alarm is referenced as AlarmA

References:
* STM32 RTC v2/v3: AN4759 - Rev 10: https://www.st.com/resource/en/application_note/an4759-introduction-to-using-the-hardware-realtime-clock-rtc-and-the-tamper-management-unit-tamp-with-stm32-mcus-stmicroelectronics.pdf
* STM32C0: RM0490 - Rev 5: https://www.st.com/resource/en/reference_manual/rm0490-stm32c0x1-advanced-armbased-32bit-mcus-stmicroelectronics.pdf

Tested on STM32C011F6P6