### PR TITLE
Feat/support wba6xxx

### DIFF
--- a/d
+++ b/d
@@ -4,7 +4,7 @@ set -e
 cd $(dirname $0)
 
 CMD=$1
-REV=1659e761beb29d3949bd1ec72039c3ce5f6bdf6c
+REV=db4473fae6a41fcad7f5c824dcaadba3a6e060e9
 shift
 
 case "$CMD" in

--- a/data/registers/rcc_wba.yaml
+++ b/data/registers/rcc_wba.yaml
@@ -307,9 +307,29 @@ fieldset/AHB2ENR:
     description: "IO port C bus clock enable\r Set and cleared by software.\r Access can be secured by GPIOC SECx. When secure, a non-secure read/write access is RAZ/WI. It does not generate an illegal access interrupt. This bit can be protected against unprivileged access when secure with RCC SPRIV or when non-secure with RCC NSPRIV."
     bit_offset: 2
     bit_size: 1
+  - name: GPIODEN
+    description: "IO port D bus clock enable\r Set and cleared by software.\r Access can be secured by GPIOD SECx. When secure, a non-secure read/write access is RAZ/WI. It does not generate an illegal access interrupt. This bit can be protected against unprivileged access when secure with RCC SPRIV or when non-secure with RCC NSPRIV."
+    bit_offset: 3
+    bit_size: 1
+  - name: GPIOEEN
+    description: "IO port E bus clock enable\r Set and cleared by software.\r Access can be secured by GPIOE SECx. When secure, a non-secure read/write access is RAZ/WI. It does not generate an illegal access interrupt. This bit can be protected against unprivileged access when secure with RCC SPRIV or when non-secure with RCC NSPRIV."
+    bit_offset: 4
+    bit_size: 1
+  - name: GPIOGEN
+    description: "IO port G bus clock enable\r Set and cleared by software.\r Access can be secured by GPIOG SECx. When secure, a non-secure read/write access is RAZ/WI. It does not generate an illegal access interrupt. This bit can be protected against unprivileged access when secure with RCC SPRIV or when non-secure with RCC NSPRIV."
+    bit_offset: 6
+    bit_size: 1
   - name: GPIOHEN
     description: "IO port H bus clock enable\r Set and cleared by software.\r Access can be secured by GPIOH SECx. When secure, a non-secure read/write access is RAZ/WI. It does not generate an illegal access interrupt. This bit can be protected against unprivileged access when secure with RCC SPRIV or when non-secure with RCC NSPRIV."
     bit_offset: 7
+    bit_size: 1
+  - name: OTGEN
+    description: "USB OTG_HS bus and kernel clock enable\r Set and cleared by software.\r Access can be secured by GTZC_TZSC OTGSEC. When secure, a non-secure read/write access is RAZ/WI. It does not generate an illegal access interrupt. This bit can be protected against unprivileged access when secure with RCC SPRIV or when non-secure with RCC NSPRIV."
+    bit_offset: 14
+    bit_size: 1
+  - name: OTGHSPHYEN
+    description: "USB OTG_HS PHY kernel clock enable\r Set and cleared by software.\r Access can be secured by GTZC_TZSC OTGSEC. When secure, a non-secure read/write access is RAZ/WI. It does not generate an illegal access interrupt. This bit can be protected against unprivileged access when secure with RCC SPRIV or when non-secure with RCC NSPRIV."
+    bit_offset: 15
     bit_size: 1
   - name: AESEN
     description: "AES bus clock enable\r Set and cleared by software.\r Access can be secured by GTZC_TZSC AESSEC. When secure, a non-secure read/write access is RAZ/WI. It does not generate an illegal access interrupt. This bit can be protected against unprivileged access when secure with RCC SPRIV or when non-secure with RCC NSPRIV."
@@ -354,9 +374,25 @@ fieldset/AHB2RSTR:
     description: "IO port C reset\r Set and cleared by software.\r Access can be secured by GPIOC SECx. When secure, a non-secure read/write access is RAZ/WI. It does not generate an illegal access interrupt. This bit can be protected against unprivileged access when secure with RCC SPRIV or when non-secure with RCC NSPRIV."
     bit_offset: 2
     bit_size: 1
+  - name: GPIODRST
+    description: "IO port D reset\r Set and cleared by software.\r Access can be secured by GPIOD SECx. When secure, a non-secure read/write access is RAZ/WI. It does not generate an illegal access interrupt. This bit can be protected against unprivileged access when secure with RCC SPRIV or when non-secure with RCC NSPRIV."
+    bit_offset: 3
+    bit_size: 1
+  - name: GPIOERST
+    description: "IO port E reset\r Set and cleared by software.\r Access can be secured by GPIOE SECx. When secure, a non-secure read/write access is RAZ/WI. It does not generate an illegal access interrupt. This bit can be protected against unprivileged access when secure with RCC SPRIV or when non-secure with RCC NSPRIV."
+    bit_offset: 4
+    bit_size: 1
+  - name: GPIOGRST
+    description: "IO port G reset\r Set and cleared by software.\r Access can be secured by GPIOG SECx. When secure, a non-secure read/write access is RAZ/WI. It does not generate an illegal access interrupt. This bit can be protected against unprivileged access when secure with RCC SPRIV or when non-secure with RCC NSPRIV."
+    bit_offset: 6
+    bit_size: 1
   - name: GPIOHRST
     description: "IO port H reset\r Set and cleared by software.\r Access can be secured by GPIOH SECx. When secure, a non-secure read/write access is RAZ/WI. It does not generate an illegal access interrupt. This bit can be protected against unprivileged access when secure with RCC SPRIV or when non-secure with RCC NSPRIV."
     bit_offset: 7
+    bit_size: 1
+  - name: OTGRST
+    description: "USB OTG_HS reset\r Set and cleared by software.\r Access can be secured by GTZC_TZSC OTGSEC. When secure, a non-secure read/write access is RAZ/WI. It does not generate an illegal access interrupt. This bit can be protected against unprivileged access when secure with RCC SPRIV or when non-secure with RCC NSPRIV."
+    bit_offset: 14
     bit_size: 1
   - name: AESRST
     description: "AES hardware accelerator reset\r Set and cleared by software.\r Access can be secured by GTZC_TZSC AESSEC. When secure, a non-secure read/write access is RAZ/WI. It does not generate an illegal access interrupt. This bit can be protected against unprivileged access when secure with RCC SPRIV or when non-secure with RCC NSPRIV."
@@ -397,9 +433,29 @@ fieldset/AHB2SMENR:
     description: "IO port C bus clock enable during Sleep and Stop modes\r Set and cleared by software.\r Access can be secured by GPIOC SECx. When secure, a non-secure read/write access is RAZ/WI. It does not generate an illegal access interrupt. This bit can be protected against unprivileged access when secure with RCC SPRIV or when non-secure with RCC NSPRIV."
     bit_offset: 2
     bit_size: 1
+  - name: GPIODSMEN
+    description: "IO port D bus clock enable during Sleep and Stop modes\r Set and cleared by software.\r Access can be secured by GPIOD SECx. When secure, a non-secure read/write access is RAZ/WI. It does not generate an illegal access interrupt. This bit can be protected against unprivileged access when secure with RCC SPRIV or when non-secure with RCC NSPRIV."
+    bit_offset: 3
+    bit_size: 1
+  - name: GPIOESMEN
+    description: "IO port E bus clock enable during Sleep and Stop modes\r Set and cleared by software.\r Access can be secured by GPIOE SECx. When secure, a non-secure read/write access is RAZ/WI. It does not generate an illegal access interrupt. This bit can be protected against unprivileged access when secure with RCC SPRIV or when non-secure with RCC NSPRIV."
+    bit_offset: 4
+    bit_size: 1
+  - name: GPIOGSMEN
+    description: "IO port G bus clock enable during Sleep and Stop modes\r Set and cleared by software.\r Access can be secured by GPIOG SECx. When secure, a non-secure read/write access is RAZ/WI. It does not generate an illegal access interrupt. This bit can be protected against unprivileged access when secure with RCC SPRIV or when non-secure with RCC NSPRIV."
+    bit_offset: 6
+    bit_size: 1
   - name: GPIOHSMEN
     description: "IO port H bus clock enable during Sleep and Stop modes\r Set and cleared by software.\r Access can be secured by GPIOH SECx. When secure, a non-secure read/write access is RAZ/WI. It does not generate an illegal access interrupt. This bit can be protected against unprivileged access when secure with RCC SPRIV or when non-secure with RCC NSPRIV."
     bit_offset: 7
+    bit_size: 1
+  - name: OTGSMEN
+    description: "USB OTG_HS bus and kernel clock enable during Sleep and Stop modes\r Set and cleared by software.\r Access can be secured by GTZC_TZSC OTGSEC. When secure, a non-secure read/write access is RAZ/WI. It does not generate an illegal access interrupt. This bit can be protected against unprivileged access when secure with RCC SPRIV or when non-secure with RCC NSPRIV."
+    bit_offset: 14
+    bit_size: 1
+  - name: OTGHSPHYSMEN
+    description: "USB OTG_HS PHY kernel clock enable during Sleep and Stop modes\r Set and cleared by software.\r Access can be secured by GTZC_TZSC OTGSEC. When secure, a non-secure read/write access is RAZ/WI. It does not generate an illegal access interrupt. This bit can be protected against unprivileged access when secure with RCC SPRIV or when non-secure with RCC NSPRIV."
+    bit_offset: 15
     bit_size: 1
   - name: AESSMEN
     description: "AES bus clock enable during Sleep and Stop modes\r Set and cleared by software.\r Access can be secured by GTZC_TZSC AESSEC. When secure, a non-secure read/write access is RAZ/WI. It does not generate an illegal access interrupt. This bit can be protected against unprivileged access when secure with RCC SPRIV or when non-secure with RCC NSPRIV."
