### PR TITLE
Add support for I2Sext peripherals on stm32f3xx / stm32f4xx

### DIFF
--- a/data/registers/i2sext_v1.yaml
+++ b/data/registers/i2sext_v1.yaml
@@ -1,0 +1,681 @@
+block/SPI1:
+  description: Serial peripheral interface.
+  items:
+  - name: CR1
+    description: control register 1.
+    byte_offset: 0
+    fieldset: CR1
+  - name: CR2
+    description: control register 2.
+    byte_offset: 4
+    fieldset: CR2
+  - name: SR
+    description: status register.
+    byte_offset: 8
+    fieldset: SR
+  - name: DR
+    description: data register.
+    byte_offset: 12
+    fieldset: DR
+  - name: CRCPR
+    description: CRC polynomial register.
+    byte_offset: 16
+    fieldset: CRCPR
+  - name: RXCRCR
+    description: RX CRC register.
+    byte_offset: 20
+    access: Read
+    fieldset: RXCRCR
+  - name: TXCRCR
+    description: TX CRC register.
+    byte_offset: 24
+    access: Read
+    fieldset: TXCRCR
+  - name: I2SCFGR
+    description: I2S configuration register.
+    byte_offset: 28
+    fieldset: I2SCFGR
+  - name: I2SPR
+    description: I2S prescaler register.
+    byte_offset: 32
+    fieldset: I2SPR
+fieldset/CR1:
+  description: control register 1.
+  fields:
+  - name: CPHA
+    description: Clock phase.
+    bit_offset: 0
+    bit_size: 1
+    enum: CPHA
+  - name: CPOL
+    description: Clock polarity.
+    bit_offset: 1
+    bit_size: 1
+    enum: CPOL
+  - name: MSTR
+    description: Master selection.
+    bit_offset: 2
+    bit_size: 1
+    enum: MSTR
+  - name: BR
+    description: Baud rate control.
+    bit_offset: 3
+    bit_size: 3
+    enum: BR
+  - name: SPE
+    description: SPI enable.
+    bit_offset: 6
+    bit_size: 1
+    enum: SPE
+  - name: LSBFIRST
+    description: Frame format.
+    bit_offset: 7
+    bit_size: 1
+    enum: LSBFIRST
+  - name: SSI
+    description: Internal slave select.
+    bit_offset: 8
+    bit_size: 1
+    enum: SSI
+  - name: SSM
+    description: Software slave management.
+    bit_offset: 9
+    bit_size: 1
+    enum: SSM
+  - name: RXONLY
+    description: Receive only.
+    bit_offset: 10
+    bit_size: 1
+    enum: RXONLY
+  - name: DFF
+    description: Data frame format.
+    bit_offset: 11
+    bit_size: 1
+    enum: DFF
+  - name: CRCNEXT
+    description: CRC transfer next.
+    bit_offset: 12
+    bit_size: 1
+    enum: CRCNEXT
+  - name: CRCEN
+    description: Hardware CRC calculation enable.
+    bit_offset: 13
+    bit_size: 1
+    enum: CRCEN
+  - name: BIDIOE
+    description: Output enable in bidirectional mode.
+    bit_offset: 14
+    bit_size: 1
+    enum: BIDIOE
+  - name: BIDIMODE
+    description: Bidirectional data mode enable.
+    bit_offset: 15
+    bit_size: 1
+    enum: BIDIMODE
+fieldset/CR2:
+  description: control register 2.
+  fields:
+  - name: RXDMAEN
+    description: Rx buffer DMA enable.
+    bit_offset: 0
+    bit_size: 1
+    enum: RXDMAEN
+  - name: TXDMAEN
+    description: Tx buffer DMA enable.
+    bit_offset: 1
+    bit_size: 1
+    enum: TXDMAEN
+  - name: SSOE
+    description: SS output enable.
+    bit_offset: 2
+    bit_size: 1
+    enum: SSOE
+  - name: FRF
+    description: Frame format.
+    bit_offset: 4
+    bit_size: 1
+    enum: FRF
+  - name: ERRIE
+    description: Error interrupt enable.
+    bit_offset: 5
+    bit_size: 1
+    enum: ERRIE
+  - name: RXNEIE
+    description: RX buffer not empty interrupt enable.
+    bit_offset: 6
+    bit_size: 1
+    enum: RXNEIE
+  - name: TXEIE
+    description: Tx buffer empty interrupt enable.
+    bit_offset: 7
+    bit_size: 1
+    enum: TXEIE
+fieldset/CRCPR:
+  description: CRC polynomial register.
+  fields:
+  - name: CRCPOLY
+    description: CRC polynomial register.
+    bit_offset: 0
+    bit_size: 16
+fieldset/DR:
+  description: data register.
+  fields:
+  - name: DR
+    description: Data register.
+    bit_offset: 0
+    bit_size: 16
+fieldset/I2SCFGR:
+  description: I2S configuration register.
+  fields:
+  - name: CHLEN
+    description: Channel length (number of bits per audio channel).
+    bit_offset: 0
+    bit_size: 1
+    enum: CHLEN
+  - name: DATLEN
+    description: Data length to be transferred.
+    bit_offset: 1
+    bit_size: 2
+    enum: DATLEN
+  - name: CKPOL
+    description: Steady state clock polarity.
+    bit_offset: 3
+    bit_size: 1
+    enum: CKPOL
+  - name: I2SSTD
+    description: I2S standard selection.
+    bit_offset: 4
+    bit_size: 2
+    enum: I2SSTD
+  - name: PCMSYNC
+    description: PCM frame synchronization.
+    bit_offset: 7
+    bit_size: 1
+    enum: PCMSYNC
+  - name: I2SCFG
+    description: I2S configuration mode.
+    bit_offset: 8
+    bit_size: 2
+    enum: I2SCFG
+  - name: I2SE
+    description: I2S Enable.
+    bit_offset: 10
+    bit_size: 1
+    enum: I2SE
+  - name: I2SMOD
+    description: I2S mode selection.
+    bit_offset: 11
+    bit_size: 1
+    enum: I2SMOD
+fieldset/I2SPR:
+  description: I2S prescaler register.
+  fields:
+  - name: I2SDIV
+    description: I2S Linear prescaler.
+    bit_offset: 0
+    bit_size: 8
+  - name: ODD
+    description: Odd factor for the prescaler.
+    bit_offset: 8
+    bit_size: 1
+    enum: ODD
+  - name: MCKOE
+    description: Master clock output enable.
+    bit_offset: 9
+    bit_size: 1
+    enum: MCKOE
+fieldset/RXCRCR:
+  description: RX CRC register.
+  fields:
+  - name: RxCRC
+    description: Rx CRC register.
+    bit_offset: 0
+    bit_size: 16
+fieldset/SR:
+  description: status register.
+  fields:
+  - name: RXNE
+    description: Receive buffer not empty.
+    bit_offset: 0
+    bit_size: 1
+    enum: RXNE
+  - name: TXE
+    description: Transmit buffer empty.
+    bit_offset: 1
+    bit_size: 1
+    enum: TXE
+  - name: CHSIDE
+    description: Channel side.
+    bit_offset: 2
+    bit_size: 1
+    enum: CHSIDE
+  - name: UDR
+    description: Underrun flag.
+    bit_offset: 3
+    bit_size: 1
+    enum: UDR
+  - name: CRCERR
+    description: CRC error flag.
+    bit_offset: 4
+    bit_size: 1
+    enum: CRCERR
+  - name: MODF
+    description: Mode fault.
+    bit_offset: 5
+    bit_size: 1
+    enum: MODF
+  - name: OVR
+    description: Overrun flag.
+    bit_offset: 6
+    bit_size: 1
+    enum: OVR
+  - name: BSY
+    description: Busy flag.
+    bit_offset: 7
+    bit_size: 1
+    enum: BSY
+  - name: FRE
+    description: TI frame format error.
+    bit_offset: 8
+    bit_size: 1
+    enum: FRE
+fieldset/TXCRCR:
+  description: TX CRC register.
+  fields:
+  - name: TxCRC
+    description: Tx CRC register.
+    bit_offset: 0
+    bit_size: 16
+enum/BIDIMODE:
+  bit_size: 1
+  variants:
+  - name: Unidirectional
+    description: 2-line unidirectional data mode selected.
+    value: 0
+  - name: Bidirectional
+    description: 1-line bidirectional data mode selected.
+    value: 1
+enum/BIDIOE:
+  bit_size: 1
+  variants:
+  - name: OutputDisabled
+    description: Output disabled (receive-only mode).
+    value: 0
+  - name: OutputEnabled
+    description: Output enabled (transmit-only mode).
+    value: 1
+enum/BR:
+  bit_size: 3
+  variants:
+  - name: Div2
+    description: f_PCLK / 2.
+    value: 0
+  - name: Div4
+    description: f_PCLK / 4.
+    value: 1
+  - name: Div8
+    description: f_PCLK / 8.
+    value: 2
+  - name: Div16
+    description: f_PCLK / 16.
+    value: 3
+  - name: Div32
+    description: f_PCLK / 32.
+    value: 4
+  - name: Div64
+    description: f_PCLK / 64.
+    value: 5
+  - name: Div128
+    description: f_PCLK / 128.
+    value: 6
+  - name: Div256
+    description: f_PCLK / 256.
+    value: 7
+enum/BSY:
+  bit_size: 1
+  variants:
+  - name: NotBusy
+    description: SPI not busy.
+    value: 0
+  - name: Busy
+    description: SPI busy.
+    value: 1
+enum/CHLEN:
+  bit_size: 1
+  variants:
+  - name: SixteenBit
+    description: 16-bit wide.
+    value: 0
+  - name: ThirtyTwoBit
+    description: 32-bit wide.
+    value: 1
+enum/CHSIDE:
+  bit_size: 1
+  variants:
+  - name: Left
+    description: Channel left has to be transmitted or has been received.
+    value: 0
+  - name: Right
+    description: Channel right has to be transmitted or has been received.
+    value: 1
+enum/CKPOL:
+  bit_size: 1
+  variants:
+  - name: IdleLow
+    description: I2S clock inactive state is low level.
+    value: 0
+  - name: IdleHigh
+    description: I2S clock inactive state is high level.
+    value: 1
+enum/CPHA:
+  bit_size: 1
+  variants:
+  - name: FirstEdge
+    description: The first clock transition is the first data capture edge.
+    value: 0
+  - name: SecondEdge
+    description: The second clock transition is the first data capture edge.
+    value: 1
+enum/CPOL:
+  bit_size: 1
+  variants:
+  - name: IdleLow
+    description: CK to 0 when idle.
+    value: 0
+  - name: IdleHigh
+    description: CK to 1 when idle.
+    value: 1
+enum/CRCEN:
+  bit_size: 1
+  variants:
+  - name: Disabled
+    description: CRC calculation disabled.
+    value: 0
+  - name: Enabled
+    description: CRC calculation enabled.
+    value: 1
+enum/CRCERR:
+  bit_size: 1
+  variants:
+  - name: R_Match_W_Clear
+    description: CRC value received matches the SPIx_RXCRCR value.
+    value: 0
+  - name: NoMatch
+    description: CRC value received does not match the SPIx_RXCRCR value.
+    value: 1
+enum/CRCNEXT:
+  bit_size: 1
+  variants:
+  - name: TxBuffer
+    description: Next transmit value is from Tx buffer.
+    value: 0
+  - name: CRC
+    description: Next transmit value is from Tx CRC register.
+    value: 1
+enum/DATLEN:
+  bit_size: 2
+  variants:
+  - name: SixteenBit
+    description: 16-bit data length.
+    value: 0
+  - name: TwentyFourBit
+    description: 24-bit data length.
+    value: 1
+  - name: ThirtyTwoBit
+    description: 32-bit data length.
+    value: 2
+enum/DFF:
+  bit_size: 1
+  variants:
+  - name: EightBit
+    description: 8-bit data frame format is selected for transmission/reception.
+    value: 0
+  - name: SixteenBit
+    description: 16-bit data frame format is selected for transmission/reception.
+    value: 1
+enum/ERRIE:
+  bit_size: 1
+  variants:
+  - name: Masked
+    description: Error interrupt masked.
+    value: 0
+  - name: NotMasked
+    description: Error interrupt not masked.
+    value: 1
+enum/FRE:
+  bit_size: 1
+  variants:
+  - name: NoError
+    description: No frame format error.
+    value: 0
+  - name: Error
+    description: A frame format error occurred.
+    value: 1
+enum/FRF:
+  bit_size: 1
+  variants:
+  - name: Motorola
+    description: SPI Motorola mode.
+    value: 0
+  - name: TI
+    description: SPI TI mode.
+    value: 1
+enum/I2SCFG:
+  bit_size: 2
+  variants:
+  - name: SlaveTx
+    description: Slave - transmit.
+    value: 0
+  - name: SlaveRx
+    description: Slave - receive.
+    value: 1
+  - name: MasterTx
+    description: Master - transmit.
+    value: 2
+  - name: MasterRx
+    description: Master - receive.
+    value: 3
+enum/I2SE:
+  bit_size: 1
+  variants:
+  - name: Disabled
+    description: I2S peripheral is disabled.
+    value: 0
+  - name: Enabled
+    description: I2S peripheral is enabled.
+    value: 1
+enum/I2SMOD:
+  bit_size: 1
+  variants:
+  - name: SPIMode
+    description: SPI mode is selected.
+    value: 0
+  - name: I2SMode
+    description: I2S mode is selected.
+    value: 1
+enum/I2SSTD:
+  bit_size: 2
+  variants:
+  - name: Philips
+    description: I2S Philips standard.
+    value: 0
+  - name: MSB
+    description: MSB justified standard.
+    value: 1
+  - name: LSB
+    description: LSB justified standard.
+    value: 2
+  - name: PCM
+    description: PCM standard.
+    value: 3
+enum/LSBFIRST:
+  bit_size: 1
+  variants:
+  - name: MSBFirst
+    description: Data is transmitted/received with the MSB first.
+    value: 0
+  - name: LSBFirst
+    description: Data is transmitted/received with the LSB first.
+    value: 1
+enum/MCKOE:
+  bit_size: 1
+  variants:
+  - name: Disabled
+    description: Master clock output is disabled.
+    value: 0
+  - name: Enabled
+    description: Master clock output is enabled.
+    value: 1
+enum/MODF:
+  bit_size: 1
+  variants:
+  - name: NoFault
+    description: No mode fault occurred.
+    value: 0
+  - name: Fault
+    description: Mode fault occurred.
+    value: 1
+enum/MSTR:
+  bit_size: 1
+  variants:
+  - name: Slave
+    description: Slave configuration.
+    value: 0
+  - name: Master
+    description: Master configuration.
+    value: 1
+enum/ODD:
+  bit_size: 1
+  variants:
+  - name: Even
+    description: Real divider value is I2SDIV * 2.
+    value: 0
+  - name: Odd
+    description: Real divider value is (I2SDIV * 2) + 1.
+    value: 1
+enum/OVR:
+  bit_size: 1
+  variants:
+  - name: NoOverrun
+    description: No overrun occurred.
+    value: 0
+  - name: Overrun
+    description: Overrun occurred.
+    value: 1
+enum/PCMSYNC:
+  bit_size: 1
+  variants:
+  - name: Short
+    description: Short frame synchronisation.
+    value: 0
+  - name: Long
+    description: Long frame synchronisation.
+    value: 1
+enum/RXDMAEN:
+  bit_size: 1
+  variants:
+  - name: Disabled
+    description: Rx buffer DMA disabled.
+    value: 0
+  - name: Enabled
+    description: Rx buffer DMA enabled.
+    value: 1
+enum/RXNE:
+  bit_size: 1
+  variants:
+  - name: Empty
+    description: Rx buffer empty.
+    value: 0
+  - name: NotEmpty
+    description: Rx buffer not empty.
+    value: 1
+enum/RXNEIE:
+  bit_size: 1
+  variants:
+  - name: Masked
+    description: RXE interrupt masked.
+    value: 0
+  - name: NotMasked
+    description: RXE interrupt not masked.
+    value: 1
+enum/RXONLY:
+  bit_size: 1
+  variants:
+  - name: FullDuplex
+    description: Full duplex (Transmit and receive).
+    value: 0
+  - name: OutputDisabled
+    description: Output disabled (Receive-only mode).
+    value: 1
+enum/SPE:
+  bit_size: 1
+  variants:
+  - name: Disabled
+    description: Peripheral disabled.
+    value: 0
+  - name: Enabled
+    description: Peripheral enabled.
+    value: 1
+enum/SSI:
+  bit_size: 1
+  variants:
+  - name: SlaveSelected
+    description: 0 is forced onto the NSS pin and the I/O value of the NSS pin is ignored.
+    value: 0
+  - name: SlaveNotSelected
+    description: 1 is forced onto the NSS pin and the I/O value of the NSS pin is ignored.
+    value: 1
+enum/SSM:
+  bit_size: 1
+  variants:
+  - name: Disabled
+    description: Software slave management disabled.
+    value: 0
+  - name: Enabled
+    description: Software slave management enabled.
+    value: 1
+enum/SSOE:
+  bit_size: 1
+  variants:
+  - name: Disabled
+    description: SS output is disabled in master mode.
+    value: 0
+  - name: Enabled
+    description: SS output is enabled in master mode.
+    value: 1
+enum/TXDMAEN:
+  bit_size: 1
+  variants:
+  - name: Disabled
+    description: Tx buffer DMA disabled.
+    value: 0
+  - name: Enabled
+    description: Tx buffer DMA enabled.
+    value: 1
+enum/TXE:
+  bit_size: 1
+  variants:
+  - name: NotEmpty
+    description: Tx buffer not empty.
+    value: 0
+  - name: Empty
+    description: Tx buffer empty.
+    value: 1
+enum/TXEIE:
+  bit_size: 1
+  variants:
+  - name: Masked
+    description: TXE interrupt masked.
+    value: 0
+  - name: NotMasked
+    description: TXE interrupt not masked.
+    value: 1
+enum/UDR:
+  bit_size: 1
+  variants:
+  - name: NoUnderrun
+    description: No underrun occurred.
+    value: 0
+  - name: Underrun
+    description: Underrun occurred.
+    value: 1

