### PR TITLE
gen: decompose GTZC into typed sub-peripherals (TZSC, TZIC, MPCBB)

### DIFF
--- a/data/registers/gtzc_l5.yaml
+++ b/data/registers/gtzc_l5.yaml
@@ -13,10 +13,6 @@ block/GTZC_TZSC:
     description: GTZC1 TZSC secure configuration register 2.
     byte_offset: 20
     fieldset: TZSC_SECCFGR2
-  - name: TZSC_SECCFGR3
-    description: GTZC1 TZSC secure configuration register 3.
-    byte_offset: 24
-    fieldset: TZSC_SECCFGR3
   - name: TZSC_PRIVCFGR1
     description: GTZC1 TZSC privilege configuration register 1.
     byte_offset: 32
@@ -25,10 +21,6 @@ block/GTZC_TZSC:
     description: GTZC1 TZSC privilege configuration register 2.
     byte_offset: 36
     fieldset: TZSC_PRIVCFGR2
-  - name: TZSC_PRIVCFGR3
-    description: GTZC1 TZSC privilege configuration register 3.
-    byte_offset: 40
-    fieldset: TZSC_PRIVCFGR3
 fieldset/TZSC_CR:
   description: GTZC1 TZSC control register.
   fields:
@@ -142,57 +134,7 @@ fieldset/TZSC_PRIVCFGR2:
     description: Privileged access mode for VREFBUF.
     bit_offset: 25
     bit_size: 1
-fieldset/TZSC_PRIVCFGR3:
-  description: GTZC1 TZSC privilege configuration register 3.
-  fields:
-  - name: CRCPRIV
-    description: Privileged access mode for CRC.
-    bit_offset: 3
-    bit_size: 1
-  - name: TSCPRIV
-    description: Privileged access mode for TSC.
-    bit_offset: 4
-    bit_size: 1
-  - name: ICACHE_REGPRIV
-    description: Privileged access mode for ICACHE registers.
-    bit_offset: 6
-    bit_size: 1
-  - name: OTGPRIV
-    description: Privileged access mode for USB OTG_HS.
-    bit_offset: 10
-    bit_size: 1
-  - name: AESPRIV
-    description: Privileged access mode for AES.
-    bit_offset: 11
-    bit_size: 1
-  - name: HASHPRIV
-    description: Privileged access mode for HASH.
-    bit_offset: 12
-    bit_size: 1
-  - name: RNGPRIV
-    description: Privileged access mode for RNG.
-    bit_offset: 13
-    bit_size: 1
-  - name: SAESPRIV
-    description: Privileged access mode for SAES.
-    bit_offset: 14
-    bit_size: 1
-  - name: PKAPRIV
-    description: Privileged access mode for PKA.
-    bit_offset: 16
-    bit_size: 1
-  - name: RAMCFGPRIV
-    description: Privileged access mode for RAMCFG.
-    bit_offset: 22
-    bit_size: 1
-  - name: RADIOPRIV
-    description: Privileged access mode for 2.
-    bit_offset: 23
-    bit_size: 1
-  - name: PTACONVPRIV
-    description: Privileged access mode for PTACONV.
-    bit_offset: 24
-    bit_size: 1
+
 fieldset/TZSC_SECCFGR1:
   description: GTZC1 TZSC secure configuration register 1.
   fields:
@@ -299,83 +241,6 @@ fieldset/TZSC_SECCFGR2:
     description: Secure access mode for VREFBUF.
     bit_offset: 25
     bit_size: 1