@@ -486,21 +542,41 @@ fieldset/APB1ENR1:
     description: "TIM3 bus and kernel clocks enable\r Set and cleared by software.\r Access can be secured by GTZC_TZSC TIM2SEC. When secure, a non-secure read/write access is RAZ/WI. It does not generate an illegal access interrupt. This bit can be protected against unprivileged access when secure with RCC SPRIV or when non-secure with RCC NSPRIV."
     bit_offset: 1
     bit_size: 1
+  - name: TIM4EN
+    description: "TIM4 bus and kernel clocks enable\r Set and cleared by software.\r Access can be secured by GTZC_TZSC TIM4SEC. When secure, a non-secure read/write access is RAZ/WI. It does not generate an illegal access interrupt. This bit can be protected against unprivileged access when secure with RCC SPRIV or when non-secure with RCC NSPRIV."
+    bit_offset: 2
+    bit_size: 1
   - name: WWDGEN
     description: "WWDG bus clock enable\r Set by software to enable the window watchdog bus clock. Reset by hardware system reset.\r This bit can also be set by hardware if the WWDG_SW option bit is reset.\r Access can be secured by GTZC_TZSC WWDGSEC. When secure, a non-secure read/write access is RAZ/WI. It does not generate an illegal access interrupt. This bit can be protected against unprivileged access when secure with RCC SPRIV or when non-secure with RCC NSPRIV."
     bit_offset: 11
+    bit_size: 1
+  - name: SPI2EN
+    description: "SPI2 bus and kernel clocks enable\r Set and cleared by software.\r Access can be secured by GTZC_TZSC SPI2SEC. When secure, a non-secure read/write access is RAZ/WI. It does not generate an illegal access interrupt. This bit can be protected against unprivileged access when secure with RCC SPRIV or when non-secure with RCC NSPRIV."
+    bit_offset: 14
     bit_size: 1
   - name: USART2EN
     description: "USART2 bus and kernel clocks enable\r Set and cleared by software.\r Access can be secured by GTZC_TZSC USART2SEC When secure, a non-secure read/write access is RAZ/WI. It does not generate an illegal access interrupt. This bit can be protected against unprivileged access when secure with RCC SPRIV or when non-secure with RCC NSPRIV.."
     bit_offset: 17
     bit_size: 1
+  - name: USART3EN
+    description: "USART3 bus and kernel clocks enable\r Set and cleared by software.\r Access can be secured by GTZC_TZSC USART3SEC When secure, a non-secure read/write access is RAZ/WI. It does not generate an illegal access interrupt. This bit can be protected against unprivileged access when secure with RCC SPRIV or when non-secure with RCC NSPRIV.."
+    bit_offset: 18
+    bit_size: 1
   - name: I2C1EN
     description: "I2C1 bus and kernel clocks enable\r Set and cleared by software.\r Access can be secured by GTZC_TZSC I2C1SEC. When secure, a non-secure read/write access is RAZ/WI. It does not generate an illegal access interrupt. This bit can be protected against unprivileged access when secure with RCC SPRIV or when non-secure with RCC NSPRIV."
     bit_offset: 21
     bit_size: 1
+  - name: I2C2EN
+    description: "I2C2 bus and kernel clocks enable\r Set and cleared by software.\r Access can be secured by GTZC_TZSC I2C2SEC. When secure, a non-secure read/write access is RAZ/WI. It does not generate an illegal access interrupt. This bit can be protected against unprivileged access when secure with RCC SPRIV or when non-secure with RCC NSPRIV."
+    bit_offset: 22
+    bit_size: 1
 fieldset/APB1ENR2:
   description: RCC APB1 peripheral clock enable register 2
   fields:
+  - name: I2C4EN
+    description: "I2C4 bus and kernel clocks enable\r Set and cleared by software.\r Access can be secured by GTZC_TZSC I2C4SEC. When secure, a non-secure read/write access is RAZ/WI. It does not generate an illegal access interrupt. This bit can be protected against unprivileged access when secure with RCC SPRIV or when non-secure with RCC NSPRIV."
+    bit_offset: 1
+    bit_size: 1
   - name: LPTIM2EN
     description: "LPTIM2 bus and kernel clocks enable\r Set and cleared by software.\r Access can be secured by GTZC_TZSC LPTIM2SEC. When secure, a non-secure read/write access is RAZ/WI. It does not generate an illegal access interrupt. This bit can be protected against unprivileged access when secure with RCC SPRIV or when non-secure with RCC NSPRIV."
     bit_offset: 5
@@ -516,13 +592,29 @@ fieldset/APB1RSTR1:
     description: "TIM3 reset\r Set and cleared by software.\r Access can be secured by GTZC_TZSC TIM3SEC. When secure, a non-secure read/write access is RAZ/WI. It does not generate an illegal access interrupt. This bit can be protected against unprivileged access when secure with RCC SPRIV or when non-secure with RCC NSPRIV."
     bit_offset: 1
     bit_size: 1
+  - name: TIM4RST
+    description: "TIM4 reset\r Set and cleared by software.\r Access can be secured by GTZC_TZSC TIM4SEC. When secure, a non-secure read/write access is RAZ/WI. It does not generate an illegal access interrupt. This bit can be protected against unprivileged access when secure with RCC SPRIV or when non-secure with RCC NSPRIV."
+    bit_offset: 2
+    bit_size: 1
+  - name: SPI2RST
+    description: "SPI2 reset\r Set and cleared by software.\r Access can be secured by GTZC_TZSC SPI2SEC. When secure, a non-secure read/write access is RAZ/WI. It does not generate an illegal access interrupt. This bit can be protected against unprivileged access when secure with RCC SPRIV or when non-secure with RCC NSPRIV."
+    bit_offset: 14
+    bit_size: 1
   - name: USART2RST
     description: "USART2 reset\r Set and cleared by software.\r Access can be secured by GTZC_TZSC UART2SEC. When secure, a non-secure read/write access is RAZ/WI. It does not generate an illegal access interrupt. This bit can be protected against unprivileged access when secure with RCC SPRIV or when non-secure with RCC NSPRIV."
     bit_offset: 17
     bit_size: 1
+  - name: USART3RST
+    description: "USART3 reset\r Set and cleared by software.\r Access can be secured by GTZC_TZSC UART3SEC. When secure, a non-secure read/write access is RAZ/WI. It does not generate an illegal access interrupt. This bit can be protected against unprivileged access when secure with RCC SPRIV or when non-secure with RCC NSPRIV."
+    bit_offset: 18
+    bit_size: 1
   - name: I2C1RST
     description: "I2C1 reset\r Set and cleared by software.\r Access can be secured by GTZC_TZSC I2C1SEC. When secure, a non-secure read/write access is RAZ/WI. It does not generate an illegal access interrupt. This bit can be protected against unprivileged access when secure with RCC SPRIV or when non-secure with RCC NSPRIV."
     bit_offset: 21
+    bit_size: 1
+  - name: I2C2RST
+    description: "I2C2 reset\r Set and cleared by software.\r Access can be secured by GTZC_TZSC I2C2SEC. When secure, a non-secure read/write access is RAZ/WI. It does not generate an illegal access interrupt. This bit can be protected against unprivileged access when secure with RCC SPRIV or when non-secure with RCC NSPRIV."
+    bit_offset: 22
     bit_size: 1
 fieldset/APB1RSTR2:
   description: RCC APB1 peripheral reset register 2
@@ -653,6 +745,10 @@ fieldset/APB7ENR:
     description: "LPTIM1 bus and kernel clocks enable\r Set and cleared by software.\r Access can be secured by GTZC_TZSC LPTIM1SEC. When secure, a non-secure read/write access is RAZ/WI. It does not generate an illegal access interrupt. This bit can be protected against unprivileged access when secure with RCC SPRIV or when non-secure with RCC NSPRIV."
     bit_offset: 11
     bit_size: 1
+  - name: VREFEN
+    description: "VREFBUF bus clock enable\r Set and cleared by software.\r Access can be secured by GTZC_TZSC VREFBUFSEC. When secure, a non-secure read/write access is RAZ/WI. It does not generate an illegal access interrupt. This bit can be protected against unprivileged access when secure with RCC SPRIV or when non-secure with RCC NSPRIV."
+    bit_offset: 20
+    bit_size: 1
   - name: RTCAPBEN
     description: "RTC and TAMP bus clock enable\r Set and cleared by software.\r Can only be accessed secure when one or more features in the RTC or TAMP is/are secure. When secure, a non-secure read/write access is RAZ/WI. It does not generate an illegal access interrupt. This bit can be protected against unprivileged access when secure with RCC SPRIV or when non-secure with RCC NSPRIV."
     bit_offset: 21
@@ -679,6 +775,14 @@ fieldset/APB7RSTR:
   - name: LPTIM1RST
     description: "LPTIM1 reset\r Set and cleared by software.\r Access can be secured by GTZC_TZSC LPTIM1SEC. When secure, a non-secure read/write access is RAZ/WI. It does not generate an illegal access interrupt. This bit can be protected against unprivileged access when secure with RCC SPRIV or when non-secure with RCC NSPRIV."
     bit_offset: 11
+    bit_size: 1
+  - name: COMPRST
+    description: "COMP reset\r Set and cleared by software.\r Access can be secured by GTZC_TZSC COMPSEC. When secure, a non-secure read/write access is RAZ/WI. It does not generate an illegal access interrupt. This bit can be protected against unprivileged access when secure with RCC SPRIV or when non-secure with RCC NSPRIV."
+    bit_offset: 15
+    bit_size: 1
+  - name: VREFRST
+    description: "VREF reset\r Set and cleared by software.\r Access can be secured by GTZC_TZSC VREFSEC. When secure, a non-secure read/write access is RAZ/WI. It does not generate an illegal access interrupt. This bit can be protected against unprivileged access when secure with RCC SPRIV or when non-secure with RCC NSPRIV."
+    bit_offset: 20
     bit_size: 1
 fieldset/APB7SMENR:
   description: RCC APB7 peripheral clock enable in Sleep and Stop modes register