--- a/data/registers/i2sext_v2.yaml
+++ b/data/registers/i2sext_v2.yaml
@@ -1,0 +1,824 @@
+block/SPI1:
+  description: Serial peripheral interface/Inter-IC sound.
+  items:
+  - name: CR1
+    description: control register 1.
+    byte_offset: 0
+    fieldset: CR1
+  - name: CR2
+    description: control register 2.
+    byte_offset: 4
+    fieldset: CR2
+  - name: SR
+    description: status register.
+    byte_offset: 8
+    fieldset: SR
+  - name: DR
+    description: data register.
+    byte_offset: 12
+    fieldset: DR
+  - name: CRCPR
+    description: CRC polynomial register.
+    byte_offset: 16
+    fieldset: CRCPR
+  - name: RXCRCR
+    description: RX CRC register.
+    byte_offset: 20
+    access: Read
+    fieldset: RXCRCR
+  - name: TXCRCR
+    description: TX CRC register.
+    byte_offset: 24
+    access: Read
+    fieldset: TXCRCR
+  - name: I2SCFGR
+    description: I2S configuration register.
+    byte_offset: 28
+    fieldset: I2SCFGR
+  - name: I2SPR
+    description: I2S prescaler register.
+    byte_offset: 32
+    fieldset: I2SPR
+fieldset/CR1:
+  description: control register 1.
+  fields:
+  - name: CPHA
+    description: Clock phase.
+    bit_offset: 0
+    bit_size: 1
+    enum: CPHA
+  - name: CPOL
+    description: Clock polarity.
+    bit_offset: 1
+    bit_size: 1
+    enum: CPOL
+  - name: MSTR
+    description: Master selection.
+    bit_offset: 2
+    bit_size: 1
+    enum: MSTR
+  - name: BR
+    description: Baud rate control.
+    bit_offset: 3
+    bit_size: 3
+    enum: BR
+  - name: SPE
+    description: SPI enable.
+    bit_offset: 6
+    bit_size: 1
+    enum: SPE
+  - name: LSBFIRST
+    description: Frame format.
+    bit_offset: 7
+    bit_size: 1
+    enum: LSBFIRST
+  - name: SSI
+    description: Internal slave select.
+    bit_offset: 8
+    bit_size: 1
+    enum: SSI
+  - name: SSM
+    description: Software slave management.
+    bit_offset: 9
+    bit_size: 1
+    enum: SSM
+  - name: RXONLY
+    description: Receive only.
+    bit_offset: 10
+    bit_size: 1
+    enum: RXONLY
+  - name: CRCL
+    description: CRC length.
+    bit_offset: 11
+    bit_size: 1
+    enum: CRCL
+  - name: CRCNEXT
+    description: CRC transfer next.
+    bit_offset: 12
+    bit_size: 1
+    enum: CRCNEXT
+  - name: CRCEN
+    description: Hardware CRC calculation enable.
+    bit_offset: 13
+    bit_size: 1
+    enum: CRCEN
+  - name: BIDIOE
+    description: Output enable in bidirectional mode.
+    bit_offset: 14
+    bit_size: 1
+    enum: BIDIOE
+  - name: BIDIMODE
+    description: Bidirectional data mode enable.
+    bit_offset: 15
+    bit_size: 1
+    enum: BIDIMODE
+fieldset/CR2:
+  description: control register 2.
+  fields:
+  - name: RXDMAEN
+    description: Rx buffer DMA enable.
+    bit_offset: 0
+    bit_size: 1
+    enum: RXDMAEN
+  - name: TXDMAEN
+    description: Tx buffer DMA enable.
+    bit_offset: 1
+    bit_size: 1
+    enum: TXDMAEN
+  - name: SSOE
+    description: SS output enable.
+    bit_offset: 2
+    bit_size: 1
+    enum: SSOE
+  - name: NSSP
+    description: NSS pulse management.
+    bit_offset: 3
+    bit_size: 1
+    enum: NSSP
+  - name: FRF
+    description: Frame format.
+    bit_offset: 4
+    bit_size: 1
+    enum: FRF
+  - name: ERRIE
+    description: Error interrupt enable.
+    bit_offset: 5
+    bit_size: 1
+    enum: ERRIE
+  - name: RXNEIE
+    description: RX buffer not empty interrupt enable.
+    bit_offset: 6
+    bit_size: 1
+    enum: RXNEIE
+  - name: TXEIE
+    description: Tx buffer empty interrupt enable.
+    bit_offset: 7
+    bit_size: 1
+    enum: TXEIE
+  - name: DS
+    description: Data size.
+    bit_offset: 8
+    bit_size: 4
+    enum: DS
+  - name: FRXTH
+    description: FIFO reception threshold.
+    bit_offset: 12
+    bit_size: 1
+    enum: FRXTH
+  - name: LDMA_RX
+    description: Last DMA transfer for reception.
+    bit_offset: 13
+    bit_size: 1
+    enum: LDMA_RX
+  - name: LDMA_TX
+    description: Last DMA transfer for transmission.
+    bit_offset: 14
+    bit_size: 1
+    enum: LDMA_TX
+fieldset/CRCPR:
+  description: CRC polynomial register.
+  fields:
+  - name: CRCPOLY
+    description: CRC polynomial register.
+    bit_offset: 0
+    bit_size: 16
+fieldset/DR:
+  description: data register.
+  fields:
+  - name: DR
+    description: Data register.
+    bit_offset: 0
+    bit_size: 16
+fieldset/I2SCFGR:
+  description: I2S configuration register.
+  fields:
+  - name: CHLEN
+    description: Channel length (number of bits per audio channel).
+    bit_offset: 0
+    bit_size: 1
+    enum: CHLEN
+  - name: DATLEN
+    description: Data length to be transferred.
+    bit_offset: 1
+    bit_size: 2
+    enum: DATLEN
+  - name: CKPOL
+    description: Steady state clock polarity.
+    bit_offset: 3
+    bit_size: 1
+    enum: CKPOL
+  - name: I2SSTD
+    description: I2S standard selection.
+    bit_offset: 4
+    bit_size: 2
+    enum: I2SSTD
+  - name: PCMSYNC
+    description: PCM frame synchronization.
+    bit_offset: 7
+    bit_size: 1
+    enum: PCMSYNC
+  - name: I2SCFG
+    description: I2S configuration mode.
+    bit_offset: 8
+    bit_size: 2
+    enum: I2SCFG
+  - name: I2SE
+    description: I2S Enable.
+    bit_offset: 10
+    bit_size: 1
+    enum: I2SE
+  - name: I2SMOD
+    description: I2S mode selection.
+    bit_offset: 11
+    bit_size: 1
+    enum: I2SMOD
+fieldset/I2SPR:
+  description: I2S prescaler register.
+  fields:
+  - name: I2SDIV
+    description: I2S Linear prescaler.
+    bit_offset: 0
+    bit_size: 8
+  - name: ODD
+    description: Odd factor for the prescaler.
+    bit_offset: 8
+    bit_size: 1
+    enum: ODD
+  - name: MCKOE
+    description: Master clock output enable.
+    bit_offset: 9
+    bit_size: 1
+    enum: MCKOE
+fieldset/RXCRCR:
+  description: RX CRC register.
+  fields:
+  - name: RxCRC
+    description: Rx CRC register.
+    bit_offset: 0
+    bit_size: 16
+fieldset/SR:
+  description: status register.
+  fields:
+  - name: RXNE
+    description: Receive buffer not empty.
+    bit_offset: 0
+    bit_size: 1
+    enum: RXNE
+  - name: TXE
+    description: Transmit buffer empty.
+    bit_offset: 1
+    bit_size: 1
+    enum: TXE
+  - name: CHSIDE
+    description: Channel side.
+    bit_offset: 2
+    bit_size: 1
+    enum: CHSIDE
+  - name: UDR
+    description: Underrun flag.
+    bit_offset: 3
+    bit_size: 1
+    enum: UDR
+  - name: CRCERR
+    description: CRC error flag.
+    bit_offset: 4
+    bit_size: 1
+    enum: CRCERR
+  - name: MODF
+    description: Mode fault.
+    bit_offset: 5
+    bit_size: 1
+    enum: MODF
+  - name: OVR
+    description: Overrun flag.
+    bit_offset: 6
+    bit_size: 1
+    enum: OVR
+  - name: BSY
+    description: Busy flag.
+    bit_offset: 7
+    bit_size: 1
+    enum: BSY
+  - name: FRE
+    description: TI frame format error.
+    bit_offset: 8
+    bit_size: 1
+    enum: FRE
+  - name: FRLVL
+    description: FIFO reception level.
+    bit_offset: 9
+    bit_size: 2
+    enum: FRLVL
+  - name: FTLVL
+    description: FIFO transmission level.
+    bit_offset: 11
+    bit_size: 2
+    enum: FTLVL
+fieldset/TXCRCR:
+  description: TX CRC register.
+  fields:
+  - name: TxCRC
+    description: Tx CRC register.
+    bit_offset: 0
+    bit_size: 16
+enum/BIDIMODE:
+  bit_size: 1
+  variants:
+  - name: Unidirectional
+    description: 2-line unidirectional data mode selected.
+    value: 0
+  - name: Bidirectional
+    description: 1-line bidirectional data mode selected.
+    value: 1
+enum/BIDIOE:
+  bit_size: 1
+  variants:
+  - name: OutputDisabled
+    description: Output disabled (receive-only mode).
+    value: 0
+  - name: OutputEnabled
+    description: Output enabled (transmit-only mode).
+    value: 1
+enum/BR:
+  bit_size: 3
+  variants:
+  - name: Div2
+    description: f_PCLK / 2.
+    value: 0
+  - name: Div4
+    description: f_PCLK / 4.
+    value: 1
+  - name: Div8
+    description: f_PCLK / 8.
+    value: 2
+  - name: Div16
+    description: f_PCLK / 16.
+    value: 3
+  - name: Div32
+    description: f_PCLK / 32.
+    value: 4
+  - name: Div64
+    description: f_PCLK / 64.
+    value: 5
+  - name: Div128
+    description: f_PCLK / 128.
+    value: 6
+  - name: Div256
+    description: f_PCLK / 256.
+    value: 7
+enum/BSY:
+  bit_size: 1
+  variants:
+  - name: NotBusy
+    description: SPI not busy.
+    value: 0
+  - name: Busy
+    description: SPI busy.
+    value: 1
+enum/CHLEN:
+  bit_size: 1
+  variants:
+  - name: SixteenBit
+    description: 16-bit wide.
+    value: 0
+  - name: ThirtyTwoBit
+    description: 32-bit wide.
+    value: 1
+enum/CHSIDE:
+  bit_size: 1
+  variants:
+  - name: Left
+    description: Channel left has to be transmitted or has been received.
+    value: 0
+  - name: Right
+    description: Channel right has to be transmitted or has been received.
+    value: 1
+enum/CKPOL:
+  bit_size: 1
+  variants:
+  - name: IdleLow
+    description: I2S clock inactive state is low level.
+    value: 0
+  - name: IdleHigh
+    description: I2S clock inactive state is high level.
+    value: 1
+enum/CPHA:
+  bit_size: 1
+  variants:
+  - name: FirstEdge
+    description: The first clock transition is the first data capture edge.
+    value: 0
+  - name: SecondEdge
+    description: The second clock transition is the first data capture edge.
+    value: 1
+enum/CPOL:
+  bit_size: 1
+  variants:
+  - name: IdleLow
+    description: CK to 0 when idle.
+    value: 0
+  - name: IdleHigh
+    description: CK to 1 when idle.
+    value: 1
+enum/CRCEN:
+  bit_size: 1
+  variants:
+  - name: Disabled
+    description: CRC calculation disabled.
+    value: 0
+  - name: Enabled
+    description: CRC calculation enabled.
+    value: 1
+enum/CRCERR:
+  bit_size: 1
+  variants:
+  - name: R_Match_W_Clear
+    description: CRC value received matches the SPIx_RXCRCR value.
+    value: 0
+  - name: NoMatch
+    description: CRC value received does not match the SPIx_RXCRCR value.
+    value: 1
+enum/CRCL:
+  bit_size: 1
+  variants:
+  - name: EightBit
+    description: 8-bit CRC length.
+    value: 0
+  - name: SixteenBit
+    description: 16-bit CRC length.
+    value: 1
+enum/CRCNEXT:
+  bit_size: 1
+  variants:
+  - name: TxBuffer
+    description: Next transmit value is from Tx buffer.
+    value: 0
+  - name: CRC
+    description: Next transmit value is from Tx CRC register.
+    value: 1
+enum/DATLEN:
+  bit_size: 2
+  variants:
+  - name: SixteenBit
+    description: 16-bit data length.
+    value: 0
+  - name: TwentyFourBit
+    description: 24-bit data length.
+    value: 1
+  - name: ThirtyTwoBit
+    description: 32-bit data length.
+    value: 2
+enum/DS:
+  bit_size: 4
+  variants:
+  - name: FourBit
+    description: 4-bit.
+    value: 3
+  - name: FiveBit
+    description: 5-bit.
+    value: 4
+  - name: SixBit
+    description: 6-bit.
+    value: 5
+  - name: SevenBit
+    description: 7-bit.
+    value: 6
+  - name: EightBit
+    description: 8-bit.
+    value: 7
+  - name: NineBit
+    description: 9-bit.
+    value: 8
+  - name: TenBit
+    description: 10-bit.
+    value: 9
+  - name: ElevenBit
+    description: 11-bit.
+    value: 10
+  - name: TwelveBit
+    description: 12-bit.
+    value: 11
+  - name: ThirteenBit
+    description: 13-bit.
+    value: 12
+  - name: FourteenBit
+    description: 14-bit.
+    value: 13
+  - name: FifteenBit
+    description: 15-bit.
+    value: 14
+  - name: SixteenBit
+    description: 16-bit.
+    value: 15
+enum/ERRIE:
+  bit_size: 1
+  variants:
+  - name: Masked
+    description: Error interrupt masked.
+    value: 0
+  - name: NotMasked
+    description: Error interrupt not masked.
+    value: 1
+enum/FRE:
+  bit_size: 1
+  variants:
+  - name: NoError
+    description: No frame format error.
+    value: 0
+  - name: Error
+    description: A frame format error occurred.
+    value: 1
+enum/FRF:
+  bit_size: 1
+  variants:
+  - name: Motorola
+    description: SPI Motorola mode.
+    value: 0
+  - name: TI
+    description: SPI TI mode.
+    value: 1
+enum/FRLVL:
+  bit_size: 2
+  variants:
+  - name: Empty
+    description: Rx FIFO Empty.
+    value: 0
+  - name: Quarter
+    description: Rx 1/4 FIFO.
+    value: 1
+  - name: Half
+    description: Rx 1/2 FIFO.
+    value: 2
+  - name: Full
+    description: Rx FIFO full.
+    value: 3
+enum/FRXTH:
+  bit_size: 1
+  variants:
+  - name: Half
+    description: RXNE event is generated if the FIFO level is greater than or equal to 1/2 (16-bit).
+    value: 0
+  - name: Quarter
+    description: RXNE event is generated if the FIFO level is greater than or equal to 1/4 (8-bit).
+    value: 1
+enum/FTLVL:
+  bit_size: 2
+  variants:
+  - name: Empty
+    description: Tx FIFO Empty.
+    value: 0
+  - name: Quarter
+    description: Tx 1/4 FIFO.
+    value: 1
+  - name: Half
+    description: Tx 1/2 FIFO.
+    value: 2
+  - name: Full
+    description: Tx FIFO full.
+    value: 3
+enum/I2SCFG:
+  bit_size: 2
+  variants:
+  - name: SlaveTx
+    description: Slave - transmit.
+    value: 0
+  - name: SlaveRx
+    description: Slave - receive.
+    value: 1
+  - name: MasterTx
+    description: Master - transmit.
+    value: 2
+  - name: MasterRx
+    description: Master - receive.
+    value: 3
+enum/I2SE:
+  bit_size: 1
+  variants:
+  - name: Disabled
+    description: I2S peripheral is disabled.
+    value: 0
+  - name: Enabled
+    description: I2S peripheral is enabled.
+    value: 1
+enum/I2SMOD:
+  bit_size: 1
+  variants:
+  - name: SPIMode
+    description: SPI mode is selected.
+    value: 0
+  - name: I2SMode
+    description: I2S mode is selected.
+    value: 1
+enum/I2SSTD:
+  bit_size: 2
+  variants:
+  - name: Philips
+    description: I2S Philips standard.
+    value: 0
+  - name: MSB
+    description: MSB justified standard.
+    value: 1
+  - name: LSB
+    description: LSB justified standard.
+    value: 2
+  - name: PCM
+    description: PCM standard.
+    value: 3
+enum/LDMA_RX:
+  bit_size: 1
+  variants:
+  - name: Even
+    description: Number of data to transfer for receive is even.
+    value: 0
+  - name: Odd
+    description: Number of data to transfer for receive is odd.
+    value: 1
+enum/LDMA_TX:
+  bit_size: 1
+  variants:
+  - name: Even
+    description: Number of data to transfer for transmit is even.
+    value: 0
+  - name: Odd
+    description: Number of data to transfer for transmit is odd.
+    value: 1
+enum/LSBFIRST:
+  bit_size: 1
+  variants:
+  - name: MSBFirst
+    description: Data is transmitted/received with the MSB first.
+    value: 0
+  - name: LSBFirst
+    description: Data is transmitted/received with the LSB first.
+    value: 1
+enum/MCKOE:
+  bit_size: 1
+  variants:
+  - name: Disabled
+    description: Master clock output is disabled.
+    value: 0
+  - name: Enabled
+    description: Master clock output is enabled.
+    value: 1
+enum/MODF:
+  bit_size: 1
+  variants:
+  - name: NoFault
+    description: No mode fault occurred.
+    value: 0
+  - name: Fault
+    description: Mode fault occurred.
+    value: 1
+enum/MSTR:
+  bit_size: 1
+  variants:
+  - name: Slave
+    description: Slave configuration.
+    value: 0
+  - name: Master
+    description: Master configuration.
+    value: 1
+enum/NSSP:
+  bit_size: 1
+  variants:
+  - name: NoPulse
+    description: No NSS pulse.
+    value: 0
+  - name: PulseGenerated
+    description: NSS pulse generated.
+    value: 1
+enum/ODD:
+  bit_size: 1
+  variants:
+  - name: Even
+    description: Real divider value is I2SDIV * 2.
+    value: 0
+  - name: Odd
+    description: Real divider value is (I2SDIV * 2) + 1.
+    value: 1
+enum/OVR:
+  bit_size: 1
+  variants:
+  - name: NoOverrun
+    description: No overrun occurred.
+    value: 0
+  - name: Overrun
+    description: Overrun occurred.
+    value: 1
+enum/PCMSYNC:
+  bit_size: 1
+  variants:
+  - name: Short
+    description: Short frame synchronisation.
+    value: 0
+  - name: Long
+    description: Long frame synchronisation.
+    value: 1
+enum/RXDMAEN:
+  bit_size: 1
+  variants:
+  - name: Disabled
+    description: Rx buffer DMA disabled.
+    value: 0
+  - name: Enabled
+    description: Rx buffer DMA enabled.
+    value: 1
+enum/RXNE:
+  bit_size: 1
+  variants:
+  - name: Empty
+    description: Rx buffer empty.
+    value: 0
+  - name: NotEmpty
+    description: Rx buffer not empty.
+    value: 1
+enum/RXNEIE:
+  bit_size: 1
+  variants:
+  - name: Masked
+    description: RXE interrupt masked.
+    value: 0
+  - name: NotMasked
+    description: RXE interrupt not masked.
+    value: 1
+enum/RXONLY:
+  bit_size: 1
+  variants:
+  - name: FullDuplex
+    description: Full duplex (Transmit and receive).
+    value: 0
+  - name: OutputDisabled
+    description: Output disabled (Receive-only mode).
+    value: 1
+enum/SPE:
+  bit_size: 1
+  variants:
+  - name: Disabled
+    description: Peripheral disabled.
+    value: 0
+  - name: Enabled
+    description: Peripheral enabled.
+    value: 1
+enum/SSI:
+  bit_size: 1
+  variants:
+  - name: SlaveSelected
+    description: 0 is forced onto the NSS pin and the I/O value of the NSS pin is ignored.
+    value: 0
+  - name: SlaveNotSelected
+    description: 1 is forced onto the NSS pin and the I/O value of the NSS pin is ignored.
+    value: 1
+enum/SSM:
+  bit_size: 1
+  variants:
+  - name: Disabled
+    description: Software slave management disabled.
+    value: 0
+  - name: Enabled
+    description: Software slave management enabled.
+    value: 1
+enum/SSOE:
+  bit_size: 1
+  variants:
+  - name: Disabled
+    description: SS output is disabled in master mode.
+    value: 0
+  - name: Enabled
+    description: SS output is enabled in master mode.
+    value: 1
+enum/TXDMAEN:
+  bit_size: 1
+  variants:
+  - name: Disabled
+    description: Tx buffer DMA disabled.
+    value: 0
+  - name: Enabled
+    description: Tx buffer DMA enabled.
+    value: 1
+enum/TXE:
+  bit_size: 1
+  variants:
+  - name: NotEmpty
+    description: Tx buffer not empty.
+    value: 0
+  - name: Empty
+    description: Tx buffer empty.
+    value: 1
+enum/TXEIE:
+  bit_size: 1
+  variants:
+  - name: Masked
+    description: TXE interrupt masked.
+    value: 0
+  - name: NotMasked
+    description: TXE interrupt not masked.
+    value: 1
+enum/UDR:
+  bit_size: 1
+  variants:
+  - name: NoUnderrun
+    description: No underrun occurred.
+    value: 0
+  - name: Underrun
+    description: Underrun occurred.
+    value: 1

