### PR TITLE
Regenerate adc_g0 from g030

### DIFF
--- a/data/registers/adc_g0.yaml
+++ b/data/registers/adc_g0.yaml
@@ -1,668 +1,2289 @@
 block/ADC:
-  description: Analog to Digital Converter
+  description: Analog to Digital Converter instance 1.
   items:
   - name: ISR
-    description: ADC interrupt and status register
+    description: ADC interrupt and status register.
     byte_offset: 0
     fieldset: ISR
   - name: IER
-    description: ADC interrupt enable register
+    description: ADC interrupt enable register.
     byte_offset: 4
     fieldset: IER
   - name: CR
-    description: ADC control register
+    description: ADC control register.
     byte_offset: 8
     fieldset: CR
   - name: CFGR1
-    description: ADC configuration register 1
+    description: ADC configuration register 1.
     byte_offset: 12
     fieldset: CFGR1
   - name: CFGR2
-    description: ADC configuration register 2
+    description: ADC configuration register 2.
     byte_offset: 16
     fieldset: CFGR2
   - name: SMPR
-    description: ADC sampling time register
+    description: ADC sampling time register.
     byte_offset: 20
     fieldset: SMPR
   - name: AWD1TR
-    description: watchdog threshold register
+    description: watchdog threshold register.
     byte_offset: 32
     fieldset: AWD1TR
   - name: AWD2TR
-    description: watchdog threshold register
+    description: watchdog threshold register.
     byte_offset: 36
     fieldset: AWD2TR
-  - name: CHSELR
-    description: channel selection register
+  - name: CHSELR0
+    description: channel selection register.
     byte_offset: 40
-    fieldset: CHSELR
-  - name: CHSELR_1
-    description: channel selection register CHSELRMOD = 1 in ADC_CFGR1
+    fieldset: CHSELR0
+  - name: CHSELR1
+    description: channel selection register CHSELRMOD = 1 in ADC_CFGR1.
     byte_offset: 40
-    fieldset: CHSELR_1
+    fieldset: CHSELR1
   - name: AWD3TR
-    description: watchdog threshold register
+    description: watchdog threshold register.
     byte_offset: 44
     fieldset: AWD3TR
   - name: DR
-    description: ADC group regular conversion data register
+    description: ADC group regular conversion data register.
     byte_offset: 64
     access: Read
     fieldset: DR
   - name: AWD2CR
-    description: ADC analog watchdog 2 configuration register
+    description: ADC analog watchdog 2 configuration register.
     byte_offset: 160
     fieldset: AWD2CR
   - name: AWD3CR
-    description: ADC analog watchdog 3 configuration register
+    description: ADC analog watchdog 3 configuration register.
     byte_offset: 164
     fieldset: AWD3CR
   - name: CALFACT
-    description: ADC calibration factors register
+    description: ADC calibration factors register.
     byte_offset: 180
     fieldset: CALFACT
   - name: CCR
-    description: ADC common control register
+    description: ADC common control register.
     byte_offset: 776
     fieldset: CCR
-  - name: HWCFGR6
-    description: Hardware Configuration Register
-    byte_offset: 984
-    fieldset: HWCFGR6
-  - name: HWCFGR5
-    description: Hardware Configuration Register
-    byte_offset: 988
-    fieldset: HWCFGR5
-  - name: HWCFGR4
-    description: Hardware Configuration Register
-    byte_offset: 992
-    fieldset: HWCFGR4
-  - name: HWCFGR3
-    description: Hardware Configuration Register
-    byte_offset: 996
-    fieldset: HWCFGR3
-  - name: HWCFGR2
-    description: Hardware Configuration Register
-    byte_offset: 1000
-    fieldset: HWCFGR2
-  - name: HWCFGR1
-    description: Hardware Configuration Register
-    byte_offset: 1004
-    fieldset: HWCFGR1
-  - name: HWCFGR0
-    description: Hardware Configuration Register
-    byte_offset: 1008
-    access: Read
-    fieldset: HWCFGR0
-  - name: VERR
-    description: EXTI IP Version register
-    byte_offset: 1012
-    access: Read
-    fieldset: VERR
-  - name: IPIDR
-    description: EXTI Identification register
-    byte_offset: 1016
-    access: Read
-    fieldset: IPIDR
-  - name: SIDR
-    description: EXTI Size ID register
-    byte_offset: 1020
-    access: Read
-    fieldset: SIDR
 fieldset/AWD1TR:
-  description: watchdog threshold register
+  description: watchdog threshold register.
   fields:
   - name: LT1
-    description: ADC analog watchdog 1 threshold low
+    description: ADC analog watchdog 1 threshold low.
     bit_offset: 0
     bit_size: 12
   - name: HT1
-    description: ADC analog watchdog 1 threshold high
+    description: ADC analog watchdog 1 threshold high.
     bit_offset: 16
     bit_size: 12
 fieldset/AWD2CR:
-  description: ADC analog watchdog 2 configuration register
+  description: ADC analog watchdog 2 configuration register.
   fields:
-  - name: AWD2CH
-    description: ADC analog watchdog 2 monitored channel selection
+  - name: AWD2CH0
+    description: ADC analog watchdog 2 monitored channel selection.
     bit_offset: 0
-    bit_size: 19
+    bit_size: 1
+    enum: AWD2CH0
+  - name: AWD2CH1
+    description: ADC analog watchdog 2 monitored channel selection.
+    bit_offset: 1
+    bit_size: 1
+    enum: AWD2CH1
+  - name: AWD2CH2
+    description: ADC analog watchdog 2 monitored channel selection.
+    bit_offset: 2
+    bit_size: 1
+    enum: AWD2CH2
+  - name: AWD2CH3
+    description: ADC analog watchdog 2 monitored channel selection.
+    bit_offset: 3
+    bit_size: 1
+    enum: AWD2CH3
+  - name: AWD2CH4
+    description: ADC analog watchdog 2 monitored channel selection.
+    bit_offset: 4
+    bit_size: 1
+    enum: AWD2CH4
+  - name: AWD2CH5
+    description: ADC analog watchdog 2 monitored channel selection.
+    bit_offset: 5
+    bit_size: 1
+    enum: AWD2CH5
+  - name: AWD2CH6
+    description: ADC analog watchdog 2 monitored channel selection.
+    bit_offset: 6
+    bit_size: 1
+    enum: AWD2CH6
+  - name: AWD2CH7
+    description: ADC analog watchdog 2 monitored channel selection.
+    bit_offset: 7
+    bit_size: 1
+    enum: AWD2CH7
+  - name: AWD2CH8
+    description: ADC analog watchdog 2 monitored channel selection.
+    bit_offset: 8
+    bit_size: 1
+    enum: AWD2CH8
+  - name: AWD2CH9
+    description: ADC analog watchdog 2 monitored channel selection.
+    bit_offset: 9
+    bit_size: 1
+    enum: AWD2CH9
+  - name: AWD2CH10
+    description: ADC analog watchdog 2 monitored channel selection.
+    bit_offset: 10
+    bit_size: 1
+    enum: AWD2CH10
+  - name: AWD2CH11
+    description: ADC analog watchdog 2 monitored channel selection.
+    bit_offset: 11
+    bit_size: 1
+    enum: AWD2CH11
+  - name: AWD2CH12
+    description: ADC analog watchdog 2 monitored channel selection.
+    bit_offset: 12
+    bit_size: 1
+    enum: AWD2CH12
+  - name: AWD2CH13
+    description: ADC analog watchdog 2 monitored channel selection.
+    bit_offset: 13
+    bit_size: 1
+    enum: AWD2CH13
+  - name: AWD2CH14
+    description: ADC analog watchdog 2 monitored channel selection.
+    bit_offset: 14
+    bit_size: 1
+    enum: AWD2CH14
+  - name: AWD2CH15
+    description: ADC analog watchdog 2 monitored channel selection.
+    bit_offset: 15
+    bit_size: 1
+    enum: AWD2CH15
+  - name: AWD2CH16
+    description: ADC analog watchdog 2 monitored channel selection.
+    bit_offset: 16
+    bit_size: 1
+    enum: AWD2CH16
+  - name: AWD2CH17
+    description: ADC analog watchdog 2 monitored channel selection.
+    bit_offset: 17
+    bit_size: 1
+    enum: AWD2CH17
+  - name: AWD2CH18
+    description: ADC analog watchdog 2 monitored channel selection.
+    bit_offset: 18
+    bit_size: 1
+    enum: AWD2CH18
 fieldset/AWD2TR:
-  description: watchdog threshold register
+  description: watchdog threshold register.
   fields:
   - name: LT2
-    description: ADC analog watchdog 2 threshold low
+    description: ADC analog watchdog 2 threshold low.
     bit_offset: 0
     bit_size: 12
   - name: HT2
-    description: ADC analog watchdog 2 threshold high
+    description: ADC analog watchdog 2 threshold high.
     bit_offset: 16
     bit_size: 12
 fieldset/AWD3CR:
-  description: ADC analog watchdog 3 configuration register
+  description: ADC analog watchdog 3 configuration register.
   fields:
-  - name: AWD3CH
-    description: ADC analog watchdog 3 monitored channel selection
+  - name: AWD3CH0
+    description: ADC analog watchdog 3 monitored channel selection.
     bit_offset: 0
