### PR TITLE
Fixed missing fields for TrustZone on WBA series

### DIFF
--- a/data/registers/flash_u5.yaml
+++ b/data/registers/flash_u5.yaml
@@ -197,22 +197,18 @@ fieldset/ACR:
     description: "Low-power read mode\r This bit puts the Flash memory in low-power read mode."
     bit_offset: 11
     bit_size: 1
-    enum: LPM
   - name: PDREQ1
     description: "Bank 1 power-down mode request\r This bit is write-protected with FLASH_PDKEY1R. This bit requests bank 1 to enter power-down mode. When bank 1 enters power-down mode, this bit is cleared by hardware and the PDKEY1R is locked."
     bit_offset: 12
     bit_size: 1
-    enum: PDREQ
   - name: PDREQ2
     description: "Bank 2 power-down mode request\r This bit is write-protected with FLASH_PDKEY2R. This bit requests bank 2 to enter power-down mode. When bank 2 enters power-down mode, this bit is cleared by hardware and the PDKEY2R is locked."
     bit_offset: 13
     bit_size: 1
-    enum: PDREQ
   - name: SLEEP_PD
     description: "Flash memory power-down mode during Sleep mode\r This bit determines whether the Flash memory is in power-down mode or Idle mode when the device is in Sleep mode.\r The Flash must not be put in power-down while a program or an erase operation is on-going."
     bit_offset: 14
     bit_size: 1
-    enum: SLEEP_PD
 fieldset/ECCR:
   description: FLASH ECC register
   fields:
@@ -224,7 +220,6 @@ fieldset/ECCR:
     description: ECC fail bank
     bit_offset: 21
     bit_size: 1
-    enum: BK_ECC
   - name: SYSF_ECC
     description: "System Flash memory ECC fail\r This bit indicates that the ECC error correction or double ECC error detection is located in the system Flash memory."
     bit_offset: 22
@@ -233,7 +228,6 @@ fieldset/ECCR:
     description: "ECC correction interrupt enable\r This bit enables the interrupt generation when the ECCC bit in the FLASH_ECCR register is set."
     bit_offset: 24
     bit_size: 1
-    enum: ECCIE
   - name: ECCC
     description: "ECC correction\r This bit is set by hardware when one ECC error has been detected and corrected (only if ECCC and ECCD were previously cleared). An interrupt is generated if ECCIE is set. This bit is cleared by writing 1."
     bit_offset: 30
@@ -263,12 +257,10 @@ fieldset/NSCR:
     description: Non-secure programming
     bit_offset: 0
     bit_size: 1
-    enum: NSCR_PG
   - name: PER
     description: Non-secure page erase
     bit_offset: 1
     bit_size: 1
-    enum: NSCR_PER
   - name: MER1
     description: "Non-secure bank 1 mass erase\r This bit triggers the bank 1 non-secure mass erase (all bank 1 user pages) when set."
     bit_offset: 2
@@ -281,7 +273,6 @@ fieldset/NSCR:
     description: Non-secure bank selection for page erase
     bit_offset: 11
     bit_size: 1
-    enum: NSCR_BKER
   - name: BWR
     description: "Non-secure burst write programming mode\r When set, this bit selects the burst write programming mode."
     bit_offset: 14
@@ -302,17 +293,14 @@ fieldset/NSCR:
     description: "Non-secure end of operation interrupt enable\r This bit enables the interrupt generation when the EOP bit in the FLASH_NSSR is set to 1."
     bit_offset: 24
     bit_size: 1
-    enum: NSCR_EOPIE
   - name: ERRIE
     description: "Non-secure error interrupt enable\r This bit enables the interrupt generation when the OPERR bit in the FLASH_NSSR is set to 1."
     bit_offset: 25
     bit_size: 1
-    enum: NSCR_ERRIE
   - name: OBL_LAUNCH
     description: "Force the option byte loading\r When set to 1, this bit forces the option byte reloading. This bit is cleared only when the option byte loading is complete. It cannot be written if OPTLOCK is set."
     bit_offset: 27
     bit_size: 1
-    enum: OBL_LAUNCH
   - name: OPTLOCK
     description: "Option lock\r This bit is set only. When set, all bits concerning user options in FLASH_NSCR register are locked. This bit is cleared by hardware after detecting the unlock sequence. The LOCK bit in the FLASH_NSCR must be cleared before doing the unlock sequence for OPTLOCK bit.\r In case of an unsuccessful unlock operation, this bit remains set until the next reset."
     bit_offset: 30
@@ -419,7 +407,6 @@ fieldset/OPSR:
     description: "Interrupted operation bank\r This bit indicates which Flash memory bank was accessed when reset occurred"
     bit_offset: 21
     bit_size: 1
-    enum: BK_OP
   - name: SYSF_OP
     description: "Operation in system Flash memory interrupted\r This bit indicates that the reset occurred during an operation in the system Flash memory."
     bit_offset: 22
@@ -446,17 +433,14 @@ fieldset/OPTR:
     description: Reset generation in Stop mode
     bit_offset: 12
     bit_size: 1
-    enum: nRST_STOP
   - name: nRST_STDBY
     description: Reset generation in Standby mode
     bit_offset: 13
     bit_size: 1
-    enum: nRST_STDBY
   - name: nRST_SHDW
     description: Reset generation in Shutdown mode
     bit_offset: 14
     bit_size: 1
-    enum: nRST_SHDW
   - name: SRAM1345_RST
     description: SRAM1, SRAM3 and SRAM4 erase upon system reset
     bit_offset: 15
@@ -465,47 +449,38 @@ fieldset/OPTR:
     description: Independent watchdog selection
     bit_offset: 16
     bit_size: 1
-    enum: IWDG_SW
   - name: IWDG_STOP
     description: Independent watchdog counter freeze in Stop mode
     bit_offset: 17
     bit_size: 1
-    enum: IWDG_STOP
   - name: IWDG_STDBY
     description: Independent watchdog counter freeze in Standby mode
     bit_offset: 18
     bit_size: 1
-    enum: IWDG_STDBY
   - name: WWDG_SW
     description: Window watchdog selection
     bit_offset: 19
     bit_size: 1
-    enum: WWDG_SW
   - name: SWAP_BANK
     description: Swap banks
     bit_offset: 20
     bit_size: 1
-    enum: SWAP_BANK
   - name: DUALBANK
     description: Dual-bank on 1-Mbyte and 512-Kbyte Flash memory devices
     bit_offset: 21
     bit_size: 1
-    enum: DUALBANK
   - name: BKPSRAM_ECC
     description: Backup RAM ECC detection and correction enable
     bit_offset: 22
     bit_size: 1
-    enum: BKPSRAM_ECC
   - name: SRAM3_ECC
     description: SRAM3 ECC detection and correction enable
     bit_offset: 23
     bit_size: 1
-    enum: SRAM_ECC
   - name: SRAM2_ECC
     description: SRAM2 ECC detection and correction enable
     bit_offset: 24
     bit_size: 1
-    enum: SRAM_ECC
   - name: SRAM2_RST
     description: SRAM2 erase when system reset
     bit_offset: 25
@@ -514,12 +489,10 @@ fieldset/OPTR:
     description: Software BOOT0
     bit_offset: 26
     bit_size: 1
-    enum: nSWBOOT
   - name: nBOOT0
     description: nBOOT0 option bit
     bit_offset: 27
     bit_size: 1
-    enum: nBOOT
   - name: PA15_PUPEN
     description: PA15 pull-up enable
     bit_offset: 28
@@ -528,12 +501,10 @@ fieldset/OPTR:
     description: "High-speed IO at low VDD voltage configuration bit\r This bit can be set only with VDD below 2.5V"
     bit_offset: 29
     bit_size: 1
-    enum: IO_VDD_HSLV
   - name: IO_VDDIO2_HSLV
     description: "High-speed IO at low VDDIO2 voltage configuration bit\r This bit can be set only with VDDIO2 below 2.5 V."
     bit_offset: 30
     bit_size: 1
-    enum: IO_VDDIO_HSLV
   - name: TZEN
     description: Global TrustZone security enable
     bit_offset: 31
@@ -1607,12 +1578,10 @@ fieldset/PRIVCFGR:
     description: "Privileged protection for secure registers\r This bit can be accessed only when TrustZone is enabled (TZEN = 1). This bit can be read by both privileged or unprivileged, secure and non-secure access.\r The SPRIV bit can be written only by a secure privileged access. A non-secure write access on SPRIV bit is ignored. A secure unprivileged write access on SPRIV bit is ignored."
     bit_offset: 0
     bit_size: 1
-    enum: SPRIV
   - name: NSPRIV
     description: "Privileged protection for non-secure registers\r This bit can be read by both privileged or unprivileged, secure and non-secure access.\r The NSPRIV bit can be written by a secure or non-secure privileged access. A secure or non-secure unprivileged write access on NSPRIV bit is ignored."
     bit_offset: 1
     bit_size: 1
-    enum: NSPRIV
 fieldset/SEC1BBR1:
   description: FLASH secure block based bank 1 register 1
   fields:
@@ -2679,12 +2648,10 @@ fieldset/SECCR:
     description: Secure programming
     bit_offset: 0
     bit_size: 1
-    enum: SECCR_PG
   - name: PER
     description: Secure page erase
     bit_offset: 1
     bit_size: 1
-    enum: SECCR_PER
   - name: MER1
     description: "Secure bank 1 mass erase\r This bit triggers the bank 1 secure mass erase (all bank 1 user pages) when set."
     bit_offset: 2
@@ -2697,7 +2664,6 @@ fieldset/SECCR:
     description: Secure bank selection for page erase
     bit_offset: 11
     bit_size: 1
-    enum: SECCR_BKER
   - name: BWR
     description: "Secure burst write programming mode\r When set, this bit selects the burst write programming mode."
     bit_offset: 14
@@ -2714,12 +2680,10 @@ fieldset/SECCR:
     description: "Secure End of operation interrupt enable\r This bit enables the interrupt generation when the EOP bit in the FLASH_SECSR is set to 1."
     bit_offset: 24
     bit_size: 1
