### PR TITLE
Add GTZC and RAMCFG peripheral support for STM32H5/U5/WBA

### DIFF
--- a/data/registers/gtzc_h503.yaml
+++ b/data/registers/gtzc_h503.yaml
@@ -1,0 +1,500 @@
+block/GTZC1:
+  description: Global privilege controller.
+  items:
+  - name: TZSC_PRIVCFGR1
+    description: GTZC1 TZSC privilege configuration register 1.
+    byte_offset: 32
+    fieldset: TZSC_PRIVCFGR1
+  - name: TZSC_PRIVCFGR2
+    description: GTZC1 TZSC privilege configuration register 2.
+    byte_offset: 36
+    fieldset: TZSC_PRIVCFGR2
+  - name: TZSC_PRIVCFGR3
+    description: GTZC1 TZSC privilege configuration register 3.
+    byte_offset: 40
+    fieldset: TZSC_PRIVCFGR3
+  - name: TZSC_MPCWM4ACFGR
+    description: GTZC1 TZSC BKPSRAM sub-region A watermark configuration register.
+    byte_offset: 112
+    fieldset: TZSC_MPCWM4ACFGR
+  - name: TZSC_MPCWM4AR
+    description: GTZC1 TZSC BKPSRAM sub-region A watermark register.
+    byte_offset: 116
+    fieldset: TZSC_MPCWM4AR
+  - name: TZSC_MPCWM4BCFGR
+    description: GTZC1 TZSC BKPSRAM sub-region B watermark configuration register.
+    byte_offset: 120
+    fieldset: TZSC_MPCWM4BCFGR
+  - name: TZSC_MPCWM4BR
+    description: GTZC1 TZSC BKPSRAM sub-region B watermark register.
+    byte_offset: 124
+    fieldset: TZSC_MPCWM4BR
+  - name: MPCBB1_PRIVCFGR
+    description: GTZC1 SRAM1 MPCBB privileged configuration for super-block 0 register.
+    array:
+      len: 32
+      stride: 4
+    byte_offset: 512
+    fieldset: MPCBB1_PRIVCFGR
+  - name: MPCBB2_PRIVCFGR
+    description: GTZC1 SRAM2 MPCBB privileged configuration for super-block 0 register.
+    array:
+      len: 32
+      stride: 4
+    byte_offset: 1536
+    fieldset: MPCBB2_PRIVCFGR
+fieldset/MPCBB1_PRIVCFGR:
+  description: GTZC1 SRAM1 MPCBB privileged configuration for super-block 0 register.
+  fields:
+  - name: PRIV0
+    description: Privileged configuration for block y, belonging to super-block x (y = 31 to 0).
+    bit_offset: 0
+    bit_size: 1
+  - name: PRIV1
+    description: Privileged configuration for block y, belonging to super-block x (y = 31 to 0).
+    bit_offset: 1
+    bit_size: 1
+  - name: PRIV2
+    description: Privileged configuration for block y, belonging to super-block x (y = 31 to 0).
+    bit_offset: 2
+    bit_size: 1
+  - name: PRIV3
+    description: Privileged configuration for block y, belonging to super-block x (y = 31 to 0).
+    bit_offset: 3
+    bit_size: 1
+  - name: PRIV4
+    description: Privileged configuration for block y, belonging to super-block x (y = 31 to 0).
+    bit_offset: 4
+    bit_size: 1
+  - name: PRIV5
+    description: Privileged configuration for block y, belonging to super-block x (y = 31 to 0).
+    bit_offset: 5
+    bit_size: 1
+  - name: PRIV6
+    description: Privileged configuration for block y, belonging to super-block x (y = 31 to 0).
+    bit_offset: 6
+    bit_size: 1
+  - name: PRIV7
+    description: Privileged configuration for block y, belonging to super-block x (y = 31 to 0).
+    bit_offset: 7
+    bit_size: 1
+  - name: PRIV8
+    description: Privileged configuration for block y, belonging to super-block x (y = 31 to 0).
+    bit_offset: 8
+    bit_size: 1
+  - name: PRIV9
+    description: Privileged configuration for block y, belonging to super-block x (y = 31 to 0).
+    bit_offset: 9
+    bit_size: 1
+  - name: PRIV10
+    description: Privileged configuration for block y, belonging to super-block x (y = 31 to 0).
+    bit_offset: 10
+    bit_size: 1
+  - name: PRIV11
+    description: Privileged configuration for block y, belonging to super-block x (y = 31 to 0).
+    bit_offset: 11
+    bit_size: 1
+  - name: PRIV12
+    description: Privileged configuration for block y, belonging to super-block x (y = 31 to 0).
+    bit_offset: 12
+    bit_size: 1
+  - name: PRIV13
+    description: Privileged configuration for block y, belonging to super-block x (y = 31 to 0).
+    bit_offset: 13
+    bit_size: 1
+  - name: PRIV14
+    description: Privileged configuration for block y, belonging to super-block x (y = 31 to 0).
+    bit_offset: 14
+    bit_size: 1
+  - name: PRIV15
+    description: Privileged configuration for block y, belonging to super-block x (y = 31 to 0).
+    bit_offset: 15
+    bit_size: 1
+  - name: PRIV16
+    description: Privileged configuration for block y, belonging to super-block x (y = 31 to 0).
+    bit_offset: 16
+    bit_size: 1
+  - name: PRIV17
+    description: Privileged configuration for block y, belonging to super-block x (y = 31 to 0).
+    bit_offset: 17
+    bit_size: 1
+  - name: PRIV18
+    description: Privileged configuration for block y, belonging to super-block x (y = 31 to 0).
+    bit_offset: 18
+    bit_size: 1
+  - name: PRIV19
+    description: Privileged configuration for block y, belonging to super-block x (y = 31 to 0).
+    bit_offset: 19
+    bit_size: 1
+  - name: PRIV20
+    description: Privileged configuration for block y, belonging to super-block x (y = 31 to 0).
+    bit_offset: 20
+    bit_size: 1
+  - name: PRIV21
+    description: Privileged configuration for block y, belonging to super-block x (y = 31 to 0).
+    bit_offset: 21
+    bit_size: 1
+  - name: PRIV22
+    description: Privileged configuration for block y, belonging to super-block x (y = 31 to 0).
+    bit_offset: 22
+    bit_size: 1
+  - name: PRIV23
+    description: Privileged configuration for block y, belonging to super-block x (y = 31 to 0).
+    bit_offset: 23
+    bit_size: 1
+  - name: PRIV24
+    description: Privileged configuration for block y, belonging to super-block x (y = 31 to 0).
+    bit_offset: 24
+    bit_size: 1
+  - name: PRIV25
+    description: Privileged configuration for block y, belonging to super-block x (y = 31 to 0).
+    bit_offset: 25
+    bit_size: 1
+  - name: PRIV26
+    description: Privileged configuration for block y, belonging to super-block x (y = 31 to 0).
+    bit_offset: 26
+    bit_size: 1
+  - name: PRIV27
+    description: Privileged configuration for block y, belonging to super-block x (y = 31 to 0).
+    bit_offset: 27
+    bit_size: 1
+  - name: PRIV28
+    description: Privileged configuration for block y, belonging to super-block x (y = 31 to 0).
+    bit_offset: 28
+    bit_size: 1
+  - name: PRIV29
+    description: Privileged configuration for block y, belonging to super-block x (y = 31 to 0).
+    bit_offset: 29
+    bit_size: 1
+  - name: PRIV30
+    description: Privileged configuration for block y, belonging to super-block x (y = 31 to 0).
+    bit_offset: 30
+    bit_size: 1
+  - name: PRIV31
+    description: Privileged configuration for block y, belonging to super-block x (y = 31 to 0).
+    bit_offset: 31
+    bit_size: 1
+fieldset/MPCBB2_PRIVCFGR:
+  description: GTZC1 SRAM2 MPCBB privileged configuration for super-block 0 register.
+  fields:
+  - name: PRIV0
+    description: Privileged configuration for block y, belonging to super-block x (y = 31 to 0).
+    bit_offset: 0
+    bit_size: 1
+  - name: PRIV1
+    description: Privileged configuration for block y, belonging to super-block x (y = 31 to 0).
+    bit_offset: 1
+    bit_size: 1
+  - name: PRIV2
+    description: Privileged configuration for block y, belonging to super-block x (y = 31 to 0).
+    bit_offset: 2
+    bit_size: 1
+  - name: PRIV3
+    description: Privileged configuration for block y, belonging to super-block x (y = 31 to 0).
+    bit_offset: 3
+    bit_size: 1
+  - name: PRIV4
+    description: Privileged configuration for block y, belonging to super-block x (y = 31 to 0).
+    bit_offset: 4
+    bit_size: 1
+  - name: PRIV5
+    description: Privileged configuration for block y, belonging to super-block x (y = 31 to 0).
+    bit_offset: 5
+    bit_size: 1
+  - name: PRIV6
+    description: Privileged configuration for block y, belonging to super-block x (y = 31 to 0).
+    bit_offset: 6
+    bit_size: 1
+  - name: PRIV7
+    description: Privileged configuration for block y, belonging to super-block x (y = 31 to 0).
+    bit_offset: 7
+    bit_size: 1
+  - name: PRIV8
+    description: Privileged configuration for block y, belonging to super-block x (y = 31 to 0).
+    bit_offset: 8
+    bit_size: 1
+  - name: PRIV9
+    description: Privileged configuration for block y, belonging to super-block x (y = 31 to 0).
+    bit_offset: 9
+    bit_size: 1
+  - name: PRIV10
+    description: Privileged configuration for block y, belonging to super-block x (y = 31 to 0).
+    bit_offset: 10
+    bit_size: 1
+  - name: PRIV11
+    description: Privileged configuration for block y, belonging to super-block x (y = 31 to 0).
+    bit_offset: 11
+    bit_size: 1
+  - name: PRIV12
+    description: Privileged configuration for block y, belonging to super-block x (y = 31 to 0).
+    bit_offset: 12
+    bit_size: 1
+  - name: PRIV13
+    description: Privileged configuration for block y, belonging to super-block x (y = 31 to 0).
+    bit_offset: 13
+    bit_size: 1
+  - name: PRIV14
+    description: Privileged configuration for block y, belonging to super-block x (y = 31 to 0).
+    bit_offset: 14
+    bit_size: 1
+  - name: PRIV15
+    description: Privileged configuration for block y, belonging to super-block x (y = 31 to 0).
+    bit_offset: 15
+    bit_size: 1
+  - name: PRIV16
+    description: Privileged configuration for block y, belonging to super-block x (y = 31 to 0).
+    bit_offset: 16
+    bit_size: 1
+  - name: PRIV17
+    description: Privileged configuration for block y, belonging to super-block x (y = 31 to 0).
+    bit_offset: 17
+    bit_size: 1
+  - name: PRIV18
+    description: Privileged configuration for block y, belonging to super-block x (y = 31 to 0).
+    bit_offset: 18
+    bit_size: 1
+  - name: PRIV19
+    description: Privileged configuration for block y, belonging to super-block x (y = 31 to 0).
+    bit_offset: 19
+    bit_size: 1
+  - name: PRIV20
+    description: Privileged configuration for block y, belonging to super-block x (y = 31 to 0).
+    bit_offset: 20
+    bit_size: 1
+  - name: PRIV21
+    description: Privileged configuration for block y, belonging to super-block x (y = 31 to 0).
+    bit_offset: 21
+    bit_size: 1
+  - name: PRIV22
+    description: Privileged configuration for block y, belonging to super-block x (y = 31 to 0).
+    bit_offset: 22
+    bit_size: 1
+  - name: PRIV23
+    description: Privileged configuration for block y, belonging to super-block x (y = 31 to 0).
+    bit_offset: 23
+    bit_size: 1
+  - name: PRIV24
+    description: Privileged configuration for block y, belonging to super-block x (y = 31 to 0).
+    bit_offset: 24
+    bit_size: 1
+  - name: PRIV25
+    description: Privileged configuration for block y, belonging to super-block x (y = 31 to 0).
+    bit_offset: 25
+    bit_size: 1
+  - name: PRIV26
+    description: Privileged configuration for block y, belonging to super-block x (y = 31 to 0).
+    bit_offset: 26
+    bit_size: 1
+  - name: PRIV27
+    description: Privileged configuration for block y, belonging to super-block x (y = 31 to 0).
+    bit_offset: 27
+    bit_size: 1
+  - name: PRIV28
+    description: Privileged configuration for block y, belonging to super-block x (y = 31 to 0).
+    bit_offset: 28
+    bit_size: 1
+  - name: PRIV29
+    description: Privileged configuration for block y, belonging to super-block x (y = 31 to 0).
+    bit_offset: 29
+    bit_size: 1
+  - name: PRIV30
+    description: Privileged configuration for block y, belonging to super-block x (y = 31 to 0).
+    bit_offset: 30
+    bit_size: 1
+  - name: PRIV31
+    description: Privileged configuration for block y, belonging to super-block x (y = 31 to 0).
+    bit_offset: 31
+    bit_size: 1
+fieldset/TZSC_MPCWM4ACFGR:
+  description: GTZC1 TZSC BKPSRAM sub-region A watermark configuration register.
+  fields:
+  - name: SREN
+    description: Sub-region z enable.
+    bit_offset: 0
+    bit_size: 1
+  - name: SRLOCK
+    description: Sub-region z lock This bit, once set, can be cleared only by a system reset.
+    bit_offset: 1
+    bit_size: 1
+  - name: PRIV
+    description: Privileged sub-region z This bit is taken into account only if SREN is set.
+    bit_offset: 9
+    bit_size: 1
+fieldset/TZSC_MPCWM4AR:
+  description: GTZC1 TZSC BKPSRAM sub-region A watermark register.
+  fields:
+  - name: SUBA_START
+    description: Start of sub-region A This field defines the address offset of the sub-region A, to be multiplied by the granularity defined in Table 16.
+    bit_offset: 0
+    bit_size: 11
+  - name: SUBA_LENGTH
+    description: Length of sub-region A This field defines the length of the sub-region A, to be multiplied by the granularity defined in Table 16. When SUBA_START + SUBA_LENGTH is higher than the maximum size allowed for the memory, a saturation of SUBA_LENGTH is applied automatically. If SUBA_LENGTH = 0, the sub-region A is disabled (SREN bit in TZSC_MPCMWACFGR is cleared).
+    bit_offset: 16
+    bit_size: 12
+fieldset/TZSC_MPCWM4BCFGR:
+  description: GTZC1 TZSC BKPSRAM sub-region B watermark configuration register.
+  fields:
+  - name: SREN
+    description: Sub-region z enable.
+    bit_offset: 0
+    bit_size: 1
+  - name: SRLOCK
+    description: Sub-region z lock This bit, once set, can be cleared only by a system reset.
+    bit_offset: 1
+    bit_size: 1
+  - name: PRIV
+    description: Privileged sub-region z This bit is taken into account only if SREN is set.
+    bit_offset: 9
+    bit_size: 1
+fieldset/TZSC_MPCWM4BR:
+  description: GTZC1 TZSC BKPSRAM sub-region B watermark register.
+  fields:
+  - name: SUBB_START
+    description: Start of sub-region B This field defines the address offset of the sub-region B, to be multiplied by the granularity defined in Table 16.
+    bit_offset: 0
+    bit_size: 11
+  - name: SUBB_LENGTH
+    description: Length of sub-region B This field defines the length of the sub-region B, to be multiplied by the granularity defined in Table 16. When SUBB_START + SUBB_LENGTH is higher than the maximum size allowed for the memory, a saturation of SUBB_LENGTH is applied automatically. If SUBB_LENGTH = 0, the sub-region B is disabled (SREN bit in TZSC_MPCMWBCFGR is cleared).
+    bit_offset: 16
+    bit_size: 12
+fieldset/TZSC_PRIVCFGR1:
+  description: GTZC1 TZSC privilege configuration register 1.
+  fields:
+  - name: TIM2PRIV
+    description: privileged access mode for TIM2.
+    bit_offset: 0
+    bit_size: 1
+  - name: TIM3PRIV
+    description: privileged access mode for TIM3.
+    bit_offset: 1
+    bit_size: 1
+  - name: TIM6PRIV
+    description: privileged access mode for TIM6.
+    bit_offset: 4
+    bit_size: 1
+  - name: TIM7PRIV
+    description: privileged access mode for TIM7.
+    bit_offset: 5
+    bit_size: 1
+  - name: WWDGPRIV
+    description: privileged access mode for WWDG.
+    bit_offset: 9
+    bit_size: 1
+  - name: IWDGPRIV
+    description: privileged access mode for IWDG.
+    bit_offset: 10
+    bit_size: 1
+  - name: SPI2PRIV
+    description: privileged access mode for SPI2.
+    bit_offset: 11
+    bit_size: 1
+  - name: SPI3PRIV
+    description: privileged access mode for SPI3.
+    bit_offset: 12
+    bit_size: 1
+  - name: USART2PRIV
+    description: privileged access mode for USART2.
+    bit_offset: 13
+    bit_size: 1
+  - name: USART3PRIV
+    description: privileged access mode for USART3.
+    bit_offset: 14
+    bit_size: 1
+  - name: I2C1PRIV
+    description: privileged access mode for I2C1.
+    bit_offset: 17
+    bit_size: 1
+  - name: I2C2PRIV
+    description: privileged access mode for I2C2.
+    bit_offset: 18
+    bit_size: 1
+  - name: I3C1PRIV
+    description: privileged access mode for I3C1.
+    bit_offset: 19
+    bit_size: 1
+  - name: CRSPRIV
+    description: privileged access mode for CRS.
+    bit_offset: 20
+    bit_size: 1
+  - name: DAC1PRIV
+    description: privileged access mode for DAC1.
+    bit_offset: 25
+    bit_size: 1
+  - name: DTSPRIV
+    description: privileged access mode for DTS.
+    bit_offset: 30
+    bit_size: 1
+  - name: LPTIM2PRIV
+    description: privileged access mode for LPTIM2.
+    bit_offset: 31
+    bit_size: 1
+fieldset/TZSC_PRIVCFGR2:
+  description: GTZC1 TZSC privilege configuration register 2.
+  fields:
+  - name: FDCAN1PRIV
+    description: privileged access mode for FDCAN1.
+    bit_offset: 0
+    bit_size: 1
+  - name: OPAMPPRIV
+    description: privileged access mode for OPAMP.
+    bit_offset: 3
+    bit_size: 1
+  - name: COMPPRIV
+    description: privileged access mode for COMP.
+    bit_offset: 4
+    bit_size: 1
+  - name: TIM1PRIV
+    description: privileged access mode for TIM1.
+    bit_offset: 8
+    bit_size: 1
+  - name: SPI1PRIV
+    description: privileged access mode for SPI1.
+    bit_offset: 9
+    bit_size: 1
+  - name: USART1PRIV
+    description: privileged access mode for USART1.
+    bit_offset: 11
+    bit_size: 1
+  - name: USBFSPRIV
+    description: privileged access mode for USBSF.
+    bit_offset: 19
+    bit_size: 1
+  - name: LPUART1PRIV
+    description: privileged access mode for LPUART.
+    bit_offset: 25
+    bit_size: 1
+  - name: LPTIM1PRIV
+    description: privileged access mode for LPTIM1.
+    bit_offset: 28
+    bit_size: 1
+fieldset/TZSC_PRIVCFGR3:
+  description: GTZC1 TZSC privilege configuration register 3.
+  fields:
+  - name: I3C2PRIV
+    description: privileged access mode for I3C2.
+    bit_offset: 2
+    bit_size: 1
+  - name: CRCPRIV
+    description: privileged access mode for CRC.
+    bit_offset: 8
+    bit_size: 1
+  - name: ICACHEPRIV
+    description: privileged access mode for ICACHE.
+    bit_offset: 12
+    bit_size: 1
+  - name: ADC1PRIV
+    description: privileged access mode for ADC1.
+    bit_offset: 14
+    bit_size: 1
+  - name: HASHPRIV
+    description: privileged access mode for HASH.
+    bit_offset: 17
+    bit_size: 1
+  - name: RNGPRIV
+    description: privileged access mode for RNG.
+    bit_offset: 18
+    bit_size: 1
+  - name: RAMCFGPRIV
+    description: privileged access mode for RAMSCFG.
+    bit_offset: 26
+    bit_size: 1

