### PR TITLE
Add AFIO_MAPR.SWJ_CFG enum

### DIFF
--- a/data/registers/afio_f1.yaml
+++ b/data/registers/afio_f1.yaml
@@ -125,9 +125,10 @@ fieldset/MAPR:
     bit_offset: 23
     bit_size: 1
   - name: SWJ_CFG
-    description: Serial wire JTAG configuration
+    description: Serial wire JTAG configuration (must be set to NoOp to leave it unchanged!)
     bit_offset: 24
     bit_size: 3
+    enum: SWJ_CFG
   - name: SPI3_REMAP
     description: SPI3/I2S3 remapping
     bit_offset: 28
@@ -140,6 +141,24 @@ fieldset/MAPR:
     description: Ethernet PTP PPS remapping
     bit_offset: 30
     bit_size: 1
+enum/SWJ_CFG:
+  bit_size: 3
+  variants:
+  - name: Reset
+    description: Full SWJ (JTAG-DP + SW-DP) (Reset state)
+    value: 0
+  - name: NoJntRst
+    description: Full SWJ (JTAG-DP + SW-DP) but without NJTRST
+    value: 1
+  - name: JtagDisable
+    description: JTAG-DP Disabled and SW-DP Enabled
+    value: 2
+  - name: Disable
+    description: JTAG-DP Disabled and SW-DP Disabled
+    value: 4
+  - name: NoOp
+    description: Sets all bits to 1, indicating that the configuration should remain unchanged
+    value: 7
 fieldset/MAPR2:
   description: AF remap and debug I/O configuration register
   fields:


### PR DESCRIPTION
This field is write-only. When other fields in the register are written, SWJ_CFG must be written as 0b111 to indicate that SWJ_CFG shall remain unchanged:
<img width="1002" height="300" alt="grafik" src="https://github.com/user-attachments/assets/ebb75166-6ea6-4867-bfee-ab3f0e61c2a2" />
Therefore, I added a "NoOp" variant, writing 0b111. This is what the C HAL does, too, when writing to other fields.

This is relevant here (two occurrences): https://github.com/embassy-rs/embassy/blob/a18e79eddbda2d58a05af51d1f06f16059a58578/embassy-stm32/src/eth/v1/mod.rs#L125