### PR TITLE
stm32wle5: StopMode::Standby for LP enabled peripherals

### DIFF
--- a/stm32-data-gen/src/low_power.rs
+++ b/stm32-data-gen/src/low_power.rs
@@ -24,6 +24,7 @@ pub(crate) fn peripheral_stop_mode_info(mcu_name: &str, peripheral: &str) -> Opt
         (r"^STM32WLE5.*:I2C3", StopMode::Standby),
         (r"^STM32WLE5.*:LPTIM1", StopMode::Standby),
         (r"^STM32WLE5.*:SUBGHZSPI", StopMode::Stop2),
+        (r"^STM32WLE5.*:ADC1", StopMode::Stop2),
 
         // __ATTENTION__: Keep these rules at the bottom to grant precedence to the more specific rules above
         // Every peripheral with LP prefix is assumed to be able enter up to Stop1 mode


### PR DESCRIPTION
Mark LPUART1, I2C3, LPTIM1 as not blocking STOP2.