--- a/data/registers/gtzc_v1.yaml
+++ b/data/registers/gtzc_v1.yaml
@@ -1,0 +1,920 @@
+block/GTZC1_TZSC:
+  description: Global TrustZone controller.
+  items:
+  - name: CR
+    description: GTZC1 TZSC control register.
+    byte_offset: 0
+    fieldset: CR
+  - name: SECCFGR1
+    description: GTZC1 TZSC secure configuration register 1.
+    byte_offset: 16
+    fieldset: SECCFGR1
+  - name: SECCFGR2
+    description: GTZC1 TZSC secure configuration register 2.
+    byte_offset: 20
+    fieldset: SECCFGR2
+  - name: SECCFGR3
+    description: GTZC1 TZSC secure configuration register 3.
+    byte_offset: 24
+    fieldset: SECCFGR3
+  - name: PRIVCFGR1
+    description: GTZC1 TZSC privilege configuration register 1.
+    byte_offset: 32
+    fieldset: PRIVCFGR1
+  - name: PRIVCFGR2
+    description: GTZC1 TZSC privilege configuration register 2.
+    byte_offset: 36
+    fieldset: PRIVCFGR2
+  - name: PRIVCFGR3
+    description: GTZC1 TZSC privilege configuration register 3.
+    byte_offset: 40
+    fieldset: PRIVCFGR3
+  - name: MPCWM1ACFGR
+    description: GTZC1 TZSC memory 1 sub-region A watermark configuration register.
+    byte_offset: 64
+    fieldset: MPCWM1ACFGR
+  - name: MPCWM1AR
+    description: GTZC1 TZSC memory 1 sub-region A watermark register.
+    byte_offset: 68
+    fieldset: MPCWM1AR
+  - name: MPCWM1BCFGR
+    description: GTZC1 TZSC memory 1 sub-region B watermark configuration register.
+    byte_offset: 72
+    fieldset: MPCWM1BCFGR
+  - name: MPCWM1BR
+    description: GTZC1 TZSC memory 1 sub-region B watermark register.
+    byte_offset: 76
+    fieldset: MPCWM1BR
+  - name: MPCWM2ACFGR
+    description: GTZC1 TZSC memory 2 sub-region A watermark configuration register.
+    byte_offset: 80
+    fieldset: MPCWM2ACFGR
+  - name: MPCWM2AR
+    description: GTZC1 TZSC memory 2 sub-region A watermark register.
+    byte_offset: 84
+    fieldset: MPCWM2AR
+  - name: MPCWM2BCFGR
+    description: GTZC1 TZSC memory 2 sub-region B watermark configuration register.
+    byte_offset: 88
+    fieldset: MPCWM2BCFGR
+  - name: MPCWM2BR
+    description: GTZC1 TZSC memory 2 sub-region B watermark register.
+    byte_offset: 92
+    fieldset: MPCWM2BR
+  - name: MPCWM3ACFGR
+    description: GTZC1 TZSC memory 3 sub-region A watermark configuration register.
+    byte_offset: 96
+    fieldset: MPCWM3ACFGR
+  - name: MPCWM3AR
+    description: GTZC1 TZSC memory 3 sub-region A watermark register.
+    byte_offset: 100
+    fieldset: MPCWM3AR
+  - name: MPCWM3BCFGR
+    description: GTZC1 TZSC memory 3 sub-region B watermark configuration register.
+    byte_offset: 104
+    fieldset: MPCWM3BCFGR
+  - name: MPCWM3BR
+    description: GTZC1 TZSC memory 3 sub-region B watermark register.
+    byte_offset: 108
+    fieldset: MPCWM3BR
+  - name: MPCWM4ACFGR
+    description: GTZC1 TZSC memory 4 sub-region A watermark configuration register.
+    byte_offset: 112
+    fieldset: MPCWM4ACFGR
+  - name: MPCWM4AR
+    description: GTZC1 TZSC memory 4 sub-region A watermark register.
+    byte_offset: 116
+    fieldset: MPCWM4AR
+  - name: MPCWM4BCFGR
+    description: GTZC1 TZSC memory 4 sub-region B watermark configuration register.
+    byte_offset: 120
+    fieldset: MPCWM4BCFGR
+  - name: MPCWM4BR
+    description: GTZC1 TZSC memory 4 sub-region B watermark register.
+    byte_offset: 124
+    fieldset: MPCWM4BR
+fieldset/CR:
+  description: GTZC1 TZSC control register.
+  fields:
+  - name: LCK
+    description: lock the configuration of TZSC_SECCFGRx and TZSC_PRIVCFGRx until next reset This bit is cleared by default and once set, it can not be reset until system reset.
+    bit_offset: 0
+    bit_size: 1
+fieldset/MPCWM1ACFGR:
+  description: GTZC1 TZSC memory 1 sub-region A watermark configuration register.
+  fields:
+  - name: SREN
+    description: 'Sub-region z enable Note: External memories that are watermark controlled start fully non-secure/unprivileged at reset when TZEN = 0xC3. When TZEN = 0xB4, external memories start fully secure/fully privileged (inverted reset-value).'
+    bit_offset: 0
+    bit_size: 1
+  - name: SRLOCK
+    description: Sub-region A lock This bit, once set, can be cleared only by a system reset.
+    bit_offset: 1
+    bit_size: 1
+  - name: SEC
+    description: Secure sub-region A of base region x This bit is taken into account only if SREN is set.
+    bit_offset: 8
+    bit_size: 1
+  - name: PRIV
+    description: Privileged sub-region A of base region x This bit is taken into account only if SREN is set.
+    bit_offset: 9
+    bit_size: 1
+fieldset/MPCWM1AR:
+  description: GTZC1 TZSC memory 1 sub-region A watermark register.
+  fields:
+  - name: SUBA_START
+    description: Start of sub-region A in region x This field defines the address offset of the sub-region A, to be multiplied by the granularity defined in Table�30, versus the start of the region x. External memories that are watermark controlled, start fully non-secure at reset when TZEN�=�0xC3. When TZEN�=�0xB4, external memories start fully secure (inverted reset value).
+    bit_offset: 0
+    bit_size: 11
+  - name: SUBA_LENGTH
+    description: Length of sub-region A in region x This field defines the length of the sub-region A, to be multiplied by the granularity defined in Table�30. When SUBA_START + SUBA_LENGTH is higher than the maximum size allowed for the memory, a saturation of SUBA_LENGTH is applied automatically. If SUBA_LENGTH = 0, the sub-region A is disabled.(SREN bit in TZSC_MPCMWxACFGR is cleared).
+    bit_offset: 16
+    bit_size: 12
+fieldset/MPCWM1BCFGR:
+  description: GTZC1 TZSC memory 1 sub-region B watermark configuration register.
+  fields:
+  - name: SREN
+    description: 'Sub-region B enable Note: External memories that are watermark controlled start fully non-secure/unprivileged at reset when TZEN = 0xC3. When TZEN = 0xB4, external memories start fully secure/fully privileged (inverted reset-value).'
+    bit_offset: 0
+    bit_size: 1
+  - name: SRLOCK
+    description: Sub-region B lock This bit, once set, can be cleared only by a system reset.
+    bit_offset: 1
+    bit_size: 1
+  - name: SEC
+    description: Secure sub-region B of base region x This bit is taken into account only if SREN is set.
+    bit_offset: 8
+    bit_size: 1
+  - name: PRIV
+    description: Privileged sub-region B of base region x This bit is taken into account only if SREN is set.
+    bit_offset: 9
+    bit_size: 1
+fieldset/MPCWM1BR:
+  description: GTZC1 TZSC memory 1 sub-region B watermark register.
+  fields:
+  - name: SUBB_START
+    description: Start of sub-region B in region x This field defines the address offset of the sub-region B, to be multiplied by the granularity defined in Table�30, versus the start of the region x. External memories that are watermark controlled, start fully non-secure at reset when TZEN�=�0xC3. When TZEN�=�0xB4, external memories start fully secure (inverted reset value).
+    bit_offset: 0
+    bit_size: 11
+  - name: SUBB_LENGTH
+    description: Length of sub-region B in region x This field defines the length of the sub-region B, to be multiplied by the granularity defined in Table�30. When SUBB_START + SUBB_LENGTH is higher than the maximum size allowed for the memory, a saturation of SUBB_LENGTH is applied automatically. If SUBB_LENGTH = 0, the sub-region B is disabled.(SREN bit in TZSC_MPCMWxBCFGR is cleared).
+    bit_offset: 16
+    bit_size: 12
+fieldset/MPCWM2ACFGR:
+  description: GTZC1 TZSC memory 2 sub-region A watermark configuration register.
+  fields:
+  - name: SREN
+    description: 'Sub-region z enable Note: External memories that are watermark controlled start fully non-secure/unprivileged at reset when TZEN = 0xC3. When TZEN = 0xB4, external memories start fully secure/fully privileged (inverted reset-value).'
+    bit_offset: 0
+    bit_size: 1
+  - name: SRLOCK
+    description: Sub-region A lock This bit, once set, can be cleared only by a system reset.
+    bit_offset: 1
+    bit_size: 1
+  - name: SEC
+    description: Secure sub-region A of base region x This bit is taken into account only if SREN is set.
+    bit_offset: 8
+    bit_size: 1
+  - name: PRIV
+    description: Privileged sub-region A of base region x This bit is taken into account only if SREN is set.
+    bit_offset: 9
+    bit_size: 1
+fieldset/MPCWM2AR:
+  description: GTZC1 TZSC memory 2 sub-region A watermark register.
+  fields:
+  - name: SUBA_START
+    description: Start of sub-region A in region x This field defines the address offset of the sub-region A, to be multiplied by the granularity defined in Table�30, versus the start of the region x. External memories that are watermark controlled, start fully non-secure at reset when TZEN�=�0xC3. When TZEN�=�0xB4, external memories start fully secure (inverted reset value).
+    bit_offset: 0
+    bit_size: 11
+  - name: SUBA_LENGTH
+    description: Length of sub-region A in region x This field defines the length of the sub-region A, to be multiplied by the granularity defined in Table�30. When SUBA_START + SUBA_LENGTH is higher than the maximum size allowed for the memory, a saturation of SUBA_LENGTH is applied automatically. If SUBA_LENGTH = 0, the sub-region A is disabled.(SREN bit in TZSC_MPCMWxACFGR is cleared).
+    bit_offset: 16
+    bit_size: 12
+fieldset/MPCWM2BCFGR:
+  description: GTZC1 TZSC memory 2 sub-region B watermark configuration register.
+  fields:
+  - name: SREN
+    description: 'Sub-region B enable Note: External memories that are watermark controlled start fully non-secure/unprivileged at reset when TZEN = 0xC3. When TZEN = 0xB4, external memories start fully secure/fully privileged (inverted reset-value).'
+    bit_offset: 0
+    bit_size: 1
+  - name: SRLOCK
+    description: Sub-region B lock This bit, once set, can be cleared only by a system reset.
+    bit_offset: 1
+    bit_size: 1
+  - name: SEC
+    description: Secure sub-region B of base region x This bit is taken into account only if SREN is set.
+    bit_offset: 8
+    bit_size: 1
+  - name: PRIV
+    description: Privileged sub-region B of base region x This bit is taken into account only if SREN is set.
+    bit_offset: 9
+    bit_size: 1
+fieldset/MPCWM2BR:
+  description: GTZC1 TZSC memory 2 sub-region B watermark register.
+  fields:
+  - name: SUBB_START
+    description: Start of sub-region B in region x This field defines the address offset of the sub-region B, to be multiplied by the granularity defined in Table�30, versus the start of the region x. External memories that are watermark controlled, start fully non-secure at reset when TZEN�=�0xC3. When TZEN�=�0xB4, external memories start fully secure (inverted reset value).
+    bit_offset: 0
+    bit_size: 11
+  - name: SUBB_LENGTH
+    description: Length of sub-region B in region x This field defines the length of the sub-region B, to be multiplied by the granularity defined in Table�30. When SUBB_START + SUBB_LENGTH is higher than the maximum size allowed for the memory, a saturation of SUBB_LENGTH is applied automatically. If SUBB_LENGTH = 0, the sub-region B is disabled.(SREN bit in TZSC_MPCMWxBCFGR is cleared).
+    bit_offset: 16
+    bit_size: 12
+fieldset/MPCWM3ACFGR:
+  description: GTZC1 TZSC memory 3 sub-region A watermark configuration register.
+  fields:
+  - name: SREN
+    description: 'Sub-region z enable Note: External memories that are watermark controlled start fully non-secure/unprivileged at reset when TZEN = 0xC3. When TZEN = 0xB4, external memories start fully secure/fully privileged (inverted reset-value).'
+    bit_offset: 0
+    bit_size: 1
+  - name: SRLOCK
+    description: Sub-region A lock This bit, once set, can be cleared only by a system reset.
+    bit_offset: 1
+    bit_size: 1
+  - name: SEC
+    description: Secure sub-region A of base region x This bit is taken into account only if SREN is set.
+    bit_offset: 8
+    bit_size: 1
+  - name: PRIV
+    description: Privileged sub-region A of base region x This bit is taken into account only if SREN is set.
+    bit_offset: 9
+    bit_size: 1
+fieldset/MPCWM3AR:
+  description: GTZC1 TZSC memory 3 sub-region A watermark register.
+  fields:
+  - name: SUBA_START
+    description: Start of sub-region A in region x This field defines the address offset of the sub-region A, to be multiplied by the granularity defined in Table�30, versus the start of the region x. External memories that are watermark controlled, start fully non-secure at reset when TZEN�=�0xC3. When TZEN�=�0xB4, external memories start fully secure (inverted reset value).
+    bit_offset: 0
+    bit_size: 11
+  - name: SUBA_LENGTH
+    description: Length of sub-region A in region x This field defines the length of the sub-region A, to be multiplied by the granularity defined in Table�30. When SUBA_START + SUBA_LENGTH is higher than the maximum size allowed for the memory, a saturation of SUBA_LENGTH is applied automatically. If SUBA_LENGTH = 0, the sub-region A is disabled.(SREN bit in TZSC_MPCMWxACFGR is cleared).
+    bit_offset: 16
+    bit_size: 12
+fieldset/MPCWM3BCFGR:
+  description: GTZC1 TZSC memory 3 sub-region B watermark configuration register.
+  fields:
+  - name: SREN
+    description: 'Sub-region B enable Note: External memories that are watermark controlled start fully non-secure/unprivileged at reset when TZEN = 0xC3. When TZEN = 0xB4, external memories start fully secure/fully privileged (inverted reset-value).'
+    bit_offset: 0
+    bit_size: 1
+  - name: SRLOCK
+    description: Sub-region B lock This bit, once set, can be cleared only by a system reset.
+    bit_offset: 1
+    bit_size: 1
+  - name: SEC
+    description: Secure sub-region B of base region x This bit is taken into account only if SREN is set.
+    bit_offset: 8
+    bit_size: 1
+  - name: PRIV
+    description: Privileged sub-region B of base region x This bit is taken into account only if SREN is set.
+    bit_offset: 9
+    bit_size: 1
+fieldset/MPCWM3BR:
+  description: GTZC1 TZSC memory 3 sub-region B watermark register.
+  fields:
+  - name: SUBB_START
+    description: Start of sub-region B in region x This field defines the address offset of the sub-region B, to be multiplied by the granularity defined in Table�30, versus the start of the region x. External memories that are watermark controlled, start fully non-secure at reset when TZEN�=�0xC3. When TZEN�=�0xB4, external memories start fully secure (inverted reset value).
+    bit_offset: 0
+    bit_size: 11
+  - name: SUBB_LENGTH
+    description: Length of sub-region B in region x This field defines the length of the sub-region B, to be multiplied by the granularity defined in Table�30. When SUBB_START + SUBB_LENGTH is higher than the maximum size allowed for the memory, a saturation of SUBB_LENGTH is applied automatically. If SUBB_LENGTH = 0, the sub-region B is disabled.(SREN bit in TZSC_MPCMWxBCFGR is cleared).
+    bit_offset: 16
+    bit_size: 12
+fieldset/MPCWM4ACFGR:
+  description: GTZC1 TZSC memory 4 sub-region A watermark configuration register.
+  fields:
+  - name: SREN
+    description: 'Sub-region z enable Note: External memories that are watermark controlled start fully non-secure/unprivileged at reset when TZEN = 0xC3. When TZEN = 0xB4, external memories start fully secure/fully privileged (inverted reset-value).'
+    bit_offset: 0
+    bit_size: 1
+  - name: SRLOCK
+    description: Sub-region A lock This bit, once set, can be cleared only by a system reset.
+    bit_offset: 1
+    bit_size: 1
+  - name: SEC
+    description: Secure sub-region A of base region x This bit is taken into account only if SREN is set.
+    bit_offset: 8
+    bit_size: 1
+  - name: PRIV
+    description: Privileged sub-region A of base region x This bit is taken into account only if SREN is set.
+    bit_offset: 9
+    bit_size: 1
+fieldset/MPCWM4AR:
+  description: GTZC1 TZSC memory 4 sub-region A watermark register.
+  fields:
+  - name: SUBA_START
+    description: Start of sub-region A in region x This field defines the address offset of the sub-region A, to be multiplied by the granularity defined in Table�30, versus the start of the region x. External memories that are watermark controlled, start fully non-secure at reset when TZEN�=�0xC3. When TZEN�=�0xB4, external memories start fully secure (inverted reset value).
+    bit_offset: 0
+    bit_size: 11
+  - name: SUBA_LENGTH
+    description: Length of sub-region A in region x This field defines the length of the sub-region A, to be multiplied by the granularity defined in Table�30. When SUBA_START + SUBA_LENGTH is higher than the maximum size allowed for the memory, a saturation of SUBA_LENGTH is applied automatically. If SUBA_LENGTH = 0, the sub-region A is disabled.(SREN bit in TZSC_MPCMWxACFGR is cleared).
+    bit_offset: 16
+    bit_size: 12
+fieldset/MPCWM4BCFGR:
+  description: GTZC1 TZSC memory 4 sub-region B watermark configuration register.
+  fields:
+  - name: SREN
+    description: 'Sub-region B enable Note: External memories that are watermark controlled start fully non-secure/unprivileged at reset when TZEN = 0xC3. When TZEN = 0xB4, external memories start fully secure/fully privileged (inverted reset-value).'
+    bit_offset: 0
+    bit_size: 1
+  - name: SRLOCK
+    description: Sub-region B lock This bit, once set, can be cleared only by a system reset.
+    bit_offset: 1
+    bit_size: 1
+  - name: SEC
+    description: Secure sub-region B of base region x This bit is taken into account only if SREN is set.
+    bit_offset: 8
+    bit_size: 1
+  - name: PRIV
+    description: Privileged sub-region B of base region x This bit is taken into account only if SREN is set.
+    bit_offset: 9
+    bit_size: 1
+fieldset/MPCWM4BR:
+  description: GTZC1 TZSC memory 4 sub-region B watermark register.
+  fields:
+  - name: SUBB_START
+    description: Start of sub-region B in region x This field defines the address offset of the sub-region B, to be multiplied by the granularity defined in Table�30, versus the start of the region x. External memories that are watermark controlled, start fully non-secure at reset when TZEN�=�0xC3. When TZEN�=�0xB4, external memories start fully secure (inverted reset value).
+    bit_offset: 0
+    bit_size: 11
+  - name: SUBB_LENGTH
+    description: Length of sub-region B in region x This field defines the length of the sub-region B, to be multiplied by the granularity defined in Table�30. When SUBB_START + SUBB_LENGTH is higher than the maximum size allowed for the memory, a saturation of SUBB_LENGTH is applied automatically. If SUBB_LENGTH = 0, the sub-region B is disabled.(SREN bit in TZSC_MPCMWxBCFGR is cleared).
+    bit_offset: 16
+    bit_size: 12
+fieldset/PRIVCFGR1:
+  description: GTZC1 TZSC privilege configuration register 1.
+  fields:
+  - name: TIM2PRIV
+    description: privileged access mode for TIM2.
+    bit_offset: 0
+    bit_size: 1
+  - name: TIM3PRIV
+    description: privileged access mode for TIM3.
+    bit_offset: 1
+    bit_size: 1
+  - name: TIM4PRIV
+    description: privileged access mode for TIM4.
+    bit_offset: 2
+    bit_size: 1
+  - name: TIM5PRIV
+    description: privileged access mode for TIM5.
+    bit_offset: 3
+    bit_size: 1
+  - name: TIM6PRIV
+    description: privileged access mode for TIM6.
+    bit_offset: 4
+    bit_size: 1
+  - name: TIM7PRIV
+    description: privileged access mode for TIM7.
+    bit_offset: 5
+    bit_size: 1
+  - name: TIM12PRIV
+    description: privileged access mode for TIM12.
+    bit_offset: 6
+    bit_size: 1
+  - name: TIM13PRIV
+    description: privileged access mode for TIM13.
+    bit_offset: 7
+    bit_size: 1
+  - name: TIM14PRIV
+    description: privileged access mode for TIM14.
+    bit_offset: 8
+    bit_size: 1
+  - name: WWDGPRIV
+    description: privileged access mode for WWDG.
+    bit_offset: 9
+    bit_size: 1
+  - name: IWDGPRIV
+    description: privileged access mode for IWDG.
+    bit_offset: 10
+    bit_size: 1
+  - name: SPI2PRIV
+    description: privileged access mode for SPI2.
+    bit_offset: 11
+    bit_size: 1
+  - name: SPI3PRIV
+    description: privileged access mode for SPI3.
+    bit_offset: 12
+    bit_size: 1
+  - name: USART2PRIV
+    description: privileged access mode for USART2.
+    bit_offset: 13
+    bit_size: 1
+  - name: USART3PRIV
+    description: privileged access mode for USART3.
+    bit_offset: 14
+    bit_size: 1
+  - name: UART4PRIV
+    description: privileged access mode for UART4.
+    bit_offset: 15
+    bit_size: 1
+  - name: UART5PRIV
+    description: privileged access mode for UART5.
+    bit_offset: 16
+    bit_size: 1
+  - name: I2C1PRIV
+    description: privileged access mode for I2C1.
+    bit_offset: 17
+    bit_size: 1
+  - name: I2C2PRIV
+    description: privileged access mode for I2C2.
+    bit_offset: 18
+    bit_size: 1
+  - name: I3C1PRIV
+    description: privileged access mode for I3C1.
+    bit_offset: 19
+    bit_size: 1
+  - name: CRSPRIV
+    description: privileged access mode for CRS.
+    bit_offset: 20
+    bit_size: 1
+  - name: USART6PRIV
+    description: privileged access mode for USART6.
+    bit_offset: 21
+    bit_size: 1
+  - name: USART10PRIV
+    description: privileged access mode for USART10.
+    bit_offset: 22
+    bit_size: 1
+  - name: USART11PRIV
+    description: privileged access mode for USART11.
+    bit_offset: 23
+    bit_size: 1
+  - name: HDMICECPRIV
+    description: privileged access mode for HDMICEC.
+    bit_offset: 24
+    bit_size: 1
+  - name: DAC1PRIV
+    description: privileged access mode for DAC1.
+    bit_offset: 25
+    bit_size: 1
+  - name: UART7PRIV
+    description: privileged access mode for UART7.
+    bit_offset: 26
+    bit_size: 1
+  - name: UART8PRIV
+    description: privileged access mode for UART8.
+    bit_offset: 27
+    bit_size: 1
+  - name: UART9PRIV
+    description: privileged access mode for UART9.
+    bit_offset: 28
+    bit_size: 1
+  - name: UART12PRIV
+    description: privileged access mode for UART12.
+    bit_offset: 29
+    bit_size: 1
+  - name: DTSPRIV
+    description: privileged access mode for DTS.
+    bit_offset: 30
+    bit_size: 1
+  - name: LPTIM2PRIV
+    description: privileged access mode for LPTIM2.
+    bit_offset: 31
+    bit_size: 1
+fieldset/PRIVCFGR2:
+  description: GTZC1 TZSC privilege configuration register 2.
+  fields:
+  - name: FDCAN1PRIV
+    description: privileged access mode for FDCAN1.
+    bit_offset: 0
+    bit_size: 1
+  - name: FDCAN2PRIV
+    description: privileged access mode for FDCAN2.
+    bit_offset: 1
+    bit_size: 1
+  - name: UCPDPRIV
+    description: privileged access mode for UCPD.
+    bit_offset: 2
+    bit_size: 1
+  - name: TIM1PRIV
+    description: privileged access mode for TIM1.
+    bit_offset: 8
+    bit_size: 1
+  - name: SPI1PRIV
+    description: privileged access mode for SPI1.
+    bit_offset: 9
+    bit_size: 1
+  - name: TIM8PRIV
+    description: privileged access mode for TIM8.
+    bit_offset: 10
+    bit_size: 1
+  - name: USART1PRIV
+    description: privileged access mode for USART1.
+    bit_offset: 11
+    bit_size: 1
+  - name: TIM15PRIV
+    description: privileged access mode for TIM15.
+    bit_offset: 12
+    bit_size: 1
+  - name: TIM16PRIV
+    description: privileged access mode for TIM16.
+    bit_offset: 13
+    bit_size: 1
+  - name: TIM17PRIV
+    description: privileged access mode for TIM17.
+    bit_offset: 14
+    bit_size: 1
+  - name: SPI4PRIV
+    description: privileged access mode for SPI4.
+    bit_offset: 15
+    bit_size: 1
+  - name: SPI6PRIV
+    description: privileged access mode for SPI6.
+    bit_offset: 16
+    bit_size: 1
+  - name: SAI1PRIV
+    description: privileged access mode for SAI1.
+    bit_offset: 17
+    bit_size: 1
+  - name: SAI2PRIV
+    description: privileged access mode for SAI2.
+    bit_offset: 18
+    bit_size: 1
+  - name: USBPRIV
+    description: privileged access mode for USB.
+    bit_offset: 19
+    bit_size: 1
+  - name: SPI5PRIV
+    description: privileged access mode for SPI5.
+    bit_offset: 24
+    bit_size: 1
+  - name: LPUART1PRIV
+    description: privileged access mode for LPUART.
+    bit_offset: 25
+    bit_size: 1
+  - name: I2C3PRIV
+    description: privileged access mode for I2C3.
+    bit_offset: 26
+    bit_size: 1
+  - name: I2C4PRIV
+    description: privileged access mode for I2C4.
+    bit_offset: 27
+    bit_size: 1
+  - name: LPTIM1PRIV
+    description: privileged access mode for LPTIM1.
+    bit_offset: 28
+    bit_size: 1
+  - name: LPTIM3PRIV
+    description: privileged access mode for LPTIM3.
+    bit_offset: 29
+    bit_size: 1
+  - name: LPTIM4PRIV
+    description: privileged access mode for LPTIM4.
+    bit_offset: 30
+    bit_size: 1
+  - name: LPTIM5PRIV
+    description: privileged access mode for LPTIM5.
+    bit_offset: 31
+    bit_size: 1
+fieldset/PRIVCFGR3:
+  description: GTZC1 TZSC privilege configuration register 3.
+  fields:
+  - name: LPTIM6PRIV
+    description: privileged access mode for LPTIM6.
+    bit_offset: 0
+    bit_size: 1
+  - name: VREFBUFPRIV
+    description: privileged access mode for VREFBUF.
+    bit_offset: 1
+    bit_size: 1
+  - name: CRCPRIV
+    description: privileged access mode for CRC.
+    bit_offset: 8
+    bit_size: 1
+  - name: CORDICPRIV
+    description: privileged access mode for CORDIC.
+    bit_offset: 9
+    bit_size: 1
+  - name: FMACPRIV
+    description: privileged access mode for FMAC.
+    bit_offset: 10
+    bit_size: 1
+  - name: ICACHEPRIV
+    description: privileged access mode for ICACHE.
+    bit_offset: 12
+    bit_size: 1
+  - name: DCACHEPRIV
+    description: privileged access mode for DCACHE.
+    bit_offset: 13
+    bit_size: 1
+  - name: ADC12PRIV
+    description: privileged access mode for ADC1 and ADC2.
+    bit_offset: 14
+    bit_size: 1
+  - name: DCMIPRIV
+    description: privileged access mode for DCMI.
+    bit_offset: 15
+    bit_size: 1
+  - name: HASHPRIV
+    description: privileged access mode for HASH.
+    bit_offset: 17
+    bit_size: 1
+  - name: RNGPRIV
+    description: privileged access mode for RNG.
+    bit_offset: 18
+    bit_size: 1
+  - name: SDMMC1PRIV
+    description: privileged access mode for SDMMC1.
+    bit_offset: 22
+    bit_size: 1
+  - name: FMCPRIV
+    description: privileged access mode for FMC.
+    bit_offset: 23
+    bit_size: 1
+  - name: OCTOSPI1PRIV
+    description: privileged access mode for OCTOSPI1.
+    bit_offset: 24
+    bit_size: 1
+  - name: RAMCFGPRIV
+    description: privileged access mode for RAMSCFG.
+    bit_offset: 26
+    bit_size: 1
+fieldset/SECCFGR1:
+  description: GTZC1 TZSC secure configuration register 1.
+  fields:
+  - name: TIM2SEC
+    description: secure access mode for TIM2.
+    bit_offset: 0
+    bit_size: 1
+  - name: TIM3SEC
+    description: secure access mode for TIM3.
+    bit_offset: 1
+    bit_size: 1
+  - name: TIM4SEC
+    description: secure access mode for TIM4.
+    bit_offset: 2
+    bit_size: 1
+  - name: TIM5SEC
+    description: secure access mode for TIM5.
+    bit_offset: 3
+    bit_size: 1
+  - name: TIM6SEC
+    description: secure access mode for TIM6.
+    bit_offset: 4
+    bit_size: 1
+  - name: TIM7SEC
+    description: secure access mode for TIM7.
+    bit_offset: 5
+    bit_size: 1
+  - name: TIM12SEC
+    description: secure access mode for TIM12.
+    bit_offset: 6
+    bit_size: 1
+  - name: TIM13SEC
+    description: secure access mode for TIM13.
+    bit_offset: 7
+    bit_size: 1
+  - name: TIM14SEC
+    description: secure access mode for TIM14.
+    bit_offset: 8
+    bit_size: 1
+  - name: WWDGSEC
+    description: secure access mode for WWDG.
+    bit_offset: 9
+    bit_size: 1
+  - name: IWDGSEC
+    description: secure access mode for IWDG.
+    bit_offset: 10
+    bit_size: 1
+  - name: SPI2SEC
+    description: secure access mode for SPI2.
+    bit_offset: 11
+    bit_size: 1
+  - name: SPI3SEC
+    description: secure access mode for SPI3.
+    bit_offset: 12
+    bit_size: 1
+  - name: USART2SEC
+    description: secure access mode for USART2.
+    bit_offset: 13
+    bit_size: 1
+  - name: USART3SEC
+    description: secure access mode for USART3.
+    bit_offset: 14
+    bit_size: 1
+  - name: UART4SEC
+    description: secure access mode for UART4.
+    bit_offset: 15
+    bit_size: 1
+  - name: UART5SEC
+    description: secure access mode for UART5.
+    bit_offset: 16
+    bit_size: 1
+  - name: I2C1SEC
+    description: secure access mode for I2C1.
+    bit_offset: 17
+    bit_size: 1
+  - name: I2C2SEC
+    description: secure access mode for I2C2.
+    bit_offset: 18
+    bit_size: 1
+  - name: I3C1SEC
+    description: secure access mode for I3C1.
+    bit_offset: 19
+    bit_size: 1
+  - name: CRSSEC
+    description: secure access mode for CRS.
+    bit_offset: 20
+    bit_size: 1
+  - name: USART6SEC
+    description: secure access mode for USART6.
+    bit_offset: 21
+    bit_size: 1
+  - name: USART10SEC
+    description: secure access mode for USART10.
+    bit_offset: 22
+    bit_size: 1
+  - name: USART11SEC
+    description: secure access mode for USART11.
+    bit_offset: 23
+    bit_size: 1
+  - name: HDMICECSEC
+    description: secure access mode for HDMICEC.
+    bit_offset: 24
+    bit_size: 1
+  - name: DAC1SEC
+    description: secure access mode for DAC1.
+    bit_offset: 25
+    bit_size: 1
+  - name: UART7SEC
+    description: secure access mode for UART7.
+    bit_offset: 26
+    bit_size: 1
+  - name: UART8SEC
+    description: secure access mode for UART8.
+    bit_offset: 27
+    bit_size: 1
+  - name: UART9SEC
+    description: secure access mode for UART9.
+    bit_offset: 28
+    bit_size: 1
+  - name: UART12SEC
+    description: secure access mode for UART12.
+    bit_offset: 29
+    bit_size: 1
+  - name: DTSSEC
+    description: secure access mode for DTS.
+    bit_offset: 30
+    bit_size: 1
+  - name: LPTIM2SEC
+    description: secure access mode for LPTIM2.
+    bit_offset: 31
+    bit_size: 1
+fieldset/SECCFGR2:
+  description: GTZC1 TZSC secure configuration register 2.
+  fields:
+  - name: FDCAN1SEC
+    description: secure access mode for FDCAN1.
+    bit_offset: 0
+    bit_size: 1
+  - name: FDCAN2SEC
+    description: secure access mode for FDCAN2.
+    bit_offset: 1
+    bit_size: 1
+  - name: UCPDSEC
+    description: secure access mode for UCPD.
+    bit_offset: 2
+    bit_size: 1
+  - name: TIM1SEC
+    description: secure access mode for TIM1.
+    bit_offset: 8
+    bit_size: 1
+  - name: SPI1SEC
+    description: secure access mode for SPI1.
+    bit_offset: 9
+    bit_size: 1
+  - name: TIM8SEC
+    description: secure access mode for TIM8.
+    bit_offset: 10
+    bit_size: 1
+  - name: USART1SEC
+    description: secure access mode for USART1.
+    bit_offset: 11
+    bit_size: 1
+  - name: TIM15SEC
+    description: secure access mode for TIM15.
+    bit_offset: 12
+    bit_size: 1
+  - name: TIM16SEC
+    description: secure access mode for TIM16.
+    bit_offset: 13
+    bit_size: 1
+  - name: TIM17SEC
+    description: secure access mode for TIM17.
+    bit_offset: 14
+    bit_size: 1
+  - name: SPI4SEC
+    description: secure access mode for SPI4.
+    bit_offset: 15
+    bit_size: 1
+  - name: SPI6SEC
+    description: secure access mode for SPI6.
+    bit_offset: 16
+    bit_size: 1
+  - name: SAI1SEC
+    description: secure access mode for SAI1.
+    bit_offset: 17
+    bit_size: 1
+  - name: SAI2SEC
+    description: secure access mode for SAI2.
+    bit_offset: 18
+    bit_size: 1
+  - name: USBSEC
+    description: secure access mode for USB.
+    bit_offset: 19
+    bit_size: 1
+  - name: SPI5SEC
+    description: secure access mode for SPI5.
+    bit_offset: 24
+    bit_size: 1
+  - name: LPUART1SEC
+    description: secure access mode for LPUART.
+    bit_offset: 25
+    bit_size: 1
+  - name: I2C3SEC
+    description: secure access mode for I2C3.
+    bit_offset: 26
+    bit_size: 1
+  - name: I2C4SEC
+    description: secure access mode for I2C4.
+    bit_offset: 27
+    bit_size: 1
+  - name: LPTIM1SEC
+    description: secure access mode for LPTIM1.
+    bit_offset: 28
+    bit_size: 1
+  - name: LPTIM3SEC
+    description: secure access mode for LPTIM3.
+    bit_offset: 29
+    bit_size: 1
+  - name: LPTIM4SEC
+    description: secure access mode for LPTIM4.
+    bit_offset: 30
+    bit_size: 1
+  - name: LPTIM5SEC
+    description: secure access mode for LPTIM5.
+    bit_offset: 31
+    bit_size: 1
+fieldset/SECCFGR3:
+  description: GTZC1 TZSC secure configuration register 3.
+  fields:
+  - name: LPTIM6SEC
+    description: secure access mode for LPTIM6.
+    bit_offset: 0
+    bit_size: 1
+  - name: VREFBUFSEC
+    description: secure access mode for VREFBUF.
+    bit_offset: 1
+    bit_size: 1
+  - name: CRCSEC
+    description: secure access mode for CRC.
+    bit_offset: 8
+    bit_size: 1
+  - name: CORDICSEC
+    description: secure access mode for CORDIC.
+    bit_offset: 9
+    bit_size: 1
+  - name: FMACSEC
+    description: secure access mode for FMAC.
+    bit_offset: 10
+    bit_size: 1
+  - name: ICACHESEC
+    description: secure access mode for ICACHE.
+    bit_offset: 12
+    bit_size: 1
+  - name: DCACHESEC
+    description: secure access mode for DCACHE.
+    bit_offset: 13
+    bit_size: 1
+  - name: ADC12SEC
+    description: secure access mode for ADC1 and ADC2.
+    bit_offset: 14
+    bit_size: 1
+  - name: DCMISEC
+    description: secure access mode for DCMI.
+    bit_offset: 15
+    bit_size: 1
+  - name: HASHSEC
+    description: secure access mode for HASH.
+    bit_offset: 17
+    bit_size: 1
+  - name: RNGSEC
+    description: secure access mode for RNG.
+    bit_offset: 18
+    bit_size: 1
+  - name: SDMMC1SEC
+    description: secure access mode for SDMMC1.
+    bit_offset: 22
+    bit_size: 1
+  - name: FMCSEC
+    description: secure access mode for FMC.
+    bit_offset: 23
+    bit_size: 1
+  - name: OCTOSPI1SEC
+    description: secure access mode for OCTOSPI1.
+    bit_offset: 24
+    bit_size: 1
+  - name: RAMCFGSEC
+    description: secure access mode for RAMSCFG.
+    bit_offset: 26
+    bit_size: 1

