### PR TITLE
Fix: hrtim_v2 registers for use of subtimer F

### DIFF
--- a/data/registers/hrtim_v2.yaml
+++ b/data/registers/hrtim_v2.yaml
@@ -1006,6 +1006,7 @@ fieldset/HRTIM_OENR:
       - 4
       - 6
       - 8
+      - 10
   - name: T2OEN
     description: Timer X Complementary Output Enable
     bit_offset: 1
@@ -1017,6 +1018,7 @@ fieldset/HRTIM_OENR:
       - 4
       - 6
       - 8
+      - 10
 fieldset/MCMPX:
   description: Master Timer Compare X Register
   fields:
@@ -1082,7 +1084,7 @@ fieldset/MCR:
     bit_offset: 17
     bit_size: 1
     array:
-      len: 5
+      len: 6
       stride: 1
   - name: DACSYNC
     description: AC Synchronization


### PR DESCRIPTION
**Issue:** 
The HRTIM subtimer F is not useable with PAC due to a couple of `assert!(n < 5usize);` in the generated methods producing errors:
```
0.000000 [ERROR] panicked at ../.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/stm32-metapac-19.0.0/src/chips/stm32g474re/../../peripherals/hrtim_v2.rs:3388:13:
assertion failed: n < 5usize 
```

**The fields I've found that cause issues are:**
`TCEN`
<img width="1529" height="367" alt="image" src="https://github.com/user-attachments/assets/71878b23-2127-4e96-b0d8-145d27460ffd" />
_from RM0440_

`T1OEN` and `T2OEN`
<img width="1514" height="173" alt="image" src="https://github.com/user-attachments/assets/1a905c74-86d9-4685-9e8a-809be45a91f8" />
_from RM0440_

**Tested example code with Nucleo-G474RE and scope:**
```rust
#![no_std]
#![no_main]

mod fmt;

#[cfg(not(feature = "defmt"))]
use panic_halt as _;
#[cfg(feature = "defmt")]
use {defmt_rtt as _, panic_probe as _};

use embassy_executor::Spawner;
use embassy_stm32::{
    Config,
    gpio::{Level, Output, Speed},
    pac,
};
use embassy_time::{Duration, Timer};
use fmt::info;

// Timer Index:
const TIM_F: usize = 5;

// Channel Index:
const CH1: usize = 0;
const CH2: usize = 1;

// Comparator Index:
const CMP1: usize = 0;
const CMP2: usize = 1;

const PERIOD: u16 = 8500;

#[embassy_executor::main]
async fn main(_spawner: Spawner) {
    let mut config = Config::default();
    {
        use embassy_stm32::rcc::*;
        config.rcc.pll = Some(Pll {
            source: PllSource::HSI,  // 16 Mhz
            prediv: PllPreDiv::DIV4, // /4 = 4Mhz
            mul: PllMul::MUL85,      // x85 =   340Mhz
            divp: None,
            divq: None,
            divr: Some(PllRDiv::DIV2), // /2 = 170MHz
        });
        config.rcc.mux.adc12sel = mux::Adcsel::SYS;
        config.rcc.sys = Sysclk::PLL1_R;
    }

    let p = embassy_stm32::init(config);

    let mut led = Output::new(p.PA5, Level::High, Speed::Low);

    pac::RCC.ahb2enr().modify(|w| w.set_gpiocen(true)); // Enable GPIO clock: set_gpioaen / set_gpioben / ...

    pac::RCC.apb2enr().modify(|w| w.set_hrtim1en(true));

    // Setup gpio for Hrtim1 subtimer F Channel 1
    pac::GPIOC
        .moder()
        .modify(|w| w.set_moder(6, pac::gpio::vals::Moder::ALTERNATE));
    pac::GPIOC
        .pupdr()
        .modify(|w| w.set_pupdr(6, pac::gpio::vals::Pupdr::FLOATING));
    pac::GPIOC
        .ospeedr()
        .modify(|w| w.set_ospeedr(6, pac::gpio::vals::Ospeedr::VERY_HIGH_SPEED));
    pac::GPIOC.afr(0).modify(|w| w.set_afr(6, 13)); // Set alternate function

    // Setup gpio for Hrtim1 subtimer F Channel 2
    pac::GPIOC
        .moder()
        .modify(|w| w.set_moder(7, pac::gpio::vals::Moder::ALTERNATE));
    pac::GPIOC
        .pupdr()
        .modify(|w| w.set_pupdr(7, pac::gpio::vals::Pupdr::FLOATING));
    pac::GPIOC
        .ospeedr()
        .modify(|w| w.set_ospeedr(7, pac::gpio::vals::Ospeedr::VERY_HIGH_SPEED));
    pac::GPIOC.afr(0).modify(|w| w.set_afr(7, 13)); // Set alternate function

    // Set Timer A (idx 0)  to operate in continuous mode.
    pac::HRTIM1.tim(TIM_F).cr().modify(|w| w.set_cont(true));
    pac::HRTIM1.tim(TIM_F).cr().modify(|w| w.set_ckpsc(5)); // Clock prescaler of /32

    // Set Timer F (idx 0) period to 10us.
    pac::HRTIM1.tim(TIM_F).per().modify(|w| w.set_per(8500));

    // Set Timer F Compare 1 to 50% of the Timer F period (Will result in 50% DC)
    pac::HRTIM1
        .tim(TIM_F)
        .cmp(CMP1)
        .modify(|w| w.set_cmp(PERIOD / 2));

    // Set Timer F Compare 1 to 25% of the Timer A period (Will result in 25% DC)
    pac::HRTIM1
        .tim(TIM_F)
        .cmp(CMP2)
        .modify(|w| w.set_cmp(PERIOD / 4));

    pac::HRTIM1.tim(TIM_F).setr(CH1).modify(|w| w.set_per(true)); // Tim F Ch1 set on Tim A period
    pac::HRTIM1
        .tim(TIM_F)
        .rstr(CH1)
        .modify(|w| w.set_cmp(CMP1, true)); // Tim F Ch1 reset on Tim F CMP1 event

    pac::HRTIM1.tim(TIM_F).setr(CH2).modify(|w| w.set_per(true)); // Tim F Ch2 set on Tim F period

    pac::HRTIM1
        .tim(TIM_F)
        .rstr(CH2)
        .modify(|w| w.set_cmp(CMP2, true)); // Tim F Ch2 reset on Tim F CMP2 event

    pac::HRTIM1.mcr().modify(|w| w.set_mcen(true)); // Enable hrtim globally
    pac::HRTIM1.mcr().modify(|w| w.set_tcen(TIM_F, true)); // Start Tim F
    pac::HRTIM1.oenr().modify(|w| w.set_t1oen(TIM_F, true)); // Enable Tim F Ch1 output
    pac::HRTIM1.oenr().modify(|w| w.set_t2oen(TIM_F, true)); // Enable Tim F Ch2 output

    loop {
        info!("Hello, World!");
        led.set_high();
        Timer::after(Duration::from_millis(500)).await;
        led.set_low();
        Timer::after(Duration::from_millis(500)).await;
    }
}
```