### PR TITLE
Added missing fields and enums for rcc_wba.yaml

### DIFF
--- a/d
+++ b/d
@@ -153,13 +153,13 @@ case "$CMD" in
             --- build --release --manifest-path build/stm32-metapac/Cargo.toml --target thumbv7em-none-eabi --features pac,metadata,stm32wb15cc \
             --- build --release --manifest-path build/stm32-metapac/Cargo.toml --target thumbv7em-none-eabi --features pac,metadata,stm32wb35ce \
             --- build --release --manifest-path build/stm32-metapac/Cargo.toml --target thumbv7em-none-eabi --features pac,metadata,stm32wb55rg \
-            --- build --release --manifest-path build/stm32-metapac/Cargo.toml --target thumbv7em-none-eabi --features pac,metadata,stm32wba50ke \
-            --- build --release --manifest-path build/stm32-metapac/Cargo.toml --target thumbv7em-none-eabi --features pac,metadata,stm32wba52cg \
-            --- build --release --manifest-path build/stm32-metapac/Cargo.toml --target thumbv7em-none-eabi --features pac,metadata,stm32wba55ug \
-            --- build --release --manifest-path build/stm32-metapac/Cargo.toml --target thumbv7em-none-eabi --features pac,metadata,stm32wba62mg \
-            --- build --release --manifest-path build/stm32-metapac/Cargo.toml --target thumbv7em-none-eabi --features pac,metadata,stm32wba63cg \
-            --- build --release --manifest-path build/stm32-metapac/Cargo.toml --target thumbv7em-none-eabi --features pac,metadata,stm32wba64ci \
-            --- build --release --manifest-path build/stm32-metapac/Cargo.toml --target thumbv7em-none-eabi --features pac,metadata,stm32wba65ri \
+            --- build --release --manifest-path build/stm32-metapac/Cargo.toml --target thumbv8m.main-none-eabihf --features pac,metadata,stm32wba50ke \
+            --- build --release --manifest-path build/stm32-metapac/Cargo.toml --target thumbv8m.main-none-eabihf --features pac,metadata,stm32wba52cg \
+            --- build --release --manifest-path build/stm32-metapac/Cargo.toml --target thumbv8m.main-none-eabihf --features pac,metadata,stm32wba55ug \
+            --- build --release --manifest-path build/stm32-metapac/Cargo.toml --target thumbv8m.main-none-eabihf --features pac,metadata,stm32wba62mg \
+            --- build --release --manifest-path build/stm32-metapac/Cargo.toml --target thumbv8m.main-none-eabihf --features pac,metadata,stm32wba63cg \
+            --- build --release --manifest-path build/stm32-metapac/Cargo.toml --target thumbv8m.main-none-eabihf --features pac,metadata,stm32wba64ci \
+            --- build --release --manifest-path build/stm32-metapac/Cargo.toml --target thumbv8m.main-none-eabihf --features pac,metadata,stm32wba65ri \
             --- build --release --manifest-path build/stm32-metapac/Cargo.toml --target thumbv7em-none-eabi --features pac,metadata,stm32wl54jc-cm4 \
             --- build --release --manifest-path build/stm32-metapac/Cargo.toml --target thumbv7em-none-eabi --features pac,metadata,stm32wl54jc-cm0p \
             --- build --release --manifest-path build/stm32-metapac/Cargo.toml --target thumbv7em-none-eabi --features pac,metadata,stm32wl55jc-cm4 \

--- a/data/registers/rcc_wba.yaml
+++ b/data/registers/rcc_wba.yaml
@@ -331,7 +331,7 @@ fieldset/AHB2ENR:
     description: "USB OTG_HS bus and kernel clock enable\r Set and cleared by software.\r Access can be secured by GTZC_TZSC OTGSEC. When secure, a non-secure read/write access is RAZ/WI. It does not generate an illegal access interrupt. This bit can be protected against unprivileged access when secure with RCC SPRIV or when non-secure with RCC NSPRIV."
     bit_offset: 14
     bit_size: 1
-  - name: OTGHSPHYEN
+  - name: USB_OTG_HS_PHYEN
     description: "USB OTG_HS PHY kernel clock enable\r Set and cleared by software.\r Access can be secured by GTZC_TZSC OTGSEC. When secure, a non-secure read/write access is RAZ/WI. It does not generate an illegal access interrupt. This bit can be protected against unprivileged access when secure with RCC SPRIV or when non-secure with RCC NSPRIV."
     bit_offset: 15
     bit_size: 1
@@ -457,7 +457,7 @@ fieldset/AHB2SMENR:
     description: "USB OTG_HS bus and kernel clock enable during Sleep and Stop modes\r Set and cleared by software.\r Access can be secured by GTZC_TZSC OTGSEC. When secure, a non-secure read/write access is RAZ/WI. It does not generate an illegal access interrupt. This bit can be protected against unprivileged access when secure with RCC SPRIV or when non-secure with RCC NSPRIV."
     bit_offset: 14
     bit_size: 1
-  - name: OTGHSPHYSMEN
+  - name: USB_OTG_HS_PHYSMEN
     description: "USB OTG_HS PHY kernel clock enable during Sleep and Stop modes\r Set and cleared by software.\r Access can be secured by GTZC_TZSC OTGSEC. When secure, a non-secure read/write access is RAZ/WI. It does not generate an illegal access interrupt. This bit can be protected against unprivileged access when secure with RCC SPRIV or when non-secure with RCC NSPRIV."
     bit_offset: 15
     bit_size: 1

--- a/data/registers/rcc_wba.yaml
+++ b/data/registers/rcc_wba.yaml
@@ -161,6 +161,10 @@ block/RCC:
     description: RCC control/status register
     byte_offset: 244
     fieldset: CSR
+  - name: BDCR2
+    description: RCC Backup domain control register
+    byte_offset: 248
+    fieldset: BDCR2
   - name: SECCFGR
     description: RCC secure configuration register
     byte_offset: 272
