### PR TITLE
Add STM32F1 AFIO remap

### DIFF
--- a/stm32-data-gen/src/gpio_af.rs
+++ b/stm32-data-gen/src/gpio_af.rs
@@ -86,7 +86,6 @@ impl Af {
                             pin: pin_name.clone(),
                             signal: signal_name.to_string(),
                             af: afn,
-                            afio: None,
                         },
                     );
                 }

--- a/stm32-data-serde/src/lib.rs
+++ b/stm32-data-serde/src/lib.rs
@@ -119,6 +119,8 @@ pub mod chip {
             pub interrupts: Vec<peripheral::Interrupt>,
             #[serde(default, skip_serializing_if = "Vec::is_empty")]
             pub dma_channels: Vec<peripheral::DmaChannel>,
+            #[serde(default, skip_serializing_if = "Option::is_none")]
+            pub afio: Option<peripheral::Afio>,
         }
 
         pub mod peripheral {
@@ -178,8 +180,6 @@ pub mod chip {
                 pub signal: String,
                 #[serde(skip_serializing_if = "Option::is_none")]
                 pub af: Option<u8>,
-                #[serde(skip_serializing_if = "Option::is_none")]
-                pub afio: Option<RemapInfo>,
             }
 
             #[derive(Clone, Debug, Eq, PartialEq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
@@ -208,6 +208,21 @@ pub mod chip {
                 pub register: String,
                 pub field: String,
                 pub value: u8,
+            }
+
+            #[derive(Clone, Debug, Eq, PartialEq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+            pub struct Afio {
+                pub register: String,
+                pub field: String,
+                #[serde(skip_serializing_if = "Vec::is_empty")]
+                pub values: Vec<AfioValue>,
+            }
+
+            #[derive(Clone, Debug, Eq, PartialEq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+            pub struct AfioValue {
+                pub value: u8,
+                #[serde(skip_serializing_if = "Vec::is_empty")]
+                pub pins: Vec<String>,
             }
         }
 

--- a/stm32-metapac-gen/res/src/metadata.rs
+++ b/stm32-metapac-gen/res/src/metadata.rs
@@ -178,6 +178,7 @@ pub struct Peripheral {
     pub pins: &'static [PeripheralPin],
     pub dma_channels: &'static [PeripheralDmaChannel],
     pub interrupts: &'static [PeripheralInterrupt],
+    pub afio: Option<PeripheralAfio>,
 }
 
 #[derive(Debug, Eq, PartialEq, Clone)]
@@ -192,6 +193,19 @@ pub struct PeripheralRegisters {
 pub struct PeripheralInterrupt {
     pub signal: &'static str,
     pub interrupt: &'static str,
+}
+
+#[derive(Debug, Eq, PartialEq, Clone)]
+pub struct PeripheralAfio {
+    pub register: &'static str,
+    pub field: &'static str,
+    pub values: &'static [PeripheralAfioValue],
+}
+
+#[derive(Debug, Eq, PartialEq, Clone)]
+pub struct PeripheralAfioValue {
+    pub value: u8,
+    pub pins: &'static [&'static str],
 }
 
 #[derive(Debug, Eq, PartialEq, Clone)]
@@ -228,7 +242,6 @@ pub struct PeripheralPin {
     pub pin: &'static str,
     pub signal: &'static str,
     pub af: Option<u8>,
-    pub afio: Option<RemapInfo>,
 }
 
 #[derive(Debug, Eq, PartialEq, Clone)]

--- a/stm32-metapac-gen/src/data.rs
+++ b/stm32-metapac-gen/src/data.rs
@@ -374,6 +374,8 @@ pub struct Peripheral {
     pub dma_channels: Vec<PeripheralDmaChannel>,
     #[serde(default)]
     pub interrupts: Vec<PeripheralInterrupt>,
+    #[serde(default)]
+    pub afio: Option<PeripheralAfio>,
 }
 
 // Notice:
@@ -388,6 +390,7 @@ impl std::fmt::Debug for Peripheral {
             .field("pins", &self.pins)
             .field("dma_channels", &self.dma_channels)
             .field("interrupts", &self.interrupts)
+            .field("afio", &self.afio)
             .finish()
     }
 }
@@ -396,6 +399,21 @@ impl std::fmt::Debug for Peripheral {
 pub struct PeripheralInterrupt {
     pub signal: String,
     pub interrupt: String,
+}
+
+#[derive(Debug, Eq, PartialEq, Clone, Deserialize)]
+pub struct PeripheralAfio {
+    pub register: String,
+    pub field: String,
+    #[serde(default)]
+    pub values: Vec<PeripheralAfioValue>,
+}
+
+#[derive(Debug, Eq, PartialEq, Clone, Deserialize)]
+pub struct PeripheralAfioValue {
+    pub value: u8,
+    #[serde(default)]
+    pub pins: Vec<String>,
 }
 
 #[derive(Debug, Eq, PartialEq, Clone, Deserialize)]
@@ -436,7 +454,6 @@ pub struct PeripheralPin {
     pub pin: String,
     pub signal: String,
     pub af: Option<u8>,
-    pub afio: Option<RemapInfo>,
 }
 
 #[derive(Debug, Eq, PartialEq, Clone, Deserialize)]


### PR DESCRIPTION
This adds the STM32F1 remap information for the AFIO_MAPR/AFIO_MAPR2 registers. The XML files only contain references to constants in the ST HAL. So, a custom lookup table was added.

Fixes #10