--- a/data/registers/gtzc_wba.yaml
+++ b/data/registers/gtzc_wba.yaml
@@ -1,0 +1,352 @@
+block/GTZC_TZSC:
+  description: GTZC_TZSC address block description.
+  items:
+  - name: TZSC_CR
+    description: GTZC1 TZSC control register.
+    byte_offset: 0
+    fieldset: TZSC_CR
+  - name: TZSC_SECCFGR1
+    description: GTZC1 TZSC secure configuration register 1.
+    byte_offset: 16
+    fieldset: TZSC_SECCFGR1
+  - name: TZSC_SECCFGR2
+    description: GTZC1 TZSC secure configuration register 2.
+    byte_offset: 20
+    fieldset: TZSC_SECCFGR2
+  - name: TZSC_SECCFGR3
+    description: GTZC1 TZSC secure configuration register 3.
+    byte_offset: 24
+    fieldset: TZSC_SECCFGR3
+  - name: TZSC_PRIVCFGR1
+    description: GTZC1 TZSC privilege configuration register 1.
+    byte_offset: 32
+    fieldset: TZSC_PRIVCFGR1
+  - name: TZSC_PRIVCFGR2
+    description: GTZC1 TZSC privilege configuration register 2.
+    byte_offset: 36
+    fieldset: TZSC_PRIVCFGR2
+  - name: TZSC_PRIVCFGR3
+    description: GTZC1 TZSC privilege configuration register 3.
+    byte_offset: 40
+    fieldset: TZSC_PRIVCFGR3
+fieldset/TZSC_CR:
+  description: GTZC1 TZSC control register.
+  fields:
+  - name: LCK
+    description: Lock the configuration of TZSC_SECCFGRn and TZSC_PRIVCFGRn registers until next reset.
+    bit_offset: 0
+    bit_size: 1
+fieldset/TZSC_PRIVCFGR1:
+  description: GTZC1 TZSC privilege configuration register 1.
+  fields:
+  - name: TIM2PRIV
+    description: Privileged access mode for TIM2.
+    bit_offset: 0
+    bit_size: 1
+  - name: TIM3PRIV
+    description: Privileged access mode for TIM3.
+    bit_offset: 1
+    bit_size: 1
+  - name: TIM4PRIV
+    description: Privileged access mode for TIM4.
+    bit_offset: 2
+    bit_size: 1
+  - name: WWDGPRIV
+    description: Privileged access mode for WWDG.
+    bit_offset: 6
+    bit_size: 1
+  - name: IWDGPRIV
+    description: Privileged access mode for IWDG.
+    bit_offset: 7
+    bit_size: 1
+  - name: SPI2PRIV
+    description: Privileged access mode for SPI2.
+    bit_offset: 8
+    bit_size: 1
+  - name: USART2PRIV
+    description: Privileged access mode for USART2.
+    bit_offset: 9
+    bit_size: 1
+  - name: USART3PRIV
+    description: Privileged access mode for USART3.
+    bit_offset: 10
+    bit_size: 1
+  - name: I2C1PRIV
+    description: Privileged access mode for I2C1.
+    bit_offset: 13
+    bit_size: 1
+  - name: I2C2PRIV
+    description: Privileged access mode for I2C2.
+    bit_offset: 14
+    bit_size: 1
+  - name: I2C4PRIV
+    description: Privileged access mode for I2C4.
+    bit_offset: 16
+    bit_size: 1
+  - name: LPTIM2PRIV
+    description: Privileged access mode for LPTIM2.
+    bit_offset: 17
+    bit_size: 1
+fieldset/TZSC_PRIVCFGR2:
+  description: GTZC1 TZSC privilege configuration register 2.
+  fields:
+  - name: TIM1PRIV
+    description: Privileged access mode for TIM1.
+    bit_offset: 0
+    bit_size: 1
+  - name: SPI1PRIV
+    description: Privileged access mode for SPI1PRIV.
+    bit_offset: 1
+    bit_size: 1
+  - name: USART1PRIV
+    description: Privileged access mode for USART1.
+    bit_offset: 3
+    bit_size: 1
+  - name: TIM16PRIV
+    description: Privileged access mode for TIM16.
+    bit_offset: 5
+    bit_size: 1
+  - name: TIM17PRIV
+    description: Privileged access mode for TIM17.
+    bit_offset: 6
+    bit_size: 1
+  - name: SAI1PRIV
+    description: Privileged access mode for SAI1.
+    bit_offset: 7
+    bit_size: 1
+  - name: SPI3PRIV
+    description: Privileged access mode for SPI3.
+    bit_offset: 16
+    bit_size: 1
+  - name: LPUART1PRIV
+    description: Privileged access mode for LPUART1.
+    bit_offset: 17
+    bit_size: 1
+  - name: I2C3PRIV
+    description: Privileged access mode for I2C3.
+    bit_offset: 18
+    bit_size: 1
+  - name: LPTIM1PRIV
+    description: Privileged access mode for LPTIM1.
+    bit_offset: 19
+    bit_size: 1
+  - name: COMPPRIV
+    description: Privileged access mode for COMP.
+    bit_offset: 23
+    bit_size: 1
+  - name: ADC4PRIV
+    description: Privileged access mode for ADC4.
+    bit_offset: 24
+    bit_size: 1
+  - name: VREFBUFPRIV
+    description: Privileged access mode for VREFBUF.
+    bit_offset: 25
+    bit_size: 1
+fieldset/TZSC_PRIVCFGR3:
+  description: GTZC1 TZSC privilege configuration register 3.
+  fields:
+  - name: CRCPRIV
+    description: Privileged access mode for CRC.
+    bit_offset: 3
+    bit_size: 1
+  - name: TSCPRIV
+    description: Privileged access mode for TSC.
+    bit_offset: 4
+    bit_size: 1
+  - name: ICACHE_REGPRIV
+    description: Privileged access mode for ICACHE registers.
+    bit_offset: 6
+    bit_size: 1
+  - name: OTGPRIV
+    description: Privileged access mode for USB OTG_HS.
+    bit_offset: 10
+    bit_size: 1
+  - name: AESPRIV
+    description: Privileged access mode for AES.
+    bit_offset: 11
+    bit_size: 1
+  - name: HASHPRIV
+    description: Privileged access mode for HASH.
+    bit_offset: 12
+    bit_size: 1
+  - name: RNGPRIV
+    description: Privileged access mode for RNG.
+    bit_offset: 13
+    bit_size: 1
+  - name: SAESPRIV
+    description: Privileged access mode for SAES.
+    bit_offset: 14
+    bit_size: 1
+  - name: PKAPRIV
+    description: Privileged access mode for PKA.
+    bit_offset: 16
+    bit_size: 1
+  - name: RAMCFGPRIV
+    description: Privileged access mode for RAMCFG.
+    bit_offset: 22
+    bit_size: 1
+  - name: RADIOPRIV
+    description: Privileged access mode for 2.
+    bit_offset: 23
+    bit_size: 1
+  - name: PTACONVPRIV
+    description: Privileged access mode for PTACONV.
+    bit_offset: 24
+    bit_size: 1
+fieldset/TZSC_SECCFGR1:
+  description: GTZC1 TZSC secure configuration register 1.
+  fields:
+  - name: TIM2SEC
+    description: Secure access mode for TIM2.
+    bit_offset: 0
+    bit_size: 1
+  - name: TIM3SEC
+    description: Secure access mode for TIM3.
+    bit_offset: 1
+    bit_size: 1
+  - name: TIM4SEC
+    description: Secure access mode for TIM4.
+    bit_offset: 2
+    bit_size: 1
+  - name: WWDGSEC
+    description: Secure access mode for WWDG.
+    bit_offset: 6
+    bit_size: 1
+  - name: IWDGSEC
+    description: Secure access mode for IWDG.
+    bit_offset: 7
+    bit_size: 1
+  - name: SPI2SEC
+    description: Secure access mode for SPI2.
+    bit_offset: 8
+    bit_size: 1
+  - name: USART2SEC
+    description: Secure access mode for USART2.
+    bit_offset: 9
+    bit_size: 1
+  - name: USART3SEC
+    description: Secure access mode for USART3.
+    bit_offset: 10
+    bit_size: 1
+  - name: I2C1SEC
+    description: Secure access mode for I2C1.
+    bit_offset: 13
+    bit_size: 1
+  - name: I2C2SEC
+    description: Secure access mode for I2C2.
+    bit_offset: 14
+    bit_size: 1
+  - name: I2C4SEC
+    description: Secure access mode for I2C4.
+    bit_offset: 16
+    bit_size: 1
+  - name: LPTIM2SEC
+    description: Secure access mode for LPTIM2.
+    bit_offset: 17
+    bit_size: 1
+fieldset/TZSC_SECCFGR2:
+  description: GTZC1 TZSC secure configuration register 2.
+  fields:
+  - name: TIM1SEC
+    description: Secure access mode for TIM1.
+    bit_offset: 0
+    bit_size: 1
+  - name: SPI1SEC
+    description: Secure access mode for SPI1.
+    bit_offset: 1
+    bit_size: 1
+  - name: USART1SEC
+    description: Secure access mode for USART1.
+    bit_offset: 3
+    bit_size: 1
+  - name: TIM16SEC
+    description: Secure access mode for TIM16.
+    bit_offset: 5
+    bit_size: 1
+  - name: TIM17SEC
+    description: Secure access mode for TIM17.
+    bit_offset: 6
+    bit_size: 1
+  - name: SAI1SEC
+    description: Secure access mode for SAI1.
+    bit_offset: 7
+    bit_size: 1
+  - name: SPI3SEC
+    description: Secure access mode for SPI3.
+    bit_offset: 16
+    bit_size: 1
+  - name: LPUART1SEC
+    description: Secure access mode for LPUART1.
+    bit_offset: 17
+    bit_size: 1
+  - name: I2C3SEC
+    description: Secure access mode for I2C3.
+    bit_offset: 18
+    bit_size: 1
+  - name: LPTIM1SEC
+    description: Secure access mode for LPTIM1.
+    bit_offset: 19
+    bit_size: 1
+  - name: COMPSEC
+    description: Secure access mode for COMP.
+    bit_offset: 23
+    bit_size: 1
+  - name: ADC4SEC
+    description: Secure access mode for ADC4.
+    bit_offset: 24
+    bit_size: 1
+  - name: VREFBUFSEC
+    description: Secure access mode for VREFBUF.
+    bit_offset: 25
+    bit_size: 1
+fieldset/TZSC_SECCFGR3:
+  description: GTZC1 TZSC secure configuration register 3.
+  fields:
+  - name: CRCSEC
+    description: Secure access mode for CRC.
+    bit_offset: 3
+    bit_size: 1
+  - name: TSCSEC
+    description: Secure access mode for TSC.
+    bit_offset: 4
+    bit_size: 1
+  - name: ICACHE_REGSEC
+    description: Secure access mode for ICACHE registers.
+    bit_offset: 6
+    bit_size: 1
+  - name: OTGSEC
+    description: Secure access mode for USB OTG_HS.
+    bit_offset: 10
+    bit_size: 1
+  - name: AESSEC
+    description: Secure access mode for AES.
+    bit_offset: 11
+    bit_size: 1
+  - name: HASHSEC
+    description: Secure access mode for HASH.
+    bit_offset: 12
+    bit_size: 1
+  - name: RNGSEC
+    description: Secure access mode for RNG.
+    bit_offset: 13
+    bit_size: 1
+  - name: SAESSEC
+    description: Secure access mode for SAES.
+    bit_offset: 14
+    bit_size: 1
+  - name: PKASEC
+    description: Secure access mode for PKA.
+    bit_offset: 16
+    bit_size: 1
+  - name: RAMCFGSEC
+    description: Secure access mode for RAMCFG.
+    bit_offset: 22
+    bit_size: 1
+  - name: RADIOSEC
+    description: Secure access mode for 2.
+    bit_offset: 23
+    bit_size: 1
+  - name: PTACONVSEC
+    description: Secure access mode for PTACONV.
+    bit_offset: 24
+    bit_size: 1