-fieldset/TZSC_SECCFGR3:
-  description: GTZC1 TZSC secure configuration register 3.
-  fields:
-  - name: CRCSEC
-    description: Secure access mode for CRC.
-    bit_offset: 3
-    bit_size: 1
-  - name: TSCSEC
-    description: Secure access mode for TSC.
-    bit_offset: 4
-    bit_size: 1
-  - name: ICACHE_REGSEC
-    description: Secure access mode for ICACHE registers.
-    bit_offset: 6
-    bit_size: 1
-  - name: OTGSEC
-    description: Secure access mode for USB OTG_HS.
-    bit_offset: 10
-    bit_size: 1
-  - name: AESSEC
-    description: Secure access mode for AES.
-    bit_offset: 11
-    bit_size: 1
-  - name: HASHSEC
-    description: Secure access mode for HASH.
-    bit_offset: 12
-    bit_size: 1
-  - name: RNGSEC
-    description: Secure access mode for RNG.
-    bit_offset: 13
-    bit_size: 1
-  - name: SAESSEC
-    description: Secure access mode for SAES.
-    bit_offset: 14
-    bit_size: 1
-  - name: PKASEC
-    description: Secure access mode for PKA.
-    bit_offset: 16
-    bit_size: 1
-  - name: RAMCFGSEC
-    description: Secure access mode for RAMCFG.
-    bit_offset: 22
-    bit_size: 1
-  - name: RADIOSEC
-    description: Secure access mode for 2.
-    bit_offset: 23
-    bit_size: 1
-  - name: PTACONVSEC
-    description: Secure access mode for PTACONV.
-    bit_offset: 24
-    bit_size: 1
-
-block/MPCBB:
-  description: Block-based memory protection controller.
-  items:
-  - name: CR
-    description: MPCBB control register.
-    byte_offset: 0
-    fieldset: MPCBB_CR
-  - name: CFGLOCK
-    description: MPCBB configuration lock register.
-    byte_offset: 16
-    fieldset: CFGLOCK
-  - name: SECCFGR
-    description: MPCBB security configuration register.
-    byte_offset: 256
-    array:
-      len: 4
-      stride: 4
-    fieldset: SECCFGR
-  - name: PRIVCFGR
-    description: MPCBB privilege configuration register.
-    byte_offset: 512
-    array:
-      len: 4
-      stride: 4
-    fieldset: PRIVCFGR
 
 block/TZIC:
   description: TrustZone interrupt controller.
@@ -384,57 +249,45 @@ block/TZIC:
     description: TZIC interrupt enable register.
     byte_offset: 0
     array:
-      len: 4
+      len: 3
       stride: 4
     fieldset: IER
   - name: SR
     description: TZIC status register.
     byte_offset: 16
     array:
-      len: 4
+      len: 3
       stride: 4
     fieldset: SR
   - name: FCR
     description: TZIC flag clear register.
     byte_offset: 32
     array:
-      len: 4
+      len: 3
       stride: 4
     fieldset: FCR
 
-fieldset/MPCBB_CR:
-  description: MPCBB control register.
-  fields:
-  - name: GLOCK
-    bit_offset: 0
-    bit_size: 1
-  - name: INVSECSTATE
-    bit_offset: 30
-    bit_size: 1
-  - name: SRWILADIS
-    bit_offset: 31
-    bit_size: 1
-
-fieldset/CFGLOCK:
-  description: MPCBB configuration lock register.
-  fields:
-  - name: SPLCK
-    bit_offset: 0
-    bit_size: 32
-
-fieldset/SECCFGR:
-  description: MPCBB security configuration register.
-  fields:
-  - name: SEC
-    bit_offset: 0
-    bit_size: 32
-
-fieldset/PRIVCFGR:
-  description: MPCBB privilege configuration register.
-  fields:
-  - name: PRIV
-    bit_offset: 0
-    bit_size: 32
+block/MPCBB:
+  description: Block-based memory protection controller.
+  items:
+  - name: CR
+    description: MPCBB control register.
+    byte_offset: 0
+    fieldset: MPCBB_CR
+  - name: LCKVTR
+    description: MPCBB lock vector register.
+    byte_offset: 16
+    array:
+      len: 2
+      stride: 4
+    fieldset: LCKVTR
+  - name: VCTR
+    description: MPCBB security configuration register.
+    byte_offset: 256
+    array:
+      len: 64
+      stride: 4
+    fieldset: VCTR
 
 fieldset/IER:
   description: TZIC interrupt enable register.
@@ -454,5 +307,32 @@ fieldset/FCR:
   description: TZIC flag clear register.
   fields:
   - name: CF