--- a/stm32-data-gen/src/perimap.rs
+++ b/stm32-data-gen/src/perimap.rs
@@ -52,6 +52,8 @@ pub static PERIMAP: RegexMap<(&str, &str, &str)> = RegexMap::new(&[
     ("STM32(H5|WBA).*:AES:.*", ("aes", "v3b", "AES")),
     ("STM32(H5|WBA).*:SAES:.*", ("saes", "v1a", "SAES")),
     ("STM32U5.*:SAES:.*", ("saes", "v1b", "SAES")),
+    ("STM32F3.*:I2S.ext:.*", ("i2sext", "v2", "I2Sext")),
+    ("STM32F4.*:I2S.ext:.*", ("i2sext", "v1", "I2Sext")),
     ("STM32F10[57].*:SPI:.*", ("spi", "v1_i2s", "SPI")),
     ("STM32F10[13].[CDEFG].*:SPI:.*", ("spi", "v1_i2s", "SPI")),
     ("STM32F1.*:SPI:.*", ("spi", "v1", "SPI")),


### PR DESCRIPTION
Full-duplex I2S opeeration on these platforms requires "I2Sext" peripherals that work alongside the SPI/I2S peripherals.  This PR attempts to add support for these peripherals, in support of [enabling full-duplex operation at the `embassy-stm32` layer](https://github.com/embassy-rs/embassy/issues/4698).

I tried following the directions in the README, invoking `./d extract-all` for `I2S2ext` and `I2S3ext`.  This produced a few dozen YAML files, of which there were two unique classes modulo renaming of fields.  I called these `i2sext_v1.yaml` for the F4 family and `_v2.yaml` for the F3 family (following release date order).  I added lines to `perimap.rs` which ought to have caught the relevant peripherals.

However, I hit a roadblock here.  The entries in `PERIMAP` never hit, apparently because the I2Sext peripherals don't appear in the chip XML in `data/cubedb`, from which the `ChipGroup` values are generated.  Those XML files *do* contain the pin definitions that the ext-peripherals require (e.g., in `STM32F405RGTx.xml`, pin `PB4` has `I2S3_ext_SD`).

I would appreciate guidance on how to move forward here.  I suspect that the I2Sext peripherals might need special handling like the I2S peripherals, but this is exceeding the bounds of my knowledge here.