### PR TITLE
feat(datagen): multiplication support in parse_value method

### DIFF
--- a/stm32-data-gen/src/header.rs
+++ b/stm32-data-gen/src/header.rs
@@ -143,6 +143,8 @@ impl Defines {
             self.parse_value(x)
         } else if let Some(m) = regex!(r"^\*?\([0-9A-Za-z_]+ *\*?\)(.*)$").captures(val) {
             self.parse_value(m.get(1).unwrap().as_str())
+        } else if let Some(m) = regex!(r"^(.*)\*(.*)$").captures(val) {
+            Ok(self.parse_value(m.get(1).unwrap().as_str())? * self.parse_value(m.get(2).unwrap().as_str())?)
         } else if let Some(m) = regex!(r"^(.*)/(.*)$").captures(val) {
             Ok(self.parse_value(m.get(1).unwrap().as_str())? / self.parse_value(m.get(2).unwrap().as_str())?)
         } else if let Some(m) = regex!(r"^(.*)<<(.*)$").captures(val) {
@@ -162,8 +164,6 @@ impl Defines {
             Ok(self.parse_value(m.get(1).unwrap().as_str())? + self.parse_value(m.get(2).unwrap().as_str())?)
         } else if let Some(m) = regex!(r"^(.*)-(.*)$").captures(val) {
             Ok(self.parse_value(m.get(1).unwrap().as_str())? - self.parse_value(m.get(2).unwrap().as_str())?)
-        } else if let Some(m) = regex!(r"^(.*)\*(.*)$").captures(val) {
-            Ok(self.parse_value(m.get(1).unwrap().as_str())? * self.parse_value(m.get(2).unwrap().as_str())?)
         } else {
             Err(anyhow::anyhow!("Cant parse {val}"))
         }


### PR DESCRIPTION
In `STM32MP2` (though I don't know if embassy-stm32 is gonna support its MCU), it uses `*` operations. Adding `*` support might help ensure compatibility with future MCUs that have more memory blocks.
<img width="1260" height="410" alt="image" src="https://github.com/user-attachments/assets/ef2d49bb-748e-4ca2-af47-27f074903dc7" />