-    enum: SECCR_EOPIE
   - name: ERRIE
     description: Secure error interrupt enable
     bit_offset: 25
     bit_size: 1
-    enum: SECCR_ERRIE
   - name: RDERRIE
     description: Secure PCROP read error interrupt enable
     bit_offset: 26
@@ -2739,12 +2703,10 @@ fieldset/SECHDPCR:
     description: "HDP1 area access disable\r When set, this bit is only cleared by a system reset."
     bit_offset: 0
     bit_size: 1
-    enum: HDP_ACCDIS
   - name: HDP2_ACCDIS
     description: "HDP2 area access disable\r When set, this bit is only cleared by a system reset."
     bit_offset: 1
     bit_size: 1
-    enum: HDP_ACCDIS
 fieldset/SECSR:
   description: FLASH secure status register
   fields:
@@ -2843,7 +2805,6 @@ fieldset/WRP1AR:
     description: Bank 1 WPR first area A unlock
     bit_offset: 31
     bit_size: 1
-    enum: WRPAR_UNLOCK
 fieldset/WRP1BR:
   description: FLASH WRP1 area B address register
   fields:
@@ -2859,7 +2820,6 @@ fieldset/WRP1BR:
     description: Bank 1 WPR second area B unlock
     bit_offset: 31
     bit_size: 1
-    enum: WRPBR_UNLOCK
 fieldset/WRP2AR:
   description: FLASH WPR2 area A address register
   fields:
@@ -2875,7 +2835,6 @@ fieldset/WRP2AR:
     description: Bank 2 WPR first area A unlock
     bit_offset: 31
     bit_size: 1
-    enum: WRPAR_UNLOCK
 fieldset/WRP2BR:
   description: FLASH WPR2 area B address register
   fields:
@@ -2891,229 +2850,48 @@ fieldset/WRP2BR:
     description: Bank 2 WPR second area B unlock
     bit_offset: 31
     bit_size: 1
-    enum: WRPBR_UNLOCK
-enum/BKPSRAM_ECC:
-  bit_size: 1
-  variants:
-  - name: B_0x0
-    description: Backup RAM ECC check enabled
-    value: 0
-  - name: B_0x1
-    description: Backup RAM ECC check disabled
-    value: 1
-enum/BK_ECC:
-  bit_size: 1
-  variants:
-  - name: B_0x0
-    description: Bank 1
-    value: 0
-  - name: B_0x1
-    description: Bank 2
-    value: 1
-enum/BK_OP:
-  bit_size: 1
-  variants:
-  - name: B_0x0
-    description: Bank 1
-    value: 0
-  - name: B_0x1
-    description: Bank 2
-    value: 1
 enum/BOR_LEV:
   bit_size: 3
   variants:
-  - name: B_0x0
-    description: BOR level 0 (reset level threshold around 1.7 V)
+  - name: Level0
+    description: BOR level 0 (reset level threshold around 1.7V)
     value: 0
-  - name: B_0x1
-    description: BOR level 1 (reset level threshold around 2.0 V)
+  - name: Level1
+    description: BOR level 1 (reset level threshold around 2.0V)
     value: 1
-  - name: B_0x2
-    description: BOR level 2 (reset level threshold around 2.2 V)
+  - name: Level2
+    description: BOR level 2 (reset level threshold around 2.2V)
     value: 2
-  - name: B_0x3
-    description: BOR level 3 (reset level threshold around 2.5 V)
+  - name: Level3
+    description: BOR level 3 (reset level threshold around 2.5V)
     value: 3
-  - name: B_0x4
-    description: BOR level 4 (reset level threshold around 2.8 V)
+  - name: Level4
+    description: BOR level 4 (reset level threshold around 2.8V)
     value: 4
 enum/CODE_OP:
   bit_size: 3
   variants:
-  - name: B_0x0
+  - name: NoFlashInt
     description: No Flash operation interrupted by previous reset
     value: 0
-  - name: B_0x1
+  - name: SingleWrInt
     description: Single write operation interrupted
     value: 1
-  - name: B_0x2
+  - name: BurstWrInt
     description: Burst write operation interrupted
     value: 2
-  - name: B_0x3
+  - name: PgEraseInt
     description: Page erase operation interrupted
     value: 3
-  - name: B_0x4
+  - name: BankEraseInt
     description: Bank erase operation interrupted
     value: 4
-  - name: B_0x5
+  - name: MassEraseInt
     description: Mass erase operation interrupted
     value: 5
-  - name: B_0x6
+  - name: OptChangeInt
     description: Option change operation interrupted
     value: 6
-enum/DUALBANK:
-  bit_size: 1
-  variants:
-  - name: B_0x0
-    description: Single bank Flash with contiguous address in bank 1
-    value: 0
-  - name: B_0x1
-    description: Dual-bank Flash with contiguous addresses
-    value: 1
-enum/ECCIE:
-  bit_size: 1
-  variants:
-  - name: B_0x0
-    description: ECCC interrupt disabled
-    value: 0
-  - name: B_0x1
-    description: ECCC interrupt enabled.
-    value: 1
-enum/HDP_ACCDIS:
-  bit_size: 1
-  variants:
-  - name: B_0x0
-    description: Access to HDP2 area granted
-    value: 0
-  - name: B_0x1
-    description: Access to HDP2 area denied (SECWM2Ry option bytes modification bocked -refer to )
-    value: 1
-enum/IO_VDDIO_HSLV:
-  bit_size: 1
-  variants:
-  - name: B_0x0
-    description: High-speed IO at low VDDIO2 voltage feature disabled (VDDIO2 can exceed 2.5 V)
-    value: 0
-  - name: B_0x1
-    description: High-speed IO at low VDDIO2 voltage feature enabled (VDDIO2 remains below 2.5 V)
-    value: 1
-enum/IO_VDD_HSLV:
-  bit_size: 1
-  variants:
-  - name: B_0x0
-    description: High-speed IO at low VDD voltage feature disabled (VDD can exceed 2.5 V)
-    value: 0
-  - name: B_0x1
-    description: High-speed IO at low VDD voltage feature enabled (VDD remains below 2.5 V)
-    value: 1
-enum/IWDG_STDBY:
-  bit_size: 1
-  variants:
-  - name: B_0x0
-    description: Independent watchdog counter frozen in Standby mode
-    value: 0
-  - name: B_0x1
-    description: Independent watchdog counter running in Standby mode
-    value: 1
-enum/IWDG_STOP:
-  bit_size: 1
-  variants:
-  - name: B_0x0
-    description: Independent watchdog counter frozen in Stop mode
-    value: 0
-  - name: B_0x1
-    description: Independent watchdog counter running in Stop mode
-    value: 1
-enum/IWDG_SW:
-  bit_size: 1
-  variants:
-  - name: B_0x0
-    description: Hardware independent watchdog selected
-    value: 0
-  - name: B_0x1
-    description: Software independent watchdog selected
-    value: 1
-enum/LPM:
-  bit_size: 1
-  variants:
-  - name: B_0x0
-    description: Flash not in low-power read mode
-    value: 0
-  - name: B_0x1
-    description: Flash in low-power read mode
-    value: 1
-enum/NSCR_BKER:
-  bit_size: 1
-  variants:
-  - name: B_0x0
-    description: Bank 1 selected for non-secure page erase
-    value: 0
-  - name: B_0x1
-    description: Bank 2 selected for non-secure page erase
-    value: 1
-enum/NSCR_EOPIE:
-  bit_size: 1
-  variants:
-  - name: B_0x0
-    description: Non-secure EOP Interrupt disabled
-    value: 0
-  - name: B_0x1
-    description: Non-secure EOP Interrupt enabled
-    value: 1
-enum/NSCR_ERRIE:
-  bit_size: 1
-  variants:
-  - name: B_0x0
-    description: Non-secure OPERR error interrupt disabled
-    value: 0
-  - name: B_0x1
-    description: Non-secure OPERR error interrupt enabled
-    value: 1
-enum/NSCR_PER:
-  bit_size: 1
-  variants:
-  - name: B_0x0
-    description: Non-secure page erase disabled
-    value: 0
-  - name: B_0x1
-    description: Non-secure page erase enabled
-    value: 1
-enum/NSCR_PG:
-  bit_size: 1
-  variants:
-  - name: B_0x0
-    description: Non-secure Flash programming disabled
-    value: 0
-  - name: B_0x1
-    description: Non-secure Flash programming enabled
-    value: 1
-enum/NSPRIV:
-  bit_size: 1
-  variants:
-  - name: B_0x0
-    description: Non-secure Flash registers can be read and written by privileged or unprivileged access.
-    value: 0
-  - name: B_0x1
-    description: Non-secure Flash registers can be read and written by privileged access only.
-    value: 1
-enum/OBL_LAUNCH:
-  bit_size: 1
-  variants:
-  - name: B_0x0
-    description: Option byte loading complete
-    value: 0
-  - name: B_0x1
-    description: Option byte loading requested
-    value: 1
-enum/PDREQ:
-  bit_size: 1
-  variants:
-  - name: B_0x0
-    description: No request for bank 2 to enter power-down mode
-    value: 0
-  - name: B_0x1
-    description: Bank 2 requested to enter power-down mode
-    value: 1
 enum/RDP:
   bit_size: 8
   variants:
@@ -3126,156 +2904,3 @@ enum/RDP:
   - name: B_0xCC
     description: Level 2 (chip readout protection active)
     value: 204