-    bit_size: 19
+    bit_size: 1
+    enum: AWD3CH0
+  - name: AWD3CH1
+    description: ADC analog watchdog 3 monitored channel selection.
+    bit_offset: 1
+    bit_size: 1
+    enum: AWD3CH1
+  - name: AWD3CH2
+    description: ADC analog watchdog 3 monitored channel selection.
+    bit_offset: 2
+    bit_size: 1
+    enum: AWD3CH2
+  - name: AWD3CH3
+    description: ADC analog watchdog 3 monitored channel selection.
+    bit_offset: 3
+    bit_size: 1
+    enum: AWD3CH3
+  - name: AWD3CH4
+    description: ADC analog watchdog 3 monitored channel selection.
+    bit_offset: 4
+    bit_size: 1
+    enum: AWD3CH4
+  - name: AWD3CH5
+    description: ADC analog watchdog 3 monitored channel selection.
+    bit_offset: 5
+    bit_size: 1
+    enum: AWD3CH5
+  - name: AWD3CH6
+    description: ADC analog watchdog 3 monitored channel selection.
+    bit_offset: 6
+    bit_size: 1
+    enum: AWD3CH6
+  - name: AWD3CH7
+    description: ADC analog watchdog 3 monitored channel selection.
+    bit_offset: 7
+    bit_size: 1
+    enum: AWD3CH7
+  - name: AWD3CH8
+    description: ADC analog watchdog 3 monitored channel selection.
+    bit_offset: 8
+    bit_size: 1
+    enum: AWD3CH8
+  - name: AWD3CH9
+    description: ADC analog watchdog 3 monitored channel selection.
+    bit_offset: 9
+    bit_size: 1
+    enum: AWD3CH9
+  - name: AWD3CH10
+    description: ADC analog watchdog 3 monitored channel selection.
+    bit_offset: 10
+    bit_size: 1
+    enum: AWD3CH10
+  - name: AWD3CH11
+    description: ADC analog watchdog 3 monitored channel selection.
+    bit_offset: 11
+    bit_size: 1
+    enum: AWD3CH11
+  - name: AWD3CH12
+    description: ADC analog watchdog 3 monitored channel selection.
+    bit_offset: 12
+    bit_size: 1
+    enum: AWD3CH12
+  - name: AWD3CH13
+    description: ADC analog watchdog 3 monitored channel selection.
+    bit_offset: 13
+    bit_size: 1
+    enum: AWD3CH13
+  - name: AWD3CH14
+    description: ADC analog watchdog 3 monitored channel selection.
+    bit_offset: 14
+    bit_size: 1
+    enum: AWD3CH14
+  - name: AWD3CH15
+    description: ADC analog watchdog 3 monitored channel selection.
+    bit_offset: 15
+    bit_size: 1
+    enum: AWD3CH15
+  - name: AWD3CH16
+    description: ADC analog watchdog 3 monitored channel selection.
+    bit_offset: 16
+    bit_size: 1
+    enum: AWD3CH16
+  - name: AWD3CH17
+    description: ADC analog watchdog 3 monitored channel selection.
+    bit_offset: 17
+    bit_size: 1
+    enum: AWD3CH17
+  - name: AWD3CH18
+    description: ADC analog watchdog 3 monitored channel selection.
+    bit_offset: 18
+    bit_size: 1
+    enum: AWD3CH18
 fieldset/AWD3TR:
-  description: watchdog threshold register
+  description: watchdog threshold register.
   fields:
   - name: LT3
-    description: ADC analog watchdog 3 threshold high
+    description: ADC analog watchdog 3 threshold high.
     bit_offset: 0
     bit_size: 12
   - name: HT3
-    description: ADC analog watchdog 3 threshold high
+    description: ADC analog watchdog 3 threshold high.
     bit_offset: 16
     bit_size: 12
 fieldset/CALFACT:
-  description: ADC calibration factors register
+  description: ADC calibration factors register.
   fields:
   - name: CALFACT
-    description: ADC calibration factor in single-ended mode
+    description: ADC calibration factor in single-ended mode.
     bit_offset: 0
     bit_size: 7
 fieldset/CCR:
-  description: ADC common control register
+  description: ADC common control register.
   fields:
   - name: PRESC
-    description: ADC prescaler
+    description: ADC prescaler.
     bit_offset: 18
     bit_size: 4
+    enum: PRESC
   - name: VREFEN
-    description: VREFINT enable
+    description: VREFINT enable.
     bit_offset: 22
     bit_size: 1
+    enum: VREFEN
   - name: TSEN
-    description: Temperature sensor enable
+    description: Temperature sensor enable.
     bit_offset: 23
     bit_size: 1
+    enum: TSEN
   - name: VBATEN
-    description: VBAT enable
+    description: VBAT enable.
     bit_offset: 24
     bit_size: 1
+    enum: VBATEN
 fieldset/CFGR1:
-  description: ADC configuration register 1
+  description: ADC configuration register 1.
   fields:
   - name: DMAEN
-    description: ADC DMA transfer enable
+    description: ADC DMA transfer enable.
     bit_offset: 0
     bit_size: 1
+    enum: DMAEN
   - name: DMACFG
-    description: Direct memory access configuration
+    description: ADC DMA transfer configuration.
     bit_offset: 1
     bit_size: 1
     enum: DMACFG
   - name: SCANDIR
-    description: Scan sequence direction
+    description: Scan sequence direction.
     bit_offset: 2
     bit_size: 1
+    enum: SCANDIR
   - name: RES
-    description: ADC data resolution
+    description: ADC data resolution.
     bit_offset: 3
     bit_size: 2
     enum: RES
   - name: ALIGN
-    description: ADC data alignement
+    description: ADC data alignement.
     bit_offset: 5
     bit_size: 1
+    enum: ALIGN
   - name: EXTSEL
-    description: ADC group regular external trigger source
+    description: ADC group regular external trigger source.
     bit_offset: 6
     bit_size: 3
+    enum: EXTSEL
   - name: EXTEN
-    description: ADC group regular external trigger polarity
+    description: ADC group regular external trigger polarity.
     bit_offset: 10
     bit_size: 2
+    enum: EXTEN
   - name: OVRMOD
-    description: ADC group regular overrun configuration
+    description: ADC group regular overrun configuration.
     bit_offset: 12
     bit_size: 1
+    enum: OVRMOD
   - name: CONT
-    description: Continuous conversion
+    description: ADC group regular continuous conversion mode.
     bit_offset: 13
     bit_size: 1
+    enum: CONT
   - name: WAIT
-    description: Wait conversion mode
+    description: Wait conversion mode.
     bit_offset: 14
     bit_size: 1
+    enum: WAIT
   - name: AUTOFF
-    description: Auto-off mode
+    description: Auto-off mode.
     bit_offset: 15
     bit_size: 1
+    enum: AUTOFF
   - name: DISCEN
-    description: ADC group regular sequencer discontinuous mode
+    description: ADC group regular sequencer discontinuous mode.
     bit_offset: 16
     bit_size: 1
+    enum: DISCEN
   - name: CHSELRMOD
-    description: Mode selection of the ADC_CHSELR register
+    description: Mode selection of the ADC_CHSELR register.
     bit_offset: 21
     bit_size: 1
+    enum: CHSELRMOD
   - name: AWD1SGL
-    description: ADC analog watchdog 1 monitoring a single channel or all channels
+    description: ADC analog watchdog 1 monitoring a single channel or all channels.
     bit_offset: 22
     bit_size: 1
+    enum: AWD1SGL
   - name: AWD1EN
-    description: ADC analog watchdog 1 enable on scope ADC group regular
+    description: ADC analog watchdog 1 enable on scope ADC group regular.
     bit_offset: 23
     bit_size: 1
-  - name: AWDCH1CH
-    description: ADC analog watchdog 1 monitored channel selection
+    enum: AWD1EN
+  - name: AWD1CH
+    description: ADC analog watchdog 1 monitored channel selection.
     bit_offset: 26
     bit_size: 5
 fieldset/CFGR2:
-  description: ADC configuration register 2
+  description: ADC configuration register 2.
   fields:
   - name: OVSE
-    description: ADC oversampler enable on scope ADC group regular
+    description: ADC oversampler enable on scope ADC group regular.
     bit_offset: 0
     bit_size: 1
+    enum: OVSE
   - name: OVSR
-    description: ADC oversampling ratio
+    description: ADC oversampling ratio.
     bit_offset: 2
     bit_size: 3
+    enum: OVSR
   - name: OVSS
-    description: ADC oversampling shift
+    description: ADC oversampling shift.
     bit_offset: 5
     bit_size: 4
+    enum: OVSS
   - name: TOVS
-    description: ADC oversampling discontinuous mode (triggered mode) for ADC group regular
+    description: ADC oversampling discontinuous mode (triggered mode) for ADC group regular.
     bit_offset: 9
     bit_size: 1
+    enum: TOVS
   - name: LFTRIG
-    description: Low frequency trigger mode enable
+    description: Low frequency trigger mode enable.
     bit_offset: 29
     bit_size: 1
+    enum: LFTRIG
   - name: CKMODE
-    description: ADC clock mode
+    description: ADC clock mode.
     bit_offset: 30
     bit_size: 2
-fieldset/CHSELR:
-  description: channel selection register
+    enum: CKMODE
+fieldset/CHSELR0:
+  description: channel selection register.
   fields:
   - name: CHSEL
-    description: Channel-x selection
+    description: Channel-x selection.
     bit_offset: 0
     bit_size: 19
-fieldset/CHSELR_1:
-  description: channel selection register CHSELRMOD = 1 in ADC_CFGR1
+    enum: CHSEL
+fieldset/CHSELR1:
+  description: channel selection register CHSELRMOD = 1 in ADC_CFGR1.
   fields:
   - name: SQ1
-    description: conversion of the sequence
+    description: conversion of the sequence.
     bit_offset: 0
     bit_size: 4
+    enum: SQ1
   - name: SQ2
-    description: conversion of the sequence
+    description: conversion of the sequence.
     bit_offset: 4
     bit_size: 4
+    enum: SQ2
   - name: SQ3
-    description: conversion of the sequence
+    description: conversion of the sequence.
     bit_offset: 8
     bit_size: 4
+    enum: SQ3
   - name: SQ4
-    description: conversion of the sequence
+    description: conversion of the sequence.
     bit_offset: 12
     bit_size: 4
+    enum: SQ4
   - name: SQ5
-    description: conversion of the sequence
+    description: conversion of the sequence.
     bit_offset: 16
     bit_size: 4
+    enum: SQ5
   - name: SQ6
-    description: conversion of the sequence
+    description: conversion of the sequence.
     bit_offset: 20
     bit_size: 4
+    enum: SQ6
   - name: SQ7
-    description: conversion of the sequence
+    description: conversion of the sequence.
     bit_offset: 24
     bit_size: 4
+    enum: SQ7
   - name: SQ8