--- a/data/registers/rcc_wba.yaml
+++ b/data/registers/rcc_wba.yaml
@@ -1442,19 +1442,33 @@ fieldset/ASCNTR:
   - name: CNT
     description: "Counter value\r This field is set by hardware.\r CNT[19:0] is the counter value at the time this register is read."
     bit_offset: 0
-    bit_size: 19
+    bit_size: 20
 fieldset/ASARR:
   description: RCC audio synchronization auto-reload register
   fields:
   - name: AR
     description: "Auto-reload value\r This field is set by software.\r CA[19:0] is the counter auto-reload value at which to restart the audio synchronization counter from value 0. It defines the counter period."
     bit_offset: 0
-    bit_size: 19
+    bit_size: 20
+fieldset/ASCAR:
+  description: RCC audio synchronization capture register
+  fields:
+  - name: CA
+    description: "Capture value\r This field is set by hardware.\r CA[26:20] is the capture period counter value loaded on the trigger event. CA[19:0] is the audio synchronization counter value loaded on the trigger event."
+    bit_offset: 0
+    bit_size: 27
+fieldset/ASCOR:
+  description: RCC audio synchronization compare register
+  fields:
+  - name: CO
+    description: "Compare value\r This field is set by software.\r CO[19:0] is the value to be compared to the audio synchronization counter to generate an compare interrupt event."
+    bit_offset: 0
+    bit_size: 20
 enum/ADCSEL:
   bit_size: 3
   variants:
-  - name: HCLK1
-    description: hclk1 clock selected
+  - name: HCLK4
+    description: hclk4 clock selected
     value: 0
   - name: SYS
     description: SYSCLK selected
@@ -1802,7 +1816,7 @@ enum/SAI1SEL:
     name: SYS
     value: 2
   - description: input pin AUDIOCLK selected.
-    name: AUDIO
+    name: AUDIOCLK
     value: 3
   - description: HSI16 clock selected.
     name: HSI
@@ -1915,66 +1929,6 @@ enum/ASSEL:
   - description: pll1qclk selected.
     name: PLL1_Q
     value: 1
-enum/HDIV:
-  bit_size: 1
-  variants:
-  - description: hclk5 = SYSCLK not divided.
-    name: SYS
-    value: 0
-  - description: hclk5 = SYSCLK divided by 2.
-    name: SYS_2
-    value: 1
-enum/ICSEL:
-  bit_size: 2
-  variants:
-  - description: pclk1 selected.
-    name: PCLK1
-    value: 0
-  - description: SYSCLK selected.
-    name: SYS
-    value: 1
-  - description: HSI16 selected.
-    name: HSI
-    value: 2
-enum/LPTIMSEL:
-  bit_size: 2
-  variants:
-  - description: pclk7 selected.
-    name: PCLK7
-    value: 0
-  - description: LSI selected.
-    name: LSI
-    value: 1
-  - description: HSI16 selected.
-    name: HSI
-    value: 2
-  - description: LSE selected.
-    name: LSE
-    value: 3
-enum/LSICFG:
-  bit_size: 4
-  variants:
-  - description: LSI2 frequency temperature sensitivity is close to 0 at +80 less thansup oless than/sup C.
-    name: LSI_80
-    value: 0
-  - description: LSI2 frequency temperature sensitivity is close to 0 at +50 less thansup oless than/sup C.
-    name: LSI_50
-    value: 1
-  - description: LSI2 frequency temperature sensitivity is close to 0 at +20 less thansup oless than/sup C.
-    name: LSI_20
-    value: 2
-enum/LSIMODE:
-  bit_size: 3
-  variants:
-  - description: nominal-power, high accuracy.
-    name: NOM
-    value: 0
-  - description: low-power, medium accuracy.
-    name: LOW
-    value: 1
-  - description: ultra-low-power, low accuracy.
-    name: ULP
-    value: 2
 enum/OTGHSSEL:
   bit_size: 2
   variants:
@@ -1985,137 +1939,8 @@ enum/OTGHSSEL:
     name: PLL1_P
     value: 1
   - description: HSE32 divided by 2 selected.
-    name: HSE_2
+    name: HSE_DIV_2
     value: 2
   - description: pll1pclk divided by 2 selected.
-    name: PLL1_P_2
-    value: 3
-enum/PLLM:
-  bit_size: 3
-  variants:
-  - description: division by 1 (bypass).
-    name: PLL1M_1
-    value: 0
-  - description: division by 2.
-    name: PLL1M_2
-    value: 1
-  - description: division by 3.
-    name: PLL1M_3
-    value: 2
-  - description: division by 8.
-    name: PLL1M_8
-    value: 7
-enum/PLLN:
-  bit_size: 9
-  variants:
-  - description: multiplication factor for PLL1 VCO= 4.
-    name: PLL1N_X4
-    value: 3
-  - description: multiplication factor for PLL1 VCO = 5.
-    name: PLL1N_X5
-    value: 4
-  - description: multiplication factor for PLL1 VCO = 6.
-    name: PLL1N_X6
-    value: 5
-  - description: multiplication factor for PLL1 VCO = 129 (default after reset).
-    name: PLL1N_X129
-    value: 128
-  - description: multiplication factor for PLL1 VCO = 512.
-    name: PLL1N_X512
-    value: 511
-enum/PLLP:
-  bit_size: 7
-  variants:
-  - description: Not allowed.
-    name: NOT_VALID
-    value: 0
-  - description: pll1pclk = VCO output frequency / 2 (default after reset).
-    name: PLL1_P_2
-    value: 1
-  - description: not allowed.
-    name: NOT_VALID2
-    value: 2
-  - description: pll1pclk = VCO output frequency / 4.
-    name: PLL1_P_4
-    value: 3
-  - description: pll1pclk = VCO output frequency / 128.
-    name: PLL1_P_128
-    value: 127
-enum/PLLQ:
-  bit_size: 7
-  variants:
-  - description: PLl1QCLK = VCO output frequency.
-    name: PLL1_Q
-    value: 0
-  - description: PLl1QCLK = VCO output frequency / 2 (default after reset).
-    name: PLL1_Q_2
-    value: 1
-  - description: PLl1QCLK = VCO output frequency / 3.
-    name: PLL1_Q_3
-    value: 2
-  - description: PLl1QCLK = VCO output frequency / 4.
-    name: PLL1_Q_4
-    value: 3
-  - description: PLl1QCLK = VCO output frequency / 128.
-    name: PLL1_Q_128
-    value: 127
-enum/PLLR:
-  bit_size: 7
-  variants:
-  - description: pll1rclk = VCO output frequency.
-    name: PLL1_R
-    value: 0
-  - description: pll1rclk = VCO output frequency / 2 (default after reset).
-    name: PLL1_R_2
-    value: 1
-  - description: pll1rclk = VCO output frequency / 3.
-    name: PLL1_R_3
-    value: 2
-  - description: pll1rclk = VCO output frequency / 4.
-    name: PLL1_R_4
-    value: 3
-  - description: pll1rclk = VCO output frequency / 128.
-    name: PLL1_R_128
-    value: 127
-enum/SAISEL:
-  bit_size: 3
-  variants:
-  - description: pll1pclk selected.
-    name: PLL1_P
-    value: 0
-  - description: pll1qclk selected.
-    name: PLL1_Q
-    value: 1
-  - description: SYSCLK selected.
-    name: SYS
-    value: 2
-  - description: input pin AUDIOCLK selected.
-    name: AUDIO
-    value: 3
-  - description: HSI16 clock selected.
-    name: HSI
-    value: 4
-enum/SPISEL:
-  bit_size: 2
-  variants:
-  - description: pclk2 selected.
-    name: PCLK2
-    value: 0
-  - description: SYSCLK selected.
-    name: SYS
-    value: 1
-  - description: HSI16 selected.
-    name: HSI
-    value: 2
-enum/SWS:
-  bit_size: 2
-  variants:
-  - description: HSI16 oscillator used as system clock.
-    name: HSI
-    value: 0
-  - description: HSE32 or HSE32/2, as defined by HSEPRE, used as system clock.
-    name: HSE
-    value: 2
-  - description: pll1rclk used as system clock.
-    name: PLL1_R
+    name: PLL1_P_DIV_2
     value: 3

--- a/data/registers/rcc_wba.yaml
+++ b/data/registers/rcc_wba.yaml
@@ -169,6 +169,36 @@ block/RCC:
     description: RCC privilege configuration register
     byte_offset: 276
     fieldset: PRIVCFGR
+  - name: ASCR
+    description: RCC audio synchronization control register
+    byte_offset: 448
+    fieldset: ASCR
+  - name: ASIER
+    description: RCC audio synchronization interrupt enable register
+    byte_offset: 452
+    fieldset: ASIER
+  - name: ASSR
+    description: RCC audio synchronization status register
+    byte_offset: 456
+    fieldset: ASSR
+  - name: ASCNTR
+    description: RCC audio synchronization counter register
+    byte_offset: 460
+    fieldset: ASCNTR
+    access: Read
+  - name: ASARR
+    description: RCC audio synchronization auto-reload register
+    byte_offset: 464
+    fieldset: ASARR
+  - name: ASCAR
+    description: RCC audio synchronization capture register
+    byte_offset: 468
+    fieldset: ASCAR
+    access: Read
+  - name: ASCOR
+    description: RCC audio synchronization compare register
+    byte_offset: 472
+    fieldset: ASCOR
   - name: CFGR4
     description: RCC clock configuration register 2
     byte_offset: 512
@@ -799,11 +829,21 @@ fieldset/CCIPR1:
 fieldset/CCIPR2:
   description: RCC peripherals independent clock configuration register 2
   fields:
+  - name: SAI1SEL
+    description: "SAI1 kernel clock source selection\r These bits allow to select the SAI1 kernel clock source.\r Access can be secured by GTZC_TZSC SAI1SEC. When secure, a non-secure read/write access is RAZ/WI. It does not generate an illegal access interrupt. This bit can be protected against unprivileged access when secure with RCC SPRIV or when non-secure with RCC NSPRIV."
+    bit_offset: 5
+    bit_size: 3
+    enum: SAI1SEL
   - name: RNGSEL
     description: "RNGSEL kernel clock source selection\r These bits allow to select the RNG kernel clock source.\r Access can be secured by GTZC_TZSC RNGSEC. When secure, a non-secure read/write access is RAZ/WI. It does not generate an illegal access interrupt. This bit can be protected against unprivileged access when secure with RCC SPRIV or when non-secure with RCC NSPRIV."
     bit_offset: 12
     bit_size: 2
     enum: RNGSEL
+  - name: OTGHSSEL
+    description: USB OTG_HS PHY kernel clock source selection.
+    bit_offset: 28
+    bit_size: 2
+    enum: OTGHSSEL
 fieldset/CCIPR3:
   description: RCC peripherals independent clock configuration register 3
   fields:
@@ -1201,8 +1241,8 @@ fieldset/SECCFGR:
 enum/ADCSEL:
   bit_size: 3
   variants:
-  - name: HCLK4
-    description: hclk4 clock selected
+  - name: HCLK1
+    description: hclk1 clock selected
     value: 0
   - name: SYS
     description: SYSCLK selected
@@ -1537,6 +1577,24 @@ enum/RTCSEL:
   - name: HSE
     description: HSE oscillator clock divided by 32 selected, and enabled
     value: 3
+enum/SAI1SEL:
+  bit_size: 3
+  variants:
+  - description: pll1pclk selected.
+    name: PLL1_P
+    value: 0
+  - description: pll1qclk selected.
+    name: PLL1_Q
+    value: 1
+  - description: SYSCLK selected.
+    name: SYS
+    value: 2
+  - description: input pin AUDIOCLK selected.
+    name: AUDIO
+    value: 3
+  - description: HSI16 clock selected.
+    name: HSI
+    value: 4
 enum/SPI1SEL:
   bit_size: 2
   variants:
@@ -1623,4 +1681,595 @@ enum/USARTSEL:
     value: 2
   - name: LSE
     description: LSE selected
