### PR TITLE
Add nRST_SHDW bit to flash_l4

### DIFF
--- a/data/registers/flash_l4.yaml
+++ b/data/registers/flash_l4.yaml
@@ -208,6 +208,10 @@ fieldset/OPTR:
     description: nRST_STDBY
     bit_offset: 13
     bit_size: 1
+  - name: nRST_SHDW
+    description: nRST_SHDW
+    bit_offset: 14
+    bit_size: 1
   - name: IDWG_SW
     description: Independent watchdog selection
     bit_offset: 16


### PR DESCRIPTION
Shutdown mode is not possible to enter on L4 as it will reset instead of entering shutdown by default.
I think this bit was omitted by mistake as it should be available in all L4 versions, or at least STM32L41xxx/42xxx/43xxx/44xxx/45xxx/46xxx (RM0394)