@@ -517,6 +521,10 @@ fieldset/AHB5ENR:
     description: "2.4 GHz RADIO bus clock enable\r Set and cleared by software.\r Access can be secured by GTZC_TZSC RADIOSEC. When secure, a non-secure read/write access is RAZ/WI. It does not generate an illegal access interrupt. This bit can be protected against unprivileged access when secure with RCC SPRIV or when non-secure with RCC NSPRIV.\r Before accessing the 2.4 GHz RADIO sleep timers registers the RADIOCLKRDY bit must be checked.\r Note: When RADIOSMEN and STRADIOCLKON are both cleared, RADIOCLKRDY bit must be re-checked when exiting low-power modes (Sleep and Stop)."
     bit_offset: 0
     bit_size: 1
+  - name: PTACONVEN
+    description: PTACONV bus clock enable
+    bit_offset: 1
+    bit_size: 1
 fieldset/AHB5RSTR:
   description: RCC AHB5 peripheral reset register
   fields:
@@ -524,12 +532,20 @@ fieldset/AHB5RSTR:
     description: "2.4 GHz RADIO reset\r Set and cleared by software.\r Access can be secured by GTZC_TZSC RADIOSEC. When secure, a non-secure read/write access is RAZ/WI. It does not generate an illegal access interrupt. This bit can be protected against unprivileged access when secure with RCC SPRIV or when non-secure with RCC NSPRIV."
     bit_offset: 0
     bit_size: 1
+  - name: PTACONVRST
+    description: PTACONV reset.
+    bit_offset: 1
+    bit_size: 1
 fieldset/AHB5SMENR:
   description: RCC AHB5 peripheral clocks enable in Sleep and Stop modes register
   fields:
   - name: RADIOSMEN
     description: "2.4 GHz RADIO bus clock enable during Sleep and Stop modes when the 2.4 GHz RADIO is active.\r Set and cleared by software.\r Access can be secured by GTZC_TZSC RADIOSEC. When secure, a non-secure read/write access is RAZ/WI. It does not generate an illegal access interrupt. This bit can be protected against unprivileged access when secure with RCC SPRIV or when non-secure with RCC NSPRIV."
     bit_offset: 0
+    bit_size: 1
+  - name: PTACONVSMEN
+    description: PTACONV bus clock enable during Sleep and Stop modes.
+    bit_offset: 1
     bit_size: 1
 fieldset/APB1ENR1:
   description: RCC APB1 peripheral clock enable register 1
@@ -619,6 +635,10 @@ fieldset/APB1RSTR1:
 fieldset/APB1RSTR2:
   description: RCC APB1 peripheral reset register 2
   fields:
+  - name: I2C4RST
+    description: I2C4 reset.
+    bit_offset: 1
+    bit_size: 1
   - name: LPTIM2RST
     description: "LPTIM2 reset\r Set and cleared by software.\r Access can be secured by GTZC_TZSC LPTIM2SEC. When secure, a non-secure read/write access is RAZ/WI. It does not generate an illegal access interrupt. This bit can be protected against unprivileged access when secure with RCC SPRIV or when non-secure with RCC NSPRIV."
     bit_offset: 5
@@ -696,6 +716,10 @@ fieldset/APB2ENR:
     description: "TIM17 bus and kernel clocks enable\r Set and cleared by software.\r Access can be secured by GTZC_TZSC TIM17SEC. When secure, a non-secure read/write access is RAZ/WI. It does not generate an illegal access interrupt. This bit can be protected against unprivileged access when secure with RCC SPRIV or when non-secure with RCC NSPRIV."
     bit_offset: 18
     bit_size: 1
+  - name: SAI1EN
+    description: SAI1 bus and kernel clocks enable
+    bit_offset: 21
+    bit_size: 1
 fieldset/APB2RSTR:
   description: RCC APB2 peripheral reset register
   fields:
@@ -718,6 +742,10 @@ fieldset/APB2RSTR:
   - name: TIM17RST
     description: "TIM17 reset\r Set and cleared by software.\r Access can be secured by GTZC_TZSC TIM17SEC. When secure, a non-secure read/write access is RAZ/WI. It does not generate an illegal access interrupt. This bit can be protected against unprivileged access when secure with RCC SPRIV or when non-secure with RCC NSPRIV."
     bit_offset: 18
+    bit_size: 1
+  - name: SAI1RST
+    description: SAI1 reset.
+    bit_offset: 21
     bit_size: 1
 fieldset/APB2SMENR:
   description: RCC APB2 peripheral clocks enable in Sleep and Stop modes register
@@ -742,6 +770,10 @@ fieldset/APB2SMENR:
     description: "TIM17 bus and kernel clocks enable during Sleep and Stop modes\r Set and cleared by software.\r Access can be secured by GTZC_TZSC TIM17SEC. When secure, a non-secure read/write access is RAZ/WI. It does not generate an illegal access interrupt. This bit can be protected against unprivileged access when secure with RCC SPRIV or when non-secure with RCC NSPRIV."
     bit_offset: 18
     bit_size: 1
+  - name: SAI1SMEN
+    description: SAI1 bus and kernel clocks enable during Sleep and Stop modes.
+    bit_offset: 21
+    bit_size: 1
 fieldset/APB7ENR:
   description: RCC APB7 peripheral clock enable register
   fields:
@@ -764,6 +796,10 @@ fieldset/APB7ENR:
   - name: LPTIM1EN
     description: "LPTIM1 bus and kernel clocks enable\r Set and cleared by software.\r Access can be secured by GTZC_TZSC LPTIM1SEC. When secure, a non-secure read/write access is RAZ/WI. It does not generate an illegal access interrupt. This bit can be protected against unprivileged access when secure with RCC SPRIV or when non-secure with RCC NSPRIV."
     bit_offset: 11
+    bit_size: 1
+  - name: COMPEN
+    description: COMP bus clock enable
+    bit_offset: 15
     bit_size: 1
   - name: VREFEN
     description: "VREFBUF bus clock enable\r Set and cleared by software.\r Access can be secured by GTZC_TZSC VREFBUFSEC. When secure, a non-secure read/write access is RAZ/WI. It does not generate an illegal access interrupt. This bit can be protected against unprivileged access when secure with RCC SPRIV or when non-secure with RCC NSPRIV."