-    description: conversion of the sequence
+    description: conversion of the sequence.
     bit_offset: 28
     bit_size: 4
+    enum: SQ8
 fieldset/CR:
-  description: ADC control register
+  description: ADC control register.
   fields:
   - name: ADEN
-    description: ADC enable
+    description: ADC enable.
     bit_offset: 0
     bit_size: 1
+    enum: ADEN
   - name: ADDIS
-    description: ADC disable
+    description: ADC disable.
     bit_offset: 1
     bit_size: 1
+    enum: ADDIS
   - name: ADSTART
-    description: ADC group regular conversion start
+    description: ADC group regular conversion start.
     bit_offset: 2
     bit_size: 1
+    enum: ADSTART
   - name: ADSTP
-    description: ADC group regular conversion stop
+    description: ADC group regular conversion stop.
     bit_offset: 4
     bit_size: 1
+    enum: ADSTP
   - name: ADVREGEN
-    description: ADC voltage regulator enable
+    description: ADC voltage regulator enable.
     bit_offset: 28
     bit_size: 1
+    enum: ADVREGEN
   - name: ADCAL
-    description: ADC calibration
+    description: ADC calibration.
     bit_offset: 31
     bit_size: 1
+    enum: ADCAL
 fieldset/DR:
-  description: ADC group regular conversion data register
+  description: ADC group regular conversion data register.
   fields:
-  - name: regularDATA
-    description: ADC group regular conversion data
+  - name: DATA
+    description: ADC group regular conversion data.
     bit_offset: 0
     bit_size: 16
-fieldset/HWCFGR0:
-  description: Hardware Configuration Register
-  fields:
-  - name: NUM_CHAN_24
-    description: NUM_CHAN_24
-    bit_offset: 0
-    bit_size: 4
-  - name: EXTRA_AWDS
-    description: Extra analog watchdog
-    bit_offset: 4
-    bit_size: 4
-  - name: OVS
-    description: Oversampling
-    bit_offset: 8
-    bit_size: 4
-fieldset/HWCFGR1:
-  description: Hardware Configuration Register
-  fields:
-  - name: CHMAP3
-    description: Input channel mapping
-    bit_offset: 0
-    bit_size: 5
-  - name: CHMAP2
-    description: Input channel mapping
-    bit_offset: 8
-    bit_size: 5
-  - name: CHMAP1
-    description: Input channel mapping
-    bit_offset: 16
-    bit_size: 5
-  - name: CHMAP0
-    description: Input channel mapping
-    bit_offset: 24
-    bit_size: 5
-fieldset/HWCFGR2:
-  description: Hardware Configuration Register
-  fields:
-  - name: CHMAP7
-    description: Input channel mapping
-    bit_offset: 0
-    bit_size: 5
-  - name: CHMAP6
-    description: Input channel mapping
-    bit_offset: 8
-    bit_size: 5
-  - name: CHMAP5
-    description: Input channel mapping
-    bit_offset: 16
-    bit_size: 5
-  - name: CHMAP4
-    description: Input channel mapping
-    bit_offset: 24
-    bit_size: 5
-fieldset/HWCFGR3:
-  description: Hardware Configuration Register
-  fields:
-  - name: CHMAP11
-    description: Input channel mapping
-    bit_offset: 0
-    bit_size: 5
-  - name: CHMAP10
-    description: Input channel mapping
-    bit_offset: 8
-    bit_size: 5
-  - name: CHMAP9
-    description: Input channel mapping
-    bit_offset: 16
-    bit_size: 5
-  - name: CHMAP8
-    description: Input channel mapping
-    bit_offset: 24
-    bit_size: 5
-fieldset/HWCFGR4:
-  description: Hardware Configuration Register
-  fields:
-  - name: CHMAP15
-    description: Input channel mapping
-    bit_offset: 0
-    bit_size: 5
-  - name: CHMAP14
-    description: Input channel mapping
-    bit_offset: 8
-    bit_size: 5
-  - name: CHMAP13
-    description: Input channel mapping
-    bit_offset: 16
-    bit_size: 5
-  - name: CHMAP12
-    description: Input channel mapping
-    bit_offset: 24
-    bit_size: 5
-fieldset/HWCFGR5:
-  description: Hardware Configuration Register
-  fields:
-  - name: CHMAP19
-    description: Input channel mapping
-    bit_offset: 0
-    bit_size: 5
-  - name: CHMAP18
-    description: Input channel mapping
-    bit_offset: 8
-    bit_size: 5
-  - name: CHMAP17
-    description: Input channel mapping
-    bit_offset: 16
-    bit_size: 5
-  - name: CHMAP16
-    description: Input channel mapping
-    bit_offset: 24
-    bit_size: 5
-fieldset/HWCFGR6:
-  description: Hardware Configuration Register
-  fields:
-  - name: CHMAP20
-    description: Input channel mapping
-    bit_offset: 0
-    bit_size: 5
-  - name: CHMAP21
-    description: Input channel mapping
-    bit_offset: 8
-    bit_size: 5
-  - name: CHMAP22
-    description: Input channel mapping
-    bit_offset: 16
-    bit_size: 5
-  - name: CHMAP23
-    description: Input channel mapping
-    bit_offset: 24
-    bit_size: 5
 fieldset/IER:
-  description: ADC interrupt enable register
+  description: ADC interrupt enable register.
   fields:
   - name: ADRDYIE
-    description: ADC ready interrupt
+    description: ADC ready interrupt.
     bit_offset: 0
     bit_size: 1
+    enum: ADRDYIE
   - name: EOSMPIE
-    description: ADC group regular end of sampling interrupt
+    description: ADC group regular end of sampling interrupt.
     bit_offset: 1
     bit_size: 1
+    enum: EOSMPIE
   - name: EOCIE
-    description: ADC group regular end of unitary conversion interrupt
+    description: ADC group regular end of unitary conversion interrupt.
     bit_offset: 2
     bit_size: 1
+    enum: EOCIE
   - name: EOSIE
-    description: ADC group regular end of sequence conversions interrupt
+    description: ADC group regular end of sequence conversions interrupt.
     bit_offset: 3
     bit_size: 1
+    enum: EOSIE
   - name: OVRIE
-    description: ADC group regular overrun interrupt
+    description: ADC group regular overrun interrupt.
     bit_offset: 4
     bit_size: 1
+    enum: OVRIE
   - name: AWD1IE
-    description: ADC analog watchdog 1 interrupt
+    description: ADC analog watchdog 1 interrupt.
     bit_offset: 7
     bit_size: 1
+    enum: AWD1IE
   - name: AWD2IE
-    description: ADC analog watchdog 2 interrupt
+    description: ADC analog watchdog 2 interrupt.
     bit_offset: 8
     bit_size: 1
+    enum: AWD2IE
   - name: AWD3IE
-    description: ADC analog watchdog 3 interrupt
+    description: ADC analog watchdog 3 interrupt.
     bit_offset: 9
     bit_size: 1
+    enum: AWD3IE
   - name: EOCALIE
-    description: End of calibration interrupt enable
+    description: End of calibration interrupt enable.
     bit_offset: 11
     bit_size: 1
+    enum: EOCALIE
   - name: CCRDYIE
-    description: Channel Configuration Ready Interrupt enable
+    description: Channel Configuration Ready Interrupt enable.
     bit_offset: 13
     bit_size: 1
-fieldset/IPIDR:
-  description: EXTI Identification register
-  fields:
-  - name: IPID
-    description: IP Identification
-    bit_offset: 0
-    bit_size: 32
+    enum: CCRDYIE
 fieldset/ISR:
-  description: ADC interrupt and status register
+  description: ADC interrupt and status register.
   fields:
   - name: ADRDY
-    description: ADC ready flag
+    description: ADC ready flag.
     bit_offset: 0
     bit_size: 1
+    enum: ADRDY
   - name: EOSMP
-    description: ADC group regular end of sampling flag
+    description: ADC group regular end of sampling flag.
     bit_offset: 1
     bit_size: 1
+    enum: EOSMP
   - name: EOC
-    description: ADC group regular end of unitary conversion flag
+    description: ADC group regular end of unitary conversion flag.
     bit_offset: 2
     bit_size: 1
+    enum: EOC
   - name: EOS
-    description: ADC group regular end of sequence conversions flag
+    description: ADC group regular end of sequence conversions flag.
     bit_offset: 3
     bit_size: 1
+    enum: EOS
   - name: OVR
-    description: ADC group regular overrun flag
+    description: ADC group regular overrun flag.
     bit_offset: 4
     bit_size: 1
+    enum: OVR
   - name: AWD1
-    description: ADC analog watchdog 1 flag
+    description: ADC analog watchdog 1 flag.
     bit_offset: 7
     bit_size: 1
+    enum: AWD1
   - name: AWD2
-    description: ADC analog watchdog 2 flag
+    description: ADC analog watchdog 2 flag.
     bit_offset: 8
     bit_size: 1
+    enum: AWD2
   - name: AWD3
-    description: ADC analog watchdog 3 flag
+    description: ADC analog watchdog 3 flag.
     bit_offset: 9
     bit_size: 1
+    enum: AWD3
   - name: EOCAL
-    description: End Of Calibration flag
+    description: End Of Calibration flag.
     bit_offset: 11
     bit_size: 1
+    enum: EOCAL
   - name: CCRDY
-    description: Channel Configuration Ready flag
+    description: Channel Configuration Ready flag.
     bit_offset: 13
     bit_size: 1
-fieldset/SIDR:
-  description: EXTI Size ID register
-  fields:
-  - name: SID
-    description: Size Identification
-    bit_offset: 0
-    bit_size: 32
+    enum: CCRDY
 fieldset/SMPR:
-  description: ADC sampling time register
+  description: ADC sampling time register.
   fields:
   - name: SMP1
-    description: Sampling time selection
+    description: Sampling time selection.
     bit_offset: 0
     bit_size: 3
-    enum: SAMPLE_TIME
+    enum: SMP1
   - name: SMP2
-    description: Sampling time selection
+    description: Sampling time selection.
     bit_offset: 4
     bit_size: 3
