### PR TITLE
stm32l4: Select rtc_v3 when cube says version is rtc2_v2_9.

### DIFF
--- a/stm32-data-gen/src/perimap.rs
+++ b/stm32-data-gen/src/perimap.rs
@@ -204,6 +204,7 @@ pub static PERIMAP: RegexMap<(&str, &str, &str)> = RegexMap::new(&[
     ("STM32H7.*:RTC:rtc2_.*", ("rtc", "v2h7", "RTC")),
     ("STM32L0.*:RTC:rtc2_.*", ("rtc", "v2l0", "RTC")),
     ("STM32L1.*:RTC:rtc2_.*", ("rtc", "v2l1", "RTC")),
+    ("STM32L4.*:RTC:rtc2_v2_9.*", ("rtc", "v3", "RTC")),
     ("STM32L4.*:RTC:rtc2_.*", ("rtc", "v2l4", "RTC")),
     ("STM32L5.*:RTC:rtc2_.*", ("rtc", "v3l5", "RTC")),
     ("STM32WBA.*:RTC:rtc2_.*", ("rtc", "v3u5", "RTC")),


### PR DESCRIPTION
The STM32L4P5 and STM32L4Q5 use the v3 RTC register definition, which is defined as `rtc2_v2_9` in the Cube database file.