### PR TITLE
stm32u0: Add UEDE field to LPTIMx_DIER register

### DIFF
--- a/data/registers/lptim_v2b.yaml
+++ b/data/registers/lptim_v2b.yaml
@@ -291,6 +291,10 @@ fieldset/DIER:
       - 9
       - 10
       - 11
+  - name: UEDE
+    description: 'Update event DMA request enable. Note: If LPTIM does not implement at least 1 channel this bit is reserved.'
+    bit_offset: 23
+    bit_size: 1
 fieldset/ICR:
   description: LPTIM interrupt clear register.
   fields:


### PR DESCRIPTION
Added the UEDE ("Update event DMA request enable") single bit field to lptim_v2b.yaml, valid for all STM32U0 parts.

See reference manual RM0503 (rev. 4) section 27.7.5.