--- a/data/registers/ramcfg_h5.yaml
+++ b/data/registers/ramcfg_h5.yaml
@@ -1,0 +1,406 @@
+block/RAMCFG:
+  description: RAMs configuration controller.
+  items:
+  - name: M1CR
+    description: RAMCFG memory 1 control register.
+    byte_offset: 0
+    fieldset: M1CR
+  - name: M1ISR
+    description: RAMCFG memory interrupt status register.
+    byte_offset: 8
+    fieldset: M1ISR
+  - name: M1ERKEYR
+    description: RAMCFG memory 1 erase key register.
+    byte_offset: 40
+    fieldset: M1ERKEYR
+  - name: M2CR
+    description: RAMCFG memory 2 control register.
+    byte_offset: 64
+    fieldset: M2CR
+  - name: M2IER
+    description: RAMCFG memory 2 interrupt enable register.
+    byte_offset: 68
+    fieldset: M2IER
+  - name: M2ISR
+    description: RAMCFG memory interrupt status register.
+    byte_offset: 72
+    fieldset: M2ISR
+  - name: M2SEAR
+    description: RAMCFG memory 2 ECC single error address register.
+    byte_offset: 76
+    fieldset: M2SEAR
+  - name: M2DEAR
+    description: RAMCFG memory 2 ECC double error address register.
+    byte_offset: 80
+    fieldset: M2DEAR
+  - name: M2ICR
+    description: RAMCFG memory 2 interrupt clear register 2.
+    byte_offset: 84
+    fieldset: M2ICR
+  - name: M2WPR1
+    description: RAMCFG memory 2 write protection register 1.
+    byte_offset: 88
+    fieldset: M2WPR1
+  - name: M2ECCKEYR
+    description: RAMCFG memory 2 ECC key register.
+    byte_offset: 100
+    fieldset: M2ECCKEYR
+  - name: M2ERKEYR
+    description: RAMCFG memory 2 erase key register.
+    byte_offset: 104
+    fieldset: M2ERKEYR
+  - name: M3IER
+    description: RAMCFG memory 3 interrupt enable register.
+    byte_offset: 132
+    fieldset: M3IER
+  - name: M3ISR
+    description: RAMCFG memory interrupt status register.
+    byte_offset: 136
+    fieldset: M3ISR
+  - name: M3SEAR
+    description: RAMCFG memory 3 ECC single error address register.
+    byte_offset: 140
+    fieldset: M3SEAR
+  - name: M3DEAR
+    description: RAMCFG memory 3 ECC double error address register.
+    byte_offset: 144
+    fieldset: M3DEAR
+  - name: M3ICR
+    description: RAMCFG memory 3 interrupt clear register 3.
+    byte_offset: 148
+    fieldset: M3ICR
+  - name: M3ECCKEYR
+    description: RAMCFG memory 3 ECC key register.
+    byte_offset: 164
+    fieldset: M3ECCKEYR
+  - name: M3ERKEYR
+    description: RAMCFG memory 3 erase key register.
+    byte_offset: 168
+    fieldset: M3ERKEYR
+  - name: M4ERKEYR
+    description: RAMCFG memory 4 erase key register.
+    byte_offset: 232
+    fieldset: M4ERKEYR
+  - name: M5CR
+    description: RAMCFG memory 5 control register.
+    byte_offset: 256
+    fieldset: M5CR
+  - name: M5IER
+    description: RAMCFG memory 5 interrupt enable register.
+    byte_offset: 260
+    fieldset: M5IER
+  - name: M5ISR
+    description: RAMCFG memory interrupt status register.
+    byte_offset: 264
+    fieldset: M5ISR
+  - name: M5SEAR
+    description: RAMCFG memory 5 ECC single error address register.
+    byte_offset: 268
+    fieldset: M5SEAR
+  - name: M5DEAR
+    description: RAMCFG memory 5 ECC double error address register.
+    byte_offset: 272
+    fieldset: M5DEAR
+  - name: M5ICR
+    description: RAMCFG memory 5 interrupt clear register 5.
+    byte_offset: 276
+    fieldset: M5ICR
+  - name: M5ECCKEYR
+    description: RAMCFG memory 5 ECC key register.
+    byte_offset: 292
+    fieldset: M5ECCKEYR
+  - name: M5ERKEYR
+    description: RAMCFG memory 5 erase key register.
+    byte_offset: 296
+    fieldset: M5ERKEYR
+fieldset/M1CR:
+  description: RAMCFG memory 1 control register.
+  fields:
+  - name: ECCE
+    description: 'ECC enable. This bit reset value is defined by the user option bit configuration. When set, it can be cleared by software only after writing the unlock sequence in the MxECCKEYR register. Note: This bit is reserved and must be kept at reset value in SRAM1 control register.'
+    bit_offset: 0
+    bit_size: 1
+  - name: ALE
+    description: 'Address latch enable Note: This bit is reserved and must be kept at reset value in SRAM1 control register.'
+    bit_offset: 4
+    bit_size: 1
+  - name: SRAMER
+    description: SRAM erase This bit can be set by software only after writing the unlock sequence in the ERASEKEY field of the MxERKEYR register. Setting this bit starts the SRAM erase. This bit is automatically cleared by hardware at the end of the erase operation.
+    bit_offset: 8
+    bit_size: 1
+fieldset/M1ERKEYR:
+  description: RAMCFG memory 1 erase key register.
+  fields:
+  - name: ERASEKEY
+    description: 'Erase write protection key The following steps are required to unlock the write protection of the SRAMER bit in the MxCR register. 1) Write 0xCA into ERASEKEY[7:0]. 2) Write 0x53 into ERASEKEY[7:0]. Note: Writing a wrong key reactivates the write protection.'
+    bit_offset: 0
+    bit_size: 8
+fieldset/M1ISR:
+  description: RAMCFG memory interrupt status register.
+  fields:
+  - name: SEDC
+    description: 'ECC single error detected and corrected Note: This bit is reserved and must be kept at reset value in SRAM1 interrupt status register.'
+    bit_offset: 0
+    bit_size: 1
+  - name: DED
+    description: 'ECC double error detected Note: This bit is reserved and must be kept at reset value in SRAM1 interrupt status register.'
+    bit_offset: 1
+    bit_size: 1
+  - name: SRAMBUSY
+    description: 'SRAM busy with erase operation Note: Depending on the SRAM, the erase operation can be performed due to software request, system reset if the option bit is enabled, tamper detection or product state regression. Refer to Table 9: Internal SRAMs features.'
+    bit_offset: 8
+    bit_size: 1
+fieldset/M2CR:
+  description: RAMCFG memory 2 control register.
+  fields:
+  - name: ECCE
+    description: 'ECC enable. This bit reset value is defined by the user option bit configuration. When set, it can be cleared by software only after writing the unlock sequence in the MxECCKEYR register. Note: This bit is reserved and must be kept at reset value in SRAM1 control register.'
+    bit_offset: 0
+    bit_size: 1
+  - name: ALE
+    description: 'Address latch enable Note: This bit is reserved and must be kept at reset value in SRAM1 control register.'
+    bit_offset: 4
+    bit_size: 1
+  - name: SRAMER
+    description: SRAM erase This bit can be set by software only after writing the unlock sequence in the ERASEKEY field of the MxERKEYR register. Setting this bit starts the SRAM erase. This bit is automatically cleared by hardware at the end of the erase operation.
+    bit_offset: 8
+    bit_size: 1
+fieldset/M2DEAR:
+  description: RAMCFG memory 2 ECC double error address register.
+  fields:
+  - name: EDEA
+    description: ECC double error address When the ALE bit is set in the MxCR register, this field is updated with the address corresponding to the ECC double error.
+    bit_offset: 0
+    bit_size: 32
+fieldset/M2ECCKEYR:
+  description: RAMCFG memory 2 ECC key register.
+  fields:
+  - name: ECCKEY
+    description: 'ECC write protection key The following steps are required to unlock the write protection of the ECCE bit in the MxCR register. 1) Write 0xAE into ECCKEY[7:0]. 2) Write 0x75 into ECCKEY[7:0]. Note: Writing a wrong key reactivates the write protection.'
+    bit_offset: 0
+    bit_size: 8
+fieldset/M2ERKEYR:
+  description: RAMCFG memory 2 erase key register.
+  fields:
+  - name: ERASEKEY
+    description: 'Erase write protection key The following steps are required to unlock the write protection of the SRAMER bit in the MxCR register. 1) Write 0xCA into ERASEKEY[7:0]. 2) Write 0x53 into ERASEKEY[7:0]. Note: Writing a wrong key reactivates the write protection.'
+    bit_offset: 0
+    bit_size: 8
+fieldset/M2ICR:
+  description: RAMCFG memory 2 interrupt clear register 2.
+  fields:
+  - name: CSEDC
+    description: Clear ECC single error detected and corrected Writing 1 to this flag clears the SEDC bit in the MxISR register. Reading this flag returns the SEDC value.
+    bit_offset: 0
+    bit_size: 1
+  - name: CDED
+    description: Clear ECC double error detected Writing 1 to this flag clears the DED bit in the MxISR register. Reading this flag returns the DED value.
+    bit_offset: 1
+    bit_size: 1
+fieldset/M2IER:
+  description: RAMCFG memory 2 interrupt enable register.
+  fields:
+  - name: SEIE
+    description: ECC single error interrupt enable.
+    bit_offset: 0
+    bit_size: 1
+  - name: DEIE
+    description: ECC double error interrupt enable.
+    bit_offset: 1
+    bit_size: 1
+  - name: ECCNMI
+    description: 'Double error NMI This bit is set by software and cleared only by a global RAMCFG reset. Note: if ECCNMI is set, the RAMCFG maskable interrupt is not generated whatever DEIE bit value.'
+    bit_offset: 3
+    bit_size: 1
+fieldset/M2ISR:
+  description: RAMCFG memory interrupt status register.
+  fields:
+  - name: SEDC
+    description: 'ECC single error detected and corrected Note: This bit is reserved and must be kept at reset value in SRAM1 interrupt status register.'
+    bit_offset: 0
+    bit_size: 1
+  - name: DED
+    description: 'ECC double error detected Note: This bit is reserved and must be kept at reset value in SRAM1 interrupt status register.'
+    bit_offset: 1
+    bit_size: 1
+  - name: SRAMBUSY
+    description: 'SRAM busy with erase operation Note: Depending on the SRAM, the erase operation can be performed due to software request, system reset if the option bit is enabled, tamper detection or product state regression. Refer to Table 9: Internal SRAMs features.'
+    bit_offset: 8
+    bit_size: 1
+fieldset/M2SEAR:
+  description: RAMCFG memory 2 ECC single error address register.
+  fields:
+  - name: ESEA
+    description: ECC single error address When the ALE bit is set in the MxCR register, this field is updated with the address corresponding to the ECC single error.
+    bit_offset: 0
+    bit_size: 32
+fieldset/M2WPR1:
+  description: RAMCFG memory 2 write protection register 1.
+  fields:
+  - name: PWP
+    description: SRAM2 1-Kbyte page y write protection These bits are set by software and cleared only by a global RAMCFG reset.
+    bit_offset: 0
+    bit_size: 1
+    array:
+      len: 16
+      stride: 1
+fieldset/M3DEAR:
+  description: RAMCFG memory 3 ECC double error address register.
+  fields:
+  - name: EDEA
+    description: ECC double error address When the ALE bit is set in the MxCR register, this field is updated with the address corresponding to the ECC double error.
+    bit_offset: 0
+    bit_size: 32
+fieldset/M3ECCKEYR:
+  description: RAMCFG memory 3 ECC key register.
+  fields:
+  - name: ECCKEY
+    description: 'ECC write protection key The following steps are required to unlock the write protection of the ECCE bit in the MxCR register. 1) Write 0xAE into ECCKEY[7:0]. 2) Write 0x75 into ECCKEY[7:0]. Note: Writing a wrong key reactivates the write protection.'
+    bit_offset: 0
+    bit_size: 8
+fieldset/M3ERKEYR:
+  description: RAMCFG memory 3 erase key register.
+  fields:
+  - name: ERASEKEY
+    description: 'Erase write protection key The following steps are required to unlock the write protection of the SRAMER bit in the MxCR register. 1) Write 0xCA into ERASEKEY[7:0]. 2) Write 0x53 into ERASEKEY[7:0]. Note: Writing a wrong key reactivates the write protection.'
+    bit_offset: 0
+    bit_size: 8
+fieldset/M3ICR:
+  description: RAMCFG memory 3 interrupt clear register 3.
+  fields:
+  - name: CSEDC
+    description: Clear ECC single error detected and corrected Writing 1 to this flag clears the SEDC bit in the MxISR register. Reading this flag returns the SEDC value.
+    bit_offset: 0
+    bit_size: 1
+  - name: CDED
+    description: Clear ECC double error detected Writing 1 to this flag clears the DED bit in the MxISR register. Reading this flag returns the DED value.
+    bit_offset: 1
+    bit_size: 1
+fieldset/M3IER:
+  description: RAMCFG memory 3 interrupt enable register.
+  fields:
+  - name: SEIE
+    description: ECC single error interrupt enable.
+    bit_offset: 0
+    bit_size: 1
+  - name: DEIE
+    description: ECC double error interrupt enable.
+    bit_offset: 1
+    bit_size: 1
+  - name: ECCNMI
+    description: 'Double error NMI This bit is set by software and cleared only by a global RAMCFG reset. Note: if ECCNMI is set, the RAMCFG maskable interrupt is not generated whatever DEIE bit value.'
+    bit_offset: 3
+    bit_size: 1
+fieldset/M3ISR:
+  description: RAMCFG memory interrupt status register.
+  fields:
+  - name: SEDC
+    description: 'ECC single error detected and corrected Note: This bit is reserved and must be kept at reset value in SRAM1 interrupt status register.'
+    bit_offset: 0
+    bit_size: 1
+  - name: DED
+    description: 'ECC double error detected Note: This bit is reserved and must be kept at reset value in SRAM1 interrupt status register.'
+    bit_offset: 1
+    bit_size: 1
+  - name: SRAMBUSY
+    description: 'SRAM busy with erase operation Note: Depending on the SRAM, the erase operation can be performed due to software request, system reset if the option bit is enabled, tamper detection or product state regression. Refer to Table 9: Internal SRAMs features.'
+    bit_offset: 8
+    bit_size: 1
+fieldset/M3SEAR:
+  description: RAMCFG memory 3 ECC single error address register.
+  fields:
+  - name: ESEA
+    description: ECC single error address When the ALE bit is set in the MxCR register, this field is updated with the address corresponding to the ECC single error.
+    bit_offset: 0
+    bit_size: 32
+fieldset/M4ERKEYR:
+  description: RAMCFG memory 4 erase key register.
+  fields:
+  - name: ERASEKEY
+    description: 'Erase write protection key The following steps are required to unlock the write protection of the SRAMER bit in the MxCR register. 1) Write 0xCA into ERASEKEY[7:0]. 2) Write 0x53 into ERASEKEY[7:0]. Note: Writing a wrong key reactivates the write protection.'
+    bit_offset: 0
+    bit_size: 8
+fieldset/M5CR:
+  description: RAMCFG memory 5 control register.
+  fields:
+  - name: ECCE
+    description: 'ECC enable. This bit reset value is defined by the user option bit configuration. When set, it can be cleared by software only after writing the unlock sequence in the MxECCKEYR register. Note: This bit is reserved and must be kept at reset value in SRAM1 control register.'
+    bit_offset: 0
+    bit_size: 1
+  - name: ALE
+    description: 'Address latch enable Note: This bit is reserved and must be kept at reset value in SRAM1 control register.'
+    bit_offset: 4
+    bit_size: 1
+  - name: SRAMER
+    description: SRAM erase This bit can be set by software only after writing the unlock sequence in the ERASEKEY field of the MxERKEYR register. Setting this bit starts the SRAM erase. This bit is automatically cleared by hardware at the end of the erase operation.
+    bit_offset: 8
+    bit_size: 1
+fieldset/M5DEAR:
+  description: RAMCFG memory 5 ECC double error address register.
+  fields:
+  - name: EDEA
+    description: ECC double error address When the ALE bit is set in the MxCR register, this field is updated with the address corresponding to the ECC double error.
+    bit_offset: 0
+    bit_size: 32
+fieldset/M5ECCKEYR:
+  description: RAMCFG memory 5 ECC key register.
+  fields:
+  - name: ECCKEY
+    description: 'ECC write protection key The following steps are required to unlock the write protection of the ECCE bit in the MxCR register. 1) Write 0xAE into ECCKEY[7:0]. 2) Write 0x75 into ECCKEY[7:0]. Note: Writing a wrong key reactivates the write protection.'
+    bit_offset: 0
+    bit_size: 8
+fieldset/M5ERKEYR:
+  description: RAMCFG memory 5 erase key register.
+  fields:
+  - name: ERASEKEY
+    description: 'Erase write protection key The following steps are required to unlock the write protection of the SRAMER bit in the MxCR register. 1) Write 0xCA into ERASEKEY[7:0]. 2) Write 0x53 into ERASEKEY[7:0]. Note: Writing a wrong key reactivates the write protection.'
+    bit_offset: 0
+    bit_size: 8
+fieldset/M5ICR:
+  description: RAMCFG memory 5 interrupt clear register 5.
+  fields:
+  - name: CSEDC
+    description: Clear ECC single error detected and corrected Writing 1 to this flag clears the SEDC bit in the MxISR register. Reading this flag returns the SEDC value.
+    bit_offset: 0
+    bit_size: 1
+  - name: CDED
+    description: Clear ECC double error detected Writing 1 to this flag clears the DED bit in the MxISR register. Reading this flag returns the DED value.
+    bit_offset: 1
+    bit_size: 1
+fieldset/M5IER:
+  description: RAMCFG memory 5 interrupt enable register.
+  fields:
+  - name: SEIE
+    description: ECC single error interrupt enable.
+    bit_offset: 0
+    bit_size: 1
+  - name: DEIE
+    description: ECC double error interrupt enable.
+    bit_offset: 1
+    bit_size: 1
+  - name: ECCNMI
+    description: 'Double error NMI This bit is set by software and cleared only by a global RAMCFG reset. Note: if ECCNMI is set, the RAMCFG maskable interrupt is not generated whatever DEIE bit value.'
+    bit_offset: 3
+    bit_size: 1
+fieldset/M5ISR:
+  description: RAMCFG memory interrupt status register.
+  fields:
+  - name: SEDC
+    description: 'ECC single error detected and corrected Note: This bit is reserved and must be kept at reset value in SRAM1 interrupt status register.'
+    bit_offset: 0
+    bit_size: 1
+  - name: DED
+    description: 'ECC double error detected Note: This bit is reserved and must be kept at reset value in SRAM1 interrupt status register.'
+    bit_offset: 1
+    bit_size: 1
+  - name: SRAMBUSY
+    description: 'SRAM busy with erase operation Note: Depending on the SRAM, the erase operation can be performed due to software request, system reset if the option bit is enabled, tamper detection or product state regression. Refer to Table 9: Internal SRAMs features.'
+    bit_offset: 8
+    bit_size: 1
+fieldset/M5SEAR:
+  description: RAMCFG memory 5 ECC single error address register.
+  fields:
+  - name: ESEA
+    description: ECC single error address When the ALE bit is set in the MxCR register, this field is updated with the address corresponding to the ECC single error.
+    bit_offset: 0
+    bit_size: 32