-    enum: SAMPLE_TIME
-  - name: SMPSEL
-    description: Channel sampling time selection
+    enum: SMP2
+  - name: SMPSEL0
+    description: Channel sampling time selection.
     bit_offset: 8
     bit_size: 1
-    array:
-      len: 19
-      stride: 1
-fieldset/VERR:
-  description: EXTI IP Version register
-  fields:
-  - name: MINREV
-    description: Minor Revision number
-    bit_offset: 0
-    bit_size: 4
-  - name: MAJREV
-    description: Major Revision number
-    bit_offset: 4
-    bit_size: 4
+    enum: SMPSEL0
+  - name: SMPSEL1
+    description: Channel sampling time selection.
+    bit_offset: 9
+    bit_size: 1
+    enum: SMPSEL1
+  - name: SMPSEL2
+    description: Channel sampling time selection.
+    bit_offset: 10
+    bit_size: 1
+    enum: SMPSEL2
+  - name: SMPSEL3
+    description: Channel sampling time selection.
+    bit_offset: 11
+    bit_size: 1
+    enum: SMPSEL3
+  - name: SMPSEL4
+    description: Channel sampling time selection.
+    bit_offset: 12
+    bit_size: 1
+    enum: SMPSEL4
+  - name: SMPSEL5
+    description: Channel sampling time selection.
+    bit_offset: 13
+    bit_size: 1
+    enum: SMPSEL5
+  - name: SMPSEL6
+    description: Channel sampling time selection.
+    bit_offset: 14
+    bit_size: 1
+    enum: SMPSEL6
+  - name: SMPSEL7
+    description: Channel sampling time selection.
+    bit_offset: 15
+    bit_size: 1
+    enum: SMPSEL7
+  - name: SMPSEL8
+    description: Channel sampling time selection.
+    bit_offset: 16
+    bit_size: 1
+    enum: SMPSEL8
+  - name: SMPSEL9
+    description: Channel sampling time selection.
+    bit_offset: 17
+    bit_size: 1
+    enum: SMPSEL9
+  - name: SMPSEL10
+    description: Channel sampling time selection.
+    bit_offset: 18
+    bit_size: 1
+    enum: SMPSEL10
+  - name: SMPSEL11
+    description: Channel sampling time selection.
+    bit_offset: 19
+    bit_size: 1
+    enum: SMPSEL11
+  - name: SMPSEL12
+    description: Channel sampling time selection.
+    bit_offset: 20
+    bit_size: 1
+    enum: SMPSEL12
+  - name: SMPSEL13
+    description: Channel sampling time selection.
+    bit_offset: 21
+    bit_size: 1
+    enum: SMPSEL13
+  - name: SMPSEL14
+    description: Channel sampling time selection.
+    bit_offset: 22
+    bit_size: 1
+    enum: SMPSEL14
+  - name: SMPSEL15
+    description: Channel sampling time selection.
+    bit_offset: 23
+    bit_size: 1
+    enum: SMPSEL15
+  - name: SMPSEL16
+    description: Channel sampling time selection.
+    bit_offset: 24
+    bit_size: 1
+    enum: SMPSEL16
+  - name: SMPSEL17
+    description: Channel sampling time selection.
+    bit_offset: 25
+    bit_size: 1
+    enum: SMPSEL17
+  - name: SMPSEL18
+    description: Channel sampling time selection.
+    bit_offset: 26
+    bit_size: 1
+    enum: SMPSEL18
+enum/ADCAL:
+  bit_size: 1
+  variants:
+  - name: NotCalibrating
+    description: ADC calibration either not yet performed or completed.
+    value: 0
+  - name: R_Calibrating_W_StartCalibration
+    description: ADC calibration in progress.
+    value: 1
+enum/ADDIS:
+  bit_size: 1
+  variants:
+  - name: NotDisabling
+    description: No disable command active.
+    value: 0
+  - name: R_Disabling_W_Disable
+    description: ADC disabling.
+    value: 1
+enum/ADEN:
+  bit_size: 1
+  variants:
+  - name: Disabled
+    description: ADC disabled.
+    value: 0
+  - name: Enabled
+    description: ADC enabled.
+    value: 1
+enum/ADRDY:
+  bit_size: 1
+  variants:
+  - name: NotReady
+    description: ADC not yet ready to start conversion.
+    value: 0
+  - name: R_Ready_W_Clear
+    description: ADC ready to start conversion.
+    value: 1
+enum/ADRDYIE:
+  bit_size: 1
+  variants:
+  - name: Disabled
+    description: ADRDY interrupt disabled.
+    value: 0
+  - name: Enabled
+    description: ADRDY interrupt enabled. An interrupt is generated when the ADRDY bit is set.
+    value: 1
+enum/ADSTART:
+  bit_size: 1
+  variants:
+  - name: NotActive
+    description: No conversion ongoing.
+    value: 0
+  - name: R_Active_W_StartConversion
+    description: ADC operating and may be converting.
+    value: 1
+enum/ADSTP:
+  bit_size: 1
+  variants:
+  - name: NotStopping
+    description: No stop command active.
+    value: 0
+  - name: R_Stopping_W_StopConversion
+    description: ADC stopping conversion.
+    value: 1
+enum/ADVREGEN:
+  bit_size: 1
+  variants:
+  - name: Disabled
+    description: ADC voltage regulator disabled.
+    value: 0
+  - name: Enabled
+    description: ADC voltage regulator enabled.
+    value: 1
+enum/ALIGN:
+  bit_size: 1
+  variants:
+  - name: Right
+    description: Right alignment.
+    value: 0
+  - name: Left
+    description: Left alignment.
+    value: 1
+enum/AUTOFF:
+  bit_size: 1
+  variants:
+  - name: Disabled
+    description: Auto-off mode disabled.
+    value: 0
+  - name: Enabled
+    description: Auto-off mode enabled.
+    value: 1
+enum/AWD1:
+  bit_size: 1
+  variants:
+  - name: NoEvent
+    description: No analog watchdog event occurred.
+    value: 0
+  - name: R_Event_W_Clear
+    description: Analog watchdog event occurred.
+    value: 1
+enum/AWD1EN:
+  bit_size: 1
+  variants:
+  - name: Disabled
+    description: Analog watchdog 1 disabled.
+    value: 0
+  - name: Enabled
+    description: Analog watchdog 1 enabled.
+    value: 1
+enum/AWD1IE:
+  bit_size: 1
+  variants:
+  - name: Disabled
+    description: Analog watchdog interrupt disabled.
+    value: 0
+  - name: Enabled
+    description: Analog watchdog interrupt enabled.
+    value: 1
+enum/AWD1SGL:
+  bit_size: 1
+  variants:
+  - name: AllChannels
+    description: Analog watchdog 1 enabled on all channels.
+    value: 0
+  - name: SingleChannel
+    description: Analog watchdog 1 enabled on a single channel.
+    value: 1
+enum/AWD2:
+  bit_size: 1
+  variants:
+  - name: NoEvent
+    description: No analog watchdog event occurred.
+    value: 0
+  - name: R_Event_W_Clear
+    description: Analog watchdog event occurred.
+    value: 1
+enum/AWD2CH0:
+  bit_size: 1
+  variants:
+  - name: NotMonitored
+    description: ADC analog channel-x is not monitored by AWD2.
+    value: 0
+  - name: Monitored
+    description: ADC analog channel-x is monitored by AWD2.
+    value: 1
+enum/AWD2CH1:
+  bit_size: 1
+  variants:
+  - name: NotMonitored
+    description: ADC analog channel-x is not monitored by AWD2.
+    value: 0
+  - name: Monitored
+    description: ADC analog channel-x is monitored by AWD2.
+    value: 1
+enum/AWD2CH10:
+  bit_size: 1
+  variants:
+  - name: NotMonitored
+    description: ADC analog channel-x is not monitored by AWD2.
+    value: 0
+  - name: Monitored
+    description: ADC analog channel-x is monitored by AWD2.
+    value: 1
+enum/AWD2CH11:
+  bit_size: 1
+  variants:
+  - name: NotMonitored
+    description: ADC analog channel-x is not monitored by AWD2.
+    value: 0
+  - name: Monitored
+    description: ADC analog channel-x is monitored by AWD2.
+    value: 1
+enum/AWD2CH12:
+  bit_size: 1
+  variants:
+  - name: NotMonitored
+    description: ADC analog channel-x is not monitored by AWD2.
+    value: 0
+  - name: Monitored
+    description: ADC analog channel-x is monitored by AWD2.
+    value: 1
+enum/AWD2CH13:
+  bit_size: 1
+  variants:
+  - name: NotMonitored
+    description: ADC analog channel-x is not monitored by AWD2.
+    value: 0
+  - name: Monitored
+    description: ADC analog channel-x is monitored by AWD2.
+    value: 1
+enum/AWD2CH14:
+  bit_size: 1
+  variants:
+  - name: NotMonitored
+    description: ADC analog channel-x is not monitored by AWD2.
+    value: 0
+  - name: Monitored
+    description: ADC analog channel-x is monitored by AWD2.
+    value: 1
+enum/AWD2CH15:
+  bit_size: 1
+  variants:
+  - name: NotMonitored
+    description: ADC analog channel-x is not monitored by AWD2.
+    value: 0
+  - name: Monitored
+    description: ADC analog channel-x is monitored by AWD2.
+    value: 1
+enum/AWD2CH16:
+  bit_size: 1
+  variants:
+  - name: NotMonitored
+    description: ADC analog channel-x is not monitored by AWD2.
+    value: 0
+  - name: Monitored
+    description: ADC analog channel-x is monitored by AWD2.
+    value: 1
+enum/AWD2CH17:
+  bit_size: 1
+  variants:
+  - name: NotMonitored
+    description: ADC analog channel-x is not monitored by AWD2.
+    value: 0
+  - name: Monitored
+    description: ADC analog channel-x is monitored by AWD2.
+    value: 1
+enum/AWD2CH18:
+  bit_size: 1
+  variants:
+  - name: NotMonitored
+    description: ADC analog channel-x is not monitored by AWD2.
+    value: 0
+  - name: Monitored
+    description: ADC analog channel-x is monitored by AWD2.
+    value: 1
+enum/AWD2CH2:
+  bit_size: 1
+  variants:
+  - name: NotMonitored
+    description: ADC analog channel-x is not monitored by AWD2.
+    value: 0
+  - name: Monitored
+    description: ADC analog channel-x is monitored by AWD2.
+    value: 1
+enum/AWD2CH3:
+  bit_size: 1
+  variants:
+  - name: NotMonitored
+    description: ADC analog channel-x is not monitored by AWD2.
+    value: 0
+  - name: Monitored
+    description: ADC analog channel-x is monitored by AWD2.
+    value: 1
+enum/AWD2CH4:
+  bit_size: 1
+  variants:
+  - name: NotMonitored
+    description: ADC analog channel-x is not monitored by AWD2.
+    value: 0
+  - name: Monitored
+    description: ADC analog channel-x is monitored by AWD2.
+    value: 1
+enum/AWD2CH5:
+  bit_size: 1
+  variants:
+  - name: NotMonitored
+    description: ADC analog channel-x is not monitored by AWD2.
+    value: 0
+  - name: Monitored
+    description: ADC analog channel-x is monitored by AWD2.
+    value: 1
+enum/AWD2CH6:
+  bit_size: 1
+  variants:
+  - name: NotMonitored
+    description: ADC analog channel-x is not monitored by AWD2.
+    value: 0
+  - name: Monitored
+    description: ADC analog channel-x is monitored by AWD2.
+    value: 1
+enum/AWD2CH7:
+  bit_size: 1
+  variants:
+  - name: NotMonitored
+    description: ADC analog channel-x is not monitored by AWD2.
+    value: 0
+  - name: Monitored
+    description: ADC analog channel-x is monitored by AWD2.
+    value: 1
+enum/AWD2CH8:
+  bit_size: 1
+  variants:
+  - name: NotMonitored
+    description: ADC analog channel-x is not monitored by AWD2.
+    value: 0
+  - name: Monitored
+    description: ADC analog channel-x is monitored by AWD2.
+    value: 1
+enum/AWD2CH9:
+  bit_size: 1
+  variants:
+  - name: NotMonitored
+    description: ADC analog channel-x is not monitored by AWD2.
+    value: 0
+  - name: Monitored
+    description: ADC analog channel-x is monitored by AWD2.
+    value: 1
+enum/AWD2IE:
+  bit_size: 1
+  variants:
+  - name: Disabled
+    description: Analog watchdog interrupt disabled.
+    value: 0
+  - name: Enabled
+    description: Analog watchdog interrupt enabled.
+    value: 1
+enum/AWD3:
+  bit_size: 1
+  variants:
+  - name: NoEvent
+    description: No analog watchdog event occurred.
+    value: 0
+  - name: R_Event_W_Clear
+    description: Analog watchdog event occurred.
+    value: 1
+enum/AWD3CH0:
+  bit_size: 1
+  variants:
+  - name: NotMonitored
+    description: ADC analog channel-x is not monitored by AWD3.
+    value: 0
+  - name: Monitored
+    description: ADC analog channel-x is monitored by AWD3.
+    value: 1
+enum/AWD3CH1:
+  bit_size: 1
+  variants:
+  - name: NotMonitored
+    description: ADC analog channel-x is not monitored by AWD3.
+    value: 0
+  - name: Monitored
+    description: ADC analog channel-x is monitored by AWD3.
+    value: 1
+enum/AWD3CH10:
+  bit_size: 1
+  variants:
+  - name: NotMonitored
+    description: ADC analog channel-x is not monitored by AWD3.
+    value: 0
+  - name: Monitored
+    description: ADC analog channel-x is monitored by AWD3.
+    value: 1
+enum/AWD3CH11:
+  bit_size: 1
+  variants:
+  - name: NotMonitored
+    description: ADC analog channel-x is not monitored by AWD3.
+    value: 0
+  - name: Monitored
+    description: ADC analog channel-x is monitored by AWD3.
+    value: 1
+enum/AWD3CH12:
+  bit_size: 1
+  variants:
+  - name: NotMonitored
+    description: ADC analog channel-x is not monitored by AWD3.
+    value: 0
+  - name: Monitored
+    description: ADC analog channel-x is monitored by AWD3.
+    value: 1
+enum/AWD3CH13:
+  bit_size: 1
+  variants:
+  - name: NotMonitored
+    description: ADC analog channel-x is not monitored by AWD3.
+    value: 0
+  - name: Monitored
+    description: ADC analog channel-x is monitored by AWD3.
+    value: 1
+enum/AWD3CH14:
+  bit_size: 1
+  variants:
+  - name: NotMonitored
+    description: ADC analog channel-x is not monitored by AWD3.
+    value: 0
+  - name: Monitored
+    description: ADC analog channel-x is monitored by AWD3.
+    value: 1
+enum/AWD3CH15:
+  bit_size: 1
+  variants:
+  - name: NotMonitored
+    description: ADC analog channel-x is not monitored by AWD3.
+    value: 0
+  - name: Monitored
+    description: ADC analog channel-x is monitored by AWD3.
+    value: 1
+enum/AWD3CH16:
+  bit_size: 1
+  variants:
+  - name: NotMonitored
+    description: ADC analog channel-x is not monitored by AWD3.
+    value: 0
+  - name: Monitored
+    description: ADC analog channel-x is monitored by AWD3.
+    value: 1
+enum/AWD3CH17:
+  bit_size: 1
+  variants:
+  - name: NotMonitored
+    description: ADC analog channel-x is not monitored by AWD3.
+    value: 0
+  - name: Monitored
+    description: ADC analog channel-x is monitored by AWD3.
+    value: 1
+enum/AWD3CH18:
+  bit_size: 1
+  variants:
+  - name: NotMonitored
+    description: ADC analog channel-x is not monitored by AWD3.
+    value: 0
+  - name: Monitored
+    description: ADC analog channel-x is monitored by AWD3.
+    value: 1
+enum/AWD3CH2:
+  bit_size: 1
+  variants:
+  - name: NotMonitored
+    description: ADC analog channel-x is not monitored by AWD3.
+    value: 0
+  - name: Monitored
+    description: ADC analog channel-x is monitored by AWD3.
+    value: 1
+enum/AWD3CH3:
+  bit_size: 1
+  variants:
+  - name: NotMonitored
+    description: ADC analog channel-x is not monitored by AWD3.
+    value: 0
+  - name: Monitored
+    description: ADC analog channel-x is monitored by AWD3.
+    value: 1
+enum/AWD3CH4:
+  bit_size: 1
+  variants:
+  - name: NotMonitored
+    description: ADC analog channel-x is not monitored by AWD3.
+    value: 0
+  - name: Monitored
+    description: ADC analog channel-x is monitored by AWD3.
+    value: 1
+enum/AWD3CH5:
+  bit_size: 1
+  variants:
+  - name: NotMonitored
+    description: ADC analog channel-x is not monitored by AWD3.
+    value: 0
+  - name: Monitored
+    description: ADC analog channel-x is monitored by AWD3.
+    value: 1
+enum/AWD3CH6:
+  bit_size: 1
+  variants:
+  - name: NotMonitored
+    description: ADC analog channel-x is not monitored by AWD3.
+    value: 0
+  - name: Monitored
+    description: ADC analog channel-x is monitored by AWD3.
+    value: 1
+enum/AWD3CH7:
+  bit_size: 1
+  variants:
+  - name: NotMonitored
+    description: ADC analog channel-x is not monitored by AWD3.
+    value: 0
+  - name: Monitored
+    description: ADC analog channel-x is monitored by AWD3.
+    value: 1
+enum/AWD3CH8:
+  bit_size: 1
+  variants:
+  - name: NotMonitored
+    description: ADC analog channel-x is not monitored by AWD3.
+    value: 0
+  - name: Monitored
+    description: ADC analog channel-x is monitored by AWD3.
+    value: 1
+enum/AWD3CH9:
+  bit_size: 1
+  variants:
+  - name: NotMonitored
+    description: ADC analog channel-x is not monitored by AWD3.
+    value: 0
+  - name: Monitored
+    description: ADC analog channel-x is monitored by AWD3.
+    value: 1
+enum/AWD3IE:
+  bit_size: 1
+  variants:
+  - name: Disabled
+    description: Analog watchdog interrupt disabled.
+    value: 0
+  - name: Enabled
+    description: Analog watchdog interrupt enabled.
+    value: 1
+enum/CCRDY:
+  bit_size: 1
+  variants:
+  - name: NotComplete
+    description: Channel configuration update not applied.
+    value: 0
+  - name: R_Complete_W_Clear
+    description: Channel configuration update is applied.
+    value: 1
+enum/CCRDYIE:
+  bit_size: 1
+  variants:
+  - name: Disabled
+    description: Channel configuration ready interrupt disabled.
+    value: 0
+  - name: Enabled
+    description: Channel configuration ready interrupt enabled.
+    value: 1
+enum/CHSEL:
+  bit_size: 19
+  variants:
+  - name: NotSelected
+    description: Input Channel is not selected for conversion.
+    value: 0
+  - name: Selected
+    description: Input Channel is selected for conversion.
+    value: 1
+enum/CHSELRMOD:
+  bit_size: 1
+  variants:
+  - name: BitPerInput
+    description: Each bit of the ADC_CHSELR register enables an input.
+    value: 0
+  - name: Sequence
+    description: ADC_CHSELR register is able to sequence up to 8 channels.
+    value: 1
+enum/CKMODE:
+  bit_size: 2
+  variants:
+  - name: ADCLK
+    description: ADCCLK (Asynchronous clock mode).
+    value: 0
+  - name: PCLK_Div2
+    description: PCLK/2 (Synchronous clock mode).
+    value: 1
+  - name: PCLK_Div4
+    description: PCLK/4 (Synchronous clock mode).
+    value: 2
+  - name: PCLK
+    description: PCLK (Synchronous clock mode).
+    value: 3
+enum/CONT:
+  bit_size: 1
+  variants:
+  - name: Single
+    description: Single conversion mode.
+    value: 0
+  - name: Continuous
+    description: Continuous conversion mode.
+    value: 1
+enum/DISCEN:
+  bit_size: 1
+  variants:
+  - name: Disabled
+    description: Discontinuous mode disabled.
+    value: 0
+  - name: Enabled
+    description: Discontinuous mode enabled.
+    value: 1
 enum/DMACFG:
   bit_size: 1
   variants:
   - name: OneShot
