### PR TITLE
Added WBA magic RNG values. Fixed N6 XML typo.

### DIFF
--- a/data/registers/rng_wba6.yaml
+++ b/data/registers/rng_wba6.yaml
@@ -83,6 +83,7 @@ fieldset/HTCR:
     description: Health test configuration
     bit_offset: 0
     bit_size: 32
+    enum: HTCFG
 fieldset/NSCR:
   description: RNG noise source control register.
   fields:
@@ -188,7 +189,10 @@ enum/RNG_CONFIG1:
     value: 15
   - name: ConfigB
     description: Recommended value for config B (not NIST certifiable)
-    value: 24
+    value: 1
+  - name: ConfigC
+    description: Recommended value for config C (not NIST certifiable) (0x0000_82)
+    value: 130
 enum/RNG_CONFIG2:
   bit_size: 3
   variants:
@@ -198,9 +202,21 @@ enum/RNG_CONFIG2:
 enum/RNG_CONFIG3:
   bit_size: 4
   variants:
+  - name: ConfigA
+    description: Recommended value for config A (NIST certifiable)
+    value: 15
   - name: ConfigB
     description: Recommended value for config B (not NIST certifiable)
     value: 0
+enum/HTCFG:
+  bit_size: 32
+  variants:
   - name: ConfigA
-    description: Recommended value for config A (NIST certifiable)
-    value: 13
+    description: Recommended value for RNG certification (0x0000_6688)
+    value: 26248
+  - name: ConfigB_C
+    description: Recommended value for config B and C (not NIST certifiable) (0x0000_AAC7)
+    value: 43727
+  - name: Magic
+    description: Magic number to be written before any write (0x1759_0ABC)
+    value: 391711420

--- a/stm32-data-gen/src/interrupts.rs
+++ b/stm32-data-gen/src/interrupts.rs
@@ -149,7 +149,10 @@ impl ChipInterrupts {
             }
 
             // More typos
-            let name = name.replace("USAR11", "USART11");
+            let name = name
+                .replace("USAR11", "USART11")
+                // ST NVIC XML typo seen on STM32N6: "Channe1l4" instead of "Channel14"
+                .replace("Channe1l4", "Channel14");
             trace!("    name={name}");
 
             // Skip interrupts that don't exist.


### PR DESCRIPTION
<img width="1987" height="1343" alt="Screenshot 2025-12-16 at 3 33 35 PM" src="https://github.com/user-attachments/assets/fac65278-062c-4ff9-b824-d1a273e0b42e" />
This is sort of related to
[a previous issue](https://github.com/embassy-rs/embassy/pull/5080)
I just decided to add it to `stm32-data` so it's not as "hack-y"
This also takes in
[this documentation](https://www.st.com/resource/en/application_note/an4230-introduction-to-random-number-generation-validation-using-the-nist-statistical-test-suite-for-stm32-mcus-and-mpus-stmicroelectronics.pdf)
<img width="1339" height="959" alt="Screenshot 2025-12-16 at 3 35 16 PM" src="https://github.com/user-attachments/assets/17b85a4a-5692-41ee-a294-8d67d76bc3de" />
This adds the magic RNG values for future use. This might require further custom-mapping for other device series but for the WBA devices this handles the register enums as they currently are.

There was also a breaking situation where a N6 IRQ wasn't being handled. There was a typo in one of the XMLs. This PR also addresses that.