+    value: 3
+enum/ASSEL:
+  bit_size: 1
+  variants:
+  - description: pll1pclk selected.
+    name: PLL1_P
+    value: 0
+  - description: pll1qclk selected.
+    name: PLL1_Q
+    value: 1
+enum/HDIV:
+  bit_size: 1
+  variants:
+  - description: hclk5 = SYSCLK not divided.
+    name: SYS
+    value: 0
+  - description: hclk5 = SYSCLK divided by 2.
+    name: SYS_2
+    value: 1
+enum/HDIV5:
+  bit_size: 1
+  variants:
+  - description: hclk5 = SYSCLK not divided
+    name: SYS
+    value: 0
+  - description: hclk5 = SYSCLK divided by 2
+    name: SYS_2
+    value: 1
+enum/HPRE:
+  bit_size: 3
+  variants:
+  - description: hclk1 = SYSCLK divided by 2.
+    name: SYS_2
+    value: 4
+  - description: hclk1 = SYSCLK divided by 4.
+    name: SYS_4
+    value: 5
+  - description: hclk1 = SYSCLK divided by 8.
+    name: SYS_8
+    value: 6
+  - description: hclk1 = SYSCLK divided by 16.
+    name: SYS_16
+    value: 7
+enum/HPRE5:
+  bit_size: 3
+  variants:
+  - description: DCLK not divided
+    name: SYS
+    value: 0
+  - description: hclk5 = SYSCLK divided by 2
+    name: SYS_2
+    value: 4
+  - description: hclk5 = SYSCLK divided by 3
+    name: SYS_3
+    value: 5
+  - description: hclk5 = SYSCLK divided by 4
+    name: SYS_4
+    value: 6
+  - description: hclk5 = SYSCLK divided by 6
+    name: SYS_6
+    value: 7
+enum/HSEPRE:
+  bit_size: 1
+  variants:
+  - description: HSE32 not divided, SYSCLK = HSE32.
+    name: HSE
+    value: 0
+  - description: HSE32 divided, SYSCLK = HSE32/2.
+    name: HSE_2
+    value: 1
+enum/I2C1SEL:
+  bit_size: 2
+  variants:
+  - description: pclk1 selected
+    name: PCLK1
+    value: 0
+  - description: SYSCLK selected
+    name: SYS
+    value: 1
+  - description: HSI selected
+    name: HSI
+    value: 2
+enum/I2C3SEL:
+  bit_size: 2
+  variants:
+  - description: pclk7 selected
+    name: PCLK7
+    value: 0
+  - description: SYSCLK selected
+    name: SYS
+    value: 1
+  - description: HSI selected
+    name: HSI
+    value: 2
+enum/ICSEL:
+  bit_size: 2
+  variants:
+  - description: pclk1 selected.
+    name: PCLK1
+    value: 0
+  - description: SYSCLK selected.
+    name: SYS
+    value: 1
+  - description: HSI16 selected.
+    name: HSI
+    value: 2
+enum/LPTIM1SEL:
+  bit_size: 2
+  variants:
+  - description: pclk7 selected.
+    name: PCLK7
+    value: 0
+  - description: LSI selected
+    name: LSI
+    value: 1
+  - description: HSI selected
+    name: HSI
+    value: 2
+  - description: LSE selected
+    name: LSE
+    value: 3
+enum/LPTIM2SEL:
+  bit_size: 2
+  variants:
+  - description: pclk7 selected.
+    name: PCLK1
+    value: 0
+  - description: LSI selected
+    name: LSI
+    value: 1
+  - description: HSI selected
+    name: HSI
+    value: 2
+  - description: LSE selected
+    name: LSE
+    value: 3
+enum/LPTIMSEL:
+  bit_size: 2
+  variants:
+  - description: pclk7 selected.
+    name: PCLK7
+    value: 0
+  - description: LSI selected.
+    name: LSI
+    value: 1
+  - description: HSI16 selected.
+    name: HSI
+    value: 2
+  - description: LSE selected.
+    name: LSE
+    value: 3
+enum/LPUARTSEL:
+  bit_size: 2
+  variants:
+  - description: pclk7 selected.
+    name: PCLK7
+    value: 0
+  - description: SYSCLK selected.
+    name: SYS
+    value: 1
+  - description: HSI16 selected.
+    name: HSI
+    value: 2
+  - description: LSE selected.
+    name: LSE
+    value: 3
+enum/LSCOSEL:
+  bit_size: 1
+  variants:
+  - description: LSI clock selected.
+    name: LSI
+    value: 0
+  - description: LSE clock selected.
+    name: LSE
+    value: 1
+enum/LSEDRV:
+  bit_size: 2
+  variants:
+  - description: '''Xtal mode'' medium-low driving capability.'
+    name: LO
+    value: 1
+  - description: '''Xtal mode'' medium-high driving capability.'
+    name: MED
+    value: 2
+  - description: '''Xtal mode'' higher driving capability.'
+    name: HI
+    value: 3
+enum/LSETRIM:
+  bit_size: 2
+  variants:
+  - description: current source resistance 5/4 x R.
+    name: R_5_4
+    value: 0
+  - description: current source resistance R.
+    name: R
+    value: 1
+  - description: current source resistance 3/4 x R.
+    name: R_3_4
+    value: 2
+  - description: current source resistance 2/3 x R.
+    name: R_2_3
+    value: 3
+enum/LSICFG:
+  bit_size: 4
+  variants:
+  - description: LSI2 frequency temperature sensitivity is close to 0 at +80 less thansup oless than/sup C.
+    name: LSI_80
+    value: 0
+  - description: LSI2 frequency temperature sensitivity is close to 0 at +50 less thansup oless than/sup C.
+    name: LSI_50
+    value: 1
+  - description: LSI2 frequency temperature sensitivity is close to 0 at +20 less thansup oless than/sup C.
+    name: LSI_20
+    value: 2
+enum/LSIMODE:
+  bit_size: 3
+  variants:
+  - description: nominal-power, high accuracy.
+    name: NOM
+    value: 0
+  - description: low-power, medium accuracy.
+    name: LOW
+    value: 1
+  - description: ultra-low-power, low accuracy.
+    name: ULP
+    value: 2
+enum/LSIPREDIV:
+  bit_size: 1
+  variants:
+  - description: LSI1 not divided.
+    name: LSI1
+    value: 0
+  - description: LSI1 divided by 128.
+    name: LSI1_128
+    value: 1
+enum/MCOPRE:
+  bit_size: 3
+  variants:
+  - description: MCO divided by 1.
+    name: MCO_1
+    value: 0
+  - description: MCO divided by 2.
+    name: MCO_2
+    value: 1
+  - description: MCO divided by 4.
+    name: MCO_4
+    value: 2
+  - description: MCO divided by 8.
+    name: MCO_8
+    value: 3
+  - description: MCO divided by 16.
+    name: MCO_16
+    value: 4
+enum/MCOSEL:
+  bit_size: 4
+  variants:
+  - description: MCO output disabled, no clock on MCO.
+    name: NO_CLK
+    value: 0
+  - description: sysclkpre system clock after PLL1RCLKPRE division selected.
+    name: SYSCLKPRE
+    value: 1
+  - description: HSI16 clock selected.
+    name: HSI
+    value: 3
+  - description: HSE32 clock selected.
+    name: HSE
+    value: 4
+  - description: pll1rclk clock selected.
+    name: PLL1_R
+    value: 5
+  - description: LSI clock selected.
+    name: LSI
+    value: 6
+  - description: LSE clock selected.
+    name: LSE
+    value: 7
+  - description: pll1pclk clock selected.
+    name: PLL1_P
+    value: 8
+  - description: pll1qclk clock selected.
+    name: PLL1_Q
+    value: 9
+  - description: hclk5 clock selected.
+    name: HCLK5
+    value: 10
+enum/OTGHSSEL:
+  bit_size: 2
+  variants:
+  - description: HSE32 selected.
+    name: HSE
+    value: 0
+  - description: pll1pclk selected,.
+    name: PLL1_P
+    value: 1
+  - description: HSE32 divided by 2 selected.
+    name: HSE_2
+    value: 2
+  - description: pll1pclk divided by 2 selected.
+    name: PLL1_P_2
+    value: 3
+enum/PLLM:
+  bit_size: 3
+  variants:
+  - description: division by 1 (bypass).
+    name: PLL1M_1
+    value: 0
+  - description: division by 2.
+    name: PLL1M_2
+    value: 1
+  - description: division by 3.
+    name: PLL1M_3
+    value: 2
+  - description: division by 8.
+    name: PLL1M_8
+    value: 7
+enum/PLLN:
+  bit_size: 9
+  variants:
+  - description: multiplication factor for PLL1 VCO= 4.
+    name: PLL1N_X4
+    value: 3
+  - description: multiplication factor for PLL1 VCO = 5.
+    name: PLL1N_X5
+    value: 4
+  - description: multiplication factor for PLL1 VCO = 6.
+    name: PLL1N_X6
+    value: 5
+  - description: multiplication factor for PLL1 VCO = 129 (default after reset).
+    name: PLL1N_X129
+    value: 128
+  - description: multiplication factor for PLL1 VCO = 512.
+    name: PLL1N_X512
+    value: 511
+enum/PLLP:
+  bit_size: 7
+  variants:
+  - description: Not allowed.
+    name: NOT_VALID
+    value: 0
+  - description: pll1pclk = VCO output frequency / 2 (default after reset).
+    name: PLL1_P_2
+    value: 1
+  - description: not allowed.
+    name: NOT_VALID2
+    value: 2
+  - description: pll1pclk = VCO output frequency / 4.
+    name: PLL1_P_4
+    value: 3
+  - description: pll1pclk = VCO output frequency / 128.
+    name: PLL1_P_128
+    value: 127
+enum/PLLQ:
+  bit_size: 7
+  variants:
+  - description: PLl1QCLK = VCO output frequency.
+    name: PLL1_Q
+    value: 0
+  - description: PLl1QCLK = VCO output frequency / 2 (default after reset).
+    name: PLL1_Q_2
+    value: 1
+  - description: PLl1QCLK = VCO output frequency / 3.
+    name: PLL1_Q_3
+    value: 2
+  - description: PLl1QCLK = VCO output frequency / 4.
+    name: PLL1_Q_4
+    value: 3
+  - description: PLl1QCLK = VCO output frequency / 128.
+    name: PLL1_Q_128
+    value: 127
+enum/PLLR:
+  bit_size: 7
+  variants:
+  - description: pll1rclk = VCO output frequency.
+    name: PLL1_R
+    value: 0
+  - description: pll1rclk = VCO output frequency / 2 (default after reset).
+    name: PLL1_R_2
+    value: 1
+  - description: pll1rclk = VCO output frequency / 3.
+    name: PLL1_R_3
+    value: 2
+  - description: pll1rclk = VCO output frequency / 4.
+    name: PLL1_R_4
+    value: 3
+  - description: pll1rclk = VCO output frequency / 128.
+    name: PLL1_R_128
+    value: 127
+enum/PLLRCLKPRESTEP:
+  bit_size: 1
+  variants:
+  - description: pll1rclk 2-step division.
+    name: PLL_R_2
+    value: 0
+  - description: pll1rclk 3-step division.
+    name: PLL1_R_3
+    value: 1
+enum/PLLRGE:
+  bit_size: 2
+  variants:
+  - description: PLL1 input (ref1_ck) clock range frequency between 8 and 16 MHz.
+    name: FREQ
+    value: 3
+enum/PLLSRC:
+  bit_size: 2
+  variants:
+  - description: no clock sent to PLL1.
+    name: NO_CLK
+    value: 0
+  - description: HSI16 clock selected as PLL1 clock entry.
+    name: HSI
+    value: 2
+  - description: HSE32 clock after HSEPRE divider selected as PLL1 clock entry.
+    name: HSE
+    value: 3
+enum/PPRE:
+  bit_size: 3
+  variants:
+  - description: pclk1 = hclk1 divided by 2.
+    name: HCLK1_2
+    value: 4
+  - description: pclk1 = hclk1 divided by 4.
+    name: HCLK1_4
+    value: 5
+  - description: pclk1 = hclk1 divided by 8.
+    name: HCLK1_8
+    value: 6
+  - description: pclk1 = hclk1 divided by 16.
+    name: HCLK1_16
+    value: 7
+enum/RADIOSTSEL:
+  bit_size: 2
+  variants:
+  - description: no clock selected, 2.4 GHz RADIO sleep timer kernel clock disabled.
+    name: NO_CLK
+    value: 0
+  - description: LSE oscillator clock selected.
+    name: LSE
+    value: 1
+  - description: HSE32 oscillator clock divided by 1000 selected.
+    name: HSE
+    value: 3
+enum/RNGSEL:
+  bit_size: 2
+  variants:
+  - description: LSE selected.
+    name: LSE
+    value: 0
+  - description: LSI selected.
+    name: LSI
+    value: 1
+  - description: HSI16 selected.
+    name: HSI
+    value: 2
+  - description: pll1qclk divide by 2 selected.
+    name: PLL1_Q
+    value: 3
+enum/RTCSEL:
+  bit_size: 2
+  variants:
+  - description: no clock selected, RTC and TAMP kernel clock disabled.
+    name: NO_CLK
+    value: 0
+  - description: LSE oscillator clock selected, and enabled.
+    name: LSE
+    value: 1
+  - description: LSI oscillator clock selected, and enabled.
+    name: LSI
+    value: 2
+  - description: HSE32 oscillator clock divided by 32 selected, and enabled.
+    name: HSE
+    value: 3
+enum/SAISEL:
+  bit_size: 3
+  variants:
+  - description: pll1pclk selected.
+    name: PLL1_P
+    value: 0
+  - description: pll1qclk selected.
+    name: PLL1_Q
+    value: 1
+  - description: SYSCLK selected.
+    name: SYS
+    value: 2
+  - description: input pin AUDIOCLK selected.
+    name: AUDIO
+    value: 3
+  - description: HSI16 clock selected.
+    name: HSI
+    value: 4
+enum/SPI1SEL:
+  bit_size: 2
+  variants:
+  - description: pclk2 selected
+    name: PCLK2
+    value: 0
+  - description: SYSCLK selected
+    name: SYS
+    value: 1
+  - description: HSI selected
+    name: HSI
+    value: 2
+enum/SPI3SEL:
+  bit_size: 2
+  variants:
+  - description: pclk2 selected
+    name: PCLK7
+    value: 0
+  - description: SYSCLK selected
+    name: SYS
+    value: 1
+  - description: HSI selected
+    name: HSI
+    value: 2
+enum/SPISEL:
+  bit_size: 2
+  variants:
+  - description: pclk2 selected.
+    name: PCLK2
+    value: 0
+  - description: SYSCLK selected.
+    name: SYS
+    value: 1
+  - description: HSI16 selected.
+    name: HSI
+    value: 2
+enum/SW:
+  bit_size: 2
+  variants:
+  - description: HSI16 selected as system clock.
+    name: HSI
+    value: 0
+  - description: HSE32 or HSE32/2, as defined by HSEPRE, selected as system clock.
+    name: HSE
+    value: 2
+  - description: pll1rclk selected as system clock.
+    name: PLL1_R
+    value: 3
+enum/SWS:
+  bit_size: 2
+  variants:
+  - description: HSI16 oscillator used as system clock.
+    name: HSI
+    value: 0
+  - description: HSE32 or HSE32/2, as defined by HSEPRE, used as system clock.
+    name: HSE
+    value: 2
+  - description: pll1rclk used as system clock.
+    name: PLL1_R
+    value: 3
+enum/SYSTICKSEL:
+  bit_size: 2
+  variants:
+  - description: hclk1 divided by 8 selected.
+    name: HCLK1_8
+    value: 0
+  - description: LSI selected.
+    name: LSI
+    value: 1
+  - description: LSE selected.
+    name: LSE
+    value: 2
+enum/USART1SEL:
+  bit_size: 2
+  variants:
+  - description: pclk2 selected
+    name: PCLK2
+    value: 0
+  - description: SYSCLK selected
+    name: SYS
+    value: 1
+  - description: HSI selected
+    name: HSI
+    value: 2
+  - description: LSE selected
+    name: LSE
+    value: 3
+enum/USARTSEL:
+  bit_size: 2
+  variants:
+  - description: pclk2 selected.
+    name: PCLK2
+    value: 0
+  - description: SYSCLK selected.
+    name: SYS
+    value: 1
+  - description: HSI16 selected.
+    name: HSI
+    value: 2
+  - description: LSE selected.
+    name: LSE
     value: 3

--- a/data/registers/rcc_wba.yaml
+++ b/data/registers/rcc_wba.yaml
@@ -634,21 +634,41 @@ fieldset/APB1SMENR1:
     description: "TIM3 bus and kernel clocks enable during Sleep and Stop modes\r Set and cleared by software.\r Access can be secured by GTZC_TZSC TIM3SEC. When secure, a non-secure read/write access is RAZ/WI. It does not generate an illegal access interrupt. This bit can be protected against unprivileged access when secure with RCC SPRIV or when non-secure with RCC NSPRIV."
     bit_offset: 1
     bit_size: 1
+  - name: TIM4SMEN
+    description: "TIM4 bus and kernel clocks enable during Sleep and Stop modes\r Set and cleared by software.\r Access can be secured by GTZC_TZSC TIM4SEC. When secure, a non-secure read/write access is RAZ/WI. It does not generate an illegal access interrupt. This bit can be protected against unprivileged access when secure with RCC SPRIV or when non-secure with RCC NSPRIV."
+    bit_offset: 2
+    bit_size: 1
   - name: WWDGSMEN
     description: "Window watchdog bus clock enable during Sleep and Stop modes\r Set and cleared by software. This bit is forced to 1 by hardware when the hardware WWDG option is activated.\r Access can be secured by GTZC_TZSC WWDGSEC. When secure, a non-secure read/write access is RAZ/WI. It does not generate an illegal access interrupt. This bit can be protected against unprivileged access when secure with RCC SPRIV or when non-secure with RCC NSPRIV."
     bit_offset: 11
+    bit_size: 1
+  - name: SPI2SMEN
+    description: "SPI2 bus and kernel clock enable during Sleep and Stop modes\r Set and cleared by software.\r Access can be secured by GTZC_TZSC SPI2SEC. When secure, a non-secure read/write access is RAZ/WI. It does not generate an illegal access interrupt. This bit can be protected against unprivileged access when secure with RCC SPRIV or when non-secure with RCC NSPRIV."
+    bit_offset: 14
     bit_size: 1
   - name: USART2SMEN
     description: "USART2 bus and kernel clocks enable during Sleep and Stop modes\r Set and cleared by software.\r Access can be secured by GTZC_TZSC USART2SEC. When secure, a non-secure read/write access is RAZ/WI. It does not generate an illegal access interrupt. This bit can be protected against unprivileged access when secure with RCC SPRIV or when non-secure with RCC NSPRIV.\r Note: This bit must be set to allow the peripheral to wake up from Stop modes."
     bit_offset: 17
     bit_size: 1
+  - name: USART3SMEN
+    description: "USART3 bus and kernel clocks enable during Sleep and Stop modes\r Set and cleared by software.\r Access can be secured by GTZC_TZSC USART3SEC. When secure, a non-secure read/write access is RAZ/WI. It does not generate an illegal access interrupt. This bit can be protected against unprivileged access when secure with RCC SPRIV or when non-secure with RCC NSPRIV.\r Note: This bit must be set to allow the peripheral to wake up from Stop modes."
+    bit_offset: 18
+    bit_size: 1
   - name: I2C1SMEN
     description: "I2C1 bus and kernel clocks enable during Sleep and Stop modes\r Set and cleared by software.\r Access can be secured by GTZC_TZSC I2C1SEC. When secure, a non-secure read/write access is RAZ/WI. It does not generate an illegal access interrupt. This bit can be protected against unprivileged access when secure with RCC SPRIV or when non-secure with RCC NSPRIV.\r Note: This bit must be set to allow the peripheral to wake up from Stop modes."
     bit_offset: 21
     bit_size: 1
+  - name: I2C2SMEN
+    description: "I2C2 bus and kernel clocks enable during Sleep and Stop modes\r Set and cleared by software.\r Access can be secured by GTZC_TZSC I2C2SEC. When secure, a non-secure read/write access is RAZ/WI. It does not generate an illegal access interrupt. This bit can be protected against unprivileged access when secure with RCC SPRIV or when non-secure with RCC NSPRIV.\r Note: This bit must be set to allow the peripheral to wake up from Stop modes."
+    bit_offset: 22
+    bit_size: 1
 fieldset/APB1SMENR2:
   description: "RCC APB1 peripheral clocks enable in Sleep and Stop modes \tregister 2"
   fields:
+  - name: I2C4SMEN
+    description: "I2C4 bus and kernel clocks enable during Sleep and Stop modes\r Set and cleared by software.\r Access can be secured by GTZC_TZSC I2C4SEC. When secure, a non-secure read/write access is RAZ/WI. It does not generate an illegal access interrupt. This bit can be protected against unprivileged access when secure with RCC SPRIV or when non-secure with RCC NSPRIV.\r Note: This bit must be set to allow the peripheral to wake up from Stop modes."
+    bit_offset: 1
+    bit_size: 1
   - name: LPTIM2SMEN
     description: "LPTIM2 bus and kernel clocks enable during Sleep and Stop modes\r Set and cleared by software.\r Access can be secured by GTZC_TZSC LPTIM2SEC. When secure, a non-secure read/write access is RAZ/WI. It does not generate an illegal access interrupt. This bit can be protected against unprivileged access when secure with RCC SPRIV or when non-secure with RCC NSPRIV.\r Note: This bit must be set to allow the peripheral to wake up from Stop modes."
     bit_offset: 5
@@ -807,6 +827,10 @@ fieldset/APB7SMENR:
     description: "LPTIM1 bus and kernel clocks enable during Sleep and Stop modes\r Set and cleared by software.\r Access can be secured by GTZC_TZSC LPTIM1SEC. When secure, a non-secure read/write access is RAZ/WI. It does not generate an illegal access interrupt. This bit can be protected against unprivileged access when secure with RCC SPRIV or when non-secure with RCC NSPRIV.\r Note: This bit must be set to allow the peripheral to wake up from Stop modes."
     bit_offset: 11
     bit_size: 1
+  - name: VREFSMEN
+    description: "VREFBUF clock enable during Sleep and Stop modes\r Set and cleared by software.\r Access can be secured by GTZC_TZSC VREFBUFSEC. When secure, a non-secure read/write access is RAZ/WI. It does not generate an illegal access interrupt. This bit can be protected against unprivileged access when secure with RCC SPRIV or when non-secure with RCC NSPRIV.\r Note: This bit must be set to allow the peripheral to wake up from Stop modes."
+    bit_offset: 20
+    bit_size: 1
   - name: RTCAPBSMEN
     description: "RTC and TAMP APB clock enable during Sleep and Stop modes\r Set and cleared by software.\r Can only be accessed secure when one or more features in the RTC or TAMP is/are secure. When secure, a non-secure read/write access is RAZ/WI. It does not generate an illegal access interrupt. This bit can be protected against unprivileged access when secure with RCC SPRIV or when non-secure with RCC NSPRIV.\r Note: This bit must be set to allow the peripheral to wake up from Stop modes."
     bit_offset: 21
@@ -905,11 +929,31 @@ fieldset/CCIPR1:
     bit_offset: 2
     bit_size: 2
     enum: USARTSEL
+  - name: USART3SEL
+    description: "USART3 kernel clock source selection\r This bits are used to select the USART3 kernel clock source.\r Access can be secured by GTZC_TZSC USART2SEC. When secure, a non-secure read/write access is RAZ/WI. It does not generate an illegal access interrupt. This bit can be protected against unprivileged access when secure with RCC SPRIV or when non-secure with RCC NSPRIV.\r Note: The USART3 is functional in Stop 0 and Stop 1 mode only when the kernel clock is HSI or LSE."
+    bit_offset: 4
+    bit_size: 2
+    enum: USARTSEL
   - name: I2C1SEL
     description: "I2C1 kernel clock source selection\r These bits are used to select the I2C1 kernel clock source.\r Access can be secured by GTZC_TZSC I2C1SEC. When secure, a non-secure read/write access is RAZ/WI. It does not generate an illegal access interrupt. This bit can be protected against unprivileged access when secure with RCC SPRIV or when non-secure with RCC NSPRIV.\r Note: The I2C1 is functional in Stop 0 and Stop 1 mode only when the kernel clock is HSI."
     bit_offset: 10
     bit_size: 2
     enum: I2C1SEL
+  - name: I2C2SEL
+    description: "I2C2 kernel clock source selection\r These bits are used to select the I2C2 kernel clock source.\r Access can be secured by GTZC_TZSC I2C2SEC. When secure, a non-secure read/write access is RAZ/WI. It does not generate an illegal access interrupt. This bit can be protected against unprivileged access when secure with RCC SPRIV or when non-secure with RCC NSPRIV.\r Note: The I2C2 is functional in Stop 0 and Stop 1 mode only when the kernel clock is HSI."
+    bit_offset: 12
+    bit_size: 2
+    enum: I2C1SEL
+  - name: I2C4SEL
+    description: "I2C4 kernel clock source selection\r These bits are used to select the I2C4 kernel clock source.\r Access can be secured by GTZC_TZSC I2C4SEC. When secure, a non-secure read/write access is RAZ/WI. It does not generate an illegal access interrupt. This bit can be protected against unprivileged access when secure with RCC SPRIV or when non-secure with RCC NSPRIV.\r Note: The I2C4 is functional in Stop 0 and Stop 1 mode only when the kernel clock is HSI."
+    bit_offset: 14
+    bit_size: 2
+    enum: I2C1SEL
+  - name: SPI2SEL
+    description: "SPI2 kernel clock source selection\r These bits are used to select the SPI2 kernel clock source.\r Access can be secured by GTZC_TZSC SPI2SEC. When secure, a non-secure read/write access is RAZ/WI. It does not generate an illegal access interrupt. This bit can be protected against unprivileged access when secure with RCC SPRIV or when non-secure with RCC NSPRIV.\r Note: The SPI2 is functional in Stop 0 and Stop 1 mode only when the kernel clock is HSI."
+    bit_offset: 16
+    bit_size: 2
+    enum: SPI2SEL
   - name: LPTIM2SEL
     description: "Low-power timer 2 kernel clock source selection\r These bits are used to select the LPTIM2 kernel clock source.\r Access can be secured by GTZC_TZSC LPTIM2SEC. When secure, a non-secure read/write access is RAZ/WI. It does not generate an illegal access interrupt. This bit can be protected against unprivileged access when secure with RCC SPRIV or when non-secure with RCC NSPRIV.\r Note: The LPTIM2 is functional in Stop 0 and Stop 1 mode only when the kernel clock is LSI, LSE or HSI if HSIKERON = 1."
     bit_offset: 18
@@ -1711,11 +1755,23 @@ enum/SPI1SEL:
   - name: HSI
     description: HSI selected
     value: 2
+enum/SPI2SEL:
+  bit_size: 2
+  variants:
+  - name: PCLK1
+    description: pclk1 selected
+    value: 0
+  - name: SYS
+    description: SYSCLK selected
+    value: 1
+  - name: HSI
+    description: HSI selected
+    value: 2
 enum/SPI3SEL:
   bit_size: 2
   variants:
   - name: PCLK7
-    description: pclk2 selected
+    description: pclk7 selected
     value: 0
   - name: SYS
     description: SYSCLK selected
@@ -1804,81 +1860,6 @@ enum/HDIV:
   - description: hclk5 = SYSCLK divided by 2.
     name: SYS_2
     value: 1
-enum/HDIV5:
-  bit_size: 1
-  variants:
-  - description: hclk5 = SYSCLK not divided
-    name: SYS
-    value: 0
-  - description: hclk5 = SYSCLK divided by 2
-    name: SYS_2
-    value: 1
-enum/HPRE:
-  bit_size: 3
-  variants:
-  - description: hclk1 = SYSCLK divided by 2.
-    name: SYS_2
-    value: 4
-  - description: hclk1 = SYSCLK divided by 4.
-    name: SYS_4
-    value: 5
-  - description: hclk1 = SYSCLK divided by 8.
-    name: SYS_8
-    value: 6
-  - description: hclk1 = SYSCLK divided by 16.
-    name: SYS_16
-    value: 7
-enum/HPRE5:
-  bit_size: 3
-  variants:
-  - description: DCLK not divided
-    name: SYS
-    value: 0
-  - description: hclk5 = SYSCLK divided by 2
-    name: SYS_2
-    value: 4
-  - description: hclk5 = SYSCLK divided by 3
-    name: SYS_3
-    value: 5
-  - description: hclk5 = SYSCLK divided by 4
-    name: SYS_4
-    value: 6
-  - description: hclk5 = SYSCLK divided by 6
-    name: SYS_6
-    value: 7
-enum/HSEPRE:
-  bit_size: 1
-  variants:
-  - description: HSE32 not divided, SYSCLK = HSE32.
-    name: HSE
-    value: 0
-  - description: HSE32 divided, SYSCLK = HSE32/2.
-    name: HSE_2
-    value: 1
-enum/I2C1SEL:
-  bit_size: 2
-  variants:
-  - description: pclk1 selected
-    name: PCLK1
-    value: 0
-  - description: SYSCLK selected
-    name: SYS
-    value: 1
-  - description: HSI selected
-    name: HSI
-    value: 2
-enum/I2C3SEL:
-  bit_size: 2
-  variants:
-  - description: pclk7 selected
-    name: PCLK7
-    value: 0
-  - description: SYSCLK selected
-    name: SYS
-    value: 1
-  - description: HSI selected
-    name: HSI
-    value: 2
 enum/ICSEL:
   bit_size: 2
   variants:
@@ -1891,36 +1872,6 @@ enum/ICSEL:
   - description: HSI16 selected.
     name: HSI
     value: 2
-enum/LPTIM1SEL:
-  bit_size: 2
-  variants:
-  - description: pclk7 selected.
-    name: PCLK7
-    value: 0
-  - description: LSI selected
-    name: LSI
-    value: 1
-  - description: HSI selected
-    name: HSI
-    value: 2
-  - description: LSE selected
-    name: LSE
-    value: 3
-enum/LPTIM2SEL:
-  bit_size: 2
-  variants:
-  - description: pclk7 selected.
-    name: PCLK1
-    value: 0
-  - description: LSI selected
-    name: LSI
-    value: 1
-  - description: HSI selected
-    name: HSI
-    value: 2
-  - description: LSE selected
-    name: LSE
-    value: 3
 enum/LPTIMSEL:
   bit_size: 2
   variants:
@@ -1935,57 +1886,6 @@ enum/LPTIMSEL:
     value: 2
   - description: LSE selected.
     name: LSE
-    value: 3
-enum/LPUARTSEL:
-  bit_size: 2
-  variants:
-  - description: pclk7 selected.
-    name: PCLK7
-    value: 0
-  - description: SYSCLK selected.
-    name: SYS
-    value: 1
-  - description: HSI16 selected.
-    name: HSI
-    value: 2
-  - description: LSE selected.
-    name: LSE
-    value: 3
-enum/LSCOSEL:
-  bit_size: 1
-  variants:
-  - description: LSI clock selected.
-    name: LSI
-    value: 0
-  - description: LSE clock selected.
-    name: LSE
-    value: 1
-enum/LSEDRV:
-  bit_size: 2
-  variants:
-  - description: '''Xtal mode'' medium-low driving capability.'
-    name: LO
-    value: 1
-  - description: '''Xtal mode'' medium-high driving capability.'
-    name: MED
-    value: 2
-  - description: '''Xtal mode'' higher driving capability.'
-    name: HI
-    value: 3
-enum/LSETRIM:
-  bit_size: 2
-  variants:
-  - description: current source resistance 5/4 x R.
-    name: R_5_4
-    value: 0
-  - description: current source resistance R.
-    name: R
-    value: 1
-  - description: current source resistance 3/4 x R.
-    name: R_3_4
-    value: 2
-  - description: current source resistance 2/3 x R.
-    name: R_2_3
     value: 3
 enum/LSICFG:
   bit_size: 4
