### PR TITLE
Correct hash v3 and v4 algo field

### DIFF
--- a/data/registers/hash_v3.yaml
+++ b/data/registers/hash_v3.yaml
@@ -79,7 +79,7 @@ fieldset/CR:
   - name: ALGO
     description: Algorithm selection.
     bit_offset: 17
-    bit_size: 2
+    bit_size: 4
 fieldset/IMR:
   description: interrupt enable register.
   fields:

--- a/data/registers/hash_v4.yaml
+++ b/data/registers/hash_v4.yaml
@@ -78,7 +78,7 @@ fieldset/CR:
   - name: ALGO
     description: Algorithm selection.
     bit_offset: 17
-    bit_size: 2
+    bit_size: 4
 fieldset/IMR:
   description: interrupt enable register.
   fields:


### PR DESCRIPTION
Should be 4 bits not 2. This is required for sha384 and sha512.