+    bit_offset: 0
+    bit_size: 32
+
+fieldset/MPCBB_CR:
+  description: MPCBB control register.
+  fields:
+  - name: LCK
+    bit_offset: 0
+    bit_size: 1
+  - name: INVSECSTATE
+    bit_offset: 30
+    bit_size: 1
+  - name: SRWILADIS
+    bit_offset: 31
+    bit_size: 1
+
+fieldset/LCKVTR:
+  description: MPCBB lock vector register.
+  fields:
+  - name: LCKSB
+    bit_offset: 0
+    bit_size: 32
+
+fieldset/VCTR:
+  description: MPCBB security configuration register.
+  fields:
+  - name: B
     bit_offset: 0
     bit_size: 32

--- a/data/registers/gtzc_v1.yaml
+++ b/data/registers/gtzc_v1.yaml
@@ -918,3 +918,109 @@ fieldset/SECCFGR3:
     description: secure access mode for RAMSCFG.
     bit_offset: 26
     bit_size: 1
+
+block/MPCBB:
+  description: Block-based memory protection controller.
+  items:
+  - name: CR
+    description: MPCBB control register.
+    byte_offset: 0
+    fieldset: MPCBB_CR
+  - name: CFGLOCK
+    description: MPCBB configuration lock register.
+    byte_offset: 16
+    fieldset: CFGLOCK
+  - name: SECCFGR
+    description: MPCBB security configuration register.
+    byte_offset: 256
+    array:
+      len: 32
+      stride: 4
+    fieldset: SECCFGR
+  - name: PRIVCFGR
+    description: MPCBB privilege configuration register.
+    byte_offset: 512
+    array:
+      len: 32
+      stride: 4
+    fieldset: PRIVCFGR
+
+block/TZIC:
+  description: TrustZone interrupt controller.
+  items:
+  - name: IER
+    description: TZIC interrupt enable register.
+    byte_offset: 0
+    array:
+      len: 4
+      stride: 4
+    fieldset: IER
+  - name: SR
+    description: TZIC status register.
+    byte_offset: 16
+    array:
+      len: 4
+      stride: 4
+    fieldset: SR
+  - name: FCR
+    description: TZIC flag clear register.
+    byte_offset: 32
+    array:
+      len: 4
+      stride: 4
+    fieldset: FCR
+
+fieldset/MPCBB_CR:
+  description: MPCBB control register.
+  fields:
+  - name: GLOCK
+    bit_offset: 0
+    bit_size: 1
+  - name: INVSECSTATE
+    bit_offset: 30
+    bit_size: 1
+  - name: SRWILADIS
+    bit_offset: 31
+    bit_size: 1
+
+fieldset/CFGLOCK:
+  description: MPCBB configuration lock register.
+  fields:
+  - name: SPLCK
+    bit_offset: 0
+    bit_size: 32
+
+fieldset/SECCFGR:
+  description: MPCBB security configuration register.
+  fields:
+  - name: SEC
+    bit_offset: 0
+    bit_size: 32
+
+fieldset/PRIVCFGR:
+  description: MPCBB privilege configuration register.
+  fields:
+  - name: PRIV
+    bit_offset: 0
+    bit_size: 32
+
+fieldset/IER:
+  description: TZIC interrupt enable register.
+  fields:
+  - name: IE
+    bit_offset: 0
+    bit_size: 32
+
+fieldset/SR:
+  description: TZIC status register.
+  fields:
+  - name: F
+    bit_offset: 0
+    bit_size: 32
+
+fieldset/FCR:
+  description: TZIC flag clear register.
+  fields:
+  - name: CF
+    bit_offset: 0
+    bit_size: 32

--- a/stm32-data-gen/src/generator.rs
+++ b/stm32-data-gen/src/generator.rs
@@ -2,6 +2,7 @@ use std::collections::hash_map::Entry;
 use std::collections::{BTreeSet, HashMap, HashSet};
 
 use gpio_af::pin_sort_key;
+use log::warn;
 use perimap::PERIMAP;
 use regex::Regex;
 use stm32_data_serde::chip::core::peripheral::{Pin, Trigger};