@@ -2011,66 +1911,6 @@ enum/LSIMODE:
   - description: ultra-low-power, low accuracy.
     name: ULP
     value: 2
-enum/LSIPREDIV:
-  bit_size: 1
-  variants:
-  - description: LSI1 not divided.
-    name: LSI1
-    value: 0
-  - description: LSI1 divided by 128.
-    name: LSI1_128
-    value: 1
-enum/MCOPRE:
-  bit_size: 3
-  variants:
-  - description: MCO divided by 1.
-    name: MCO_1
-    value: 0
-  - description: MCO divided by 2.
-    name: MCO_2
-    value: 1
-  - description: MCO divided by 4.
-    name: MCO_4
-    value: 2
-  - description: MCO divided by 8.
-    name: MCO_8
-    value: 3
-  - description: MCO divided by 16.
-    name: MCO_16
-    value: 4
-enum/MCOSEL:
-  bit_size: 4
-  variants:
-  - description: MCO output disabled, no clock on MCO.
-    name: NO_CLK
-    value: 0
-  - description: sysclkpre system clock after PLL1RCLKPRE division selected.
-    name: SYSCLKPRE
-    value: 1
-  - description: HSI16 clock selected.
-    name: HSI
-    value: 3
-  - description: HSE32 clock selected.
-    name: HSE
-    value: 4
-  - description: pll1rclk clock selected.
-    name: PLL1_R
-    value: 5
-  - description: LSI clock selected.
-    name: LSI
-    value: 6
-  - description: LSE clock selected.
-    name: LSE
-    value: 7
-  - description: pll1pclk clock selected.
-    name: PLL1_P
-    value: 8
-  - description: pll1qclk clock selected.
-    name: PLL1_Q
-    value: 9
-  - description: hclk5 clock selected.
-    name: HCLK5
-    value: 10
 enum/OTGHSSEL:
   bit_size: 2
   variants:
