### PR TITLE
stm32-data-gen: Generate HSEM interrupts

### DIFF
--- a/stm32-data-gen/src/interrupts.rs
+++ b/stm32-data-gen/src/interrupts.rs
@@ -278,6 +278,8 @@ impl ChipInterrupts {
                 interrupt_signals.insert(("IWDG".to_string(), "GLOBAL".to_string()));
             } else if name == "RCC_AUDIOSYNC" {
                 // ignore
+            } else if name.starts_with("HSEM") {
+                interrupt_signals.insert(("HSEM".to_string(), "GLOBAL".to_string()));
             } else {
                 if parts[2].is_empty() {
                     trace!("    skipping because parts[2].is_empty()");


### PR DESCRIPTION
embassy-rs/embassy#4918 removed the hand-written `impl Instance` in `hsem/mod.rs` and replaced it with a macro invocation that is supposed to generate these at build time. The `stm32-data-gen` tool does not add the HSEM interrupts to the HSEM peripheral JSON object for the STM32H7* line, because they appear to be a "special case" in th STM32Cube database. Unfortunately, this makes the `HardwareSemaphore` peripheral totally unusable for the STM32H7 in `embassy-stm32` v0.5.0.

Add an exception for these interrupts, so that they're emitted into the JSON files. This allows `impl Instance` to be generated from them by the `foreach_interrupt!` macro in `hsem/mod.rs` at embassy-stm32-v0.5.0.