### PR TITLE
change remaining OCTOSPI instances in rcc_h7rs.yaml to proper XSPI

### DIFF
--- a/data/registers/rcc_h7rs.yaml
+++ b/data/registers/rcc_h7rs.yaml
@@ -816,16 +816,16 @@ fieldset/AHBPERCKSELR:
     bit_offset: 2
     bit_size: 1
     enum: SDMMCSEL
-  - name: OCTOSPI1SEL
+  - name: XSPI1SEL
     description: 'XSPI1 kernel clock source selection Set and reset by software. 1x: pll2_t_ck selected as kernel peripheral clock.'
     bit_offset: 4
     bit_size: 2
-    enum: OCTOSPISEL
-  - name: OCTOSPI2SEL
+    enum: XSPISEL
+  - name: XSPI2SEL
     description: 'XSPI2 kernel clock source selection Set and reset by software. 1x: pll2_t_ck selected as kernel peripheral clock.'
     bit_offset: 6
     bit_size: 2
-    enum: OCTOSPISEL
+    enum: XSPISEL
   - name: USBREFCKSEL
     description: 'USBPHYC kernel clock frequency selection Set and reset by software. This field is used to indicate to the USBPHYC, the frequency of the reference kernel clock provided to the USBPHYC. others: reserved.'
     bit_offset: 8
@@ -1991,7 +1991,7 @@ fieldset/CKPROTR:
   description: RCC clock protection register.
   fields:
   - name: XSPICKP
-    description: 'XSPI clock protection Set and cleared by software. When set to 1, this bit prevents disabling accidentally the XSPIs. The following fields cannot be modified when this bit is set to 1: PLL2ON, PLL2DIVSEN, PLL2DIVTEN, HSEON, HSION, CSION, XSPIxEN, OCTOSPIxLPEN, OCTOSPIxRST.'
+    description: 'XSPI clock protection Set and cleared by software. When set to 1, this bit prevents disabling accidentally the XSPIs. The following fields cannot be modified when this bit is set to 1: PLL2ON, PLL2DIVSEN, PLL2DIVTEN, HSEON, HSION, CSION, XSPIxEN, XSPIxLPEN, XSPIxRST.'
     bit_offset: 0
     bit_size: 1
   - name: FMCCKP
@@ -2673,7 +2673,7 @@ enum/MCOPRE:
   - name: Div15
     description: Divide by 15
     value: 15
-enum/OCTOSPISEL:
+enum/XSPISEL:
   bit_size: 2
   variants:
   - name: HCLK5


### PR DESCRIPTION
* stm32 h7rs series transitioned from OCTOSPI to XSPI
* this fix is required in order to select the xspi rcc mux channel
  * eg, ```config.rcc.mux.xspi2sel = mux::Xspisel::PLL2_S;```