-    description: DMA One Shot mode selected
+    description: DMA one shot mode selected.
     value: 0
   - name: Circular
-    description: DMA Circular mode selected
+    description: DMA circular mode selected.
     value: 1
+enum/DMAEN:
+  bit_size: 1
+  variants:
+  - name: Disabled
+    description: DMA disabled.
+    value: 0
+  - name: Enabled
+    description: DMA enabled.
+    value: 1
+enum/EOC:
+  bit_size: 1
+  variants:
+  - name: NotComplete
+    description: Channel conversion is not complete.
+    value: 0
+  - name: R_Complete_W_Clear
+    description: Channel conversion complete.
+    value: 1
+enum/EOCAL:
+  bit_size: 1
+  variants:
+  - name: NotComplete
+    description: Calibration is not complete.
+    value: 0
+  - name: R_Complete_W_Clear
+    description: Calibration complete.
+    value: 1
+enum/EOCALIE:
+  bit_size: 1
+  variants:
+  - name: Disabled
+    description: End of calibration interrupt disabled.
+    value: 0
+  - name: Enabled
+    description: End of calibration interrupt enabled.
+    value: 1
+enum/EOCIE:
+  bit_size: 1
+  variants:
+  - name: Disabled
+    description: EOC interrupt disabled.
+    value: 0
+  - name: Enabled
+    description: EOC interrupt enabled. An interrupt is generated when the EOC bit is set.
+    value: 1
+enum/EOS:
+  bit_size: 1
+  variants:
+  - name: NotComplete
+    description: Conversion sequence is not complete.
+    value: 0
+  - name: R_Complete_W_Clear
+    description: Conversion sequence complete.
+    value: 1
+enum/EOSIE:
+  bit_size: 1
+  variants:
+  - name: Disabled
+    description: EOS interrupt disabled.
+    value: 0
+  - name: Enabled
+    description: EOS interrupt enabled. An interrupt is generated when the EOS bit is set.
+    value: 1
+enum/EOSMP:
+  bit_size: 1
+  variants:
+  - name: NotAtEnd
+    description: Not at the end of the samplings phase.
+    value: 0
+  - name: R_AtEnd_W_Clear
+    description: End of sampling phase reached.
+    value: 1
+enum/EOSMPIE:
+  bit_size: 1
+  variants:
+  - name: Disabled
+    description: EOSMP interrupt disabled.
+    value: 0
+  - name: Enabled
+    description: EOSMP interrupt enabled. An interrupt is generated when the EOSMP bit is set.
+    value: 1
+enum/EXTEN:
+  bit_size: 2
+  variants:
+  - name: Disabled
+    description: Hardware trigger detection disabled.
+    value: 0
+  - name: RisingEdge
+    description: Hardware trigger detection on the rising edge.
+    value: 1
+  - name: FallingEdge
+    description: Hardware trigger detection on the falling edge.
+    value: 2
+  - name: BothEdges
+    description: Hardware trigger detection on both the rising and falling edges.
+    value: 3
+enum/EXTSEL:
+  bit_size: 3
+  variants:
+  - name: TIM1_TRGO
+    description: Timer 1 TRGO event.
+    value: 0
+  - name: TIM1_CC4
+    description: Timer 1 CC4 event.
+    value: 1
+  - name: TIM2_TRGO
+    description: Timer 2 TRGO event.
+    value: 2
+  - name: TIM2_CH4
+    description: Timer 2 CH4 event.
+    value: 3
+  - name: TIM2_CH3
+    description: Timer 2 CH3 event.
+    value: 5
+  - name: EXTI_LINE11
+    description: EXTI line 11 event.
+    value: 7
+enum/LFTRIG:
+  bit_size: 1
+  variants:
+  - name: Disabled
+    description: Low Frequency Trigger Mode disabled.
+    value: 0
+  - name: Enabled
+    description: Low Frequency Trigger Mode enabled.
+    value: 1
+enum/OVR:
+  bit_size: 1
+  variants:
+  - name: NoOverrun
+    description: No overrun occurred.
+    value: 0
+  - name: R_Overrun_W_Clear
+    description: Overrun occurred.
+    value: 1
+enum/OVRIE:
+  bit_size: 1
+  variants:
+  - name: Disabled
+    description: Overrun interrupt disabled.
+    value: 0
+  - name: Enabled
+    description: Overrun interrupt enabled. An interrupt is generated when the OVR bit is set.
+    value: 1
+enum/OVRMOD:
+  bit_size: 1
+  variants:
+  - name: Preserve
+    description: ADC_DR register is preserved with the old data when an overrun is detected.
+    value: 0
+  - name: Overwrite
+    description: ADC_DR register is overwritten with the last conversion result when an overrun is detected.
+    value: 1
+enum/OVSE:
+  bit_size: 1
+  variants:
+  - name: Disabled
+    description: Oversampler disabled.
+    value: 0
+  - name: Enabled
+    description: Oversampler enabled.
+    value: 1
+enum/OVSR:
+  bit_size: 3
+  variants:
+  - name: Mul2
+    description: 2x.
+    value: 0
+  - name: Mul4
+    description: 4x.
+    value: 1
+  - name: Mul8
+    description: 8x.
+    value: 2
+  - name: Mul16
+    description: 16x.
+    value: 3
+  - name: Mul32
+    description: 32x.
+    value: 4
+  - name: Mul64
+    description: 64x.
+    value: 5
+  - name: Mul128
+    description: 128x.
+    value: 6
+  - name: Mul256
+    description: 256x.
+    value: 7
+enum/OVSS:
+  bit_size: 4
+  variants:
+  - name: NoShift
+    description: No shift.
+    value: 0
+  - name: Shift1
+    description: Shift 1-bit.
+    value: 1
+  - name: Shift2
+    description: Shift 2-bits.
+    value: 2
+  - name: Shift3
+    description: Shift 3-bits.
+    value: 3
+  - name: Shift4
+    description: Shift 4-bits.
+    value: 4
+  - name: Shift5
+    description: Shift 5-bits.
+    value: 5
+  - name: Shift6
+    description: Shift 6-bits.
+    value: 6
+  - name: Shift7
+    description: Shift 7-bits.
+    value: 7
+  - name: Shift8
+    description: Shift 8-bits.
+    value: 8
+enum/PRESC:
+  bit_size: 4
+  variants:
+  - name: Div1
+    description: Input ADC clock not divided.
+    value: 0
+  - name: Div2
+    description: Input ADC clock divided by 2.
+    value: 1
+  - name: Div4
+    description: Input ADC clock divided by 4.
+    value: 2
+  - name: Div6
+    description: Input ADC clock divided by 6.
+    value: 3
+  - name: Div8
+    description: Input ADC clock divided by 8.
+    value: 4
+  - name: Div10
+    description: Input ADC clock divided by 10.
+    value: 5
+  - name: Div12
+    description: Input ADC clock divided by 12.
+    value: 6
+  - name: Div16
+    description: Input ADC clock divided by 16.
+    value: 7
+  - name: Div32
+    description: Input ADC clock divided by 32.
+    value: 8
+  - name: Div64
+    description: Input ADC clock divided by 64.
+    value: 9
+  - name: Div128
+    description: Input ADC clock divided by 128.
+    value: 10
+  - name: Div256
+    description: Input ADC clock divided by 256.
+    value: 11
 enum/RES:
   bit_size: 2
   variants:
   - name: Bits12
