### PR TITLE
[STM32WB0] Fix SRAM0 Errors

### DIFF
--- a/stm32-data-gen/src/memory.rs
+++ b/stm32-data-gen/src/memory.rs
@@ -402,6 +402,7 @@ static MEMS: RegexMap<&[&[Mem]]> = RegexMap::new(&[
 struct FlashInfo {
     write_size: u32,
     erase_size: &'static [(u32, u32)],
+    /// If erasing flash memory leaves behind 1's: 0xFF; If 0's: 0x00
     erase_value: u8,
 }
 


### PR DESCRIPTION
Initial PR missed that ST reserves a few bytes for itself at the beginning of the always-on user SRAM0. Also, there were typo'd missing zeroes. Verified erase value from the ST-provided flash algorithm for the WB0 series.