--- a/data/registers/ramcfg_u5.yaml
+++ b/data/registers/ramcfg_u5.yaml
@@ -1,0 +1,492 @@
+block/RAMCFG:
+  description: RAMCFG.
+  items:
+  - name: RAM1CR
+    description: RAMCFG SRAM x control register.
+    byte_offset: 0
+    fieldset: RAM1CR
+  - name: RAM1ISR
+    description: RAMCFG RAMx interrupt status register.
+    byte_offset: 8
+    access: Read
+    fieldset: RAM1ISR
+  - name: RAM1ERKEYR
+    description: RAMCFG SRAM x erase key register.
+    byte_offset: 40
+    access: Write
+    fieldset: RAM1ERKEYR
+  - name: RAM2CR
+    description: RAMCFG SRAM x control register.
+    byte_offset: 64
+    fieldset: RAM2CR
+  - name: RAM2IER
+    description: RAMCFG SRAM x interrupt enable register.
+    byte_offset: 68
+    fieldset: RAM2IER
+  - name: RAM2ISR
+    description: RAMCFG RAMx interrupt status register.
+    byte_offset: 72
+    access: Read
+    fieldset: RAM2ISR
+  - name: RAM2SEAR
+    description: RAMCFG RAM x ECC single error address register.
+    byte_offset: 76
+    access: Read
+    fieldset: RAM2SEAR
+  - name: RAM2DEAR
+    description: RAMCFG RAM x ECC double error address register.
+    byte_offset: 80
+    access: Read
+    fieldset: RAM2DEAR
+  - name: RAM2ICR
+    description: RAMCFG RAM x interrupt clear register x.
+    byte_offset: 84
+    fieldset: RAM2ICR
+  - name: RAM2WPR1
+    description: RAMCFG SRAM2 write protection register 1.
+    byte_offset: 88
+    fieldset: RAM2WPR1
+  - name: RAM2WPR2
+    description: RAMCFG SRAM2 write protection register 2.
+    byte_offset: 92
+    fieldset: RAM2WPR2
+  - name: RAM2ECCKEYR
+    description: RAMCFG SRAM x ECC key register.
+    byte_offset: 100
+    access: Write
+    fieldset: RAM2ECCKEYR
+  - name: RAM2ERKEYR
+    description: RAMCFG SRAM x erase key register.
+    byte_offset: 104
+    access: Write
+    fieldset: RAM2ERKEYR
+  - name: RAM3CR
+    description: RAMCFG SRAM x control register.
+    byte_offset: 128
+    fieldset: RAM3CR
+  - name: RAM3IER
+    description: RAMCFG SRAM x interrupt enable register.
+    byte_offset: 132
+    fieldset: RAM3IER
+  - name: RAM3ISR
+    description: RAMCFG RAMx interrupt status register.
+    byte_offset: 136
+    access: Read
+    fieldset: RAM3ISR
+  - name: RAM3SEAR
+    description: RAMCFG RAM x ECC single error address register.
+    byte_offset: 140
+    access: Read
+    fieldset: RAM3SEAR
+  - name: RAM3DEAR
+    description: RAMCFG RAM x ECC double error address register.
+    byte_offset: 144
+    access: Read
+    fieldset: RAM3DEAR
+  - name: RAM3ICR
+    description: RAMCFG RAM x interrupt clear register x.
+    byte_offset: 148
+    fieldset: RAM3ICR
+  - name: RAM3ECCKEYR
+    description: RAMCFG SRAM x ECC key register.
+    byte_offset: 164
+    access: Write
+    fieldset: RAM3ECCKEYR
+  - name: RAM3ERKEYR
+    description: RAMCFG SRAM x erase key register.
+    byte_offset: 168
+    access: Write
+    fieldset: RAM3ERKEYR
+  - name: RAM4CR
+    description: RAMCFG SRAM x control register.
+    byte_offset: 192
+    fieldset: RAM4CR
+  - name: RAM4ISR
+    description: RAMCFG RAMx interrupt status register.
+    byte_offset: 200
+    access: Read
+    fieldset: RAM4ISR
+  - name: RAM4ERKEYR
+    description: RAMCFG SRAM x erase key register.
+    byte_offset: 232
+    access: Write
+    fieldset: RAM4ERKEYR
+  - name: RAM5CR
+    description: RAMCFG SRAM x control register.
+    byte_offset: 256
+    fieldset: RAM5CR
+  - name: RAM5IER
+    description: RAMCFG SRAM x interrupt enable register.
+    byte_offset: 260
+    fieldset: RAM5IER
+  - name: RAM5ISR
+    description: RAMCFG RAMx interrupt status register.
+    byte_offset: 264
+    access: Read
+    fieldset: RAM5ISR
+  - name: RAM5SEAR
+    description: RAMCFG RAM x ECC single error address register.
+    byte_offset: 268
+    access: Read
+    fieldset: RAM5SEAR
+  - name: RAM5DEAR
+    description: RAMCFG RAM x ECC double error address register.
+    byte_offset: 272
+    access: Read
+    fieldset: RAM5DEAR
+  - name: RAM5ICR
+    description: RAMCFG RAM x interrupt clear register x.
+    byte_offset: 276
+    fieldset: RAM5ICR
+fieldset/RAM1CR:
+  description: RAMCFG SRAM x control register.
+  fields:
+  - name: ECCE
+    description: ECCE.
+    bit_offset: 0
+    bit_size: 1
+  - name: ALE
+    description: ALE.
+    bit_offset: 4
+    bit_size: 1
+  - name: SRAMER
+    description: SRAMER.
+    bit_offset: 8
+    bit_size: 1
+  - name: WSC
+    description: WSC.
+    bit_offset: 16
+    bit_size: 3
+fieldset/RAM1ERKEYR:
+  description: RAMCFG SRAM x erase key register.
+  fields:
+  - name: ERASEKEY
+    description: ERASEKEY.
+    bit_offset: 0
+    bit_size: 8
+fieldset/RAM1ISR:
+  description: RAMCFG RAMx interrupt status register.
+  fields:
+  - name: SEDC
+    description: SEDC.
+    bit_offset: 0
+    bit_size: 1
+  - name: DED
+    description: DED.
+    bit_offset: 1
+    bit_size: 1
+  - name: SRAMBUSY
+    description: SRAMBUSY.
+    bit_offset: 8
+    bit_size: 1
+fieldset/RAM2CR:
+  description: RAMCFG SRAM x control register.
+  fields:
+  - name: ECCE
+    description: ECCE.
+    bit_offset: 0
+    bit_size: 1
+  - name: ALE
+    description: ALE.
+    bit_offset: 4
+    bit_size: 1
+  - name: SRAMER
+    description: SRAMER.
+    bit_offset: 8
+    bit_size: 1
+  - name: WSC
+    description: WSC.
+    bit_offset: 16
+    bit_size: 3
+fieldset/RAM2DEAR:
+  description: RAMCFG RAM x ECC double error address register.
+  fields:
+  - name: EDEA
+    description: EDEA.
+    bit_offset: 0
+    bit_size: 32
+fieldset/RAM2ECCKEYR:
+  description: RAMCFG SRAM x ECC key register.
+  fields:
+  - name: ECCKEY
+    description: ECCKEY.
+    bit_offset: 0
+    bit_size: 8
+fieldset/RAM2ERKEYR:
+  description: RAMCFG SRAM x erase key register.
+  fields:
+  - name: ERASEKEY
+    description: ERASEKEY.
+    bit_offset: 0
+    bit_size: 8
+fieldset/RAM2ICR:
+  description: RAMCFG RAM x interrupt clear register x.
+  fields:
+  - name: CSEDC
+    description: CSEDC.
+    bit_offset: 0
+    bit_size: 1
+  - name: CDED
+    description: CDED.
+    bit_offset: 1
+    bit_size: 1
+fieldset/RAM2IER:
+  description: RAMCFG SRAM x interrupt enable register.
+  fields:
+  - name: SEIE
+    description: SEIE.
+    bit_offset: 0
+    bit_size: 1
+  - name: DEIE
+    description: DEIE.
+    bit_offset: 1
+    bit_size: 1
+  - name: ECCNMI
+    description: ECCNMI.
+    bit_offset: 3
+    bit_size: 1
+fieldset/RAM2ISR:
+  description: RAMCFG RAMx interrupt status register.
+  fields:
+  - name: SEDC
+    description: SEDC.
+    bit_offset: 0
+    bit_size: 1
+  - name: DED
+    description: DED.
+    bit_offset: 1
+    bit_size: 1
+  - name: SRAMBUSY
+    description: SRAMBUSY.
+    bit_offset: 8
+    bit_size: 1
+fieldset/RAM2SEAR:
+  description: RAMCFG RAM x ECC single error address register.
+  fields:
+  - name: ESEA
+    description: ESEA.
+    bit_offset: 0
+    bit_size: 32
+fieldset/RAM2WPR1:
+  description: RAMCFG SRAM2 write protection register 1.
+  fields:
+  - name: PWP
+    description: P0WP.
+    bit_offset: 0
+    bit_size: 1
+    array:
+      len: 32
+      stride: 1
+fieldset/RAM2WPR2:
+  description: RAMCFG SRAM2 write protection register 2.
+  fields:
+  - name: PWP
+    description: P32WP.
+    bit_offset: 0
+    bit_size: 1
+    array:
+      len: 32
+      stride: 1
+fieldset/RAM3CR:
+  description: RAMCFG SRAM x control register.
+  fields:
+  - name: ECCE
+    description: ECCE.
+    bit_offset: 0
+    bit_size: 1
+  - name: ALE
+    description: ALE.
+    bit_offset: 4
+    bit_size: 1
+  - name: SRAMER
+    description: SRAMER.
+    bit_offset: 8
+    bit_size: 1
+  - name: WSC
+    description: WSC.
+    bit_offset: 16
+    bit_size: 3
+fieldset/RAM3DEAR:
+  description: RAMCFG RAM x ECC double error address register.
+  fields:
+  - name: EDEA
+    description: EDEA.
+    bit_offset: 0
+    bit_size: 32
+fieldset/RAM3ECCKEYR:
+  description: RAMCFG SRAM x ECC key register.
+  fields:
+  - name: ECCKEY
+    description: ECCKEY.
+    bit_offset: 0
+    bit_size: 8
+fieldset/RAM3ERKEYR:
+  description: RAMCFG SRAM x erase key register.
+  fields:
+  - name: ERASEKEY
+    description: ERASEKEY.
+    bit_offset: 0
+    bit_size: 8
+fieldset/RAM3ICR:
+  description: RAMCFG RAM x interrupt clear register x.
+  fields:
+  - name: CSEDC
+    description: CSEDC.
+    bit_offset: 0
+    bit_size: 1
+  - name: CDED
+    description: CDED.
+    bit_offset: 1
+    bit_size: 1
+fieldset/RAM3IER:
+  description: RAMCFG SRAM x interrupt enable register.
+  fields:
+  - name: SEIE
+    description: SEIE.
+    bit_offset: 0
+    bit_size: 1
+  - name: DEIE
+    description: DEIE.
+    bit_offset: 1
+    bit_size: 1
+  - name: ECCNMI
+    description: ECCNMI.
+    bit_offset: 3
+    bit_size: 1
+fieldset/RAM3ISR:
+  description: RAMCFG RAMx interrupt status register.
+  fields:
+  - name: SEDC
+    description: SEDC.
+    bit_offset: 0
+    bit_size: 1
+  - name: DED
+    description: DED.
+    bit_offset: 1
+    bit_size: 1
+  - name: SRAMBUSY
+    description: SRAMBUSY.
+    bit_offset: 8
+    bit_size: 1
+fieldset/RAM3SEAR:
+  description: RAMCFG RAM x ECC single error address register.
+  fields:
+  - name: ESEA
+    description: ESEA.
+    bit_offset: 0
+    bit_size: 32
+fieldset/RAM4CR:
+  description: RAMCFG SRAM x control register.
+  fields:
+  - name: ECCE
+    description: ECCE.
+    bit_offset: 0
+    bit_size: 1
+  - name: ALE
+    description: ALE.
+    bit_offset: 4
+    bit_size: 1
+  - name: SRAMER
+    description: SRAMER.
+    bit_offset: 8
+    bit_size: 1
+  - name: WSC
+    description: WSC.
+    bit_offset: 16
+    bit_size: 3
+fieldset/RAM4ERKEYR:
+  description: RAMCFG SRAM x erase key register.
+  fields:
+  - name: ERASEKEY
+    description: ERASEKEY.
+    bit_offset: 0
+    bit_size: 8
+fieldset/RAM4ISR:
+  description: RAMCFG RAMx interrupt status register.
+  fields:
+  - name: SEDC
+    description: SEDC.
+    bit_offset: 0
+    bit_size: 1
+  - name: DED
+    description: DED.
+    bit_offset: 1
+    bit_size: 1
+  - name: SRAMBUSY
+    description: SRAMBUSY.
+    bit_offset: 8
+    bit_size: 1
+fieldset/RAM5CR:
+  description: RAMCFG SRAM x control register.
+  fields:
+  - name: ECCE
+    description: ECCE.
+    bit_offset: 0
+    bit_size: 1
+  - name: ALE
+    description: ALE.
+    bit_offset: 4
+    bit_size: 1
+  - name: SRAMER
+    description: SRAMER.
+    bit_offset: 8
+    bit_size: 1
+  - name: WSC
+    description: WSC.
+    bit_offset: 16
+    bit_size: 3
+fieldset/RAM5DEAR:
+  description: RAMCFG RAM x ECC double error address register.
+  fields:
+  - name: EDEA
+    description: EDEA.
+    bit_offset: 0
+    bit_size: 32
+fieldset/RAM5ICR:
+  description: RAMCFG RAM x interrupt clear register x.
+  fields:
+  - name: CSEDC
+    description: CSEDC.
+    bit_offset: 0
+    bit_size: 1
+  - name: CDED
+    description: CDED.
+    bit_offset: 1
+    bit_size: 1
+fieldset/RAM5IER:
+  description: RAMCFG SRAM x interrupt enable register.
+  fields:
+  - name: SEIE
+    description: SEIE.
+    bit_offset: 0
+    bit_size: 1
+  - name: DEIE
+    description: DEIE.
+    bit_offset: 1
+    bit_size: 1
+  - name: ECCNMI
+    description: ECCNMI.
+    bit_offset: 3
+    bit_size: 1
+fieldset/RAM5ISR:
+  description: RAMCFG RAMx interrupt status register.
+  fields:
+  - name: SEDC
+    description: SEDC.
+    bit_offset: 0
+    bit_size: 1
+  - name: DED
+    description: DED.
+    bit_offset: 1
+    bit_size: 1
+  - name: SRAMBUSY
+    description: SRAMBUSY.
+    bit_offset: 8
+    bit_size: 1
+fieldset/RAM5SEAR:
+  description: RAMCFG RAM x ECC single error address register.
+  fields:
+  - name: ESEA
+    description: ESEA.
+    bit_offset: 0
+    bit_size: 32

