### PR TITLE
Add LCD bits to L0 RCC

### DIFF
--- a/data/registers/rcc_l0_v2.yaml
+++ b/data/registers/rcc_l0_v2.yaml
@@ -192,6 +192,10 @@ fieldset/APB1ENR:
     description: Timer 7 clock enable
     bit_offset: 5
     bit_size: 1
+  - name: LCDEN
+    description: LCD clock enable
+    bit_offset: 9
+    bit_size: 1
   - name: WWDGEN
     description: Window watchdog clock enable
     bit_offset: 11
@@ -267,6 +271,10 @@ fieldset/APB1RSTR:
     description: Timer 7 reset
     bit_offset: 5
     bit_size: 1
+  - name: LCDRST
+    description: LCD reset
+    bit_offset: 9
+    bit_size: 1
   - name: WWDGRST
     description: Window watchdog reset
     bit_offset: 11
@@ -341,6 +349,10 @@ fieldset/APB1SMENR:
   - name: TIM7SMEN
     description: Timer 7 clock enable during sleep mode
     bit_offset: 5
+    bit_size: 1
+  - name: LCDSMEN
+    description: LCD clock enable during Sleep mode
+    bit_offset: 9
     bit_size: 1
   - name: WWDGSMEN
     description: Window watchdog clock enable during sleep mode


### PR DESCRIPTION
Turns out these bits are just missing from the SVD.

Required for https://github.com/embassy-rs/embassy/pull/4925