@@ -826,6 +862,10 @@ fieldset/APB7SMENR:
   - name: LPTIM1SMEN
     description: "LPTIM1 bus and kernel clocks enable during Sleep and Stop modes\r Set and cleared by software.\r Access can be secured by GTZC_TZSC LPTIM1SEC. When secure, a non-secure read/write access is RAZ/WI. It does not generate an illegal access interrupt. This bit can be protected against unprivileged access when secure with RCC SPRIV or when non-secure with RCC NSPRIV.\r Note: This bit must be set to allow the peripheral to wake up from Stop modes."
     bit_offset: 11
+    bit_size: 1
+  - name: COMPSMEN
+    description: COMP bus clock enable during Sleep and Stop modes.
+    bit_offset: 15
     bit_size: 1
   - name: VREFSMEN
     description: "VREFBUF clock enable during Sleep and Stop modes\r Set and cleared by software.\r Access can be secured by GTZC_TZSC VREFBUFSEC. When secure, a non-secure read/write access is RAZ/WI. It does not generate an illegal access interrupt. This bit can be protected against unprivileged access when secure with RCC SPRIV or when non-secure with RCC NSPRIV.\r Note: This bit must be set to allow the peripheral to wake up from Stop modes."
@@ -989,6 +1029,27 @@ fieldset/BDCR:
     bit_offset: 28
     bit_size: 1
     enum: LSIPREDIV
+  - name: LSI2ON
+    description: LSI2 oscillator enable
+    bit_offset: 29
+    bit_size: 1
+  - name: LSI2RDY
+    description: LSI2 oscillator ready.
+    bit_offset: 30
+    bit_size: 1
+fieldset/BDCR2:
+  description: RCC Backup domain control register
+  fields:
+  - name: LSI2MODE
+    description: LSI2 oscillator operating mode configuration.
+    bit_offset: 0
+    bit_size: 3
+    enum: LSI2MODE
+  - name: LSI2CFG
+    description: LSI2 oscillator configuration.
+    bit_offset: 4
+    bit_size: 4
+    enum: LSI2CFG
 fieldset/CCIPR1:
   description: RCC peripherals independent clock configuration register 1
   fields:
@@ -1187,6 +1248,10 @@ fieldset/CICR:
     description: "High speed external clock security system interrupt clear\r Writing this bit to 1 clears the HSECSSF flag. Writing 0 has no effect.\r Access to the bit can be secured by RCC HSESEC. When secure, a non-secure read/write access is RAZ/WI. It does not generate an illegal access interrupt. This bit can be protected against unprivileged access when secure with RCC SPRIV or when non-secure with RCC NSPRIV."
     bit_offset: 10
     bit_size: 1
+  - name: LSI2RDYC
+    description: LSI2 ready interrupt clear.
+    bit_offset: 16
+    bit_size: 1
 fieldset/CIER:
   description: RCC clock interrupt enable register
   fields:
@@ -1209,6 +1274,10 @@ fieldset/CIER:
   - name: PLLRDYIE
     description: "PLL1 ready interrupt enable\r Set and cleared by software to enable/disable interrupt caused by PLL1 lock.\r Access to the bit can be secured by RCC PLL1SEC. When secure, a non-secure read/write access is RAZ/WI. It does not generate an illegal access interrupt. This bit can be protected against unprivileged access when secure with RCC SPRIV or when non-secure with RCC NSPRIV."
     bit_offset: 6
+    bit_size: 1
+  - name: LSI2RDYIE
+    description: LSI2 ready interrupt enable
+    bit_offset: 16
     bit_size: 1
 fieldset/CIFR:
   description: RCC clock interrupt flag register
@@ -1236,6 +1305,10 @@ fieldset/CIFR:
   - name: HSECSSF
     description: "HSE clock security system interrupt flag\r Set by hardware when a clock security failure is detected in the HSE oscillator.\r Cleared by software setting the HSECSSC bit.\r Access to the bit can be secured by RCC HSESEC. When secure, a non-secure read/write access is RAZ/WI. It does not generate an illegal access interrupt. This bit can be protected against unprivileged access when secure with RCC SPRIV or when non-secure with RCC NSPRIV."
     bit_offset: 10
+    bit_size: 1
+  - name: LSI2RDYF
+    description: LSI2 ready interrupt flag.
+    bit_offset: 16
     bit_size: 1
 fieldset/CR:
   description: RCC clock control register
@@ -1351,6 +1424,7 @@ fieldset/PLL1CFGR:
     description: "Prescaler for PLL1\r Set and cleared by software to configure the prescaler of the PLL1. The VCO1 input frequency is PLL1 input clock frequency/PLL1M.\r This bit can be written only when the PLL1 is disabled (PLL1ON = 0 and PLL1RDY = 0). \r ..."
     bit_offset: 8
     bit_size: 3
+    enum: PLLM
   - name: PLLPEN
     description: "PLL1 DIVP divider output enable\r Set and reset by software to enable the pll1pclk output of the PLL1.\r To save power, PLL1PEN and PLL1P bits must be set to 0 when the pll1pclk is not used. \r This bit can be written only when the PLL1 is disabled (PLL1ON = 0 and PLL1RDY = 0)."
     bit_offset: 16
@@ -1384,18 +1458,22 @@ fieldset/PLL1DIVR:
     description: "Multiplication factor for PLL1 VCO\r Set and reset by software to control the multiplication factor of the VCO.\r These bits can be written only when the PLL1 is disabled (PLL1ON = 0 and PLL1RDY = 0).\r ...\r ...\r others: reserved\r VCO output frequency = F<sub>ref1_ck</sub> x multiplication factor for PLL1 VCO, when fractional value 0 has been loaded into PLL1FRACN, with: \r Multiplication factor for PLL1 VCO between 4 and 512\r input frequency F<sub>ref1_ck</sub> between 4 and 16�MHz"
     bit_offset: 0
     bit_size: 9
+    enum: PLLN
   - name: PLLP
     description: "PLL1 DIVP division factor\r Set and reset by software to control the frequency of the pll1pclk clock.\r These bits can be written only when the PLL1 is disabled (PLL1ON = 0 and PLL1RDY = 0).\r Note that odd division factors are not allowed.\r ..."
     bit_offset: 9
     bit_size: 7