@@ -114,9 +115,13 @@ fn process_group(
     let rcc_block = *PERIMAP
         .get(&format!("{chip_name}:RCC:{rcc_kind}"))
         .unwrap_or_else(|| panic!("could not get rcc for {}", &chip_name));
-    let h = headers
-        .get_for_chip(&chip_name)
-        .unwrap_or_else(|| panic!("could not get header for {}", &chip_name));
+    let h = match headers.get_for_chip(&chip_name) {
+        Some(h) => h,
+        None => {
+            warn!("could not get header for {}, skipping", &chip_name);
+            return Ok(());
+        }
+    };
     let chip_af = &group.ips.values().find(|x| x.name == "GPIO").unwrap().version;
     let chip_af = chip_af.strip_suffix("_gpio_v1_0").unwrap();
     let chip_af = af.0.get(chip_af);
@@ -548,6 +553,13 @@ fn create_peripheral_map(chip_name: &str, group: &ChipGroup, defines: &header::D
         "ADC34_COMMON",
         "ADC345_COMMON",
         "VREFBUF",
+        "GTZC",
+        "GTZC_TZSC",
+        "GTZC_TZIC",
+        "GTZC_MPCBB1",
+        "GTZC_MPCBB2",
+        "GTZC_MPCBB3",
+        "GTZC_MPCBB6",
     ];
     for pname in GHOST_PERIS {
         let normalized_pname = normalize_peri_name(pname);

--- a/stm32-data-gen/src/interrupts.rs
+++ b/stm32-data-gen/src/interrupts.rs
@@ -55,6 +55,7 @@ impl ChipInterrupts {
 
         for f in files {
             trace!("parsing {f:?}");
+
             let file = std::fs::read_to_string(&f)?;
             let parsed: xml::Ip = quick_xml::de::from_str(&file)?;
 
@@ -116,20 +117,35 @@ impl ChipInterrupts {
         // =================== Populate peripheral interrupts
         let core_name = &core.name;
         let want_nvic_name = pick_nvic(chip_name, core_name);
-        let chip_nvic = group
-            .ips
-            .values()
-            .find(|x| x.name == want_nvic_name)
-            .ok_or_else(|| {
-                format!(
-                    "couldn't find nvic. chip_name={chip_name} core_name={core_name} want_nvic_name={want_nvic_name}"
-                )
-            })
-            .unwrap();
-        let nvic_strings = match self.irqs.get(&(chip_nvic.name.clone(), chip_nvic.version.clone())) {
-            Some(strings) => strings,
-            None => return Err(anyhow::anyhow!("Failed to find NVIC strings for chip {chip_name}")),
-        };
+
+        let chip_nvic = group.ips.values().find(|x| x.name == want_nvic_name).ok_or_else(|| {
+            anyhow::anyhow!(
+                "couldn't find nvic. chip_name={chip_name} core_name={core_name} want_nvic_name={want_nvic_name}"
+            )
+        })?;
+
+        let mut nvic_strings: Vec<String> = self
+            .irqs
+            .get(&(chip_nvic.name.clone(), chip_nvic.version.clone()))
+            .ok_or_else(|| anyhow::anyhow!("Failed to find NVIC strings for chip {chip_name}"))?
+            .clone();
+
+        // For TrustZone single-core chips, pick_nvic() selects NVIC2 (non-secure). However,
+        // security peripherals like GTZC have their interrupts defined only in NVIC1 (secure).
+        // Include NVIC1 as well so that the interrupt table includes GTZC and other secure IRQs.
+        //
+        // Intentionally excludes multi-core chips (STM32H7xx, STM32WL5xx) where NVIC1 and
+        // NVIC2 belong to different CPU cores and must not be merged.
+        if want_nvic_name == "NVIC2" && !chip_name.starts_with("STM32H7") && !chip_name.starts_with("STM32WL5") {
+            if let Some(nvic1) = group.ips.values().find(|x| x.name == "NVIC1") {
+                if let Some(strings) = self.irqs.get(&(nvic1.name.clone(), nvic1.version.clone())) {
+                    nvic_strings.extend(strings.iter().cloned());
+                }
+            }
+        }
+
+        nvic_strings.sort();
+        nvic_strings.dedup();
 
         // peripheral -> signal -> interrupts
         let mut chip_signals = HashMap::<String, HashMap<String, HashSet<String>>>::new();
@@ -208,7 +224,7 @@ impl ChipInterrupts {
 
             // F100xE MISC_REMAP remaps some DMA IRQs, so ST decided to give two names
             // to the same IRQ number.
-            if chip_nvic.version == "STM32F100E" && name == "DMA2_Channel4_5" {
+            if chip_name.starts_with("STM32F100") && name == "DMA2_Channel4_5" {
                 continue;
             }
             //not supported
@@ -280,6 +296,10 @@ impl ChipInterrupts {
                 // ignore
             } else if name == "HSEM" {
                 interrupt_signals.insert(("HSEM".to_string(), "GLOBAL".to_string()));
+            } else if name == "HSEM1" {
+                interrupt_signals.insert(("HSEM".to_string(), "GLOBAL".to_string()));
+            } else if name == "HSEM2" {
+                interrupt_signals.insert(("HSEM".to_string(), "GLOBAL".to_string()));
             } else if name == "HSEM_S" {
                 interrupt_signals.insert(("HSEM".to_string(), "HSEM_S".to_string()));
             } else if name.starts_with("HSEM") {
@@ -296,6 +316,16 @@ impl ChipInterrupts {
                     .map(|x| if x == "USB_DRD_FS" { "USB" } else { x })
                     .map(|x| if x == "XPI1" { "XSPI1" } else { x })
                     .map(|x| if x == "XPI2" { "XSPI2" } else { x })
+                    // GTZC_S and GTZC_NS are IP instance names for the GTZC controller in
+                    // secure/non-secure context. The interrupt (GTZC_IRQn) belongs to GTZC_TZIC,
+                    // which is the sub-peripheral that handles TrustZone violation interrupts.
+                    .map(|x| {
+                        if x == "GTZC_S" || x == "GTZC_NS" {
+                            "GTZC_TZIC"
+                        } else {
+                            x
+                        }
+                    })
                     .map(ToString::to_string)
                     .collect();
 
@@ -392,12 +422,12 @@ impl ChipInterrupts {
                 let mut all_irqs: Vec<stm32_data_serde::chip::core::peripheral::Interrupt> = Vec::new();
 
                 // remove duplicates
-                let globals = signals.get("GLOBAL").cloned().unwrap_or_default();
+                let _globals = signals.get("GLOBAL").cloned().unwrap_or_default();
                 for (signal, irqs) in signals {
                     let mut irqs = irqs.clone();
 
-                    // Special case for LTDC LO signal with both LTDC_LO and LTDC_LO_ERR IRQs
-                    if irqs.len() != 1 && p.name == "LTDC" && signal == "LO" {
+                    // Special case for LTDC LO/UP signal with both LTDC_LO/UP and LTDC_LO/UP_ERR IRQs
+                    if irqs.len() != 1 && p.name == "LTDC" && (signal == "LO" || signal == "UP") {
                         // Prefer the IRQ name that doesn't contain "_ERR"
                         let non_err_irqs: Vec<_> = irqs.iter().filter(|x| !x.contains("_ERR")).cloned().collect();
                         if !non_err_irqs.is_empty() {
@@ -420,9 +450,72 @@ impl ChipInterrupts {
                         }
                     }
 
+                    // Special case for LTDC ER signal on N6, which has multiple error IRQs
+                    if irqs.len() != 1 && p.name == "LTDC" && signal == "ER" && chip_name.starts_with("STM32N6") {
+                        // Prefer LTDC_LO_ERR
+                        let preferred_irq = "LTDC_LO_ERR".to_string();
+                        if irqs.contains(&preferred_irq) {
+                            irqs.clear();
+                            irqs.insert(preferred_irq);
+                        }
+                    }
+
                     // If there's a duplicate irqs in a signal other than "global", keep the non-global one.
                     if irqs.len() != 1 && signal != "GLOBAL" {
-                        irqs.retain(|irq| !globals.contains(irq));
+                        irqs.retain(|irq| !_globals.contains(irq));
+                    }
+
+                    // Special case for HSEM on dual-core chips
+                    if irqs.len() != 1 && p.name == "HSEM" {
+                        if core_name == "cm7" || core_name == "cm4" || core_name == "cm0p" {
+                            let core_idx = match core_name.as_str() {
+                                "cm7" => "1",
+                                "cm4" => {
+                                    if chip_name.starts_with("STM32H7") {
+                                        "2"
+                                    } else {
+                                        "1"
+                                    }
+                                }
+                                "cm0p" => "2",
+                                _ => unreachable!(),
+                            };
+                            let preferred_irq = format!("HSEM{}", core_idx);
+                            if irqs.contains(&preferred_irq) {
+                                irqs.clear();
+                                irqs.insert(preferred_irq);
+                            }
+                        }
+                    }
+
+                    // If there's still duplicate irqs, keep the one that matches the signal name or peri name.
+                    // Only match peri name for GLOBAL signals: for specific signals (e.g. ALARM, TAMP) we
+                    // want the specific IRQ (e.g. RTC_Alarm, TAMPER) over the generic peri-name one (RTC).
+                    if irqs.len() != 1 {
+                        let matches: Vec<_> = irqs
+                            .iter()
+                            .filter(|irq| {
+                                (signal == "GLOBAL" && *irq == &p.name)
+                                    || **irq == format!("{}_{}", p.name, signal)
+                                    || (p.name == "RCC" && signal == "CRS" && *irq == "CRS")
+                                    || (**irq == *signal && !irq.ends_with("_S"))
+                            })
+                            .cloned()
+                            .collect();
+                        if matches.len() == 1 {
+                            irqs.clear();
+                            irqs.insert(matches[0].clone());
+                        }
+                    }
+
+                    // If there's still duplicate irqs, keep the one that matches the peri name.
+                    // Only for GLOBAL signals, so specific signals prefer the more specific IRQ name.
+                    if irqs.len() != 1 && signal == "GLOBAL" {
+                        let matches_peri: Vec<_> = irqs.iter().filter(|irq| *irq == &p.name).cloned().collect();
+                        if matches_peri.len() == 1 {
+                            irqs.clear();
+                            irqs.insert(matches_peri[0].clone());
+                        }
                     }
 
                     // If there's still duplicate irqs, keep the one that doesn't match the peri name.
@@ -432,8 +525,8 @@ impl ChipInterrupts {
 
                     if irqs.len() != 1 {
                         panic!(
-                            "dup irqs on chip {:?} nvic {:?} peri {} signal {}: {:?}",
-                            chip_name, chip_nvic.version, p.name, signal, irqs
+                            "dup irqs on chip {:?} peri {} signal {}: {:?}",
+                            chip_name, p.name, signal, irqs
                         );
                     }
 
@@ -486,8 +579,12 @@ fn match_peris(peris: &[String], name: &str) -> Vec<String> {
         ("TEMP", &["TEMPSENS"]),
         ("DSI", &["DSIHOST"]),
         ("HRTIM1", &["HRTIM"]),
-        ("GTZC", &["GTZC_S", "GTZC_NS"]),
-        ("TZIC", &["GTZC_S"]),
+        ("GTZC", &["GTZC_TZIC"]),
+        ("GTZC_S", &["GTZC_TZIC"]),
+        ("GTZC_NS", &["GTZC_TZIC"]),
+        ("TZIC", &["GTZC_TZIC"]),
+        ("TZIC_ILA", &["GTZC_TZIC"]),
+        ("ILA", &["ILA"]),
     ];
 
     let peri_override: HashMap<_, _> = PERI_OVERRIDE.iter().copied().collect();
@@ -503,6 +600,24 @@ fn match_peris(peris: &[String], name: &str) -> Vec<String> {
             return res;
         }
     }
+
+    if name == "ILA" || name == "TZIC_ILA" || name == "TZIC" {
+        return peris.to_vec();
+    }
+
+    if name == "GTZC" || name == "GTZC_S" || name == "GTZC_NS" {
+        for p in peris {
+            if p == "GTZC_TZIC" {
+                return vec![p.clone()];
+            }
+        }
+        for p in peris {
+            if p == "GTZC" {
+                return vec![p.clone()];
+            }
+        }
+    }
+
     let mut name = name;
     let mut res = Vec::new();
     if let Some(m) = regex!(r"^(I2C|[A-Z]+)(\d+(_\d+)*)$").captures(name) {
@@ -532,6 +647,9 @@ fn valid_signals(peri: &str, chip_name: &str) -> Vec<String> {
         // DCMIPP signals: STM32N6 supports CSI, others only basic signals
         ("DCMIPP", "STM32N6", &["GLOBAL", "CSI"]),
         ("DCMIPP", "*", &["GLOBAL"]), // Default for all other DCMIPP devices
+        // LTDC signals: STM32N6 has separate LTDC_UP and LTDC_LO interrupts; all others have a single LTDC IRQ
+        ("LTDC", "STM32N6", &["ER", "LO", "UP"]),
+        ("LTDC", "*", &["ER", "LO"]),
         // STM32WB0 Specific Mappings
         ("EXTI", "STM32WB0", &["GPIOA", "GPIOB"]),
         (
@@ -586,7 +704,9 @@ fn valid_signals(peri: &str, chip_name: &str) -> Vec<String> {
         ),
         ("MDF", &["FLT0", "FLT1", "FLT2", "FLT3", "FLT4", "FLT5", "FLT6", "FLT7"]),
         ("PWR", &["S3WU", "WKUP", "PVD"]),
-        ("GTZC", &["GLOBAL", "ILA"]),
+        ("GTZC", &["GLOBAL", "ILA", "GTZC"]),
+        ("GTZC_TZIC", &["GLOBAL", "ILA", "GTZC"]),
+        ("GTZC_MPCBB", &["GLOBAL", "ILA", "GTZC"]),
         ("WWDG", &["GLOBAL", "RST"]),
         ("USB_OTG_FS", &["GLOBAL", "EP1_OUT", "EP1_IN", "WKUP"]),
         ("USB_OTG_HS", &["GLOBAL", "EP1_OUT", "EP1_IN", "WKUP"]),

--- a/stm32-data-gen/src/perimap.rs
+++ b/stm32-data-gen/src/perimap.rs
@@ -3,14 +3,22 @@ use crate::util::RegexMap;
 pub static PERIMAP: RegexMap<(&str, &str, &str)> = RegexMap::new(&[
     // GTZC - TrustZone Security Controller
     ("STM32H503.*:GTZC:.*", ("gtzc", "h503", "GTZC1")),
-    ("STM32H503.*:GTZC1:.*", ("gtzc", "h503", "GTZC1")),
-    ("STM32H5.*:GTZC:.*", ("gtzc", "v1", "GTZC1_TZSC")),
-    ("STM32H5.*:GTZC1.*:.*", ("gtzc", "v1", "GTZC1_TZSC")),
+    ("STM32H5[2367].*:GTZC:.*", ("gtzc", "v1", "GTZC1_TZSC")),
+    ("STM32H5[2367].*:GTZC_TZIC:.*", ("gtzc", "v1", "TZIC")),
+    ("STM32H5[2367].*:GTZC_MPCBB.*:.*", ("gtzc", "v1", "MPCBB")),
+    ("STM32H5[2367].*:GTZC_TZSC:.*", ("gtzc", "v1", "GTZC1_TZSC")),
     ("STM32U5.*:GTZC:.*", ("gtzc", "v1", "GTZC1_TZSC")),
-    ("STM32U5.*:GTZC1_TZSC:.*", ("gtzc", "v1", "GTZC1_TZSC")),
+    ("STM32U5.*:GTZC_TZIC:.*", ("gtzc", "v1", "TZIC")),
+    ("STM32U5.*:GTZC_MPCBB.*:.*", ("gtzc", "v1", "MPCBB")),
+    ("STM32U5.*:GTZC_TZSC:.*", ("gtzc", "v1", "GTZC1_TZSC")),
     ("STM32WBA.*:GTZC:.*", ("gtzc", "wba", "GTZC_TZSC")),
     ("STM32WBA.*:GTZC_TZSC:.*", ("gtzc", "wba", "GTZC_TZSC")),
-    ("STM32L5.*:GTZC_TZSC:.*", ("gtzc", "wba", "GTZC_TZSC")),
+    ("STM32WBA.*:GTZC_TZIC:.*", ("gtzc", "wba", "TZIC")),
+    ("STM32WBA.*:GTZC_MPCBB.*:.*", ("gtzc", "wba", "MPCBB")),
+    ("STM32L5.*:GTZC:.*", ("gtzc", "l5", "GTZC_TZSC")),
+    ("STM32L5.*:GTZC_TZSC:.*", ("gtzc", "l5", "GTZC_TZSC")),
+    ("STM32L5.*:GTZC_TZIC:.*", ("gtzc", "l5", "TZIC")),
+    ("STM32L5.*:GTZC_MPCBB.*:.*", ("gtzc", "l5", "MPCBB")),
     // BSEC - Boot Security Engine Controller
     (".*:BSEC:.*:bsec2.*", ("bsec", "v2", "BSEC")),
     // RIFSC - Resource Isolation Framework Security Controller


### PR DESCRIPTION
Decomposes the GTZC (Global TrustZone Controller) monolithic peripheral into typed sub-peripherals — GTZC_TZSC (security configuration), GTZC_TZIC (interrupt controller), and GTZC_MPCBB1/2/3/6 (block-based memory protection) — for the L5, H5, U5, and WBA chip families.

## Register definitions

- **New `gtzc_l5.yaml`**: L5-specific TZIC block (3-word IER/SR/FCR arrays) and MPCBB block (VCTR/LCKVTR), which differ structurally from the v1/wba variants.
- **Extended `gtzc_v1.yaml` / `gtzc_wba.yaml`**: Added `block/TZIC` and `block/MPCBB` definitions (previously only GTZC_TZSC existed).

## Peripheral mapping

- Adds `perimap.rs` entries for `GTZC_TZIC` and `GTZC_MPCBB*` sub-peripherals on H5, U5, WBA, and L5.
- Fixes L5 mapping: was incorrectly pointing at the WBA variant; now has its own `l5` version.

## Generator

- Adds `GTZC`, `GTZC_TZSC`, `GTZC_TZIC`, `GTZC_MPCBB1/2/3/6` to the ghost peripherals list so their base addresses are resolved from C headers.
- Soft-fail (warn and skip) when a chip has no C header, instead of panicking.

## Interrupt routing

TrustZone chips (L5, H5, U5, WBA) use NVIC2 (non-secure) as their primary NVIC, but `GTZC_IRQn` is defined only in NVIC1 (secure). The fix merges both NVICs for single-core TrustZone chips while explicitly excluding multi-core chips (STM32H7xx, STM32WL5xx) where NVIC1 and NVIC2 belong to different CPU cores and must not be mixed.

Additionally, the NVIC XML uses `GTZC_S` / `GTZC_NS` as the IP instance name in interrupt strings, which did not match the generated peripheral name `GTZC_TZIC`. A remapping is added so `GTZC_IRQn` is correctly attributed to `GTZC_TZIC`.

Bug fixes made necessary by the NVIC merge:
- **RTC signals**: Restrict the "prefer peri-name IRQ" dedup to `GLOBAL` signals only, preventing `RTC_Alarm` and `TAMPER` from being incorrectly collapsed to `RTC`.
- **LTDC UP signal**: Scope to STM32N6 only via `CHIP_SPECIFIC_SIGNALS`; other chips only have `ER`/`LO`.
- **HSEM1/HSEM2**: Map both names to `("HSEM", "GLOBAL")` for dual-core chips where each core has its own HSEM IRQ number.
- **F100 DMA filter**: Use `chip_name.starts_with("STM32F100")` instead of NVIC version string comparison.