### PR TITLE
STM32H7: add registers to configure boot for second core

### DIFF
--- a/data/registers/flash_h7.yaml
+++ b/data/registers/flash_h7.yaml
@@ -103,6 +103,14 @@ block/FLASH:
     description: FLASH register with boot address
     byte_offset: 68
     fieldset: BOOT_PRGR
+  - name: BOOT4_CUR
+    description: FLASH register with boot address
+    byte_offset: 72
+    fieldset: BOOT4_CUR
+  - name: BOOT4_PRG
+    description: FLASH register with boot address
+    byte_offset: 76
+    fieldset: BOOT4_PRG
   - name: CRCDATAR
     description: FLASH CRC data register
     byte_offset: 92
@@ -130,6 +138,28 @@ fieldset/BOOT_CURR:
     bit_offset: 16
     bit_size: 16
 fieldset/BOOT_PRGR:
+  description: FLASH register with boot address
+  fields:
+  - name: BOOT_ADD0
+    description: Boot address 0
+    bit_offset: 0
+    bit_size: 16
+  - name: BOOT_ADD1
+    description: Boot address 1
+    bit_offset: 16
+    bit_size: 16
+fieldset/BOOT4_CUR:
+  description: FLASH register with boot address
+  fields:
+  - name: BOOT_ADD0
+    description: Boot address 0
+    bit_offset: 0
+    bit_size: 16
+  - name: BOOT_ADD1
+    description: Boot address 1
+    bit_offset: 16
+    bit_size: 16
+fieldset/BOOT4_PRG:
   description: FLASH register with boot address
   fields:
   - name: BOOT_ADD0
@@ -414,6 +444,14 @@ fieldset/OPTSR_CUR:
     description: Security enable option status bit
     bit_offset: 21
     bit_size: 1
+  - name: BOOT_CM4
+    description: Enable CM4 boot
+    bit_offset: 22
+    bit_size: 1
+  - name: BOOT_CM7
+    description: Enable CM7 boot
+    bit_offset: 23
+    bit_size: 1
   - name: RSS1
     description: User option bit 1
     bit_offset: 26
@@ -472,6 +510,14 @@ fieldset/OPTSR_PRG:
   - name: SECURITY
     description: Security option configuration bit
     bit_offset: 21
+    bit_size: 1
+  - name: BOOT_CM4
+    description: Enable CM4 boot
+    bit_offset: 22
+    bit_size: 1
+  - name: BOOT_CM7
+    description: Enable CM7 boot
+    bit_offset: 23
     bit_size: 1
   - name: RSS1
     description: User option configuration bit 1


### PR DESCRIPTION
These registers are used to configure the boot address for the Cortex M4 core on STM32H7 micros.