### PR TITLE
stm32wl5x: low-power config for IPCC and HSEM

### DIFF
--- a/stm32-data-gen/src/low_power.rs
+++ b/stm32-data-gen/src/low_power.rs
@@ -33,6 +33,8 @@ pub(crate) fn peripheral_stop_mode_info(mcu_name: &str, peripheral: &str) -> Opt
         (r"^STM32WL55.*:LPTIM1", StopMode::Standby),
         (r"^STM32WL55.*:SUBGHZSPI", StopMode::Stop2),
         (r"^STM32WL55.*:ADC1", StopMode::Stop2),
+        (r"^STM32WL55.*:IPCC", StopMode::Standby),
+        (r"^STM32WL55.*:HSEM", StopMode::Stop2),
 
         (r"^STM32U3.*:GPDMA.*", StopMode::Stop2),
         (r"^STM32U3.*:LPDMA.*", StopMode::Standby),


### PR DESCRIPTION
For stm32wl5x RM says IPCC registers retained in STOP2 and HSEM in STOP1.