+    enum: PLLDIV
   - name: PLLQ
     description: "PLL1 DIVQ division factor\r Set and reset by software to control the frequency of the PLl1QCLK clock.\r These bits can be written only when the PLL1 is disabled (PLL1ON = 0 and PLL1RDY = 0).\r ..."
     bit_offset: 16
     bit_size: 7
+    enum: PLLDIV
   - name: PLLR
     description: "PLL1 DIVR division factor\r Set and reset by software to control the frequency of the pll1rclk clock.\r These bits can be written only when the PLL1 is disabled (PLL1ON = 0 and PLL1RDY = 0).\r ..."
     bit_offset: 24
     bit_size: 7
+    enum: PLLDIV
 fieldset/PLL1FRACR:
   description: RCC PLL1 fractional divider register
   fields:
@@ -1653,6 +1731,30 @@ enum/LSETRIM:
   - name: R2_3
     description: current source resistance 2/3 x R
     value: 3
+enum/LSI2CFG:
+  bit_size: 4
+  variants:
+  - name: Sensitivity0At80C
+    description: LSI2 frequency temperature sensitivity is close to 0 at +80 less thansup oless than/sup C.
+    value: 0
+  - name: Sensitivity0At50C
+    description: LSI2 frequency temperature sensitivity is close to 0 at +50 less thansup oless than/sup C.
+    value: 1
+  - name: Sensitivity0At20C
+    description: LSI2 frequency temperature sensitivity is close to 0 at +20 less thansup oless than/sup C.
+    value: 2
+enum/LSI2MODE:
+  bit_size: 3
+  variants:
+  - name: NominalPower
+    description: nominal-power, high accuracy.
+    value: 0
+  - name: LowPower
+    description: low-power, medium accuracy.
+    value: 1
+  - name: UltraLowPower
+    description: ultra-low-power, low accuracy.
+    value: 2
 enum/LSIPREDIV:
   bit_size: 1
   variants:
@@ -1728,6 +1830,1305 @@ enum/OTGHSSEL:
   - name: PLL1_P_DIV_2
     description: pll1pclk divided by 2 selected.
     value: 3