--- a/data/registers/ramcfg_wba.yaml
+++ b/data/registers/ramcfg_wba.yaml
@@ -1,0 +1,179 @@
+block/RAMCFG:
+  description: RAMCFG address block description.
+  items:
+  - name: M1CR
+    description: RAMCFG SRAM1 control register.
+    byte_offset: 0
+    fieldset: M1CR
+  - name: M1ISR
+    description: RAMCFG SRAM1 interrupt status register.
+    byte_offset: 8
+    access: Read
+    fieldset: M1ISR
+  - name: M1ERKEYR
+    description: RAMCFG SRAM1 erase key register.
+    byte_offset: 40
+    access: Write
+    fieldset: M1ERKEYR
+  - name: M2CR
+    description: RAMCFG SRAM2 control register.
+    byte_offset: 64
+    fieldset: M2CR
+  - name: M2IER
+    description: RAMCFG SRAM2 interrupt enable register.
+    byte_offset: 68
+    fieldset: M2IER
+  - name: M2ISR
+    description: RAMCFG SRAM2 interrupt status register.
+    byte_offset: 72
+    access: Read
+    fieldset: M2ISR
+  - name: M2PEAR
+    description: RAMCFG SRAM2 parity error address register.
+    byte_offset: 80
+    access: Read
+    fieldset: M2PEAR
+  - name: M2ICR
+    description: RAMCFG SRAM2 interrupt clear register.
+    byte_offset: 84
+    fieldset: M2ICR
+  - name: M2WPR1
+    description: RAMCFG SRAM2 write protection register 1.
+    byte_offset: 88
+    fieldset: M2WPR1
+  - name: M2WPR2
+    description: RAMCFG SRAM2 write protection register 2.
+    byte_offset: 92
+    fieldset: M2WPR2
+  - name: M2ERKEYR
+    description: RAMCFG SRAM2 erase key register.
+    byte_offset: 104
+    access: Write
+    fieldset: M2ERKEYR
+fieldset/M1CR:
+  description: RAMCFG SRAM1 control register.
+  fields:
+  - name: SRAMER
+    description: SRAM1 erase.
+    bit_offset: 8
+    bit_size: 1
+  - name: WSC
+    description: SRAM1 wait state configuration.
+    bit_offset: 16
+    bit_size: 3
+fieldset/M1ERKEYR:
+  description: RAMCFG SRAM1 erase key register.
+  fields:
+  - name: ERASEKEY
+    description: Erase write protection key.
+    bit_offset: 0
+    bit_size: 8
+fieldset/M1ISR:
+  description: RAMCFG SRAM1 interrupt status register.
+  fields:
+  - name: SRAMBUSY
+    description: SRAM busy with erase operation.
+    bit_offset: 8
+    bit_size: 1
+fieldset/M2CR:
+  description: RAMCFG SRAM2 control register.
+  fields:
+  - name: ALE
+    description: SRAM2 parity fail address latch enable.
+    bit_offset: 4
+    bit_size: 1
+  - name: SRAMER
+    description: SRAM2 erase.
+    bit_offset: 8
+    bit_size: 1
+  - name: WSC
+    description: SRAM2 wait state configuration.
+    bit_offset: 16
+    bit_size: 3
+fieldset/M2ERKEYR:
+  description: RAMCFG SRAM2 erase key register.
+  fields:
+  - name: ERASEKEY
+    description: Erase write protection key.
+    bit_offset: 0
+    bit_size: 8
+fieldset/M2ICR:
+  description: RAMCFG SRAM2 interrupt clear register.
+  fields:
+  - name: CPED
+    description: Clear parity error detect bit.
+    bit_offset: 1
+    bit_size: 1
+fieldset/M2IER:
+  description: RAMCFG SRAM2 interrupt enable register.
+  fields:
+  - name: PEIE
+    description: Parity error interrupt enable.
+    bit_offset: 1
+    bit_size: 1
+  - name: PENMI
+    description: Parity error NMI.
+    bit_offset: 3
+    bit_size: 1
+fieldset/M2ISR:
+  description: RAMCFG SRAM2 interrupt status register.
+  fields:
+  - name: PED
+    description: Parity error detected.
+    bit_offset: 1
+    bit_size: 1
+  - name: SRAMBUSY
+    description: SRAM2 busy with erase operation.
+    bit_offset: 8
+    bit_size: 1
+fieldset/M2PEAR:
+  description: RAMCFG SRAM2 parity error address register.
+  fields:
+  - name: PEA
+    description: Parity error SRAM word aligned address offset.
+    bit_offset: 0
+    bit_size: 16
+  - name: ID
+    description: Parity error AHB bus master ID.
+    bit_offset: 24
+    bit_size: 4
+    enum: ID
+  - name: BYTE
+    description: Byte parity error flag.
+    bit_offset: 28
+    bit_size: 4
+fieldset/M2WPR1:
+  description: RAMCFG SRAM2 write protection register 1.
+  fields:
+  - name: PWP
+    description: SRAM2 1-Kbyte write protect page y write protection.
+    bit_offset: 0
+    bit_size: 1
+    array:
+      len: 32
+      stride: 1
+fieldset/M2WPR2:
+  description: RAMCFG SRAM2 write protection register 2.
+  fields:
+  - name: PWP
+    description: SRAM2 1-Kbyte write protect page y write protection.
+    bit_offset: 0
+    bit_size: 1
+    array:
+      len: 32
+      stride: 1
+enum/ID:
+  bit_size: 4
+  variants:
+  - name: B_0x2
+    description: parity error detected on CPU access.
+    value: 2
+  - name: B_0x3
+    description: parity error detected on Debugger access.
+    value: 3
+  - name: B_0x6
+    description: parity error detected on DMA master port o access.
+    value: 6
+  - name: B_0x7
+    description: parity error detected on DMA master port 1 access.
+    value: 7

