### PR TITLE
rcc/wb: Expose the RFWKP clock mux for IPCC

### DIFF
--- a/data/registers/rcc_wb.yaml
+++ b/data/registers/rcc_wb.yaml
@@ -2328,7 +2328,7 @@ enum/RFWKPSEL:
   - name: LSE
     description: LSE clock selected
     value: 1
-  - name: HSEDIV1024
+  - name: HSE_DIV_1024
     description: HSE/1024 clock selected
     value: 3
 enum/RNGSEL:

--- a/stm32-data-gen/src/rcc.rs
+++ b/stm32-data-gen/src/rcc.rs
@@ -135,6 +135,7 @@ impl ParsedRccs {
             "PLL1_P_DIV_2",
             "CLK48MOHCI",
             "DIV_RTCPRE",
+            "HSE_DIV_1024",
             "HSE_DIV_2",
             "HSE_DIV_RTCPRE",
             // N6 extra
@@ -178,6 +179,7 @@ impl ParsedRccs {
             regex!(r"^D\dCCIP\d?R/(.+)SEL$"),
             regex!(r"^CFGR\d/(.+)SW$"),
             regex!(r"^.+PERCKSELR/(.+)SEL$"),
+            regex!(r"^CSR/(.+)SEL$"),
         ];
         let mux_nopelist = &[regex!(r"^.+PERCKSELR/USBREFCKSEL$"), regex!(r"^.+/TIMICSEL$")];
 
@@ -334,6 +336,7 @@ impl ParsedRccs {
             ("USB_OTG_HS", &["USB", "USBPHYC", "OTGHS", "CLK48", "ICLK"]),
             ("DTS", &["TMPSENS"]),
             ("SDMMC1", &["SDMMC1", "CLK48"]),
+            ("IPCC", &["RFWKP"]),
         ];
 
         let rcc = self.rccs.get(rcc_version)?;


### PR DESCRIPTION
This exposes `rfwkpsel` in `ClockMux` within `embassy-stm32`

Follow up to #643