### PR TITLE
Added SAI for WBA on perimap.rs

### DIFF
--- a/data/registers/sai_v4_2pdm.yaml
+++ b/data/registers/sai_v4_2pdm.yaml
@@ -148,6 +148,7 @@ fieldset/CR1:
     description: Oversampling ratio for master clock
     bit_offset: 26
     bit_size: 1
+    enum: OSR
   - name: MCKEN
     description: Master clock generation enable
     bit_offset: 27
@@ -276,6 +277,7 @@ fieldset/PDMCR:
     description: Number of microphones
     bit_offset: 4
     bit_size: 2
+    enum: MICNBR
   - name: CKEN
     description: Clock enable of bitstream clock number 1
     bit_offset: 8
@@ -372,10 +374,10 @@ enum/CNRDY:
   bit_size: 1
   variants:
   - name: Ready
-    description: External AC’97 Codec is ready
+    description: External AC'97 Codec is ready
     value: 0
   - name: NotReady
-    description: External AC’97 Codec is not ready
+    description: External AC'97 Codec is not ready
     value: 1
 enum/COMP:
   bit_size: 2
@@ -393,10 +395,10 @@ enum/CPL:
   bit_size: 1
   variants:
   - name: OnesComplement
-    description: 1’s complement representation
+    description: 1's complement representation
     value: 0
   - name: TwosComplement
-    description: 2’s complement representation
+    description: 2's complement representation
     value: 1
 enum/DS:
   bit_size: 3
@@ -426,16 +428,16 @@ enum/FLVL:
     description: FIFO empty
     value: 0
   - name: Quarter1
-    description: FIFO <= 1⁄4 but not empty
+    description: FIFO <= 1/4 but not empty
     value: 1
   - name: Quarter2
-    description: 1⁄4 < FIFO <= 1⁄2
+    description: 1/4 < FIFO <= 1/2
     value: 2
   - name: Quarter3
-    description: 1⁄2 < FIFO <= 3⁄4
+    description: 1/2 < FIFO <= 3/4
     value: 3
   - name: Quarter4
-    description: 3⁄4 < FIFO but not full
+    description: 3/4 < FIFO but not full
     value: 4
   - name: Full
     description: FIFO full
@@ -465,13 +467,13 @@ enum/FTH:
     description: FIFO empty
     value: 0
   - name: Quarter1
-    description: 1⁄4 FIFO
+    description: 1/4 FIFO
     value: 1
   - name: Quarter2
-    description: 1⁄2 FIFO
+    description: 1/2 FIFO
     value: 2
   - name: Quarter3
-    description: 3⁄4 FIFO
+    description: 3/4 FIFO
     value: 3
   - name: Full
     description: FIFO full
@@ -485,6 +487,21 @@ enum/LSBFIRST:
   - name: LsbFirst
     description: Data are transferred with LSB first
     value: 1
+enum/MICNBR:
+  bit_size: 2
+  variants:
+  - name: 2Mics
+    description: Configuration with 2 microphones
+    value: 0
+  - name: 4Mics
+    description: Configuration with 4 microphones
+    value: 1
+  - name: 6Mics
+    description: Configuration with 6 microphones
+    value: 2
+  - name: 8Mics
+    description: Configuration with 8 microphones
+    value: 3
 enum/MODE:
   bit_size: 2
   variants:
@@ -527,6 +544,15 @@ enum/NODIV:
   - name: NoDiv
     description: MCLK output enable set by the MCKEN bit (where present, else 0). Ratio between FS and MCLK depends on FRL.
     value: 1
+enum/OSR:
+  bit_size: 1
+  variants:
+  - name: LessThan256
+    description: Master clock frequency = Fless thansub FSless than/sub x 256
+    value: 0
+  - name: LessThan512
+    description: Master clock frequency = Fless thansub FSless than/sub x 512
+    value: 1
 enum/OUTDRIV:
   bit_size: 1
   variants:
@@ -546,7 +572,7 @@ enum/PRTCFG:
     description: SPDIF protocol
     value: 1
   - name: Ac97
-    description: AC’97 protocol
+    description: AC'97 protocol
     value: 2
 enum/SLOTEN:
   bit_size: 16

--- a/stm32-data-gen/src/perimap.rs
+++ b/stm32-data-gen/src/perimap.rs
@@ -209,7 +209,7 @@ pub static PERIMAP: RegexMap<(&str, &str, &str)> = RegexMap::new(&[
     (".*:SAI:sai1_v2_0", ("sai", "v1", "SAI")),
     (".*:SAI:sai1_H7", ("sai", "v3_4pdm", "SAI")),
     (".*:SAI:sai1_v2_1", ("sai", "v4_4pdm", "SAI")),
-    (r"STM32[HU]5.*:SAI\d?:.*", ("sai", "v4_2pdm", "SAI")),
+    (r"STM32([HU]5|WBA).*:SAI\d?:.*", ("sai", "v4_2pdm", "SAI")),
     (r"STM32L5.*:SAI\d?:.*", ("sai", "v3_2pdm", "SAI")),
     (".*:SDIO:sdmmc_v1_2", ("sdmmc", "v1", "SDMMC")),
     (".*:SDMMC:sdmmc_v1_3", ("sdmmc", "v1", "SDMMC")),


### PR DESCRIPTION
Added SAI for WBA series of devices. There were some miscellaneous nonstandard unicode characters. I've replaced those. I've also added enums for non-trivial fields (number of mics, oversampling ratio)