### PR TITLE
Fix ADC Common register divergence between G4 and H7

### DIFF
--- a/data/registers/adccommon_g4.yaml
+++ b/data/registers/adccommon_g4.yaml
@@ -1,0 +1,270 @@
+block/ADC_COMMON:
+  description: Analog-to-Digital Converter
+  items:
+  - name: CSR
+    description: ADC Common status register
+    byte_offset: 0
+    access: Read
+    fieldset: CSR
+  - name: CCR
+    description: ADC common control register
+    byte_offset: 8
+    fieldset: CCR
+  - name: CDR
+    description: ADC common regular data register for dual and triple modes
+    byte_offset: 12
+    access: Read
+    fieldset: CDR
+  - name: CDR2
+    description: ADC x common regular data register for 32-bit dual mode
+    byte_offset: 16
+    access: Read
+    fieldset: CDR2
+fieldset/CCR:
+  description: ADC common control register
+  fields:
+  - name: DUAL
+    description: Dual ADC mode selection
+    bit_offset: 0
+    bit_size: 5
+    enum: DUAL
+  - name: DELAY
+    description: Delay between 2 sampling phases
+    bit_offset: 8
+    bit_size: 4
+  - name: DMACFG
+    desription: Dual ADC DMA Configuration
+    bit_offset: 13
+    bit_size: 1
+    enum: DMACFG
+  - name: MDMA
+    description: Dual ADC DMA Mode
+    bit_offset: 14
+    bit_size: 2
+    enum: MDMA
+  - name: CKMODE
+    description: ADC clock mode
+    bit_offset: 16
+    bit_size: 2
+    enum: CKMODE
+  - name: PRESC
+    description: ADC prescaler
+    bit_offset: 18
+    bit_size: 4
+    enum: PRESC
+  - name: VREFEN
+    description: VREFINT enable
+    bit_offset: 22
+    bit_size: 1
+  - name: VSENSEEN
+    description: Temperature sensor enable
+    bit_offset: 23
+    bit_size: 1
+  - name: VBATEN
+    description: VBAT enable
+    bit_offset: 24
+    bit_size: 1
+fieldset/CDR:
+  description: ADC common regular data register for dual and triple modes
+  fields:
+  - name: RDATA_MST
+    description: Regular data of the master ADC
+    bit_offset: 0
+    bit_size: 16
+  - name: RDATA_SLV
+    description: Regular data of the slave ADC
+    bit_offset: 16
+    bit_size: 16
+fieldset/CDR2:
+  description: ADC x common regular data register for 32-bit dual mode
+  fields:
+  - name: RDATA_ALT
+    description: Regular data of the master/slave alternated ADCs
+    bit_offset: 0
+    bit_size: 32
+fieldset/CSR:
+  description: ADC Common status register
+  fields:
+  - name: ADRDY_MST
+    description: Master ADC ready
+    bit_offset: 0
+    bit_size: 1
+  - name: EOSMP_MST
+    description: End of Sampling phase flag of the master ADC
+    bit_offset: 1
+    bit_size: 1
+  - name: EOC_MST
+    description: End of regular conversion of the master ADC
+    bit_offset: 2
+    bit_size: 1
+  - name: EOS_MST
+    description: End of regular sequence flag of the master ADC
+    bit_offset: 3
+    bit_size: 1
+  - name: OVR_MST
+    description: Overrun flag of the master ADC
+    bit_offset: 4
+    bit_size: 1
+  - name: JEOC_MST
+    description: End of injected conversion flag of the master ADC
+    bit_offset: 5
+    bit_size: 1
+  - name: JEOS_MST
+    description: End of injected sequence flag of the master ADC
+    bit_offset: 6
+    bit_size: 1
+  - name: AWD_MST
+    description: Analog watchdog flag of the master ADC
+    bit_offset: 7
+    bit_size: 1
+    array:
+      len: 3
+      stride: 1
+  - name: JQOVF_MST
+    description: Injected Context Queue Overflow flag of the master ADC
+    bit_offset: 10
+    bit_size: 1
+  - name: ADRDY_SLV
+    description: Slave ADC ready
+    bit_offset: 16
+    bit_size: 1
+  - name: EOSMP_SLV
+    description: End of Sampling phase flag of the slave ADC
+    bit_offset: 17
+    bit_size: 1
+  - name: EOC_SLV
+    description: End of regular conversion of the slave ADC
+    bit_offset: 18
+    bit_size: 1
+  - name: EOS_SLV
+    description: End of regular sequence flag of the slave ADC
+    bit_offset: 19
+    bit_size: 1
+  - name: OVR_SLV
+    description: Overrun flag of the slave ADC
+    bit_offset: 20
+    bit_size: 1
+  - name: JEOC_SLV
+    description: End of injected conversion flag of the slave ADC
+    bit_offset: 21
+    bit_size: 1
+  - name: JEOS_SLV
+    description: End of injected sequence flag of the slave ADC
+    bit_offset: 22
+    bit_size: 1
+  - name: AWD_SLV
+    description: Analog watchdog flag of the slave ADC
+    bit_offset: 23
+    bit_size: 1
+    array:
+      len: 3
+      stride: 1
+  - name: JQOVF_SLV
+    description: Injected Context Queue Overflow flag of the slave ADC
+    bit_offset: 26
+    bit_size: 1
+enum/CKMODE:
+  bit_size: 2
+  variants:
+  - name: Asynchronous
+    description: Use Kernel Clock adc_ker_ck_input divided by PRESC. Asynchronous to AHB clock
+    value: 0
+  - name: SyncDiv1
+    description: Use AHB clock rcc_hclk3. In this case rcc_hclk must equal sys_d1cpre_ck
+    value: 1
+  - name: SyncDiv2
+    description: Use AHB clock rcc_hclk3 divided by 2
+    value: 2
+  - name: SyncDiv4
+    description: Use AHB clock rcc_hclk3 divided by 4
+    value: 3
+enum/MDMA:
+  bit_size: 2
+  variants:
+  - name: Disabled
+    description: Dual DMA mode is disabled
+    value: 0
+  - name: Reserved
+    description: Reserved
+    value: 1
+  - name: Enabled12b10b
+    description: Dual DMA mode enabled for 12 and 10-bit resolution
+    value: 2
+  - name: Enabled8b6b
+    description: Dual DMA mode enabled for 8 and 6-bit resolution
+    value: 3
+enum/DMACFG:
+  bit_size: 1
+  variants:
+  - name: OneShot
+    description: DMA One Shot mode
+    value: 0
+  - name: Circular
+    description: DMA Circular Mode
+    value: 1
+enum/DUAL:
+  bit_size: 5
+  variants:
+  - name: Independent
+    description: Independent mode
+    value: 0
+  - name: DualRJ
+    description: Dual, combined regular simultaneous + injected simultaneous mode
+    value: 1
+  - name: DualRA
+    description: Dual, combined regular simultaneous + alternate trigger mode
+    value: 2
+  - name: DualIJ
+    description: Dual, combined interleaved mode + injected simultaneous mode
+    value: 3
+  - name: DualJ
+    description: Dual, injected simultaneous mode only
+    value: 5
+  - name: DualR
+    description: Dual, regular simultaneous mode only
+    value: 6
+  - name: DualI
+    description: Dual, interleaved mode only
+    value: 7
+  - name: DualA
+    description: Dual, alternate trigger mode only
+    value: 9
+enum/PRESC:
+  bit_size: 4
+  variants:
+  - name: Div1
+    description: adc_ker_ck_input not divided
+    value: 0
+  - name: Div2
+    description: adc_ker_ck_input divided by 2
+    value: 1
+  - name: Div4
+    description: adc_ker_ck_input divided by 4
+    value: 2
+  - name: Div6
+    description: adc_ker_ck_input divided by 6
+    value: 3
+  - name: Div8
+    description: adc_ker_ck_input divided by 8
+    value: 4
+  - name: Div10
+    description: adc_ker_ck_input divided by 10
+    value: 5
+  - name: Div12
+    description: adc_ker_ck_input divided by 12
+    value: 6
+  - name: Div16
+    description: adc_ker_ck_input divided by 16
+    value: 7
+  - name: Div32
+    description: adc_ker_ck_input divided by 32
+    value: 8
+  - name: Div64
+    description: adc_ker_ck_input divided by 64
+    value: 9
+  - name: Div128
+    description: adc_ker_ck_input divided by 128
+    value: 10
+  - name: Div256
+    description: adc_ker_ck_input divided by 256
+    value: 11

