### PR TITLE
Fix page number selection bug in flash_c0

### DIFF
--- a/data/registers/flash_c0.yaml
+++ b/data/registers/flash_c0.yaml
@@ -106,7 +106,7 @@ fieldset/CR:
   - name: PNB
     description: Page number
     bit_offset: 3
-    bit_size: 4
+    bit_size: 7
   - name: STRT
     description: Start
     bit_offset: 16


### PR DESCRIPTION
The field bit width for FLASH_CR register PNB (page number selection) bits 9:3 was incorrectly set to 4, when it should be 7.

This caused the page erase operations to be wrapped around to 4 bit values.

See RM0490 [1], section 4.7.5 (FLASH_CR).

[1]: https://www.st.com/resource/en/reference_manual/rm0490-stm32c0-series-advanced-armbased-32bit-mcus-stmicroelectronics.pdf