### PR TITLE
stm32l4: enable comparator support

### DIFF
--- a/stm32-data-gen/src/perimap.rs
+++ b/stm32-data-gen/src/perimap.rs
@@ -599,6 +599,7 @@ pub static PERIMAP: RegexMap<(&str, &str, &str)> = RegexMap::new(&[
     ("STM32G4.*:.*:COMP:.*", ("comp", "v2", "COMP")),
     ("STM32U0.*:.*:COMP:.*", ("comp", "u0", "COMP")),
     ("STM32WL.*:.*:COMP:.*", ("comp", "v3", "COMP")),
+    ("STM32L4.*:.*:COMP:.*", ("comp", "v3", "COMP")),
     ("STM32H7[4523].*:COMP:.*", ("comp", "h7_b", "COMP")),
     ("STM32H7[AB].*:COMP:.*", ("comp", "h7_a", "COMP")),
     ("STM32H5.*:COMP:.*", ("comp", "h5", "COMP")),


### PR DESCRIPTION
The bits for `COMP1` exactly match those in the existing definition of `comp_v3`. `COMP2` has an extra bit `WINMODE`, used to connect the positive inputs of both comparators. This is not described at the moment. I was not sure how this should be described, and don't need it at the moment.

The used register definition is lacking the description for the `INxSEL` and `INMESEL` registers. These also have variations between the different comparator units, as they select the GPIO pins used. There also appears to be an error in the reference manual ([RM0394](https://www.st.com/resource/en/reference_manual/rm0394-stm32l41xxx42xxx43xxx44xxx45xxx46xxx-advanced-armbased-32bit-mcus-stmicroelectronics.pdf) on page 538,  as for `COMP1` the description of `INMSEL` states that `0b110` uses `INMESEL` for selection, whereas the description in the `INMESEL` register states that `0b111` should be used. The later would be in line with `COMP2`. I currently don't have an easy way to check which one is correct. It also doesn't affect this change, as the enums are not described.