### PR TITLE
Add ASCR register to gpio_v2 for stm32l47x/stm32l48x

### DIFF
--- a/data/registers/gpio_v2.yaml
+++ b/data/registers/gpio_v2.yaml
@@ -42,6 +42,10 @@ block/GPIO:
       stride: 4
     byte_offset: 32
     fieldset: AFR
+  - name: ASCR
+    description: GPIO port analog switch control register
+    byte_offset: 44
+    fieldset: ASCR
 fieldset/AFR:
   description: GPIO alternate function register. This contains an array of 8 fields, which correspond to pins 0-7 of the port (for AFRL) or pins 8-15 of the port (for AFRH).
   fields:
@@ -52,6 +56,16 @@ fieldset/AFR:
     array:
       len: 8
       stride: 4
+fieldset/ASCR:
+  description: GPIO port analog switch control register
+  fields:
+  - name: ASC
+    description: Port x analog switch control I/O pin y (y= 0..15)
+    bit_offset: 0
+    bit_size: 1
+    array:
+      len: 16
+      stride: 1
 fieldset/BSRR:
   description: GPIO port bit set/reset register
   fields:


### PR DESCRIPTION
Per the STM32L476 TRM:

> On STM32L47x/L48x devices, before any conversion of an input channel coming from GPIO pads, it is necessary to configure the corresponding GPIOx_ASCR register in the GPIO, in addition to the I/O configuration in analog mode.