### PR TITLE
Fixed clock source for SDMMC1 on STM32L433RC

### DIFF
--- a/stm32-data-gen/src/rcc.rs
+++ b/stm32-data-gen/src/rcc.rs
@@ -301,6 +301,7 @@ impl ParsedRccs {
             ("USB_OTG_FS", &["USB", "CLK48", "ICLK"]),
             ("USB_OTG_HS", &["USB", "USBPHYC", "OTGHS", "CLK48", "ICLK"]),
             ("DTS", &["TMPSENS"]),
+            ("SDMMC1", &["SDMMC1", "CLK48"]),
         ];
 
         let rcc = self.rccs.get(rcc_version)?;


### PR DESCRIPTION
Fixing the issue where the SDMMC clock source was running at 4Mhz when it was expected to run at 400KHz.  Original issue here:

https://github.com/embassy-rs/embassy/issues/4314

I still cannot get the SDMMC1 peripheral working, but the clock is definitely fixed, tested with an oscilloscope and it read a 2.49µs period.