### PR TITLE
Added RNG support for STM32WBA devices

### DIFF
--- a/data/registers/rng_v3.yaml
+++ b/data/registers/rng_v3.yaml
@@ -13,10 +13,17 @@ block/RNG:
     description: data register
     byte_offset: 8
     access: Read
+  - name: NSCR
+    description: RNG noise source control register.
+    byte_offset: 12
+    fieldset: NSCR
   - name: HTCR
     description: health test control register
     byte_offset: 16
     fieldset: HTCR
+    array:
+      len: 4
+      stride: 4
 fieldset/CR:
   description: control register
   fields:
@@ -59,7 +66,7 @@ fieldset/CR:
   - name: RNG_CONFIG1
     description: RNG configuration 1
     bit_offset: 20
-    bit_size: 6
+    bit_size: 8
     enum: RNG_CONFIG1
   - name: CONDRST
     description: Conditioning soft reset
@@ -77,6 +84,16 @@ fieldset/HTCR:
     bit_offset: 0
     bit_size: 32
     enum: HTCFG
+fieldset/NSCR:
+  description: RNG noise source control register.
+  fields:
+  - name: EN_OSC
+    description: When the RNG is enabled (RNGEN bit set), each bit of this bit field enables one of the three inputs from the oscillator instance number X.
+    bit_offset: 0
+    bit_size: 3
+    array:
+      len: 6
+      stride: 3
 fieldset/SR:
   description: status register
   fields:
@@ -91,6 +108,10 @@ fieldset/SR:
   - name: SECS
     description: Seed error current status
     bit_offset: 2
+    bit_size: 1
+  - name: BUSY
+    description: Busy status
+    bit_offset: 4
     bit_size: 1
   - name: CEIS
     description: Clock error interrupt status
@@ -170,7 +191,7 @@ enum/NISTC:
     description: Custom values for NIST compliant RNG
     value: 1
 enum/RNG_CONFIG1:
-  bit_size: 6
+  bit_size: 8
   variants:
   - name: ConfigA
     description: Recommended value for config A (NIST certifiable)

--- a/stm32-data-gen/src/perimap.rs
+++ b/stm32-data-gen/src/perimap.rs
@@ -22,6 +22,7 @@ pub static PERIMAP: RegexMap<(&str, &str, &str)> = RegexMap::new(&[
     (".*:LPUART:sci3_v1_3", ("usart", "v4", "LPUART")),
     (".*:LPUART:sci3_v1_4", ("usart", "v4", "LPUART")),
     ("STM32[HU]5.*:RNG:.*", ("rng", "v3", "RNG")),
+    ("STM32WBA[56].*:RNG:.*", ("rng", "v3", "RNG")),
     ("STM32U0.*:RNG:.*", ("rng", "v3", "RNG")),
     ("STM32L5.*:RNG:.*", ("rng", "v2", "RNG")),
     ("STM32L4[PQ]5.*:RNG:.*", ("rng", "v2", "RNG")),


### PR DESCRIPTION
- STM32WBA6 devices have 4 HTCR registers
- NSCR enum was missing
- Added new regex to handle STM32WBA devices