-enum/SECCR_BKER:
-  bit_size: 1
-  variants:
-  - name: B_0x0
-    description: Bank 1 selected for secure page erase
-    value: 0
-  - name: B_0x1
-    description: Bank 2 selected for secure page erase
-    value: 1
-enum/SECCR_EOPIE:
-  bit_size: 1
-  variants:
-  - name: B_0x0
-    description: Secure EOP Interrupt disabled
-    value: 0
-  - name: B_0x1
-    description: Secure EOP Interrupt enabled
-    value: 1
-enum/SECCR_ERRIE:
-  bit_size: 1
-  variants:
-  - name: B_0x0
-    description: Secure OPERR error interrupt disabled
-    value: 0
-  - name: B_0x1
-    description: Secure OPERR error interrupt enabled
-    value: 1
-enum/SECCR_PER:
-  bit_size: 1
-  variants:
-  - name: B_0x0
-    description: Secure page erase disabled
-    value: 0
-  - name: B_0x1
-    description: Secure page erase enabled
-    value: 1
-enum/SECCR_PG:
-  bit_size: 1
-  variants:
-  - name: B_0x0
-    description: Secure Flash programming disabled
-    value: 0
-  - name: B_0x1
-    description: Secure Flash programming enabled
-    value: 1
-enum/SLEEP_PD:
-  bit_size: 1
-  variants:
-  - name: B_0x0
-    description: Flash in Idle mode during Sleep mode
-    value: 0
-  - name: B_0x1
-    description: Flash in power-down mode during Sleep mode
-    value: 1
-enum/SPRIV:
-  bit_size: 1
-  variants:
-  - name: B_0x0
-    description: Secure Flash registers can be read and written by privileged or unprivileged access.
-    value: 0
-  - name: B_0x1
-    description: Secure Flash registers can be read and written by privileged access only.
-    value: 1
-enum/SRAM_ECC:
-  bit_size: 1
-  variants:
-  - name: B_0x0
-    description: SRAM3 ECC check enabled
-    value: 0
-  - name: B_0x1
-    description: SRAM3 ECC check disabled
-    value: 1
-enum/SWAP_BANK:
-  bit_size: 1
-  variants:
-  - name: B_0x0
-    description: Bank 1 and bank 2 addresses not swapped
-    value: 0
-  - name: B_0x1
-    description: Bank 1 and bank 2 addresses swapped
-    value: 1
-enum/WRPAR_UNLOCK:
-  bit_size: 1
-  variants:
-  - name: B_0x0
-    description: WRP2A start and end pages locked
-    value: 0
-  - name: B_0x1
-    description: WRP2A start and end pages unlocked
-    value: 1
-enum/WRPBR_UNLOCK:
-  bit_size: 1
-  variants:
-  - name: B_0x0
-    description: WRP2B start and end pages locked
-    value: 0
-  - name: B_0x1
-    description: WRP2B start and end pages unlocked
-    value: 1
-enum/WWDG_SW:
-  bit_size: 1
-  variants:
-  - name: B_0x0
-    description: Hardware window watchdog selected
-    value: 0
-  - name: B_0x1
-    description: Software window watchdog selected
-    value: 1
-enum/nBOOT:
-  bit_size: 1
-  variants:
-  - name: B_0x0
-    description: nBOOT0 = 0
-    value: 0
-  - name: B_0x1
-    description: nBOOT0 = 1
-    value: 1
-enum/nRST_SHDW:
-  bit_size: 1
-  variants:
-  - name: B_0x0
-    description: Reset generated when entering the Shutdown mode
-    value: 0
-  - name: B_0x1
-    description: No reset generated when entering the Shutdown mode
-    value: 1
-enum/nRST_STDBY:
-  bit_size: 1
-  variants:
-  - name: B_0x0
-    description: Reset generated when entering the Standby mode
-    value: 0
-  - name: B_0x1
-    description: No reset generate when entering the Standby mode
-    value: 1
-enum/nRST_STOP:
-  bit_size: 1
-  variants:
-  - name: B_0x0
-    description: Reset generated when entering the Stop mode
-    value: 0
-  - name: B_0x1
-    description: No reset generated when entering the Stop mode
-    value: 1
-enum/nSWBOOT:
-  bit_size: 1
-  variants:
-  - name: B_0x0
-    description: BOOT0 taken from the option bit nBOOT0
-    value: 0
-  - name: B_0x1
-    description: BOOT0 taken from PH3/BOOT0 pin
-    value: 1

--- a/data/registers/flash_wba.yaml
+++ b/data/registers/flash_wba.yaml
@@ -163,20 +163,14 @@ fieldset/ACR:
     description: "Low-power read mode\r This bit puts the memory in low-power read mode.\r Access to the bit can be secured by PWR LPMSEC. When secure, a non-secure read/write access is RAZ/WI. It does not generate an illegal access interrupt. This bit can be protected against unprivileged access when secure with SPRIV or when non-secure with NSPRIV.\r This bit can’t be written when a program or erase operation is busy (BSY = 1) or when the write buffer is not empty (WDW = 1). Changing this bit while a program or erase operation is busy (BSY = 1) is rejected."
     bit_offset: 11
     bit_size: 1
-  - name: PDREQ
-    description: "power-down mode request\r This bit requests to enter power-down mode. When enters power-down mode, this bit is cleared by hardware and the PDKEY2R is locked.\r This bit is write-protected with PDKEY2R. \r Access to the bit can be secured by PWR LPMSEC. When secure, a non-secure read/write access is RAZ/WI. It does not generate an illegal access interrupt. This bit can be protected against unprivileged access when secure with SPRIV or when non-secure with NSPRIV."
-    bit_offset: 12
-    bit_size: 1
   - name: PDREQ1
     description: "Bank 1 power-down mode request\r This bit is write-protected with FLASH_PDKEY1R. This bit requests bank 1 to enter power-down mode. When bank 1 enters power-down mode, this bit is cleared by hardware and the PDKEY1R is locked."
     bit_offset: 12
     bit_size: 1
-    enum: PDREQ
   - name: PDREQ2
     description: "Bank 2 power-down mode request\r This bit is write-protected with FLASH_PDKEY2R. This bit requests bank 2 to enter power-down mode. When bank 2 enters power-down mode, this bit is cleared by hardware and the PDKEY2R is locked."
     bit_offset: 13
     bit_size: 1
-    enum: PDREQ
   - name: SLEEP_PD
     description: "memory power-down mode during Sleep mode\r This bit determines whether the memory is in power-down mode or Idle mode when the device is in Sleep mode.\r Access to the bit can be secured by PWR LPMSEC. When secure, a non-secure read/write access is RAZ/WI. It does not generate an illegal access interrupt. This bit can be protected against unprivileged access when secure with SPRIV or when non-secure with NSPRIV.\r The must not be put in power-down while a program or an erase operation is ongoing."
     bit_offset: 14
@@ -201,7 +195,6 @@ fieldset/ECCR:
     description: ECC fail bank
     bit_offset: 21
     bit_size: 1
-    enum: BK_ECC
   - name: SYSF_ECC
     description: "System memory ECC fail\r This bit indicates that the ECC error correction or double ECC error detection is located in the system memory."
     bit_offset: 22
@@ -239,12 +232,10 @@ fieldset/NSCR:
     description: Non-secure programming
     bit_offset: 0
     bit_size: 1
-    enum: NSCR_PG
   - name: PER
     description: Non-secure page erase
     bit_offset: 1
     bit_size: 1
-    enum: NSCR_PER
   - name: MER1
     description: "Non-secure bank 1 mass erase\r This bit triggers the bank 1 non-secure mass erase (all bank 1 user pages) when set."
     bit_offset: 2
@@ -257,7 +248,6 @@ fieldset/NSCR:
     description: Non-secure bank selection for page erase
     bit_offset: 11
     bit_size: 1
-    enum: NSCR_BKER
   - name: BWR
     description: "Non-secure burst write programming mode\r When set, this bit selects the burst write programming mode."
     bit_offset: 14
@@ -278,17 +268,14 @@ fieldset/NSCR:
     description: "Non-secure end of operation interrupt enable\r This bit enables the interrupt generation when the EOP bit in the FLASH_NSSR is set to 1."
     bit_offset: 24
     bit_size: 1
-    enum: NSCR_EOPIE
   - name: ERRIE
     description: "Non-secure error interrupt enable\r This bit enables the interrupt generation when the OPERR bit in the FLASH_NSSR is set to 1."
     bit_offset: 25
     bit_size: 1
-    enum: NSCR_ERRIE
   - name: OBL_LAUNCH
     description: "Force the option byte loading\r When set to 1, this bit forces the option byte reloading. This bit is cleared only when the option byte loading is complete. It cannot be written if OPTLOCK is set."
     bit_offset: 27
     bit_size: 1
-    enum: OBL_LAUNCH
   - name: OPTLOCK
     description: "Option lock\r This bit is set only. When set, all bits concerning user options in FLASH_NSCR register are locked. This bit is cleared by hardware after detecting the unlock sequence. The LOCK bit in the FLASH_NSCR must be cleared before doing the unlock sequence for OPTLOCK bit.\r In case of an unsuccessful unlock operation, this bit remains set until the next reset."
     bit_offset: 30
@@ -359,10 +346,6 @@ fieldset/NSSR:
     description: "OEM2 key RDP lock\r This bit indicates that the OEM2 key read during the OBL is not virgin. When set, the OEM2 key RDP lock mechanism is active."
     bit_offset: 19
     bit_size: 1
-  - name: PD
-    description: "in power-down mode\r This bit indicates that the memory is in power-down state. It is reset when is in normal mode or being awaken."
-    bit_offset: 20
-    bit_size: 1
   - name: PD1
     description: "Bank 1 in power-down mode\r This bit indicates that the Flash memory bank 1 is in power-down state. It is reset when bank 1 is in normal mode or being awaken."
     bit_offset: 20
@@ -382,7 +365,6 @@ fieldset/OPSR:
     description: "Interrupted operation bank\r This bit indicates which Flash memory bank was accessed when reset occurred"
     bit_offset: 21
     bit_size: 1
-    enum: BK_OP
   - name: SYSF_OP
     description: "Operation in system memory interrupted\r This bit indicates that the reset occurred during an operation in the system memory."
     bit_offset: 22
@@ -405,32 +387,17 @@ fieldset/OPTR:
     bit_offset: 8
     bit_size: 3
     enum: BOR_LEV
-  - name: NRST_STOP
-    description: Reset generation in Stop mode
-    bit_offset: 12
-    bit_size: 1
   - name: nRST_STOP
     description: Reset generation in Stop mode
     bit_offset: 12
-    bit_size: 1
-    enum: nRST_STOP
-  - name: NRST_STDBY
-    description: Reset generation in Standby mode
-    bit_offset: 13
     bit_size: 1
   - name: nRST_STDBY
     description: Reset generation in Standby mode
     bit_offset: 13
     bit_size: 1
