### PR TITLE
H7RS Flash: fix number of bits for ssn field in cr

### DIFF
--- a/data/registers/flash_h7rs.yaml
+++ b/data/registers/flash_h7rs.yaml
@@ -188,7 +188,7 @@ fieldset/CR:
   - name: SSN
     description: Sector erase selection number These bits are used to select the target sector for an erase operation (they are unused otherwise). ...
     bit_offset: 6
-    bit_size: 2
+    bit_size: 3
   - name: PG_OTP
     description: Program Enable for OTP Area Set this bit to enable write operations to OTP area.
     bit_offset: 16


### PR DESCRIPTION
The bit size for the h7rs flash SSN field was incorrect which was leading to the wrong flash sections being erased.