### PR TITLE
add COMP v3 to L4 and L5

### DIFF
--- a/stm32-data-gen/src/perimap.rs
+++ b/stm32-data-gen/src/perimap.rs
@@ -617,7 +617,7 @@ pub static PERIMAP: RegexMap<(&str, &str, &str)> = RegexMap::new(&[
     ("STM32G0.1.*:.*:COMP:.*", ("comp", "v1", "COMP")),
     ("STM32G4.*:.*:COMP:.*", ("comp", "v2", "COMP")),
     ("STM32U0.*:.*:COMP:.*", ("comp", "u0", "COMP")),
-    ("STM32WL.*:.*:COMP:.*", ("comp", "v3", "COMP")),
+    ("STM32(WL|L4|L5).*:.*:COMP:.*", ("comp", "v3", "COMP")),
     ("STM32H7[4523].*:COMP:.*", ("comp", "h7_b", "COMP")),
     ("STM32H7[AB].*:COMP:.*", ("comp", "h7_a", "COMP")),
     ("STM32H5.*:COMP:.*", ("comp", "h5", "COMP")),


### PR DESCRIPTION
L4 and L5 has the same COMP registers as the WL series. L5 doesn't have INMESEL (multiplex for negative pin).