+enum/PLLDIV:
+  bit_size: 7
+  variants:
+  - name: Div1
+    value: 0
+  - name: Div2
+    value: 1
+  - name: Div3
+    value: 2
+  - name: Div4
+    value: 3
+  - name: Div5
+    value: 4
+  - name: Div6
+    value: 5
+  - name: Div7
+    value: 6
+  - name: Div8
+    value: 7
+  - name: Div9
+    value: 8
+  - name: Div10
+    value: 9
+  - name: Div11
+    value: 10
+  - name: Div12
+    value: 11
+  - name: Div13
+    value: 12
+  - name: Div14
+    value: 13
+  - name: Div15
+    value: 14
+  - name: Div16
+    value: 15
+  - name: Div17
+    value: 16
+  - name: Div18
+    value: 17
+  - name: Div19
+    value: 18
+  - name: Div20
+    value: 19
+  - name: Div21
+    value: 20
+  - name: Div22
+    value: 21
+  - name: Div23
+    value: 22
+  - name: Div24
+    value: 23
+  - name: Div25
+    value: 24
+  - name: Div26
+    value: 25
+  - name: Div27
+    value: 26
+  - name: Div28
+    value: 27
+  - name: Div29
+    value: 28
+  - name: Div30
+    value: 29
+  - name: Div31
+    value: 30
+  - name: Div32
+    value: 31
+  - name: Div33
+    value: 32
+  - name: Div34
+    value: 33
+  - name: Div35
+    value: 34
+  - name: Div36
+    value: 35
+  - name: Div37
+    value: 36
+  - name: Div38
+    value: 37
+  - name: Div39
+    value: 38
+  - name: Div40
+    value: 39
+  - name: Div41
+    value: 40
+  - name: Div42
+    value: 41
+  - name: Div43
+    value: 42
+  - name: Div44
+    value: 43
+  - name: Div45
+    value: 44
+  - name: Div46
+    value: 45
+  - name: Div47
+    value: 46
+  - name: Div48
+    value: 47
+  - name: Div49
+    value: 48
+  - name: Div50
+    value: 49
+  - name: Div51
+    value: 50
+  - name: Div52
+    value: 51
+  - name: Div53
+    value: 52
+  - name: Div54
+    value: 53
+  - name: Div55
+    value: 54
+  - name: Div56
+    value: 55
+  - name: Div57
+    value: 56
+  - name: Div58
+    value: 57
+  - name: Div59
+    value: 58
+  - name: Div60
+    value: 59
+  - name: Div61
+    value: 60
+  - name: Div62
+    value: 61
+  - name: Div63
+    value: 62
+  - name: Div64
+    value: 63
+  - name: Div65
+    value: 64
+  - name: Div66
+    value: 65
+  - name: Div67
+    value: 66
+  - name: Div68
+    value: 67
+  - name: Div69
+    value: 68
+  - name: Div70
+    value: 69
+  - name: Div71
+    value: 70
+  - name: Div72
+    value: 71
+  - name: Div73
+    value: 72
+  - name: Div74
+    value: 73
+  - name: Div75
+    value: 74
+  - name: Div76
+    value: 75
+  - name: Div77
+    value: 76
+  - name: Div78
+    value: 77
+  - name: Div79
+    value: 78
+  - name: Div80
+    value: 79
+  - name: Div81
+    value: 80
+  - name: Div82
+    value: 81
+  - name: Div83
+    value: 82
+  - name: Div84
+    value: 83
+  - name: Div85
+    value: 84
+  - name: Div86
+    value: 85
+  - name: Div87
+    value: 86
+  - name: Div88
+    value: 87
+  - name: Div89
+    value: 88
+  - name: Div90
+    value: 89
+  - name: Div91
+    value: 90
+  - name: Div92
+    value: 91
+  - name: Div93
+    value: 92
+  - name: Div94
+    value: 93
+  - name: Div95
+    value: 94
+  - name: Div96
+    value: 95
+  - name: Div97
+    value: 96
+  - name: Div98
+    value: 97
+  - name: Div99
+    value: 98
+  - name: Div100
+    value: 99
+  - name: Div101
+    value: 100
+  - name: Div102
+    value: 101
+  - name: Div103
+    value: 102
+  - name: Div104
+    value: 103
+  - name: Div105
+    value: 104
+  - name: Div106
+    value: 105
+  - name: Div107
+    value: 106
+  - name: Div108
+    value: 107
+  - name: Div109
+    value: 108
+  - name: Div110
+    value: 109
+  - name: Div111
+    value: 110
+  - name: Div112
+    value: 111
+  - name: Div113
+    value: 112
+  - name: Div114
+    value: 113
+  - name: Div115
+    value: 114
+  - name: Div116
+    value: 115
+  - name: Div117
+    value: 116
+  - name: Div118
+    value: 117
+  - name: Div119
+    value: 118
+  - name: Div120
+    value: 119
+  - name: Div121
+    value: 120
+  - name: Div122
+    value: 121
+  - name: Div123
+    value: 122
+  - name: Div124
+    value: 123
+  - name: Div125
+    value: 124
+  - name: Div126
+    value: 125
+  - name: Div127
+    value: 126
+  - name: Div128
+    value: 127
+enum/PLLM:
+  bit_size: 3
+  variants:
+  - name: Div1
+    value: 0
+  - name: Div2
+    value: 1
+  - name: Div3
+    value: 2
+  - name: Div4
+    value: 3
+  - name: Div5
+    value: 4
+  - name: Div6
+    value: 5
+  - name: Div7
+    value: 6
+  - name: Div8
+    value: 7
+enum/PLLN:
+  bit_size: 9
+  variants:
+  - name: Mul4
+    value: 3
+  - name: Mul5
+    value: 4
+  - name: Mul6
+    value: 5
+  - name: Mul7
+    value: 6
+  - name: Mul8
+    value: 7
+  - name: Mul9
+    value: 8
+  - name: Mul10
+    value: 9
+  - name: Mul11
+    value: 10
+  - name: Mul12
+    value: 11
+  - name: Mul13
+    value: 12
+  - name: Mul14
+    value: 13
+  - name: Mul15
+    value: 14
+  - name: Mul16
+    value: 15
+  - name: Mul17
+    value: 16
+  - name: Mul18
+    value: 17
+  - name: Mul19
+    value: 18
+  - name: Mul20
+    value: 19
+  - name: Mul21
+    value: 20
+  - name: Mul22
+    value: 21
+  - name: Mul23
+    value: 22
+  - name: Mul24
+    value: 23
+  - name: Mul25
+    value: 24
+  - name: Mul26
+    value: 25
+  - name: Mul27
+    value: 26
+  - name: Mul28
+    value: 27
+  - name: Mul29
+    value: 28
+  - name: Mul30
+    value: 29
+  - name: Mul31
+    value: 30
+  - name: Mul32
+    value: 31
+  - name: Mul33
+    value: 32
+  - name: Mul34
+    value: 33
+  - name: Mul35
+    value: 34
+  - name: Mul36
+    value: 35
+  - name: Mul37
+    value: 36
+  - name: Mul38
+    value: 37
+  - name: Mul39
+    value: 38
+  - name: Mul40
+    value: 39
+  - name: Mul41
+    value: 40
+  - name: Mul42
+    value: 41
+  - name: Mul43
+    value: 42
+  - name: Mul44
+    value: 43
+  - name: Mul45
+    value: 44
+  - name: Mul46
+    value: 45
+  - name: Mul47
+    value: 46
+  - name: Mul48
+    value: 47
+  - name: Mul49
+    value: 48
+  - name: Mul50
+    value: 49
+  - name: Mul51
+    value: 50
+  - name: Mul52
+    value: 51
+  - name: Mul53
+    value: 52
+  - name: Mul54
+    value: 53
+  - name: Mul55
+    value: 54
+  - name: Mul56
+    value: 55
+  - name: Mul57
+    value: 56
+  - name: Mul58
+    value: 57
+  - name: Mul59
+    value: 58
+  - name: Mul60
+    value: 59
+  - name: Mul61
+    value: 60
+  - name: Mul62
+    value: 61
+  - name: Mul63
+    value: 62
+  - name: Mul64
+    value: 63
+  - name: Mul65
+    value: 64
+  - name: Mul66
+    value: 65
+  - name: Mul67
+    value: 66
+  - name: Mul68
+    value: 67
+  - name: Mul69
+    value: 68
+  - name: Mul70
+    value: 69
+  - name: Mul71
+    value: 70
+  - name: Mul72
+    value: 71
+  - name: Mul73
+    value: 72
+  - name: Mul74
+    value: 73
+  - name: Mul75
+    value: 74
+  - name: Mul76
+    value: 75
+  - name: Mul77
+    value: 76
+  - name: Mul78
+    value: 77
+  - name: Mul79
+    value: 78
+  - name: Mul80
+    value: 79
+  - name: Mul81
+    value: 80
+  - name: Mul82
+    value: 81
+  - name: Mul83
+    value: 82
+  - name: Mul84
+    value: 83
+  - name: Mul85
+    value: 84
+  - name: Mul86
+    value: 85
+  - name: Mul87
+    value: 86
+  - name: Mul88
+    value: 87
+  - name: Mul89
+    value: 88
+  - name: Mul90
+    value: 89
+  - name: Mul91
+    value: 90
+  - name: Mul92
+    value: 91
+  - name: Mul93
+    value: 92
+  - name: Mul94
+    value: 93
+  - name: Mul95
+    value: 94
+  - name: Mul96
+    value: 95
+  - name: Mul97
+    value: 96
+  - name: Mul98
+    value: 97
+  - name: Mul99
+    value: 98
+  - name: Mul100
+    value: 99
+  - name: Mul101
+    value: 100
+  - name: Mul102
+    value: 101
+  - name: Mul103
+    value: 102
+  - name: Mul104
+    value: 103
+  - name: Mul105
+    value: 104
+  - name: Mul106
+    value: 105
+  - name: Mul107
+    value: 106
+  - name: Mul108
+    value: 107
+  - name: Mul109
+    value: 108
+  - name: Mul110
+    value: 109
+  - name: Mul111
+    value: 110
+  - name: Mul112
+    value: 111
+  - name: Mul113
+    value: 112
+  - name: Mul114
+    value: 113
+  - name: Mul115
+    value: 114
+  - name: Mul116
+    value: 115
+  - name: Mul117
+    value: 116
+  - name: Mul118
+    value: 117
+  - name: Mul119
+    value: 118
+  - name: Mul120
+    value: 119
+  - name: Mul121
+    value: 120
+  - name: Mul122
+    value: 121
+  - name: Mul123
+    value: 122
+  - name: Mul124
+    value: 123
+  - name: Mul125
+    value: 124
+  - name: Mul126
+    value: 125
+  - name: Mul127
+    value: 126
+  - name: Mul128
+    value: 127
+  - name: Mul129
+    value: 128
+  - name: Mul130
+    value: 129
+  - name: Mul131
+    value: 130
+  - name: Mul132
+    value: 131
+  - name: Mul133
+    value: 132
+  - name: Mul134
+    value: 133
+  - name: Mul135
+    value: 134
+  - name: Mul136
+    value: 135
+  - name: Mul137
+    value: 136
+  - name: Mul138
+    value: 137
+  - name: Mul139
+    value: 138
+  - name: Mul140
+    value: 139
+  - name: Mul141
+    value: 140
+  - name: Mul142
+    value: 141
+  - name: Mul143
+    value: 142
+  - name: Mul144
+    value: 143
+  - name: Mul145
+    value: 144
+  - name: Mul146
+    value: 145
+  - name: Mul147
+    value: 146
+  - name: Mul148
+    value: 147
+  - name: Mul149
+    value: 148
+  - name: Mul150
+    value: 149
+  - name: Mul151
+    value: 150
+  - name: Mul152
+    value: 151
+  - name: Mul153
+    value: 152
+  - name: Mul154
+    value: 153
+  - name: Mul155
+    value: 154
+  - name: Mul156
+    value: 155
+  - name: Mul157
+    value: 156
+  - name: Mul158
+    value: 157
+  - name: Mul159
+    value: 158
+  - name: Mul160
+    value: 159
+  - name: Mul161
+    value: 160
+  - name: Mul162
+    value: 161
+  - name: Mul163
+    value: 162
+  - name: Mul164
+    value: 163
+  - name: Mul165
+    value: 164
+  - name: Mul166
+    value: 165
+  - name: Mul167
+    value: 166
+  - name: Mul168
+    value: 167
+  - name: Mul169
+    value: 168
+  - name: Mul170
+    value: 169
+  - name: Mul171
+    value: 170
+  - name: Mul172
+    value: 171
+  - name: Mul173
+    value: 172
+  - name: Mul174
+    value: 173
+  - name: Mul175
+    value: 174
+  - name: Mul176
+    value: 175
+  - name: Mul177
+    value: 176
+  - name: Mul178
+    value: 177
+  - name: Mul179
+    value: 178
+  - name: Mul180
+    value: 179
+  - name: Mul181
+    value: 180
+  - name: Mul182
+    value: 181
+  - name: Mul183
+    value: 182
+  - name: Mul184
+    value: 183
+  - name: Mul185
+    value: 184
+  - name: Mul186
+    value: 185
+  - name: Mul187
+    value: 186
+  - name: Mul188
+    value: 187
+  - name: Mul189
+    value: 188
+  - name: Mul190
+    value: 189
+  - name: Mul191
+    value: 190
+  - name: Mul192
+    value: 191
+  - name: Mul193
+    value: 192
+  - name: Mul194
+    value: 193
+  - name: Mul195
+    value: 194
+  - name: Mul196
+    value: 195
+  - name: Mul197
+    value: 196
+  - name: Mul198
+    value: 197
+  - name: Mul199
+    value: 198
+  - name: Mul200
+    value: 199
+  - name: Mul201
+    value: 200
+  - name: Mul202
+    value: 201
+  - name: Mul203
+    value: 202
+  - name: Mul204
+    value: 203
+  - name: Mul205
+    value: 204
+  - name: Mul206
+    value: 205
+  - name: Mul207
+    value: 206
+  - name: Mul208
+    value: 207
+  - name: Mul209
+    value: 208
+  - name: Mul210
+    value: 209
+  - name: Mul211
+    value: 210
+  - name: Mul212
+    value: 211
+  - name: Mul213
+    value: 212
+  - name: Mul214
+    value: 213
+  - name: Mul215
+    value: 214
+  - name: Mul216
+    value: 215
+  - name: Mul217
+    value: 216
+  - name: Mul218
+    value: 217
+  - name: Mul219
+    value: 218
+  - name: Mul220
+    value: 219
+  - name: Mul221
+    value: 220
+  - name: Mul222
+    value: 221
+  - name: Mul223
+    value: 222
+  - name: Mul224
+    value: 223
+  - name: Mul225
+    value: 224
+  - name: Mul226
+    value: 225
+  - name: Mul227
+    value: 226
+  - name: Mul228
+    value: 227
+  - name: Mul229
+    value: 228
+  - name: Mul230
+    value: 229
+  - name: Mul231
+    value: 230
+  - name: Mul232
+    value: 231
+  - name: Mul233
+    value: 232
+  - name: Mul234
+    value: 233
+  - name: Mul235
+    value: 234
+  - name: Mul236
+    value: 235
+  - name: Mul237
+    value: 236
+  - name: Mul238
+    value: 237
+  - name: Mul239
+    value: 238
+  - name: Mul240
+    value: 239
+  - name: Mul241
+    value: 240
+  - name: Mul242
+    value: 241
+  - name: Mul243
+    value: 242
+  - name: Mul244
+    value: 243
+  - name: Mul245
+    value: 244
+  - name: Mul246
+    value: 245
+  - name: Mul247
+    value: 246
+  - name: Mul248
+    value: 247
+  - name: Mul249
+    value: 248
+  - name: Mul250
+    value: 249
+  - name: Mul251
+    value: 250
+  - name: Mul252
+    value: 251
+  - name: Mul253
+    value: 252
+  - name: Mul254
+    value: 253
+  - name: Mul255
+    value: 254
+  - name: Mul256
+    value: 255
+  - name: Mul257
+    value: 256
+  - name: Mul258
+    value: 257
+  - name: Mul259
+    value: 258
+  - name: Mul260
+    value: 259
+  - name: Mul261
+    value: 260
+  - name: Mul262
+    value: 261
+  - name: Mul263
+    value: 262
+  - name: Mul264
+    value: 263
+  - name: Mul265
+    value: 264
+  - name: Mul266
+    value: 265
+  - name: Mul267
+    value: 266
+  - name: Mul268
+    value: 267
+  - name: Mul269
+    value: 268
+  - name: Mul270
+    value: 269
+  - name: Mul271
+    value: 270
+  - name: Mul272
+    value: 271
+  - name: Mul273
+    value: 272
+  - name: Mul274
+    value: 273
+  - name: Mul275
+    value: 274
+  - name: Mul276
+    value: 275
+  - name: Mul277
+    value: 276
+  - name: Mul278
+    value: 277
+  - name: Mul279
+    value: 278
+  - name: Mul280
+    value: 279
+  - name: Mul281
+    value: 280
+  - name: Mul282
+    value: 281
+  - name: Mul283
+    value: 282
+  - name: Mul284
+    value: 283
+  - name: Mul285
+    value: 284
+  - name: Mul286
+    value: 285
+  - name: Mul287
+    value: 286
+  - name: Mul288
+    value: 287
+  - name: Mul289
+    value: 288
+  - name: Mul290
+    value: 289
+  - name: Mul291
+    value: 290
+  - name: Mul292
+    value: 291
+  - name: Mul293
+    value: 292
+  - name: Mul294
+    value: 293
+  - name: Mul295
+    value: 294
+  - name: Mul296
+    value: 295
+  - name: Mul297
+    value: 296
+  - name: Mul298
+    value: 297
+  - name: Mul299
+    value: 298
+  - name: Mul300
+    value: 299
+  - name: Mul301
+    value: 300
+  - name: Mul302
+    value: 301
+  - name: Mul303
+    value: 302
+  - name: Mul304
+    value: 303
+  - name: Mul305
+    value: 304
+  - name: Mul306
+    value: 305
+  - name: Mul307
+    value: 306
+  - name: Mul308
+    value: 307
+  - name: Mul309
+    value: 308
+  - name: Mul310
+    value: 309
+  - name: Mul311
+    value: 310
+  - name: Mul312
+    value: 311
+  - name: Mul313
+    value: 312
+  - name: Mul314
+    value: 313
+  - name: Mul315
+    value: 314
+  - name: Mul316
+    value: 315
+  - name: Mul317
+    value: 316
+  - name: Mul318
+    value: 317
+  - name: Mul319
+    value: 318
+  - name: Mul320
+    value: 319
+  - name: Mul321
+    value: 320
+  - name: Mul322
+    value: 321
+  - name: Mul323
+    value: 322
+  - name: Mul324
+    value: 323
+  - name: Mul325
+    value: 324
+  - name: Mul326
+    value: 325
+  - name: Mul327
+    value: 326
+  - name: Mul328
+    value: 327
+  - name: Mul329
+    value: 328
+  - name: Mul330
+    value: 329
+  - name: Mul331
+    value: 330
+  - name: Mul332
+    value: 331
+  - name: Mul333
+    value: 332
+  - name: Mul334
+    value: 333
+  - name: Mul335
+    value: 334
+  - name: Mul336
+    value: 335
+  - name: Mul337
+    value: 336
+  - name: Mul338
+    value: 337
+  - name: Mul339
+    value: 338
+  - name: Mul340
+    value: 339
+  - name: Mul341
+    value: 340
+  - name: Mul342
+    value: 341
+  - name: Mul343
+    value: 342
+  - name: Mul344
+    value: 343
+  - name: Mul345
+    value: 344
+  - name: Mul346
+    value: 345
+  - name: Mul347
+    value: 346
+  - name: Mul348
+    value: 347
+  - name: Mul349
+    value: 348
+  - name: Mul350
+    value: 349
+  - name: Mul351
+    value: 350
+  - name: Mul352
+    value: 351
+  - name: Mul353
+    value: 352
+  - name: Mul354
+    value: 353
+  - name: Mul355
+    value: 354
+  - name: Mul356
+    value: 355
+  - name: Mul357
+    value: 356
+  - name: Mul358
+    value: 357
+  - name: Mul359
+    value: 358
+  - name: Mul360
+    value: 359
+  - name: Mul361
+    value: 360
+  - name: Mul362
+    value: 361
+  - name: Mul363
+    value: 362
+  - name: Mul364
+    value: 363
+  - name: Mul365
+    value: 364
+  - name: Mul366
+    value: 365
+  - name: Mul367
+    value: 366
+  - name: Mul368
+    value: 367
+  - name: Mul369
+    value: 368
+  - name: Mul370
+    value: 369
+  - name: Mul371
+    value: 370
+  - name: Mul372
+    value: 371
+  - name: Mul373
+    value: 372
+  - name: Mul374
+    value: 373
+  - name: Mul375
+    value: 374
+  - name: Mul376
+    value: 375
+  - name: Mul377
+    value: 376
+  - name: Mul378
+    value: 377
+  - name: Mul379
+    value: 378
+  - name: Mul380
+    value: 379
+  - name: Mul381
+    value: 380
+  - name: Mul382
+    value: 381
+  - name: Mul383
+    value: 382
+  - name: Mul384
+    value: 383
+  - name: Mul385
+    value: 384
+  - name: Mul386
+    value: 385
+  - name: Mul387
+    value: 386
+  - name: Mul388
+    value: 387
+  - name: Mul389
+    value: 388
+  - name: Mul390
+    value: 389
+  - name: Mul391
+    value: 390
+  - name: Mul392
+    value: 391
+  - name: Mul393
+    value: 392
+  - name: Mul394
+    value: 393
+  - name: Mul395
+    value: 394
+  - name: Mul396
+    value: 395
+  - name: Mul397
+    value: 396
+  - name: Mul398
+    value: 397
+  - name: Mul399
+    value: 398
+  - name: Mul400
+    value: 399
+  - name: Mul401
+    value: 400
+  - name: Mul402
+    value: 401
+  - name: Mul403
+    value: 402
+  - name: Mul404
+    value: 403
+  - name: Mul405
+    value: 404
+  - name: Mul406
+    value: 405
+  - name: Mul407
+    value: 406
+  - name: Mul408
+    value: 407
+  - name: Mul409
+    value: 408
+  - name: Mul410
+    value: 409
+  - name: Mul411
+    value: 410
+  - name: Mul412
+    value: 411
+  - name: Mul413
+    value: 412
+  - name: Mul414
+    value: 413
+  - name: Mul415
+    value: 414
+  - name: Mul416
+    value: 415
+  - name: Mul417
+    value: 416
+  - name: Mul418
+    value: 417
+  - name: Mul419
+    value: 418
+  - name: Mul420
+    value: 419
+  - name: Mul421
+    value: 420
+  - name: Mul422
+    value: 421
+  - name: Mul423
+    value: 422
+  - name: Mul424
+    value: 423
+  - name: Mul425
+    value: 424
+  - name: Mul426
+    value: 425
+  - name: Mul427
+    value: 426
+  - name: Mul428
+    value: 427
+  - name: Mul429
+    value: 428
+  - name: Mul430
+    value: 429
+  - name: Mul431
+    value: 430
+  - name: Mul432
+    value: 431
+  - name: Mul433
+    value: 432
+  - name: Mul434
+    value: 433
+  - name: Mul435
+    value: 434
+  - name: Mul436
+    value: 435
+  - name: Mul437
+    value: 436
+  - name: Mul438
+    value: 437
+  - name: Mul439
+    value: 438
+  - name: Mul440
+    value: 439
+  - name: Mul441
+    value: 440
+  - name: Mul442
+    value: 441
+  - name: Mul443
+    value: 442
+  - name: Mul444
+    value: 443
+  - name: Mul445
+    value: 444
+  - name: Mul446
+    value: 445
+  - name: Mul447
+    value: 446
+  - name: Mul448
+    value: 447
+  - name: Mul449
+    value: 448
+  - name: Mul450
+    value: 449
+  - name: Mul451
+    value: 450
+  - name: Mul452
+    value: 451
+  - name: Mul453
+    value: 452
+  - name: Mul454
+    value: 453
+  - name: Mul455
+    value: 454
+  - name: Mul456
+    value: 455
+  - name: Mul457
+    value: 456
+  - name: Mul458
+    value: 457
+  - name: Mul459
+    value: 458
+  - name: Mul460
+    value: 459
+  - name: Mul461
+    value: 460
+  - name: Mul462
+    value: 461
+  - name: Mul463
+    value: 462
+  - name: Mul464
+    value: 463
+  - name: Mul465
+    value: 464
+  - name: Mul466
+    value: 465
+  - name: Mul467
+    value: 466
+  - name: Mul468
+    value: 467
+  - name: Mul469
+    value: 468
+  - name: Mul470
+    value: 469
+  - name: Mul471
+    value: 470
+  - name: Mul472
+    value: 471
+  - name: Mul473
+    value: 472
+  - name: Mul474
+    value: 473
+  - name: Mul475
+    value: 474
+  - name: Mul476
+    value: 475
+  - name: Mul477
+    value: 476
+  - name: Mul478
+    value: 477
+  - name: Mul479
+    value: 478
+  - name: Mul480
+    value: 479
+  - name: Mul481
+    value: 480
+  - name: Mul482
+    value: 481
+  - name: Mul483
+    value: 482
+  - name: Mul484
+    value: 483
+  - name: Mul485
+    value: 484
+  - name: Mul486
+    value: 485
+  - name: Mul487
+    value: 486
+  - name: Mul488
+    value: 487
+  - name: Mul489
+    value: 488
+  - name: Mul490
+    value: 489
+  - name: Mul491
+    value: 490
+  - name: Mul492
+    value: 491
+  - name: Mul493
+    value: 492
+  - name: Mul494
+    value: 493
+  - name: Mul495
+    value: 494
+  - name: Mul496
+    value: 495
+  - name: Mul497
+    value: 496
+  - name: Mul498
+    value: 497
+  - name: Mul499
+    value: 498
+  - name: Mul500
+    value: 499
+  - name: Mul501
+    value: 500
+  - name: Mul502
+    value: 501
+  - name: Mul503
+    value: 502
+  - name: Mul504
+    value: 503
+  - name: Mul505
+    value: 504
+  - name: Mul506
+    value: 505
+  - name: Mul507
+    value: 506
+  - name: Mul508
+    value: 507
+  - name: Mul509
+    value: 508
+  - name: Mul510
+    value: 509
+  - name: Mul511
+    value: 510
+  - name: Mul512
+    value: 511
 enum/PLLRCLKPRE:
   bit_size: 1
   variants:

--- a/stm32-metapac-gen/res/Cargo.toml
+++ b/stm32-metapac-gen/res/Cargo.toml
@@ -40,6 +40,7 @@ flavors = [
     { regex_feature = "stm32l5.*", target = "thumbv8m.main-none-eabihf" },
     { regex_feature = "stm32u0.*", target = "thumbv6m-none-eabi" },
     { regex_feature = "stm32u5.*", target = "thumbv8m.main-none-eabihf" },
+    { regex_feature = "stm32wba.*", target = "thumbv8m.main-none-eabihf" },
     { regex_feature = "stm32wb.*", target = "thumbv7em-none-eabi" },
     { regex_feature = "stm32wl.*", target = "thumbv7em-none-eabi" },
 ]


### PR DESCRIPTION
In the process of trying to get the USB_OTG_HS working for a WBA6 device I found that the following fields were missing from the generated metapac.

I pulled the RCC registers off of the WBA*.svd files and performed the recommended transform. The transform needs a bit of work because it takes out stuff like "I2C2SEL" and turns it into "ICSEL". Anyways here's the most relevant changes.
