### PR TITLE
Update I2S registers in spi_v2 to be consistent with spi_v3

### DIFF
--- a/data/registers/spi_v2.yaml
+++ b/data/registers/spi_v2.yaml
@@ -197,7 +197,7 @@ fieldset/I2SCFGR:
     description: I2S standard selection
     bit_offset: 4
     bit_size: 2
-    enum: ISSTD
+    enum: I2SSTD
   - name: PCMSYNC
     description: PCM frame synchronization
     bit_offset: 7
@@ -207,7 +207,7 @@ fieldset/I2SCFGR:
     description: I2S configuration mode
     bit_offset: 8
     bit_size: 2
-    enum: ISCFG
+    enum: I2SCFG
   - name: I2SE
     description: I2S Enabled
     bit_offset: 10
@@ -216,7 +216,6 @@ fieldset/I2SCFGR:
     description: I2S mode selection
     bit_offset: 11
     bit_size: 1
-    enum: ISMOD
   - name: ASTRTEN
     description: Asynchronous start enable
     bit_offset: 12
@@ -511,7 +510,7 @@ enum/FTLVL:
   - name: Full
     description: Tx FIFO full
     value: 3
-enum/ISCFG:
+enum/I2SCFG:
   bit_size: 2
   variants:
   - name: SlaveTx
@@ -526,16 +525,7 @@ enum/ISCFG:
   - name: MasterRx
     description: Master - receive
     value: 3
-enum/ISMOD:
-  bit_size: 1
-  variants:
-  - name: SPIMode
-    description: SPI mode is selected
-    value: 0
-  - name: I2SMode
-    description: I2S mode is selected
-    value: 1
-enum/ISSTD:
+enum/I2SSTD:
   bit_size: 2
   variants:
   - name: Philips


### PR DESCRIPTION
[Problem]
spi_v2 hardware supports I2S, but it has not been enabled in the embassy HAL. Some of the fields in the I2SCFGR register for spi_v2 seem to be incorrect compared to spi_v3

[Solution]
- Make the enum for the `I2SCFG`, `I2SSTD` fields match the field name - they were missing the '2'
- Remove the enum for `I2SMOD`. It is not present in spi_v3 and falls under the category of "useless enums"