-    description: 12-bit resolution
+    description: 12 bits.
     value: 0
   - name: Bits10
-    description: 10-bit resolution
+    description: 10 bits.
     value: 1
   - name: Bits8
-    description: 8-bit resolution
+    description: 8 bits.
     value: 2
   - name: Bits6
-    description: 6-bit resolution
+    description: 6 bits.
     value: 3
-enum/SAMPLE_TIME:
+enum/SCANDIR:
+  bit_size: 1
+  variants:
+  - name: Upward
+    description: Upward scan (from CHSEL0 to CHSEL17).
+    value: 0
+  - name: Backward
+    description: Backward scan (from CHSEL17 to CHSEL0).
+    value: 1
+enum/SMP1:
   bit_size: 3
   variants:
   - name: Cycles1_5
-    description: 1.5 ADC cycles
+    description: 1.5 ADC clock cycles.
     value: 0
   - name: Cycles3_5
-    description: 3.5 ADC cycles
+    description: 3.5 ADC clock cycles.
     value: 1
   - name: Cycles7_5
-    description: 7.5 ADC cycles
+    description: 7.5 ADC clock cycles.
     value: 2
   - name: Cycles12_5
-    description: 12.5 ADC cycles
+    description: 12.5 ADC clock cycles.
     value: 3
   - name: Cycles19_5
-    description: 19.5 ADC cycles
+    description: 19.5 ADC clock cycles.
     value: 4
   - name: Cycles39_5
-    description: 39.5 ADC cycles
+    description: 39.5 ADC clock cycles.
     value: 5
   - name: Cycles79_5
-    description: 79.5 ADC cycles
+    description: 79.5 ADC clock cycles.
     value: 6
   - name: Cycles160_5
-    description: 160.5 ADC cycles
+    description: 160.5 ADC clock cycles.
     value: 7