@@ -2173,90 +2013,6 @@ enum/PLLR:
   - description: pll1rclk = VCO output frequency / 128.
     name: PLL1_R_128
     value: 127
-enum/PLLRCLKPRESTEP:
-  bit_size: 1
-  variants:
-  - description: pll1rclk 2-step division.
-    name: PLL_R_2
-    value: 0
-  - description: pll1rclk 3-step division.
-    name: PLL1_R_3
-    value: 1
-enum/PLLRGE:
-  bit_size: 2
-  variants:
-  - description: PLL1 input (ref1_ck) clock range frequency between 8 and 16 MHz.
-    name: FREQ
-    value: 3
-enum/PLLSRC:
-  bit_size: 2
-  variants:
-  - description: no clock sent to PLL1.
-    name: NO_CLK
-    value: 0
-  - description: HSI16 clock selected as PLL1 clock entry.
-    name: HSI
-    value: 2
-  - description: HSE32 clock after HSEPRE divider selected as PLL1 clock entry.
-    name: HSE
-    value: 3
-enum/PPRE:
-  bit_size: 3
-  variants:
-  - description: pclk1 = hclk1 divided by 2.
-    name: HCLK1_2
-    value: 4
-  - description: pclk1 = hclk1 divided by 4.
-    name: HCLK1_4
-    value: 5
-  - description: pclk1 = hclk1 divided by 8.
-    name: HCLK1_8
-    value: 6
-  - description: pclk1 = hclk1 divided by 16.
-    name: HCLK1_16
-    value: 7
-enum/RADIOSTSEL:
-  bit_size: 2
-  variants:
-  - description: no clock selected, 2.4 GHz RADIO sleep timer kernel clock disabled.
-    name: NO_CLK
-    value: 0
-  - description: LSE oscillator clock selected.
-    name: LSE
-    value: 1
-  - description: HSE32 oscillator clock divided by 1000 selected.
-    name: HSE
-    value: 3
-enum/RNGSEL:
-  bit_size: 2
-  variants:
-  - description: LSE selected.
-    name: LSE
-    value: 0
-  - description: LSI selected.
-    name: LSI
-    value: 1
-  - description: HSI16 selected.
-    name: HSI
-    value: 2
-  - description: pll1qclk divide by 2 selected.
-    name: PLL1_Q
-    value: 3
-enum/RTCSEL:
-  bit_size: 2
-  variants:
-  - description: no clock selected, RTC and TAMP kernel clock disabled.
-    name: NO_CLK
-    value: 0
-  - description: LSE oscillator clock selected, and enabled.
-    name: LSE
-    value: 1
-  - description: LSI oscillator clock selected, and enabled.
-    name: LSI
-    value: 2
-  - description: HSE32 oscillator clock divided by 32 selected, and enabled.
-    name: HSE
-    value: 3
 enum/SAISEL:
   bit_size: 3
   variants:
@@ -2275,30 +2031,6 @@ enum/SAISEL:
   - description: HSI16 clock selected.
     name: HSI
     value: 4
-enum/SPI1SEL:
-  bit_size: 2
-  variants:
-  - description: pclk2 selected
-    name: PCLK2
-    value: 0
-  - description: SYSCLK selected
-    name: SYS
-    value: 1
-  - description: HSI selected
-    name: HSI
-    value: 2
-enum/SPI3SEL:
-  bit_size: 2
-  variants:
-  - description: pclk2 selected
-    name: PCLK7
-    value: 0
-  - description: SYSCLK selected
-    name: SYS
-    value: 1
-  - description: HSI selected
-    name: HSI
-    value: 2
 enum/SPISEL:
   bit_size: 2
   variants:
