### PR TITLE
Add additional HRTIMv2 Registers

### DIFF
--- a/clean.sh
+++ b/clean.sh
@@ -1,6 +1,0 @@
-#!/bin/sh
-
-./yamlfmt -v data/registers/hrtim_v2.yaml
-sed -i '' 's/"/'"'"'/g' data/registers/hrtim_v2.yaml
-
-


### PR DESCRIPTION
Adds missing HRTIMv2 registers

### TimerX Registers
`CR2` centre aligned/up-down mode, centre aligned rollover modes (RM0440 28.5.54)

### Common Registers
`ADCER` extended triggers
`ADCUR` trigger update
`ADCPS1` post scaler 1
`ADCPS2` post scaler 2