+enum/SMP2:
+  bit_size: 3
+  variants:
+  - name: Cycles1_5
+    description: 1.5 ADC clock cycles.
+    value: 0
+  - name: Cycles3_5
+    description: 3.5 ADC clock cycles.
+    value: 1
+  - name: Cycles7_5
+    description: 7.5 ADC clock cycles.
+    value: 2
+  - name: Cycles12_5
+    description: 12.5 ADC clock cycles.
+    value: 3
+  - name: Cycles19_5
+    description: 19.5 ADC clock cycles.
+    value: 4
+  - name: Cycles39_5
+    description: 39.5 ADC clock cycles.
+    value: 5
+  - name: Cycles79_5
+    description: 79.5 ADC clock cycles.
+    value: 6
+  - name: Cycles160_5
+    description: 160.5 ADC clock cycles.
+    value: 7
+enum/SMPSEL0:
+  bit_size: 1
+  variants:
+  - name: Smp1
+    description: Sampling time of CHANNELx use the setting of SMP1 register.
+    value: 0
+  - name: Smp2
+    description: Sampling time of CHANNELx use the setting of SMP2 register.
+    value: 1
+enum/SMPSEL1:
+  bit_size: 1
+  variants:
+  - name: Smp1
+    description: Sampling time of CHANNELx use the setting of SMP1 register.
+    value: 0
+  - name: Smp2
+    description: Sampling time of CHANNELx use the setting of SMP2 register.
+    value: 1
+enum/SMPSEL10:
+  bit_size: 1
+  variants:
+  - name: Smp1
+    description: Sampling time of CHANNELx use the setting of SMP1 register.
+    value: 0
+  - name: Smp2
+    description: Sampling time of CHANNELx use the setting of SMP2 register.
+    value: 1
+enum/SMPSEL11:
+  bit_size: 1
+  variants:
+  - name: Smp1
+    description: Sampling time of CHANNELx use the setting of SMP1 register.
+    value: 0
+  - name: Smp2
+    description: Sampling time of CHANNELx use the setting of SMP2 register.
+    value: 1
+enum/SMPSEL12:
+  bit_size: 1
+  variants:
+  - name: Smp1
+    description: Sampling time of CHANNELx use the setting of SMP1 register.
+    value: 0
+  - name: Smp2
+    description: Sampling time of CHANNELx use the setting of SMP2 register.
+    value: 1
+enum/SMPSEL13:
+  bit_size: 1
+  variants:
+  - name: Smp1
+    description: Sampling time of CHANNELx use the setting of SMP1 register.
+    value: 0
+  - name: Smp2
+    description: Sampling time of CHANNELx use the setting of SMP2 register.
+    value: 1
+enum/SMPSEL14:
+  bit_size: 1
+  variants:
+  - name: Smp1
+    description: Sampling time of CHANNELx use the setting of SMP1 register.
+    value: 0
+  - name: Smp2
+    description: Sampling time of CHANNELx use the setting of SMP2 register.
+    value: 1
+enum/SMPSEL15:
+  bit_size: 1
+  variants:
+  - name: Smp1
+    description: Sampling time of CHANNELx use the setting of SMP1 register.
+    value: 0
+  - name: Smp2
+    description: Sampling time of CHANNELx use the setting of SMP2 register.
+    value: 1
+enum/SMPSEL16:
+  bit_size: 1
+  variants:
+  - name: Smp1
+    description: Sampling time of CHANNELx use the setting of SMP1 register.
+    value: 0
+  - name: Smp2
+    description: Sampling time of CHANNELx use the setting of SMP2 register.
+    value: 1
+enum/SMPSEL17:
+  bit_size: 1
+  variants:
+  - name: Smp1
+    description: Sampling time of CHANNELx use the setting of SMP1 register.
+    value: 0
+  - name: Smp2
+    description: Sampling time of CHANNELx use the setting of SMP2 register.
+    value: 1
+enum/SMPSEL18:
+  bit_size: 1
+  variants:
+  - name: Smp1
+    description: Sampling time of CHANNELx use the setting of SMP1 register.
+    value: 0
+  - name: Smp2
+    description: Sampling time of CHANNELx use the setting of SMP2 register.
+    value: 1
+enum/SMPSEL2:
+  bit_size: 1
+  variants:
+  - name: Smp1
+    description: Sampling time of CHANNELx use the setting of SMP1 register.
+    value: 0
+  - name: Smp2
+    description: Sampling time of CHANNELx use the setting of SMP2 register.
+    value: 1
+enum/SMPSEL3:
+  bit_size: 1
+  variants:
+  - name: Smp1
+    description: Sampling time of CHANNELx use the setting of SMP1 register.
+    value: 0
+  - name: Smp2
+    description: Sampling time of CHANNELx use the setting of SMP2 register.
+    value: 1
+enum/SMPSEL4:
+  bit_size: 1
+  variants:
+  - name: Smp1
+    description: Sampling time of CHANNELx use the setting of SMP1 register.
+    value: 0
+  - name: Smp2
+    description: Sampling time of CHANNELx use the setting of SMP2 register.
+    value: 1
+enum/SMPSEL5:
+  bit_size: 1
+  variants:
+  - name: Smp1
+    description: Sampling time of CHANNELx use the setting of SMP1 register.
+    value: 0
+  - name: Smp2
+    description: Sampling time of CHANNELx use the setting of SMP2 register.
+    value: 1
+enum/SMPSEL6:
+  bit_size: 1
+  variants:
+  - name: Smp1
+    description: Sampling time of CHANNELx use the setting of SMP1 register.
+    value: 0
+  - name: Smp2
+    description: Sampling time of CHANNELx use the setting of SMP2 register.
+    value: 1
+enum/SMPSEL7:
+  bit_size: 1
+  variants:
+  - name: Smp1
+    description: Sampling time of CHANNELx use the setting of SMP1 register.
+    value: 0
+  - name: Smp2
+    description: Sampling time of CHANNELx use the setting of SMP2 register.
+    value: 1
+enum/SMPSEL8:
+  bit_size: 1
+  variants:
+  - name: Smp1
+    description: Sampling time of CHANNELx use the setting of SMP1 register.
+    value: 0
+  - name: Smp2
+    description: Sampling time of CHANNELx use the setting of SMP2 register.
+    value: 1
+enum/SMPSEL9:
+  bit_size: 1
+  variants:
+  - name: Smp1
+    description: Sampling time of CHANNELx use the setting of SMP1 register.
+    value: 0
+  - name: Smp2
+    description: Sampling time of CHANNELx use the setting of SMP2 register.
+    value: 1
+enum/SQ1:
+  bit_size: 4
+  variants:
+  - name: Ch0
+    description: Channel 0 selected for the Nth conversion.
+    value: 0
+  - name: Ch1
+    description: Channel 1 selected for the Nth conversion.
+    value: 1
+  - name: Ch2
+    description: Channel 2 selected for the Nth conversion.
+    value: 2
+  - name: Ch3
+    description: Channel 3 selected for the Nth conversion.
+    value: 3
+  - name: Ch4
+    description: Channel 4 selected for the Nth conversion.
+    value: 4
+  - name: Ch5
+    description: Channel 5 selected for the Nth conversion.
+    value: 5
+  - name: Ch6
+    description: Channel 6 selected for the Nth conversion.
+    value: 6
+  - name: Ch7
+    description: Channel 7 selected for the Nth conversion.
+    value: 7
+  - name: Ch8
+    description: Channel 8 selected for the Nth conversion.
+    value: 8
+  - name: Ch9
+    description: Channel 9 selected for the Nth conversion.
+    value: 9
+  - name: Ch10
+    description: Channel 10 selected for the Nth conversion.
+    value: 10
+  - name: Ch11
+    description: Channel 11 selected for the Nth conversion.
+    value: 11
+  - name: Ch12
+    description: Channel 12 selected for the Nth conversion.
+    value: 12
+  - name: Ch13
+    description: Channel 13 selected for the Nth conversion.
+    value: 13
+  - name: Ch14
+    description: Channel 14 selected for the Nth conversion.
+    value: 14
+  - name: EOS
+    description: End of sequence.
+    value: 15
+enum/SQ2:
+  bit_size: 4
+  variants:
+  - name: Ch0
+    description: Channel 0 selected for the Nth conversion.
+    value: 0
+  - name: Ch1
+    description: Channel 1 selected for the Nth conversion.
+    value: 1
+  - name: Ch2
+    description: Channel 2 selected for the Nth conversion.
+    value: 2
+  - name: Ch3
+    description: Channel 3 selected for the Nth conversion.
+    value: 3
+  - name: Ch4
+    description: Channel 4 selected for the Nth conversion.
+    value: 4
+  - name: Ch5
+    description: Channel 5 selected for the Nth conversion.
+    value: 5
+  - name: Ch6
+    description: Channel 6 selected for the Nth conversion.
+    value: 6
+  - name: Ch7
+    description: Channel 7 selected for the Nth conversion.
+    value: 7
+  - name: Ch8
+    description: Channel 8 selected for the Nth conversion.
+    value: 8
+  - name: Ch9
+    description: Channel 9 selected for the Nth conversion.
+    value: 9
+  - name: Ch10
+    description: Channel 10 selected for the Nth conversion.
+    value: 10
+  - name: Ch11
+    description: Channel 11 selected for the Nth conversion.
+    value: 11
+  - name: Ch12
+    description: Channel 12 selected for the Nth conversion.
+    value: 12
+  - name: Ch13
+    description: Channel 13 selected for the Nth conversion.
+    value: 13
+  - name: Ch14
+    description: Channel 14 selected for the Nth conversion.
+    value: 14
+  - name: EOS
+    description: End of sequence.
+    value: 15
+enum/SQ3:
+  bit_size: 4
+  variants:
+  - name: Ch0
+    description: Channel 0 selected for the Nth conversion.
+    value: 0
+  - name: Ch1
+    description: Channel 1 selected for the Nth conversion.
+    value: 1
+  - name: Ch2
+    description: Channel 2 selected for the Nth conversion.
+    value: 2
+  - name: Ch3
+    description: Channel 3 selected for the Nth conversion.
+    value: 3
+  - name: Ch4
+    description: Channel 4 selected for the Nth conversion.
+    value: 4
+  - name: Ch5
+    description: Channel 5 selected for the Nth conversion.
+    value: 5
+  - name: Ch6
+    description: Channel 6 selected for the Nth conversion.
+    value: 6
+  - name: Ch7
+    description: Channel 7 selected for the Nth conversion.
+    value: 7
+  - name: Ch8
+    description: Channel 8 selected for the Nth conversion.
+    value: 8
+  - name: Ch9
+    description: Channel 9 selected for the Nth conversion.
+    value: 9
+  - name: Ch10
+    description: Channel 10 selected for the Nth conversion.
+    value: 10
+  - name: Ch11
+    description: Channel 11 selected for the Nth conversion.
+    value: 11
+  - name: Ch12
+    description: Channel 12 selected for the Nth conversion.
+    value: 12
+  - name: Ch13
+    description: Channel 13 selected for the Nth conversion.
+    value: 13
+  - name: Ch14
+    description: Channel 14 selected for the Nth conversion.
+    value: 14
+  - name: EOS
+    description: End of sequence.
+    value: 15
+enum/SQ4:
+  bit_size: 4
+  variants:
+  - name: Ch0
+    description: Channel 0 selected for the Nth conversion.
+    value: 0
+  - name: Ch1
+    description: Channel 1 selected for the Nth conversion.
+    value: 1
+  - name: Ch2
+    description: Channel 2 selected for the Nth conversion.
+    value: 2
+  - name: Ch3
+    description: Channel 3 selected for the Nth conversion.
+    value: 3
+  - name: Ch4
+    description: Channel 4 selected for the Nth conversion.
+    value: 4
+  - name: Ch5
+    description: Channel 5 selected for the Nth conversion.
+    value: 5
+  - name: Ch6
+    description: Channel 6 selected for the Nth conversion.
+    value: 6
+  - name: Ch7
+    description: Channel 7 selected for the Nth conversion.
+    value: 7
+  - name: Ch8
+    description: Channel 8 selected for the Nth conversion.
+    value: 8
+  - name: Ch9
+    description: Channel 9 selected for the Nth conversion.
+    value: 9
+  - name: Ch10
+    description: Channel 10 selected for the Nth conversion.
+    value: 10
+  - name: Ch11
+    description: Channel 11 selected for the Nth conversion.
+    value: 11
+  - name: Ch12
+    description: Channel 12 selected for the Nth conversion.
+    value: 12
+  - name: Ch13
+    description: Channel 13 selected for the Nth conversion.
+    value: 13
+  - name: Ch14
+    description: Channel 14 selected for the Nth conversion.
+    value: 14
+  - name: EOS
+    description: End of sequence.
+    value: 15
+enum/SQ5:
+  bit_size: 4
+  variants:
+  - name: Ch0
+    description: Channel 0 selected for the Nth conversion.
+    value: 0
+  - name: Ch1
+    description: Channel 1 selected for the Nth conversion.
+    value: 1
+  - name: Ch2
+    description: Channel 2 selected for the Nth conversion.
+    value: 2
+  - name: Ch3
+    description: Channel 3 selected for the Nth conversion.
+    value: 3
+  - name: Ch4
+    description: Channel 4 selected for the Nth conversion.
+    value: 4
+  - name: Ch5
+    description: Channel 5 selected for the Nth conversion.
+    value: 5
+  - name: Ch6
+    description: Channel 6 selected for the Nth conversion.
+    value: 6
+  - name: Ch7
+    description: Channel 7 selected for the Nth conversion.
+    value: 7
+  - name: Ch8
+    description: Channel 8 selected for the Nth conversion.
+    value: 8
+  - name: Ch9
+    description: Channel 9 selected for the Nth conversion.
+    value: 9
+  - name: Ch10
+    description: Channel 10 selected for the Nth conversion.
+    value: 10
+  - name: Ch11
+    description: Channel 11 selected for the Nth conversion.
+    value: 11
+  - name: Ch12
+    description: Channel 12 selected for the Nth conversion.
+    value: 12
+  - name: Ch13
+    description: Channel 13 selected for the Nth conversion.
+    value: 13
+  - name: Ch14
+    description: Channel 14 selected for the Nth conversion.
+    value: 14
+  - name: EOS
+    description: End of sequence.
+    value: 15
+enum/SQ6:
+  bit_size: 4
+  variants:
+  - name: Ch0
+    description: Channel 0 selected for the Nth conversion.
+    value: 0
+  - name: Ch1
+    description: Channel 1 selected for the Nth conversion.
+    value: 1
+  - name: Ch2
+    description: Channel 2 selected for the Nth conversion.
+    value: 2
+  - name: Ch3
+    description: Channel 3 selected for the Nth conversion.
+    value: 3
+  - name: Ch4
+    description: Channel 4 selected for the Nth conversion.
+    value: 4
+  - name: Ch5
+    description: Channel 5 selected for the Nth conversion.
+    value: 5
+  - name: Ch6
+    description: Channel 6 selected for the Nth conversion.
+    value: 6
+  - name: Ch7
+    description: Channel 7 selected for the Nth conversion.
+    value: 7
+  - name: Ch8
+    description: Channel 8 selected for the Nth conversion.
+    value: 8
+  - name: Ch9
+    description: Channel 9 selected for the Nth conversion.
+    value: 9
+  - name: Ch10
+    description: Channel 10 selected for the Nth conversion.
+    value: 10
+  - name: Ch11
+    description: Channel 11 selected for the Nth conversion.
+    value: 11
+  - name: Ch12
+    description: Channel 12 selected for the Nth conversion.
+    value: 12
+  - name: Ch13
+    description: Channel 13 selected for the Nth conversion.
+    value: 13
+  - name: Ch14
+    description: Channel 14 selected for the Nth conversion.
+    value: 14
+  - name: EOS
+    description: End of sequence.
+    value: 15
+enum/SQ7:
+  bit_size: 4
+  variants:
+  - name: Ch0
+    description: Channel 0 selected for the Nth conversion.
+    value: 0
+  - name: Ch1
+    description: Channel 1 selected for the Nth conversion.
+    value: 1
+  - name: Ch2
+    description: Channel 2 selected for the Nth conversion.
+    value: 2
+  - name: Ch3
+    description: Channel 3 selected for the Nth conversion.
+    value: 3
+  - name: Ch4
+    description: Channel 4 selected for the Nth conversion.
+    value: 4
+  - name: Ch5
+    description: Channel 5 selected for the Nth conversion.
+    value: 5
+  - name: Ch6
+    description: Channel 6 selected for the Nth conversion.
+    value: 6
+  - name: Ch7
+    description: Channel 7 selected for the Nth conversion.
+    value: 7
+  - name: Ch8
+    description: Channel 8 selected for the Nth conversion.
+    value: 8
+  - name: Ch9
+    description: Channel 9 selected for the Nth conversion.
+    value: 9
+  - name: Ch10
+    description: Channel 10 selected for the Nth conversion.
+    value: 10
+  - name: Ch11
+    description: Channel 11 selected for the Nth conversion.
+    value: 11
+  - name: Ch12
+    description: Channel 12 selected for the Nth conversion.
+    value: 12
+  - name: Ch13
+    description: Channel 13 selected for the Nth conversion.
+    value: 13
+  - name: Ch14
+    description: Channel 14 selected for the Nth conversion.
+    value: 14
+  - name: EOS
+    description: End of sequence.
+    value: 15
+enum/SQ8:
+  bit_size: 4
+  variants:
+  - name: Ch0
+    description: Channel 0 selected for the Nth conversion.
+    value: 0
+  - name: Ch1
+    description: Channel 1 selected for the Nth conversion.
+    value: 1
+  - name: Ch2
+    description: Channel 2 selected for the Nth conversion.
+    value: 2
+  - name: Ch3
+    description: Channel 3 selected for the Nth conversion.
+    value: 3
+  - name: Ch4
+    description: Channel 4 selected for the Nth conversion.
+    value: 4
+  - name: Ch5
+    description: Channel 5 selected for the Nth conversion.
+    value: 5
+  - name: Ch6
+    description: Channel 6 selected for the Nth conversion.
+    value: 6
+  - name: Ch7
+    description: Channel 7 selected for the Nth conversion.
+    value: 7
+  - name: Ch8
+    description: Channel 8 selected for the Nth conversion.
+    value: 8
+  - name: Ch9
+    description: Channel 9 selected for the Nth conversion.
+    value: 9
+  - name: Ch10
+    description: Channel 10 selected for the Nth conversion.
+    value: 10
+  - name: Ch11
+    description: Channel 11 selected for the Nth conversion.
+    value: 11
+  - name: Ch12
+    description: Channel 12 selected for the Nth conversion.
+    value: 12
+  - name: Ch13
+    description: Channel 13 selected for the Nth conversion.
+    value: 13
+  - name: Ch14
+    description: Channel 14 selected for the Nth conversion.
+    value: 14
+  - name: EOS
+    description: End of sequence.
+    value: 15
+enum/TOVS:
+  bit_size: 1
+  variants:
+  - name: TriggerAll
+    description: All oversampled conversions for a channel are done consecutively after a trigger.
+    value: 0
+  - name: TriggerEach
+    description: Each oversampled conversion for a channel needs a trigger.
+    value: 1
+enum/TSEN:
+  bit_size: 1
+  variants:
+  - name: Disabled
+    description: Temperature sensor disabled.
+    value: 0
+  - name: Enabled
+    description: Temperature sensor enabled.
+    value: 1
+enum/VBATEN:
+  bit_size: 1
+  variants:
+  - name: Disabled
+    description: VBAT channel disabled.
+    value: 0
+  - name: Enabled
+    description: VBAT channel enabled.
+    value: 1
+enum/VREFEN:
+  bit_size: 1
+  variants:
+  - name: Disabled
+    description: VREFINT disabled.
+    value: 0
+  - name: Enabled
+    description: VREFINT enabled.
+    value: 1
+enum/WAIT:
+  bit_size: 1
+  variants:
+  - name: Disabled
+    description: Wait conversion mode off.
+    value: 0
+  - name: Enabled
+    description: Wait conversion mode on.
+    value: 1


### PR DESCRIPTION
This adds enums for many registers.

The previous version contains registers not listed in the reference manual [RM0454](https://www.st.com/resource/en/reference_manual/rm0454-stm32g0x0-advanced-armbased-32bit-mcus-stmicroelectronics.pdf). Those are mapped to the very end of the ADC address range. They are still present in the g070 SVD.

Not sure if you tolerate the trailing dots in the descriptions. This is the unedited chiptool output.