### PR TITLE
N6 Fix IC Selection

### DIFF
--- a/data/registers/rcc_n6.yaml
+++ b/data/registers/rcc_n6.yaml
@@ -11347,16 +11347,16 @@ enum/ICSEL:
     bit_size: 2
     variants:
         - name: PLL1
-          description: pll1_ck is selected (default after reset).
+          description: pll1_ck is selected.
           value: 0
         - name: PLL2
           description: pll2_ck is selected.
           value: 1
-        - name: HSI_OSC_DIV4
-          description: hsi_ck = hsi_osc_ck / 4.
+        - name: PLL3
+          description: pll3_ck is selected.
           value: 2
-        - name: HSI_OSC_DIV8
-          description: hsi_ck = hsi_osc_ck / 8.
+        - name: PLL4
+          description: pll4_ck is selected.
           value: 3
 enum/ICLOCK:
     bit_size: 1


### PR DESCRIPTION
IC selection is between PLL1-4, not HSI. I would appreciate someone else verifying this, but at least for the N6 Discovery kit and the reference manual (RM0486 `rm0486-stm32n647657xx-armbased-32bit-mcus-stmicroelectronics.pdf)` this is the case.

---

**Reference manual showing IC selection between PLL1-4**
<img width="757" height="475" alt="image" src="https://github.com/user-attachments/assets/f68c290e-dd80-46b1-9181-57cb5702c26e" />

---

**Example showing a different default**
<img width="757" height="680" alt="image" src="https://github.com/user-attachments/assets/1b37638b-e8ed-48be-ac81-f8d8d4add31e" />

---

Twin PR to https://github.com/embassy-rs/embassy/pull/5383