--- a/stm32-data-gen/src/header.rs
+++ b/stm32-data-gen/src/header.rs
@@ -210,6 +210,54 @@ impl Defines {
             ("SYSCFG", &["SYSCFG_BASE", "SBS_BASE"]),
             ("XSPI1", &["XSPI1_R_BASE"]),
             ("XSPI2", &["XSPI2_R_BASE"]),
+            ("RAMCFG", &["RAMCFG_BASE", "RAMCFG_BASE_NS", "RAMCFG_BASE_S"]),
+            (
+                "GTZC",
+                &[
+                    "GTZC_BASE",
+                    "GTZC_TZSC_BASE",
+                    "GTZC_TZSC_BASE_NS",
+                    "GTZC_TZSC_BASE_S",
+                    "GTZC_TZSC1_BASE_NS",
+                    "GTZC_TZSC1_BASE_S",
+                ],
+            ),
+            ("GTZC1", &["GTZC1_BASE", "GTZC1_BASE_NS", "GTZC1_BASE_S"]),
+            (
+                "GTZC_TZSC",
+                &[
+                    "GTZC_TZSC_BASE",
+                    "GTZC_TZSC_BASE_NS",
+                    "GTZC_TZSC_BASE_S",
+                    "GTZC_TZSC1_BASE_NS",
+                    "GTZC_TZSC1_BASE_S",
+                ],
+            ),
+            (
+                "GTZC_TZIC",
+                &[
+                    "GTZC_TZIC_BASE",
+                    "GTZC_TZIC_BASE_S",
+                    "GTZC_TZIC1_BASE_NS",
+                    "GTZC_TZIC1_BASE_S",
+                ],
+            ),
+            (
+                "GTZC_MPCBB1",
+                &["GTZC_MPCBB1_BASE", "GTZC_MPCBB1_BASE_NS", "GTZC_MPCBB1_BASE_S"],
+            ),
+            (
+                "GTZC_MPCBB2",
+                &["GTZC_MPCBB2_BASE", "GTZC_MPCBB2_BASE_NS", "GTZC_MPCBB2_BASE_S"],
+            ),
+            (
+                "GTZC_MPCBB3",
+                &["GTZC_MPCBB3_BASE", "GTZC_MPCBB3_BASE_NS", "GTZC_MPCBB3_BASE_S"],
+            ),
+            (
+                "GTZC_MPCBB6",
+                &["GTZC_MPCBB6_BASE", "GTZC_MPCBB6_BASE_NS", "GTZC_MPCBB6_BASE_S"],
+            ),
         ];
         let alt_peri_defines: HashMap<_, _> = ALT_PERI_DEFINES.iter().copied().collect();
 