@@ -2311,18 +2043,6 @@ enum/SPISEL:
   - description: HSI16 selected.
     name: HSI
     value: 2
-enum/SW:
-  bit_size: 2
-  variants:
-  - description: HSI16 selected as system clock.
-    name: HSI
-    value: 0
-  - description: HSE32 or HSE32/2, as defined by HSEPRE, selected as system clock.
-    name: HSE
-    value: 2
-  - description: pll1rclk selected as system clock.
-    name: PLL1_R
-    value: 3
 enum/SWS:
   bit_size: 2
   variants:
@@ -2334,46 +2054,4 @@ enum/SWS:
     value: 2
   - description: pll1rclk used as system clock.
     name: PLL1_R
-    value: 3
-enum/SYSTICKSEL:
-  bit_size: 2
-  variants:
-  - description: hclk1 divided by 8 selected.
-    name: HCLK1_8
-    value: 0
-  - description: LSI selected.
-    name: LSI
-    value: 1
-  - description: LSE selected.
-    name: LSE
-    value: 2
-enum/USART1SEL:
-  bit_size: 2
-  variants:
-  - description: pclk2 selected
-    name: PCLK2
-    value: 0
-  - description: SYSCLK selected
-    name: SYS
-    value: 1
-  - description: HSI selected
-    name: HSI
-    value: 2
-  - description: LSE selected
-    name: LSE
-    value: 3
-enum/USARTSEL:
-  bit_size: 2
-  variants:
-  - description: pclk2 selected.
-    name: PCLK2
-    value: 0
-  - description: SYSCLK selected.
-    name: SYS
-    value: 1
-  - description: HSI16 selected.
-    name: HSI
-    value: 2
-  - description: LSE selected.
-    name: LSE
     value: 3

--- a/data/registers/rcc_wba.yaml
+++ b/data/registers/rcc_wba.yaml
@@ -992,6 +992,11 @@ fieldset/CCIPR2:
     bit_offset: 28
     bit_size: 2
     enum: OTGHSSEL
+  - name: ASSEL
+    description: "RCC audio synchronization kernel clock source selection\r This bit allows to select the audio synchronization kernel clock source.\r Access can be secured by GTZC_TZSC SAI1SEC. When secure, a non-secure read/write access is RAZ/WI. It does not generate an illegal access interrupt. This bit can be protected against unprivileged access when secure with RCC SPRIV or when non-secure with RCC NSPRIV."
+    bit_offset: 30
+    bit_size: 1
+    enum: ASSEL
 fieldset/CCIPR3:
   description: RCC peripherals independent clock configuration register 3
   fields:
@@ -1386,6 +1391,65 @@ fieldset/SECCFGR:
     description: "Remove reset flag security\r Set and reset by software."
     bit_offset: 12
     bit_size: 1
+fieldset/ASCR:
+  description: RCC audio synchronization control register
+  fields:
+  - name: CEN
+    description: "Counter enable\r This bit is set and cleared by software.\r Clearing this bit will reset the audio synchronization counter and capture prescaler and all associated registers ASCR, ASIER, ASSR, ASCNTR, ASARR, ASCAR, and ASCOR."
+    bit_offset: 0
+    bit_size: 1
+  - name: PSC
+    description: "Clock prescaler\r This field is set and cleared by software.\r Counter clock frequency = f_audiosync_ker_ck / (PSC + 1)"
+    bit_offset: 8
+    bit_size: 7
+  - name: CPS
+    description: "Capture prescaler\r This field is set and cleared by software.\r Capture period in number of counter periods. Capture period = counter period * (TPS + 1)"
+    bit_offset: 16
+    bit_size: 7
+fieldset/ASIER:
+  description: RCC audio synchronization interrupt enable register
+  fields:
+  - name: CAIE
+    description: "Capture trigger interrupt enable\r This bit is set and cleared by software."
+    bit_offset: 0
+    bit_size: 1
+  - name: COIE
+    description: "Comparer interrupt enable\r This field is set and cleared by software."
+    bit_offset: 1
+    bit_size: 1
+  - name: CAEIE
+    description: "Capture error interrupt enable\r This field is set and cleared by software."
+    bit_offset: 2
+    bit_size: 1
+fieldset/ASSR:
+  description: RCC audio synchronization status register
+  fields:
+  - name: CAF
+    description: "Capture trigger interrupt flag\r This field is set by hardware, only when CAIE is enabled. This bit is cleared by software by writing it to 0 or masked when CAIE is 0."
+    bit_offset: 0
+    bit_size: 1
+  - name: COF
+    description: "Comparer interrupt flag\r This field is set by hardware, only when COIE is enabled. This bit is cleared by software by writing it to 0 or masked when COIE is 0."
+    bit_offset: 1
+    bit_size: 1
+  - name: CAEF
+    description: "Capture error interrupt flag\r This field is set by hardware, only when CAEIE is enabled. This bit is cleared by software by writing it to 0 or masked when CAEIE is 0."
+    bit_offset: 2
+    bit_size: 1
+fieldset/ASCNTR:
+  description: RCC audio synchronization counter register
+  fields:
+  - name: CNT
+    description: "Counter value\r This field is set by hardware.\r CNT[19:0] is the counter value at the time this register is read."
+    bit_offset: 0
+    bit_size: 19
+fieldset/ASARR:
+  description: RCC audio synchronization auto-reload register
+  fields:
+  - name: AR
+    description: "Auto-reload value\r This field is set by software.\r CA[19:0] is the counter auto-reload value at which to restart the audio synchronization counter from value 0. It defines the counter period."
+    bit_offset: 0
+    bit_size: 19
 enum/ADCSEL:
   bit_size: 3
   variants:

--- a/stm32-data-gen/src/chips.rs
+++ b/stm32-data-gen/src/chips.rs
@@ -145,7 +145,6 @@ static NOPELIST: RegexSet = RegexSet::new(&[
     "STM32N6.*",
     "STM32G41[14].*",
     "STM32G4.*xZ",
-    "STM32WBA6.*",
     "STM32WB0.*",
     "STM32WL3.*",
     // Does not exist in ST website. No datasheet, no RM.

--- a/stm32-data-gen/src/interrupts.rs
+++ b/stm32-data-gen/src/interrupts.rs
@@ -502,7 +502,7 @@ fn valid_signals(peri: &str) -> Vec<String> {
         ("GTZC", &["GLOBAL", "ILA"]),
         ("WWDG", &["GLOBAL", "RST"]),
         ("USB_OTG_FS", &["GLOBAL", "EP1_OUT", "EP1_IN", "WKUP"]),
-        ("USB_OTG_HS", &["GLOBAL", "EP1_OUT", "EP1_IN", "WKUP"]),
+        ("USB_OTG_HS", &["GLOBAL", "EP1_OUT", "EP1_IN", "WKUP", "USB"]),
         ("USB", &["LP", "HP", "WKUP"]),
         ("GPU2D", &["ER"]),
         ("SAI", &["A", "B"]),
@@ -525,7 +525,7 @@ static PICK_NVIC: RegexMap<&str> = RegexMap::new(&[
     ("STM32WL5.*:cm4", "NVIC1"),
     ("STM32WL5.*:cm0p", "NVIC2"),
     // Exception 2: TrustZone: NVIC1 is Secure mode, NVIC2 is NonSecure mode. For now, we pick the NonSecure one.
-    ("STM32(L5|U5|H5[2367]|WBA5[245]).*", "NVIC2"),
+    ("STM32(L5|U5|H5[2367]|WBA5[245]|WBA6[2345]).*", "NVIC2"),
     // Exception 3: NVICs are split for "bootloader" and "application", not sure what that means?
     ("STM32H7[RS].*", "NVIC2"),
     // catch-all: Most chips have a single NVIC, named "NVIC"

--- a/stm32-data-gen/src/memory.rs
+++ b/stm32-data-gen/src/memory.rs
@@ -384,6 +384,8 @@ static MEMS: RegexMap<&[&[Mem]]> = RegexMap::new(&[
     // WBA
     ("STM32WBA...E",                 &[mem!(BANK_1 { 0x08000000 512 },  SRAM { 0x20000000 96 }, OTP { 0x0bf90000 512 bytes })]),
     ("STM32WBA...G",                 &[mem!(BANK_1 { 0x08000000 1024 }, SRAM { 0x20000000 128 }, OTP { 0x0bf90000 512 bytes })]),
+    ("STM32WBA6..G",                 &[mem!(BANK_1 { 0x08000000 512 },  BANK_2 { 0x08080000 512},  SRAM { 0x20000000 192 }, SRAM2 { 0x20070000 64 }, OTP { 0x0bfa0000 512 bytes })]),
+    ("STM32WBA6..I",                 &[mem!(BANK_1 { 0x08000000 1024 }, BANK_2 { 0x08100000 1024}, SRAM { 0x20000000 448 }, SRAM2 { 0x20070000 64 }, OTP { 0x0bfa0000 512 bytes })]),
     // WL
     ("STM32WL[5E]..8",               &[mem!(BANK_1 { 0x08000000 64 },  SRAM1 { 0x20000000 10 }, SRAM2 { 0x20002800 10 })]),
     ("STM32WL[5E]..B",               &[mem!(BANK_1 { 0x08000000 128 }, SRAM1 { 0x20000000 24 }, SRAM2 { 0x20006000 24 })]),

--- a/stm32-data-gen/src/rcc.rs
+++ b/stm32-data-gen/src/rcc.rs
@@ -132,7 +132,10 @@ impl ParsedRccs {
             "SPDIFRX_SYMB",
             "ETH_RMII_REF",
             "ETH",
+            "PLL1_P_DIV_2",
             "CLK48MOHCI",
+            "DIV_RTCPRE",
+            "HSE_DIV_2",
             "HSE_DIV_RTCPRE",
         ]);
 


### PR DESCRIPTION
Added support for WBA65XX devices:

- Used RM0515 from ST to add new registers, enums.
- Used `chiptool` to parse out errors.