### PR TITLE
Renamed C0v2 CCIPR1 register to CCIPR to match datasheet as svd is in…

### DIFF
--- a/data/registers/rcc_c0v2.yaml
+++ b/data/registers/rcc_c0v2.yaml
@@ -80,10 +80,10 @@ block/RCC:
     description: RCC APB peripheral clock enable in Sleep/Stop mode register 2
     byte_offset: 80
     fieldset: APBSMENR2
-  - name: CCIPR1
+  - name: CCIPR
     description: RCC peripherals independent clock configuration register 1
     byte_offset: 84
-    fieldset: CCIPR1
+    fieldset: CCIPR
   - name: CCIPR2
     description: RCC peripherals independent clock configuration register 2.
     byte_offset: 88
@@ -395,7 +395,7 @@ fieldset/APBSMENR2:
     description: "ADC clock enable during Sleep mode\r Set and cleared by software."
     bit_offset: 20
     bit_size: 1
-fieldset/CCIPR1:
+fieldset/CCIPR:
   description: RCC peripherals independent clock configuration register
   fields:
   - name: USART1SEL


### PR DESCRIPTION
STM32C071 has a CCIPR register which is incorrectly named as CCIPR1 in the svd file from ST Micro.
Renamed it in rcc_c0v2.yaml to match the the datasheet (which uses CCIPR).