--- a/stm32-data-gen/src/perimap.rs
+++ b/stm32-data-gen/src/perimap.rs
@@ -1,6 +1,23 @@
 use crate::util::RegexMap;
 
 pub static PERIMAP: RegexMap<(&str, &str, &str)> = RegexMap::new(&[
+    // GTZC - TrustZone Security Controller
+    ("STM32H503.*:GTZC:.*", ("gtzc", "h503", "GTZC1")),
+    ("STM32H503.*:GTZC1:.*", ("gtzc", "h503", "GTZC1")),
+    ("STM32H5.*:GTZC:.*", ("gtzc", "v1", "GTZC1_TZSC")),
+    ("STM32H5.*:GTZC1.*:.*", ("gtzc", "v1", "GTZC1_TZSC")),
+    ("STM32U5.*:GTZC:.*", ("gtzc", "v1", "GTZC1_TZSC")),
+    ("STM32U5.*:GTZC1_TZSC:.*", ("gtzc", "v1", "GTZC1_TZSC")),
+    ("STM32WBA.*:GTZC:.*", ("gtzc", "wba", "GTZC_TZSC")),
+    ("STM32WBA.*:GTZC_TZSC:.*", ("gtzc", "wba", "GTZC_TZSC")),
+    ("STM32L5.*:GTZC_TZSC:.*", ("gtzc", "wba", "GTZC_TZSC")),
+    // RAMCFG - RAM Configuration
+    ("STM32H5.*:RAMCFG:.*", ("ramcfg", "h5", "RAMCFG")),
+    ("STM32H7[RS].*:RAMCFG:.*", ("ramcfg", "h5", "RAMCFG")),
+    ("STM32N6.*:RAMCFG:.*", ("ramcfg", "h5", "RAMCFG")),
+    ("STM32U5.*:RAMCFG:.*", ("ramcfg", "u5", "RAMCFG")),
+    ("STM32U3.*:RAMCFG:.*", ("ramcfg", "u5", "RAMCFG")),
+    ("STM32WBA.*:RAMCFG:.*", ("ramcfg", "wba", "RAMCFG")),
     (".*:USART:sci2_v1_1", ("usart", "v1", "USART")),
     (".*:USART:sci2_v1_2_F1", ("usart", "v1", "USART")),
     (".*:USART:sci2_v1_2", ("usart", "v2", "USART")),

--- a/transforms/GTZC.yaml
+++ b/transforms/GTZC.yaml
@@ -1,0 +1,12 @@
+transforms:
+  # Delete all PRIV enums (privileged/unprivileged = useless)
+  - !DeleteEnums
+    from: ^.*PRIV$
+
+  # Delete all SEC enums (secure/nonsecure = useless)
+  - !DeleteEnums
+    from: ^.*SEC$
+
+  # Delete LCK enum (locked/unlocked = useless)
+  - !DeleteEnums
+    from: ^LCK$

--- a/transforms/GTZC_h503.yaml
+++ b/transforms/GTZC_h503.yaml
@@ -1,0 +1,40 @@
+transforms:
+  # Convert MPCBB1_PRIVCFGR0-31 to array
+  - !MergeFieldsets
+    from: MPCBB1_PRIVCFGR\d+
+    to: MPCBB1_PRIVCFGR
+
+  - !MakeRegisterArray
+    blocks: GTZC1
+    from: MPCBB1_PRIVCFGR\d+
+    to: MPCBB1_PRIVCFGR
+
+  # Convert MPCBB1_SECCFGR0-31 to array
+  - !MergeFieldsets
+    from: MPCBB1_SECCFGR\d+
+    to: MPCBB1_SECCFGR
+
+  - !MakeRegisterArray
+    blocks: GTZC1
+    from: MPCBB1_SECCFGR\d+
+    to: MPCBB1_SECCFGR
+
+  # Convert MPCBB2_PRIVCFGR0-7 to array
+  - !MergeFieldsets
+    from: MPCBB2_PRIVCFGR\d+
+    to: MPCBB2_PRIVCFGR
+
+  - !MakeRegisterArray
+    blocks: GTZC1
+    from: MPCBB2_PRIVCFGR\d+
+    to: MPCBB2_PRIVCFGR
+
+  # Convert MPCBB2_SECCFGR0-7 to array
+  - !MergeFieldsets
+    from: MPCBB2_SECCFGR\d+
+    to: MPCBB2_SECCFGR
+
+  - !MakeRegisterArray
+    blocks: GTZC1
+    from: MPCBB2_SECCFGR\d+
+    to: MPCBB2_SECCFGR

--- a/transforms/RAMCFG.yaml
+++ b/transforms/RAMCFG.yaml
@@ -1,0 +1,24 @@
+transforms:
+  # Delete useless enable/disable enums (single-bit fields)
+  - !DeleteEnums
+    from: ^(ALE|PEIE|PENMI|PED|SRAMER|SRAMBUSY|ECCE|ECCMIE|SEDC|DEDC)$
+
+  # Delete field-specific useless enums
+  - !DeleteEnums
+    from: ^M\d(CR|ISR)_(ALE|PEIE|PENMI|PED|SRAMER|SRAMBUSY|ECCE|WSC)$
+
+  # Delete write protection enums (all PxxWP fields)
+  - !DeleteEnums
+    from: ^P\d+WP$
+
+  # Convert PxxWP fields to arrays in WPR1 registers
+  - !MakeFieldArray
+    fieldsets: ^M\dWPR1$
+    from: P\d+WP
+    to: PWP
+
+  # Convert PxxWP fields to arrays in WPR2 registers
+  - !MakeFieldArray
+    fieldsets: ^M\dWPR2$
+    from: P\d+WP
+    to: PWP


### PR DESCRIPTION
## Summary

Add missing GTZC (Global TrustZone Controller) and RAMCFG (RAM Configuration) peripherals that were present in SVD files but missing from generated chip data.

### Changes

**Register files added:**
- `data/registers/gtzc_h503.yaml` - Simplified GTZC for STM32H503
- `data/registers/gtzc_v1.yaml` - Full GTZC TZSC for STM32H5/U5 series  
- `data/registers/gtzc_wba.yaml` - GTZC TZSC for STM32WBA series
- `data/registers/ramcfg_h5.yaml` - For STM32H5/H7RS/N6 series
- `data/registers/ramcfg_u5.yaml` - For STM32U5/U3 series
- `data/registers/ramcfg_wba.yaml` - For STM32WBA series

**Code changes:**
- Updated `stm32-data-gen/src/header.rs` with ALT_PERI_DEFINES for address resolution with `_NS`/`_S` suffixes
- Updated `stm32-data-gen/src/perimap.rs` with PERIMAP entries mapping chip IPs to register definitions

**Transform documentation:**
- `transforms/GTZC.yaml` - Documents GTZC cleanup transformations
- `transforms/GTZC_h503.yaml` - Documents H503-specific array conversions
- `transforms/RAMCFG.yaml` - Documents RAMCFG cleanup transformations

### Register cleanup applied

Following stm32-data best practices:
- Removed 150+ useless enable/disable enums
- Converted 80+ repeated registers to arrays (MPCBB, PWP fields)
- Removed redundant prefixes (`RAMCFG_`, `TZSC_TZSC_`)
- Applied `chiptool fmt` for consistent formatting
- **Result:** 77% file size reduction (13,276 → 2,951 lines)

### Affected chip families

STM32H5, STM32H7RS, STM32N6, STM32U5, STM32U3, STM32WBA, STM32L5

## Test plan

- [x] Extracted peripherals from SVD using `./d extract-all`
- [x] Created register YAML files following existing patterns
- [x] Applied cleanup transformations and formatting
- [x] Ran `./d gen-all` successfully
- [x] Verified GTZC and RAMCFG appear in generated chip JSON files with valid addresses and register definitions