-    enum: nRST_STDBY
   - name: nRST_SHDW
     description: Reset generation in Shutdown mode
     bit_offset: 14
-    bit_size: 1
-    enum: nRST_SHDW
-  - name: SRAM1345_RST
-    description: SRAM1, SRAM3 and SRAM4 erase upon system reset
-    bit_offset: 15
     bit_size: 1
   - name: SRAM1_RST
     description: SRAM1 erase upon system reset
@@ -456,27 +423,10 @@ fieldset/OPTR:
     description: Swap banks
     bit_offset: 20
     bit_size: 1
-    enum: SWAP_BANK
   - name: DUALBANK
     description: Dual-bank on 1-Mbyte and 512-Kbyte Flash memory devices
     bit_offset: 21
     bit_size: 1
-    enum: DUALBANK
-  - name: BKPSRAM_ECC
-    description: Backup RAM ECC detection and correction enable
-    bit_offset: 22
-    bit_size: 1
-    enum: BKPSRAM_ECC
-  - name: SRAM3_ECC
-    description: SRAM3 ECC detection and correction enable
-    bit_offset: 23
-    bit_size: 1
-    enum: SRAM_ECC
-  - name: SRAM2_ECC
-    description: SRAM2 ECC detection and correction enable
-    bit_offset: 24
-    bit_size: 1
-    enum: SRAM_ECC
   - name: SRAM2_PE
     description: SRAM2 parity check enable
     bit_offset: 24
@@ -485,38 +435,22 @@ fieldset/OPTR:
     description: SRAM2 erase when system reset
     bit_offset: 25
     bit_size: 1
-  - name: NSWBOOT0
-    description: Software BOOT0
-    bit_offset: 26
-    bit_size: 1
   - name: nSWBOOT0
     description: Software BOOT0
     bit_offset: 26
-    bit_size: 1
-    enum: nSWBOOT
-  - name: NBOOT0
-    description: NBOOT0 option bit
-    bit_offset: 27
     bit_size: 1
   - name: nBOOT0
     description: nBOOT0 option bit
     bit_offset: 27
     bit_size: 1
-    enum: nBOOT
-  - name: PA15_PUPEN
-    description: PA15 pull-up enable
-    bit_offset: 28
-    bit_size: 1
   - name: IO_VDD_HSLV
     description: "High-speed IO at low VDD voltage configuration bit\r This bit can be set only with VDD below 2.5V"
     bit_offset: 29
     bit_size: 1
-    enum: IO_VDD_HSLV
   - name: IO_VDDIO2_HSLV
     description: "High-speed IO at low VDDIO2 voltage configuration bit\r This bit can be set only with VDDIO2 below 2.5 V."
     bit_offset: 30
     bit_size: 1
-    enum: IO_VDDIO_HSLV
   - name: TZEN
     description: Global TrustZone security enable
     bit_offset: 31
@@ -550,12 +484,10 @@ fieldset/SECCR:
     description: Secure programming
     bit_offset: 0
     bit_size: 1
-    enum: SECCR_PG
   - name: PER
     description: Secure page erase
     bit_offset: 1
     bit_size: 1
-    enum: SECCR_PER
   - name: MER1
     description: "Secure bank 1 mass erase\r This bit triggers the bank 1 secure mass erase (all bank 1 user pages) when set."
     bit_offset: 2
@@ -568,7 +500,6 @@ fieldset/SECCR:
     description: Secure bank selection for page erase
     bit_offset: 11
     bit_size: 1
-    enum: SECCR_BKER
   - name: BWR
     description: "Secure burst write programming mode\r When set, this bit selects the burst write programming mode."
     bit_offset: 14
@@ -585,12 +516,10 @@ fieldset/SECCR:
     description: "Secure End of operation interrupt enable\r This bit enables the interrupt generation when the EOP bit in the FLASH_SECSR is set to 1."
     bit_offset: 24
     bit_size: 1
-    enum: SECCR_EOPIE
   - name: ERRIE
     description: Secure error interrupt enable
     bit_offset: 25
     bit_size: 1
-    enum: SECCR_ERRIE
   - name: RDERRIE
     description: Secure PCROP read error interrupt enable
     bit_offset: 26
@@ -621,16 +550,10 @@ fieldset/SECHDPCR:
     description: "HDP1 area access disable\r When set, this bit is only cleared by a system reset."
     bit_offset: 0
     bit_size: 1
-    enum: HDP_ACCDIS
-  - name: HDP_ACCDIS
-    description: "Secure HDP area access disable \r When set, this bit is only cleared by a system reset."
-    bit_offset: 0
-    bit_size: 1
   - name: HDP2_ACCDIS
     description: "HDP2 area access disable\r When set, this bit is only cleared by a system reset."
     bit_offset: 1
     bit_size: 1
-    enum: HDP_ACCDIS
 fieldset/SECSR:
   description: FLASH secure status register
   fields:
@@ -774,177 +697,48 @@ fieldset/WRP2BR:
     description: WPR bank 2 area B unlock
     bit_offset: 31
     bit_size: 1
-enum/BKPSRAM_ECC:
-  bit_size: 1
-  variants:
-  - name: B_0x0
-    description: Backup RAM ECC check enabled
-    value: 0
-  - name: B_0x1
-    description: Backup RAM ECC check disabled
-    value: 1
-enum/BK_ECC:
-  bit_size: 1
-  variants:
-  - name: B_0x0
-    description: Bank 1
-    value: 0
-  - name: B_0x1
-    description: Bank 2
-    value: 1
-enum/BK_OP:
-  bit_size: 1
-  variants:
-  - name: B_0x0
-    description: Bank 1
-    value: 0
-  - name: B_0x1
-    description: Bank 2
-    value: 1
 enum/BOR_LEV:
   bit_size: 3
   variants:
   - name: Level0
-    description: BOR level 0 (reset level threshold around 1.7�V)
+    description: BOR level 0 (reset level threshold around 1.7V)
     value: 0
   - name: Level1
-    description: BOR level 1 (reset level threshold around 2.0�V)
+    description: BOR level 1 (reset level threshold around 2.0V)
     value: 1
   - name: Level2
-    description: BOR level 2 (reset level threshold around 2.2�V)
+    description: BOR level 2 (reset level threshold around 2.2V)
     value: 2
   - name: Level3
-    description: BOR level 3 (reset level threshold around 2.5�V)
+    description: BOR level 3 (reset level threshold around 2.5V)
     value: 3
   - name: Level4
-    description: BOR level 4 (reset level threshold around 2.8�V)
+    description: BOR level 4 (reset level threshold around 2.8V)
     value: 4
 enum/CODE_OP:
   bit_size: 3
   variants:
-  - name: B_0x0
-    description: No operation interrupted by previous reset
+  - name: NoFlashInt
+    description: No Flash operation interrupted by previous reset
     value: 0
-  - name: B_0x1
+  - name: SingleWrInt
     description: Single write operation interrupted
     value: 1
-  - name: B_0x2
+  - name: BurstWrInt
     description: Burst write operation interrupted
     value: 2
-  - name: B_0x3
+  - name: PgEraseInt
     description: Page erase operation interrupted
     value: 3
-  - name: B_0x4
-    description: Reserved
+  - name: BankEraseInt
+    description: Bank erase operation interrupted
     value: 4
-  - name: B_0x5
+  - name: MassEraseInt
     description: Mass erase operation interrupted
     value: 5
-  - name: B_0x6
+  - name: OptChangeInt
     description: Option change operation interrupted
     value: 6
-  - name: B_0x7
-    description: Reserved
-    value: 7
-enum/DUALBANK:
-  bit_size: 1
-  variants:
-  - name: B_0x0
-    description: Single bank Flash with contiguous address in bank 1
-    value: 0
-  - name: B_0x1
-    description: Dual-bank Flash with contiguous addresses
-    value: 1
-enum/HDP_ACCDIS:
-  bit_size: 1
-  variants:
-  - name: B_0x0
-    description: Access to HDP2 area granted
-    value: 0
-  - name: B_0x1
-    description: Access to HDP2 area denied (SECWM2Ry option bytes modification bocked -refer to )
-    value: 1
-enum/IO_VDDIO_HSLV:
-  bit_size: 1
-  variants:
-  - name: B_0x0
-    description: High-speed IO at low VDDIO2 voltage feature disabled (VDDIO2 can exceed 2.5 V)
-    value: 0
-  - name: B_0x1
-    description: High-speed IO at low VDDIO2 voltage feature enabled (VDDIO2 remains below 2.5 V)
-    value: 1
-enum/IO_VDD_HSLV:
-  bit_size: 1
-  variants:
-  - name: B_0x0
-    description: High-speed IO at low VDD voltage feature disabled (VDD can exceed 2.5 V)
-    value: 0
-  - name: B_0x1
-    description: High-speed IO at low VDD voltage feature enabled (VDD remains below 2.5 V)
-    value: 1
-enum/NSCR_BKER:
-  bit_size: 1
-  variants:
-  - name: B_0x0
-    description: Bank 1 selected for non-secure page erase
-    value: 0
-  - name: B_0x1
-    description: Bank 2 selected for non-secure page erase
-    value: 1
-enum/NSCR_EOPIE:
-  bit_size: 1
-  variants:
-  - name: B_0x0
-    description: Non-secure EOP Interrupt disabled
-    value: 0
-  - name: B_0x1
-    description: Non-secure EOP Interrupt enabled
-    value: 1
-enum/NSCR_ERRIE:
-  bit_size: 1
-  variants:
-  - name: B_0x0
-    description: Non-secure OPERR error interrupt disabled
-    value: 0
-  - name: B_0x1
-    description: Non-secure OPERR error interrupt enabled
-    value: 1
-enum/NSCR_PER:
-  bit_size: 1
-  variants:
-  - name: B_0x0
-    description: Non-secure page erase disabled
-    value: 0
-  - name: B_0x1
-    description: Non-secure page erase enabled
-    value: 1
-enum/NSCR_PG:
-  bit_size: 1
-  variants:
-  - name: B_0x0
-    description: Non-secure Flash programming disabled
-    value: 0
-  - name: B_0x1
-    description: Non-secure Flash programming enabled
-    value: 1
-enum/OBL_LAUNCH:
-  bit_size: 1
-  variants:
-  - name: B_0x0
-    description: Option byte loading complete
-    value: 0
-  - name: B_0x1
-    description: Option byte loading requested
-    value: 1
-enum/PDREQ:
-  bit_size: 1
-  variants:
-  - name: B_0x0
-    description: No request for bank 2 to enter power-down mode
-    value: 0
-  - name: B_0x1
-    description: Bank 2 requested to enter power-down mode
-    value: 1
 enum/RDP:
   bit_size: 8
   variants:
@@ -957,111 +751,3 @@ enum/RDP:
   - name: B_0xCC
     description: Level 2 (chip readout protection active)
     value: 204
-enum/SECCR_BKER:
-  bit_size: 1
-  variants:
-  - name: B_0x0
-    description: Bank 1 selected for secure page erase
-    value: 0
-  - name: B_0x1
-    description: Bank 2 selected for secure page erase
-    value: 1
-enum/SECCR_EOPIE:
-  bit_size: 1
-  variants:
-  - name: B_0x0
-    description: Secure EOP Interrupt disabled
-    value: 0
-  - name: B_0x1
-    description: Secure EOP Interrupt enabled
-    value: 1
-enum/SECCR_ERRIE:
-  bit_size: 1
-  variants:
-  - name: B_0x0
-    description: Secure OPERR error interrupt disabled
-    value: 0
-  - name: B_0x1
-    description: Secure OPERR error interrupt enabled
-    value: 1
-enum/SECCR_PER:
-  bit_size: 1
-  variants:
-  - name: B_0x0
-    description: Secure page erase disabled
-    value: 0
-  - name: B_0x1
-    description: Secure page erase enabled
-    value: 1
-enum/SECCR_PG:
-  bit_size: 1
-  variants:
-  - name: B_0x0
-    description: Secure Flash programming disabled
-    value: 0
-  - name: B_0x1
-    description: Secure Flash programming enabled
-    value: 1
-enum/SRAM_ECC:
-  bit_size: 1
-  variants:
-  - name: B_0x0
-    description: SRAM3 ECC check enabled
-    value: 0
-  - name: B_0x1
-    description: SRAM3 ECC check disabled
-    value: 1
-enum/SWAP_BANK:
-  bit_size: 1
-  variants:
-  - name: B_0x0
-    description: Bank 1 and bank 2 addresses not swapped
-    value: 0
-  - name: B_0x1
-    description: Bank 1 and bank 2 addresses swapped
-    value: 1
-enum/nBOOT:
-  bit_size: 1
-  variants:
-  - name: B_0x0
-    description: nBOOT0 = 0
-    value: 0
-  - name: B_0x1
-    description: nBOOT0 = 1
-    value: 1
-enum/nRST_SHDW:
-  bit_size: 1
-  variants:
-  - name: B_0x0
-    description: Reset generated when entering the Shutdown mode
-    value: 0
-  - name: B_0x1
-    description: No reset generated when entering the Shutdown mode
-    value: 1
-enum/nRST_STDBY:
-  bit_size: 1
-  variants:
-  - name: B_0x0
-    description: Reset generated when entering the Standby mode
-    value: 0
-  - name: B_0x1
-    description: No reset generate when entering the Standby mode
-    value: 1
-enum/nRST_STOP:
-  bit_size: 1
-  variants:
-  - name: B_0x0
-    description: Reset generated when entering the Stop mode
-    value: 0
-  - name: B_0x1
-    description: No reset generated when entering the Stop mode
-    value: 1
-enum/nSWBOOT:
-  bit_size: 1
-  variants:
-  - name: B_0x0
-    description: BOOT0 taken from the option bit nBOOT0
-    value: 0
-  - name: B_0x1
-    description: BOOT0 taken from PH3/BOOT0 pin
-    value: 1

--- a/data/registers/flash_wba.yaml
+++ b/data/registers/flash_wba.yaml
@@ -1,5 +1,5 @@
 block/FLASH:
-  description: Embedded memory
+  description: Flash
   items:
   - name: ACR
     description: access control register
@@ -28,14 +28,14 @@ block/FLASH:
     description: secure status register
     byte_offset: 36
     fieldset: SECSR
-  - name: NSCR1
-    description: control register
+  - name: NSCR
+    description: FLASH non-secure control register
     byte_offset: 40
-    fieldset: NSCR1
-  - name: SECCR1
-    description: secure control register
+    fieldset: NSCR
+  - name: SECCR
+    description: FLASH secure control register
     byte_offset: 44
-    fieldset: SECCR1
+    fieldset: SECCR
   - name: ECCR
     description: ECC register
     byte_offset: 48
@@ -68,14 +68,14 @@ block/FLASH:
     description: secure boot address 0 register
     byte_offset: 76
     fieldset: SECBOOTADD0R
-  - name: SECWMR1
-    description: secure watermark register 1
+  - name: SECWM1R1
+    description: FLASH secure watermark1 register 1
     byte_offset: 80
-    fieldset: SECWMR1
-  - name: SECWMR2
-    description: secure watermark register 2
+    fieldset: SECWM1R1
+  - name: SECWM1R2
+    description: FLASH secure watermark1 register 2
     byte_offset: 84
-    fieldset: SECWMR2
+    fieldset: SECWM1R2
   - name: WRP1AR
     description: Flash WRP bank 1 area A address register
     byte_offset: 88
@@ -149,7 +149,7 @@ block/FLASH:
     byte_offset: 240
     fieldset: BBR
 fieldset/ACR:
-  description: access control register
+  description: FLASH access control register
   fields:
   - name: LATENCY
     description: "Latency\r These bits represent the ratio between the AHB hclk1 clock period and the memory access time.\r Access to the bit can be secured by RCC SYSCLKSEC. When secure, a non-secure read/write access is RAZ/WI. It does not generate an illegal access interrupt. This bit can be protected against unprivileged access when secure with SPRIV or when non-secure with NSPRIV.\r ...\r Note: Before entering Stop 1 mode software must set wait state latency to at least 1."
@@ -167,6 +167,16 @@ fieldset/ACR:
     description: "power-down mode request\r This bit requests to enter power-down mode. When enters power-down mode, this bit is cleared by hardware and the PDKEY2R is locked.\r This bit is write-protected with PDKEY2R. \r Access to the bit can be secured by PWR LPMSEC. When secure, a non-secure read/write access is RAZ/WI. It does not generate an illegal access interrupt. This bit can be protected against unprivileged access when secure with SPRIV or when non-secure with NSPRIV."
     bit_offset: 12
     bit_size: 1
+  - name: PDREQ1
+    description: "Bank 1 power-down mode request\r This bit is write-protected with FLASH_PDKEY1R. This bit requests bank 1 to enter power-down mode. When bank 1 enters power-down mode, this bit is cleared by hardware and the PDKEY1R is locked."
+    bit_offset: 12
+    bit_size: 1
+    enum: PDREQ
+  - name: PDREQ2
+    description: "Bank 2 power-down mode request\r This bit is write-protected with FLASH_PDKEY2R. This bit requests bank 2 to enter power-down mode. When bank 2 enters power-down mode, this bit is cleared by hardware and the PDKEY2R is locked."
+    bit_offset: 13
+    bit_size: 1
+    enum: PDREQ
   - name: SLEEP_PD
     description: "memory power-down mode during Sleep mode\r This bit determines whether the memory is in power-down mode or Idle mode when the device is in Sleep mode.\r Access to the bit can be secured by PWR LPMSEC. When secure, a non-secure read/write access is RAZ/WI. It does not generate an illegal access interrupt. This bit can be protected against unprivileged access when secure with SPRIV or when non-secure with NSPRIV.\r The must not be put in power-down while a program or an erase operation is ongoing."
     bit_offset: 14
@@ -181,12 +191,17 @@ fieldset/BBR:
       len: 32
       stride: 1
 fieldset/ECCR:
-  description: ECC register
+  description: FLASH ECC register
   fields:
   - name: ADDR_ECC
     description: "ECC fail address\r This field indicates which address is concerned by the ECC error correction or by the double ECC error detection. The address is given relative to base address, from offset 0x0�0000 to 0xF�FFF0.\r Note that bit 19 is reserved on STM32WBAxEx devices."
     bit_offset: 0
     bit_size: 20
+  - name: BK_ECC
+    description: ECC fail bank
+    bit_offset: 21
+    bit_size: 1
+    enum: BK_ECC
   - name: SYSF_ECC
     description: "System memory ECC fail\r This bit indicates that the ECC error correction or double ECC error detection is located in the system memory."
     bit_offset: 22
@@ -204,68 +219,82 @@ fieldset/ECCR:
     bit_offset: 31
     bit_size: 1
 fieldset/NSBOOTADD0R:
-  description: boot address 0 register
+  description: FLASH non-secure boot address 0 register
   fields:
   - name: NSBOOTADD0
     description: "Non-secure boot base address 0\r This address is only used when TZEN = 0.\r The non-secure boot memory address can be programmed to any address in the valid address range (see Table 28: Boot space versus RDP protection) with a granularity of 128 bytes. These bits correspond to address [31:7]. The NSBOOTADD0 option bytes are selected following the BOOT0 pin or NSWBOOT0 state.\r Examples:\r NSBOOTADD0[24:0] = 0x0100000: Boot from memory (0x0800 0000)\r NSBOOTADD0[24:0] = 0x017F100: Boot from system memory bootloader (0x0BF8 8000)\r NSBOOTADD0[24:0] = 0x0400200: Boot from SRAM2 on S-Bus (0x2001 0000)"
     bit_offset: 7
     bit_size: 25
 fieldset/NSBOOTADD1R:
-  description: boot address 1 register
+  description: FLASH non-secure boot address 1 register
   fields:
   - name: NSBOOTADD1
     description: "Non-secure boot address 1\r This address is only used when TZEN = 0.\r The non-secure boot memory address can be programmed to any address in the valid address range (see Table 28: Boot space versus RDP protection) with a granularity of 128 bytes. These bits correspond to address [31:7]. The NSBOOTADD0 option bytes are selected following the BOOT0 pin or NSWBOOT0 state. \r Examples:\r NSBOOTADD1[24:0] = 0x0100000: Boot from memory (0x0800 0000)\r NSBOOTADD1[24:0] = 0x017F100: Boot from system memory bootloader (0x0BF8 8000)\r NSBOOTADD1[24:0] = 0x0400200: Boot from SRAM2 (0x2001 0000)"
     bit_offset: 7
     bit_size: 25
-fieldset/NSCR1:
-  description: control register
+fieldset/NSCR:
+  description: FLASH non-secure control register
   fields:
   - name: PG
     description: Non-secure programming
     bit_offset: 0
     bit_size: 1
+    enum: NSCR_PG
   - name: PER
     description: Non-secure page erase
     bit_offset: 1
     bit_size: 1
-  - name: MER
-    description: "Non-secure mass erase\r This bit triggers the non-secure mass erase (all user pages) when set."
+    enum: NSCR_PER
+  - name: MER1
+    description: "Non-secure bank 1 mass erase\r This bit triggers the bank 1 non-secure mass erase (all bank 1 user pages) when set."
     bit_offset: 2
     bit_size: 1
   - name: PNB
-    description: "Non-secure page number selection\r These bits select the page to erase.\r ...\r Note that bit 9 is reserved on STM32WBA5xEx devices."
+    description: "Non-secure page number selection\r These bits select the page to erase.\r ..."
     bit_offset: 3
-    bit_size: 7
+    bit_size: 8
+  - name: BKER
+    description: Non-secure bank selection for page erase
+    bit_offset: 11
+    bit_size: 1
+    enum: NSCR_BKER
   - name: BWR
     description: "Non-secure burst write programming mode\r When set, this bit selects the burst write programming mode."
     bit_offset: 14
     bit_size: 1
+  - name: MER2
+    description: "Non-secure bank 2 mass erase\r This bit triggers the bank 2 non-secure mass erase (all bank 2 user pages) when set."
+    bit_offset: 15
+    bit_size: 1
   - name: STRT
-    description: "Non-secure operation start \r This bit triggers a non-secure erase operation when set. If MER and PER bits are reset and the STRT bit is set, the PGSERR bit in NSSR is set (this condition is forbidden).\r This bit is set only by software and is cleared when the BSY bit is cleared in NSSR."
+    description: "Non-secure start\r This bit triggers a non-secure erase operation when set. If MER1, MER2 and PER bits are reset and the STRT bit is set, the PGSERR bit in FLASH_NSSR is set (this condition is forbidden).\r This bit is set only by software and is cleared when the BSY bit is cleared in FLASH_NSSR."
     bit_offset: 16
     bit_size: 1
   - name: OPTSTRT
-    description: "Options modification start\r This bit triggers an option bytes erase and program operation when set. This bit is write-protected with OPTLOCK.. This bit is set only by software, and is cleared when the BSY bit is cleared in NSSR."
+    description: "Options modification start\r This bit triggers an options operation when set. It can not be written if OPTLOCK bit is set. This bit is set only by software, and is cleared when the BSY bit is cleared in FLASH_NSSR."
     bit_offset: 17
     bit_size: 1
   - name: EOPIE
-    description: "Non-secure end of operation interrupt enable\r This bit enables the interrupt generation when the EOP bit in the NSSR is set to 1."
+    description: "Non-secure end of operation interrupt enable\r This bit enables the interrupt generation when the EOP bit in the FLASH_NSSR is set to 1."
     bit_offset: 24
     bit_size: 1
+    enum: NSCR_EOPIE
   - name: ERRIE
-    description: "Non-secure error interrupt enable\r This bit enables the interrupt generation when the OPERR bit in the NSSR is set to 1."
+    description: "Non-secure error interrupt enable\r This bit enables the interrupt generation when the OPERR bit in the FLASH_NSSR is set to 1."
     bit_offset: 25
     bit_size: 1
+    enum: NSCR_ERRIE
   - name: OBL_LAUNCH
-    description: "Force the option byte loading\r When set to 1, this bit forces the option byte reloading. This bit is cleared only when the option byte loading is complete. This bit is write-protected with OPTLOCK.\r Note: The LSE oscillator must be disabled, LSEON = 0 and LSERDY = 0, before starting OBL_LAUNCH."
+    description: "Force the option byte loading\r When set to 1, this bit forces the option byte reloading. This bit is cleared only when the option byte loading is complete. It cannot be written if OPTLOCK is set."
     bit_offset: 27
     bit_size: 1
+    enum: OBL_LAUNCH
   - name: OPTLOCK
-    description: "Option lock\r This bit is set only. When set, the NSCR1.OPTSRT and OBL_LAUNCH bits concerning user options write access is locked. This bit is cleared by hardware after detecting the unlock sequence in OPTKEYR. The NSCR1.LOCK bit must be cleared before doing the OPTKEYR unlock sequence.\r In case of an unsuccessful unlock operation, this bit remains set until the next reset."
+    description: "Option lock\r This bit is set only. When set, all bits concerning user options in FLASH_NSCR register are locked. This bit is cleared by hardware after detecting the unlock sequence. The LOCK bit in the FLASH_NSCR must be cleared before doing the unlock sequence for OPTLOCK bit.\r In case of an unsuccessful unlock operation, this bit remains set until the next reset."
     bit_offset: 30
     bit_size: 1
   - name: LOCK
-    description: "Non-secure lock\r This bit is set only.\r When set, the NSCR1 register write access is locked. This bit is cleared by hardware after detecting the unlock sequence in NSKEYR.\r In case of an unsuccessful unlock operation, this bit remains set until the next system reset."
+    description: "Non-secure lock\r This bit is set only. When set, the FLASH_NSCR register is locked. It is cleared by hardware after detecting the unlock sequence in FLASH_NSKEYR register.\r In case of an unsuccessful unlock operation, this bit remains set until the next system reset."
     bit_offset: 31
     bit_size: 1
 fieldset/NSCR2:
@@ -280,7 +309,7 @@ fieldset/NSCR2:
     bit_offset: 1
     bit_size: 1
 fieldset/NSSR:
-  description: status register
+  description: FLASH non-secure status register
   fields:
   - name: EOP
     description: "Non-secure end of operation\r This bit is set by hardware when one or more memory non-secure operation (program/erase) has been completed successfully. This bit is set only if the non-secure end of operation interrupts are enabled (EOPIE = 1 in NSCR1). This bit is cleared by writing�1."
@@ -334,13 +363,26 @@ fieldset/NSSR:
     description: "in power-down mode\r This bit indicates that the memory is in power-down state. It is reset when is in normal mode or being awaken."
     bit_offset: 20
     bit_size: 1
+  - name: PD1
+    description: "Bank 1 in power-down mode\r This bit indicates that the Flash memory bank 1 is in power-down state. It is reset when bank 1 is in normal mode or being awaken."
+    bit_offset: 20
+    bit_size: 1
+  - name: PD2
+    description: "Bank 2 in power-down mode\r This bit indicates that the Flash memory bank 2 is in power-down state. It is reset when bank 2 is in normal mode or being awaken."
+    bit_offset: 21
+    bit_size: 1
 fieldset/OPSR:
-  description: operation status register
+  description: FLASH operation status register
   fields:
   - name: ADDR_OP
     description: "Interrupted operation address\r This field indicates which address in the memory was accessed when reset occurred. The address is given relative to the base address, from offset 0x0�0000 to 0xF�FFF0.\r Note that bit 19 is reserved on STM32WBAxEx devices."
     bit_offset: 0
     bit_size: 20
+  - name: BK_OP
+    description: "Interrupted operation bank\r This bit indicates which Flash memory bank was accessed when reset occurred"
+    bit_offset: 21
+    bit_size: 1
+    enum: BK_OP
   - name: SYSF_OP
     description: "Operation in system memory interrupted\r This bit indicates that the reset occurred during an operation in the system memory."
     bit_offset: 22
@@ -351,7 +393,7 @@ fieldset/OPSR:
     bit_size: 3
     enum: CODE_OP
 fieldset/OPTR:
-  description: option register
+  description: FLASH option register
   fields:
   - name: RDP
     description: "Readout protection level\r Others: Level 1 (memories readout protection active)\r Note: Refer to Section�7.6.2: Readout protection (RDP) for more details."
@@ -367,9 +409,28 @@ fieldset/OPTR:
     description: Reset generation in Stop mode
     bit_offset: 12
     bit_size: 1
+  - name: nRST_STOP
+    description: Reset generation in Stop mode
+    bit_offset: 12
+    bit_size: 1
+    enum: nRST_STOP
   - name: NRST_STDBY
     description: Reset generation in Standby mode
     bit_offset: 13
+    bit_size: 1
+  - name: nRST_STDBY
+    description: Reset generation in Standby mode
+    bit_offset: 13
+    bit_size: 1
+    enum: nRST_STDBY
+  - name: nRST_SHDW
+    description: Reset generation in Shutdown mode
+    bit_offset: 14
+    bit_size: 1
+    enum: nRST_SHDW
+  - name: SRAM1345_RST
+    description: SRAM1, SRAM3 and SRAM4 erase upon system reset
+    bit_offset: 15
     bit_size: 1
   - name: SRAM1_RST
     description: SRAM1 erase upon system reset
@@ -391,6 +452,31 @@ fieldset/OPTR:
     description: Window watchdog selection
     bit_offset: 19
     bit_size: 1
+  - name: SWAP_BANK
+    description: Swap banks
+    bit_offset: 20
+    bit_size: 1
+    enum: SWAP_BANK
+  - name: DUALBANK
+    description: Dual-bank on 1-Mbyte and 512-Kbyte Flash memory devices
+    bit_offset: 21
+    bit_size: 1
+    enum: DUALBANK
+  - name: BKPSRAM_ECC
+    description: Backup RAM ECC detection and correction enable
+    bit_offset: 22
+    bit_size: 1
+    enum: BKPSRAM_ECC
+  - name: SRAM3_ECC
+    description: SRAM3 ECC detection and correction enable
+    bit_offset: 23
+    bit_size: 1
+    enum: SRAM_ECC
+  - name: SRAM2_ECC
+    description: SRAM2 ECC detection and correction enable
+    bit_offset: 24
+    bit_size: 1
+    enum: SRAM_ECC
   - name: SRAM2_PE
     description: SRAM2 parity check enable
     bit_offset: 24