--- a/stm32-data-gen/src/perimap.rs
+++ b/stm32-data-gen/src/perimap.rs
@@ -139,7 +139,7 @@ pub static PERIMAP: RegexMap<(&str, &str, &str)> = RegexMap::new(&[
     ("STM32C0.*:ADC\\d*_COMMON:.*", ("adccommon", "c0", "ADC_COMMON")),
     ("STM32G0.*:ADC\\d*_COMMON:.*", ("adccommon", "v3", "ADC_COMMON")),
     ("STM32U0.*:ADC\\d*_COMMON:.*", ("adccommon", "v3", "ADC_COMMON")),
-    ("STM32G4.*:ADC\\d*_COMMON:.*", ("adccommon", "v4", "ADC_COMMON")),
+    ("STM32G4.*:ADC\\d*_COMMON:.*", ("adccommon", "g4", "ADC_COMMON")),
     ("STM32U5.*:ADC\\d*_COMMON:.*", ("adccommon", "u5", "ADC_COMMON")),
     ("STM32U3.*:ADC\\d*_COMMON:.*", ("adccommon", "u3", "ADC_COMMON")),
     (


### PR DESCRIPTION
G4 and H7 currently share `adccommon_v4`, however the registers differ.

H7 has DAMDF field at bits 15:14 (See RM0468 28.7.2)
G4 has MDMA field at bits 15:14, as well as DMACFG at bit 13 (See RM0440 21.8.2)

This creates a G4 specific `adccommon_g4.yaml` with the corrections and updates perimap.