@@ -403,16 +489,40 @@ fieldset/OPTR:
     description: Software BOOT0
     bit_offset: 26
     bit_size: 1
+  - name: nSWBOOT0
+    description: Software BOOT0
+    bit_offset: 26
+    bit_size: 1
+    enum: nSWBOOT
   - name: NBOOT0
     description: NBOOT0 option bit
     bit_offset: 27
     bit_size: 1
+  - name: nBOOT0
+    description: nBOOT0 option bit
+    bit_offset: 27
+    bit_size: 1
+    enum: nBOOT
+  - name: PA15_PUPEN
+    description: PA15 pull-up enable
+    bit_offset: 28
+    bit_size: 1
+  - name: IO_VDD_HSLV
+    description: "High-speed IO at low VDD voltage configuration bit\r This bit can be set only with VDD below 2.5V"
+    bit_offset: 29
+    bit_size: 1
+    enum: IO_VDD_HSLV
+  - name: IO_VDDIO2_HSLV
+    description: "High-speed IO at low VDDIO2 voltage configuration bit\r This bit can be set only with VDDIO2 below 2.5 V."
+    bit_offset: 30
+    bit_size: 1
+    enum: IO_VDDIO_HSLV
   - name: TZEN
     description: Global TrustZone security enable
     bit_offset: 31
     bit_size: 1
 fieldset/PRIVCFGR:
-  description: privilege configuration register
+  description: FLASH privilege configuration register
   fields:
   - name: SPRIV
     description: "Privileged protection for secure registers\r This bit is secure write protected. It can only be written by a secure privileged access when TrustZone is enabled (TZEN�=�1)."
@@ -423,7 +533,7 @@ fieldset/PRIVCFGR:
     bit_offset: 1
     bit_size: 1
 fieldset/SECBOOTADD0R:
-  description: secure boot address 0 register
+  description: FLASH secure boot address 0 register
   fields:
   - name: BOOT_LOCK
     description: "Boot lock\r This lock is only used when TZEN = 0.\r When set, the boot is always forced to base address value programmed in SECBOOTADD0[24:0] option bytes whatever the boot selection option. When set, this bit can only be cleared by an RDP regression level 1 to level 0."
@@ -433,47 +543,64 @@ fieldset/SECBOOTADD0R:
     description: "Secure boot base address 0\r This address is only used when TZEN = 1.\r The secure boot memory address can be programmed to any address in the valid address range (see Table�28: Boot space versus RDP protection) with a granularity of 128 bytes. This bits correspond to address [31:7] The SECBOOTADD0 option bytes are selected following the BOOT0 pin or NSWBOOT0 state. \r Examples:\r SECBOOTADD0[24:0] = 0x018 0000: Boot from secure user memory (0x0C00 0000)\r SECBOOTADD0[24:0] = 0x01F F000: Boot from RSS system memory (0x0FF8 0000)\r SECBOOTADD0[24:0] = 0x060 0000: Boot from secure SRAM1 on S-Bus (0x3000 0000)"
     bit_offset: 7
     bit_size: 25
-fieldset/SECCR1:
-  description: secure control register
+fieldset/SECCR:
+  description: FLASH secure control register
   fields:
   - name: PG
     description: Secure programming
     bit_offset: 0
     bit_size: 1
+    enum: SECCR_PG
   - name: PER
     description: Secure page erase
     bit_offset: 1
     bit_size: 1
-  - name: MER
-    description: "Secure mass erase\r This bit triggers the secure mass erase (all user pages) when set."
+    enum: SECCR_PER
+  - name: MER1
+    description: "Secure bank 1 mass erase\r This bit triggers the bank 1 secure mass erase (all bank 1 user pages) when set."
     bit_offset: 2
     bit_size: 1
   - name: PNB
-    description: "Secure page number selection\r These bits select the page to erase:\r ...\r Note that bit 9 is reserved on STM32WBA5xEx devices."
+    description: "Secure page number selection\r These bits select the page to erase:\r ..."
     bit_offset: 3
-    bit_size: 7
+    bit_size: 8
+  - name: BKER
+    description: Secure bank selection for page erase
+    bit_offset: 11
+    bit_size: 1
+    enum: SECCR_BKER
   - name: BWR
     description: "Secure burst write programming mode\r When set, this bit selects the burst write programming mode."
     bit_offset: 14
     bit_size: 1
+  - name: MER2
+    description: "Secure bank 2 mass erase\r This bit triggers the bank 2 secure mass erase (all bank 2 user pages) when set."
+    bit_offset: 15
+    bit_size: 1
   - name: STRT
-    description: "Secure start \r This bit triggers a secure erase operation when set. If MER and PER bits are reset and the STRT bit is set, the PGSERR in the SECSR is set (this condition is forbidden).\r This bit is set only by software and is cleared when the BSY bit is cleared in SECSR."
+    description: "Secure start\r This bit triggers a secure erase operation when set. If MER1, MER2 and PER bits are reset and the STRT bit is set, the PGSERR in the FLASH_SECSR is set (this condition is forbidden).\r This bit is set only by software and is cleared when the BSY bit is cleared in FLASH_SECSR."
     bit_offset: 16
     bit_size: 1
   - name: EOPIE
-    description: "Secure End of operation interrupt enable\r This bit enables the interrupt generation when the EOP bit in SECSR is set to 1."
+    description: "Secure End of operation interrupt enable\r This bit enables the interrupt generation when the EOP bit in the FLASH_SECSR is set to 1."
     bit_offset: 24
     bit_size: 1
+    enum: SECCR_EOPIE
   - name: ERRIE
-    description: "Secure error interrupt enable\r This bit enables the interrupt generation when the OPERR bit in SECSR is set to 1."
+    description: Secure error interrupt enable
     bit_offset: 25
     bit_size: 1
+    enum: SECCR_ERRIE
+  - name: RDERRIE
+    description: Secure PCROP read error interrupt enable
+    bit_offset: 26
+    bit_size: 1
   - name: INV
-    description: "memory security state invert\r This bit inverts the memory security state."
+    description: "Flash memory security state invert\r This bit inverts the Flash memory security state."
     bit_offset: 29
     bit_size: 1
   - name: LOCK
-    description: "Secure lock\r This bit is set only. When set, the SECCR1 register is locked. It is cleared by hardware after detecting the unlock sequence in SECKEYR register.\r In case of an unsuccessful unlock operation, this bit remains set until the next system reset."
+    description: "Secure lock\r This bit is set only. When set, the FLASH_SECCR register is locked. It is cleared by hardware after detecting the unlock sequence in FLASH_SECKEYR register.\r In case of an unsuccessful unlock operation, this bit remains set until the next system reset."
     bit_offset: 31
     bit_size: 1
 fieldset/SECCR2:
@@ -488,14 +615,24 @@ fieldset/SECCR2:
     bit_offset: 1
     bit_size: 1
 fieldset/SECHDPCR:
-  description: secure HDP control register
+  description: FLASH secure HDP control register
   fields:
+  - name: HDP1_ACCDIS
+    description: "HDP1 area access disable\r When set, this bit is only cleared by a system reset."
+    bit_offset: 0
+    bit_size: 1
+    enum: HDP_ACCDIS
   - name: HDP_ACCDIS
     description: "Secure HDP area access disable \r When set, this bit is only cleared by a system reset."
     bit_offset: 0
     bit_size: 1
+  - name: HDP2_ACCDIS
+    description: "HDP2 area access disable\r When set, this bit is only cleared by a system reset."
+    bit_offset: 1
+    bit_size: 1
+    enum: HDP_ACCDIS
 fieldset/SECSR:
-  description: secure status register
+  description: FLASH secure status register
   fields:
   - name: EOP
     description: "Secure end of operation\r This bit is set by hardware when one or more memory secure operation (program/erase) has been completed successfully. This bit is set only if the secure end of operation interrupts are enabled (EOPIE = 1 in SECCR1). This bit is cleared by writing�1."
@@ -533,8 +670,30 @@ fieldset/SECSR:
     description: "Secure wait data to write\r This bit indicates that the memory write buffer has been written by a secure or non-secure operation. It is set when the first data is stored in the buffer and cleared when the write is performed in the memory."
     bit_offset: 17
     bit_size: 1
+fieldset/SECWM1R1:
+  description: FLASH secure watermark1 register 1
+  fields:
+  - name: SECWM1_PSTRT
+    description: "Start page of first secure area\r This field contains the first page of the secure area in bank 1."
+    bit_offset: 0
+    bit_size: 7
+  - name: SECWM1_PEND
+    description: "End page of first secure area\r This field contains the last page of the secure area in bank 1."
+    bit_offset: 16
+    bit_size: 7
+fieldset/SECWM1R2:
+  description: FLASH secure watermark1 register 2
+  fields:
+  - name: HDP1_PEND
+    description: "End page of first hide protection area\r This field contains the last page of the HDP area in bank 1."
+    bit_offset: 16
+    bit_size: 7
+  - name: HDP1EN
+    description: Hide protection first area enable
+    bit_offset: 31
+    bit_size: 1
 fieldset/SECWM2R1:
-  description: Flash bank 2 secure watermark register 1
+  description: FLASH secure watermark2 register 1
   fields:
   - name: SECWM2_PSTRT
     description: "WRP area B start page\r This field contains the first page of the secure area in bank 2."
@@ -545,7 +704,7 @@ fieldset/SECWM2R1:
     bit_offset: 16
     bit_size: 7
 fieldset/SECWM2R2:
-  description: Flash bank 2 secure watermark register 2
+  description: FLASH secure watermark2 register 2
   fields:
   - name: HDP2_PEND
     description: "Bank 2 end page of secure hide protection area\r This field contains the last page of the secure HDP area in bank 2."
@@ -555,30 +714,8 @@ fieldset/SECWM2R2:
     description: Bank 2 secure Hide protection area enable
     bit_offset: 31
     bit_size: 1
-fieldset/SECWMR1:
-  description: secure watermark register 1
-  fields:
-  - name: SECWM_PSTRT
-    description: "Start page of secure area\r This field contains the first page of the secure area."
-    bit_offset: 0
-    bit_size: 7
-  - name: SECWM_PEND
-    description: "End page of secure area\r This field contains the last page of the secure area."
-    bit_offset: 16
-    bit_size: 7
-fieldset/SECWMR2:
-  description: secure watermark register 2
-  fields:
-  - name: HDP_PEND
-    description: "End page of secure hide protection area\r This field contains the last page of the secure HDP area."
-    bit_offset: 16
-    bit_size: 7
-  - name: HDPEN
-    description: Secure Hide protection area enable
-    bit_offset: 31
-    bit_size: 1
 fieldset/WRP1AR:
-  description: WRP bank 1 area A address register
+  description: FLASH WRP1 area A address register
   fields:
   - name: WRP1A_PSTRT
     description: "WPR area A start page\r This field contains the first page of the WPR area A.\r Note that bit 6 is reserved on STM32WBAxEx devices."
@@ -593,7 +730,7 @@ fieldset/WRP1AR:
     bit_offset: 31
     bit_size: 1
 fieldset/WRP1BR:
-  description: WRP bank 1 area B address register
+  description: FLASH WRP1 area B address register
   fields:
   - name: WRP1B_PSTRT
     description: "WRP area B start page\r This field contains the first page of the WRP area B.\r Note that bit 6 is reserved on STM32WBAxEx devices."
@@ -608,7 +745,7 @@ fieldset/WRP1BR:
     bit_offset: 31
     bit_size: 1
 fieldset/WRP2AR:
-  description: WRP bank 2 area A address register
+  description: FLASH WPR2 area A address register
   fields:
   - name: WRP2A_PSTRT
     description: "WRP bank 2 area A start page\r This field contains the first page of the WRP bank 2 area A."
@@ -623,7 +760,7 @@ fieldset/WRP2AR:
     bit_offset: 31
     bit_size: 1
 fieldset/WRP2BR:
-  description: WRP bank 2 area B address register
+  description: FLASH WPR2 area B address register
   fields:
   - name: WRP2B_PSTRT
     description: "WRP bank 2 area B start page\r This field contains the first page of the WRP bank 2 area B."
@@ -637,6 +774,33 @@ fieldset/WRP2BR:
     description: WPR bank 2 area B unlock
     bit_offset: 31
     bit_size: 1
+enum/BKPSRAM_ECC:
+  bit_size: 1
+  variants:
+  - name: B_0x0
+    description: Backup RAM ECC check enabled
+    value: 0
+  - name: B_0x1
+    description: Backup RAM ECC check disabled
+    value: 1
+enum/BK_ECC:
+  bit_size: 1
+  variants:
+  - name: B_0x0
+    description: Bank 1
+    value: 0
+  - name: B_0x1
+    description: Bank 2
+    value: 1
+enum/BK_OP:
+  bit_size: 1
+  variants:
+  - name: B_0x0
+    description: Bank 1
+    value: 0
+  - name: B_0x1
+    description: Bank 2
+    value: 1
 enum/BOR_LEV:
   bit_size: 3
   variants:
@@ -682,6 +846,105 @@ enum/CODE_OP:
   - name: B_0x7
     description: Reserved
     value: 7
+enum/DUALBANK:
+  bit_size: 1
+  variants:
+  - name: B_0x0
+    description: Single bank Flash with contiguous address in bank 1
+    value: 0
+  - name: B_0x1
+    description: Dual-bank Flash with contiguous addresses
+    value: 1
+enum/HDP_ACCDIS:
+  bit_size: 1
+  variants:
+  - name: B_0x0
+    description: Access to HDP2 area granted
+    value: 0
+  - name: B_0x1
+    description: Access to HDP2 area denied (SECWM2Ry option bytes modification bocked -refer to )
+    value: 1
+enum/IO_VDDIO_HSLV:
+  bit_size: 1
+  variants:
+  - name: B_0x0
+    description: High-speed IO at low VDDIO2 voltage feature disabled (VDDIO2 can exceed 2.5 V)
+    value: 0
+  - name: B_0x1
+    description: High-speed IO at low VDDIO2 voltage feature enabled (VDDIO2 remains below 2.5 V)
+    value: 1
+enum/IO_VDD_HSLV:
+  bit_size: 1
+  variants:
+  - name: B_0x0
+    description: High-speed IO at low VDD voltage feature disabled (VDD can exceed 2.5 V)
+    value: 0
+  - name: B_0x1
+    description: High-speed IO at low VDD voltage feature enabled (VDD remains below 2.5 V)
+    value: 1
+enum/NSCR_BKER:
+  bit_size: 1
+  variants:
+  - name: B_0x0
+    description: Bank 1 selected for non-secure page erase
+    value: 0
+  - name: B_0x1
+    description: Bank 2 selected for non-secure page erase
+    value: 1
+enum/NSCR_EOPIE:
+  bit_size: 1
+  variants:
+  - name: B_0x0
+    description: Non-secure EOP Interrupt disabled
+    value: 0
+  - name: B_0x1
+    description: Non-secure EOP Interrupt enabled
+    value: 1
+enum/NSCR_ERRIE:
+  bit_size: 1
+  variants:
+  - name: B_0x0
+    description: Non-secure OPERR error interrupt disabled
+    value: 0
+  - name: B_0x1
+    description: Non-secure OPERR error interrupt enabled
+    value: 1
+enum/NSCR_PER:
+  bit_size: 1
+  variants:
+  - name: B_0x0
+    description: Non-secure page erase disabled
+    value: 0
+  - name: B_0x1
+    description: Non-secure page erase enabled
+    value: 1
+enum/NSCR_PG:
+  bit_size: 1
+  variants:
+  - name: B_0x0
+    description: Non-secure Flash programming disabled
+    value: 0
+  - name: B_0x1
+    description: Non-secure Flash programming enabled
+    value: 1
+enum/OBL_LAUNCH:
+  bit_size: 1
+  variants:
+  - name: B_0x0
+    description: Option byte loading complete
+    value: 0
+  - name: B_0x1
+    description: Option byte loading requested
+    value: 1
+enum/PDREQ:
+  bit_size: 1
+  variants:
+  - name: B_0x0
+    description: No request for bank 2 to enter power-down mode
+    value: 0
+  - name: B_0x1
+    description: Bank 2 requested to enter power-down mode
+    value: 1
 enum/RDP:
   bit_size: 8
   variants:
@@ -694,3 +957,111 @@ enum/RDP:
   - name: B_0xCC
     description: Level 2 (chip readout protection active)
     value: 204
+enum/SECCR_BKER:
+  bit_size: 1
+  variants:
+  - name: B_0x0
+    description: Bank 1 selected for secure page erase
+    value: 0
+  - name: B_0x1
+    description: Bank 2 selected for secure page erase
+    value: 1
+enum/SECCR_EOPIE:
+  bit_size: 1
+  variants:
+  - name: B_0x0
+    description: Secure EOP Interrupt disabled
+    value: 0
+  - name: B_0x1
+    description: Secure EOP Interrupt enabled
+    value: 1
+enum/SECCR_ERRIE:
+  bit_size: 1
+  variants:
+  - name: B_0x0
+    description: Secure OPERR error interrupt disabled
+    value: 0
+  - name: B_0x1
+    description: Secure OPERR error interrupt enabled
+    value: 1
+enum/SECCR_PER:
+  bit_size: 1
+  variants:
+  - name: B_0x0
+    description: Secure page erase disabled
+    value: 0
+  - name: B_0x1
+    description: Secure page erase enabled
+    value: 1
+enum/SECCR_PG:
+  bit_size: 1
+  variants:
+  - name: B_0x0
+    description: Secure Flash programming disabled
+    value: 0
+  - name: B_0x1
+    description: Secure Flash programming enabled
+    value: 1
+enum/SRAM_ECC:
+  bit_size: 1
+  variants:
+  - name: B_0x0
+    description: SRAM3 ECC check enabled
+    value: 0
+  - name: B_0x1
+    description: SRAM3 ECC check disabled
+    value: 1
+enum/SWAP_BANK:
+  bit_size: 1
+  variants:
+  - name: B_0x0
+    description: Bank 1 and bank 2 addresses not swapped
+    value: 0
+  - name: B_0x1
+    description: Bank 1 and bank 2 addresses swapped
+    value: 1
+enum/nBOOT:
+  bit_size: 1
+  variants:
+  - name: B_0x0
+    description: nBOOT0 = 0
+    value: 0
+  - name: B_0x1
+    description: nBOOT0 = 1
+    value: 1
+enum/nRST_SHDW:
+  bit_size: 1
+  variants:
+  - name: B_0x0
+    description: Reset generated when entering the Shutdown mode
+    value: 0
+  - name: B_0x1
+    description: No reset generated when entering the Shutdown mode
+    value: 1
+enum/nRST_STDBY:
+  bit_size: 1
+  variants:
+  - name: B_0x0
+    description: Reset generated when entering the Standby mode
+    value: 0
+  - name: B_0x1
+    description: No reset generate when entering the Standby mode
+    value: 1
+enum/nRST_STOP:
+  bit_size: 1
+  variants:
+  - name: B_0x0
+    description: Reset generated when entering the Stop mode
+    value: 0
+  - name: B_0x1
+    description: No reset generated when entering the Stop mode
+    value: 1
+enum/nSWBOOT:
+  bit_size: 1
+  variants:
+  - name: B_0x0
+    description: BOOT0 taken from the option bit nBOOT0
+    value: 0
+  - name: B_0x1
+    description: BOOT0 taken from PH3/BOOT0 pin
+    value: 1


### PR DESCRIPTION
- Part of a future addition for TrustZone support on WBA devices on Embassy
- Original work based off of WB devices, but more similar to U5