### PR TITLE
STM32N6: add sdmmc and camera/csi-2 peripherals

### DIFF
--- a/data/registers/csi_v1.yaml
+++ b/data/registers/csi_v1.yaml
@@ -1,0 +1,1483 @@
+block/CSI:
+  description: CSI-2 Host.
+  items:
+  - name: CR
+    description: CSI-2 Host control register.
+    byte_offset: 0
+    fieldset: CR
+  - name: PCR
+    description: CSI-2 Host DPHY_RX control register.
+    byte_offset: 4
+    fieldset: PCR
+  - name: VC0CFGR1
+    description: CSI-2 Host virtual channel 0 configuration register 1.
+    byte_offset: 16
+    fieldset: VC0CFGR1
+  - name: VC0CFGR2
+    description: CSI-2 Host virtual channel 0 configuration register 2.
+    byte_offset: 20
+    fieldset: VC0CFGR2
+  - name: VC0CFGR3
+    description: CSI-2 Host virtual channel 0 configuration register 3.
+    byte_offset: 24
+    fieldset: VC0CFGR3
+  - name: VC0CFGR4
+    description: CSI-2 Host virtual channel 0 configuration register 4.
+    byte_offset: 28
+    fieldset: VC0CFGR4
+  - name: VC1CFGR1
+    description: CSI-2 Host virtual channel 1 configuration register 1.
+    byte_offset: 32
+    fieldset: VC1CFGR1
+  - name: VC1CFGR2
+    description: CSI-2 Host virtual channel 1 configuration register 2.
+    byte_offset: 36
+    fieldset: VC1CFGR2
+  - name: VC1CFGR3
+    description: CSI-2 Host virtual channel 1 configuration register 3.
+    byte_offset: 40
+    fieldset: VC1CFGR3
+  - name: VC1CFGR4
+    description: CSI-2 Host virtual channel 1 configuration register 4.
+    byte_offset: 44
+    fieldset: VC1CFGR4
+  - name: VC2CFGR1
+    description: CSI-2 Host virtual channel 2 configuration register 1.
+    byte_offset: 48
+    fieldset: VC2CFGR1
+  - name: VC2CFGR2
+    description: CSI-2 Host virtual channel 2 configuration register 2.
+    byte_offset: 52
+    fieldset: VC2CFGR2
+  - name: VC2CFGR3
+    description: CSI-2 Host virtual channel 2 configuration register 3.
+    byte_offset: 56
+    fieldset: VC2CFGR3
+  - name: VC2CFGR4
+    description: CSI-2 Host virtual channel 2 configuration register 4.
+    byte_offset: 60
+    fieldset: VC2CFGR4
+  - name: VC3CFGR1
+    description: CSI-2 Host virtual channel 3 configuration register 1.
+    byte_offset: 64
+    fieldset: VC3CFGR1
+  - name: VC3CFGR2
+    description: CSI-2 Host virtual channel 3 configuration register 2.
+    byte_offset: 68
+    fieldset: VC3CFGR2
+  - name: VC3CFGR3
+    description: CSI-2 Host virtual channel 3 configuration register 3.
+    byte_offset: 72
+    fieldset: VC3CFGR3
+  - name: VC3CFGR4
+    description: CSI-2 Host virtual channel 3 configuration register 4.
+    byte_offset: 76
+    fieldset: VC3CFGR4
+  - name: LB0CFGR
+    description: CSI-2 Host line byte 0 configuration register.
+    byte_offset: 80
+    fieldset: LB0CFGR
+  - name: LB1CFGR
+    description: CSI-2 Host line byte 1 configuration register.
+    byte_offset: 84
+    fieldset: LB1CFGR
+  - name: LB2CFGR
+    description: CSI-2 Host line byte 2 configuration register.
+    byte_offset: 88
+    fieldset: LB2CFGR
+  - name: LB3CFGR
+    description: CSI-2 Host line byte 3 configuration register.
+    byte_offset: 92
+    fieldset: LB3CFGR
+  - name: TIM0CFGR
+    description: CSI-2 Host timer 0 configuration register.
+    byte_offset: 96
+    fieldset: TIM0CFGR
+  - name: TIM1CFGR
+    description: CSI-2 Host timer 1 configuration register.
+    byte_offset: 100
+    fieldset: TIM1CFGR
+  - name: TIM2CFGR
+    description: CSI-2 Host timer 2 configuration register.
+    byte_offset: 104
+    fieldset: TIM2CFGR
+  - name: TIM3CFGR
+    description: CSI-2 Host timer 3 configuration register.
+    byte_offset: 108
+    fieldset: TIM3CFGR
+  - name: LMCFGR
+    description: CSI-2 Host lane merger configuration register.
+    byte_offset: 112
+    fieldset: LMCFGR
+  - name: PRGITR
+    description: CSI-2 Host program interrupt register.
+    byte_offset: 116
+    fieldset: PRGITR
+  - name: WDR
+    description: CSI-2 Host watchdog register.
+    byte_offset: 120
+    fieldset: WDR
+  - name: IER0
+    description: CSI-2 Host interrupt enable register 0.
+    byte_offset: 128
+    fieldset: IER0
+  - name: IER1
+    description: CSI-2 Host interrupt enable register 1.
+    byte_offset: 132
+    fieldset: IER1
+  - name: SR0
+    description: CSI-2 Host status register 0.
+    byte_offset: 144
+    fieldset: SR0
+  - name: SR1
+    description: CSI-2 Host status register 1.
+    byte_offset: 148
+    fieldset: SR1
+  - name: FCR0
+    description: CSI-2 Host flag clear register 0.
+    byte_offset: 256
+    fieldset: FCR0
+  - name: FCR1
+    description: CSI-2 Host flag clear register 1.
+    byte_offset: 260
+    fieldset: FCR1
+  - name: SPDFR
+    description: CSI-2 Host short packet data field register.
+    byte_offset: 272
+    fieldset: SPDFR
+  - name: ERR1
+    description: CSI-2 Host error register 1.
+    byte_offset: 276
+    fieldset: ERR1
+  - name: ERR2
+    description: CSI-2 Host error register 2.
+    byte_offset: 280
+    fieldset: ERR2
+  - name: PRCR
+    description: CSI PHY reset control register.
+    byte_offset: 4096
+    fieldset: PRCR
+  - name: PMCR
+    description: CSI PHY mode control register.
+    byte_offset: 4100
+    fieldset: PMCR
+  - name: PFCR
+    description: CSI PHY frequency control register.
+    byte_offset: 4104
+    fieldset: PFCR
+  - name: PTCR0
+    description: CSI PHY test control register 0.
+    byte_offset: 4112
+    fieldset: PTCR0
+  - name: PTCR1
+    description: CSI PHY test control register 1.
+    byte_offset: 4116
+    fieldset: PTCR1
+  - name: PTSR
+    description: CSI PHY test status register.
+    byte_offset: 4120
+    fieldset: PTSR
+fieldset/CR:
+  description: CSI-2 Host control register.
+  fields:
+  - name: CSIEN
+    description: CSI-2 enable.
+    bit_offset: 0
+    bit_size: 1
+  - name: VC0START
+    description: Virtual channel 0 start.
+    bit_offset: 2
+    bit_size: 1
+  - name: VC0STOP
+    description: Virtual channel 0 stop.
+    bit_offset: 3
+    bit_size: 1
+  - name: VC1START
+    description: Virtual channel 1 start.
+    bit_offset: 6
+    bit_size: 1
+  - name: VC1STOP
+    description: Virtual channel 1 stop.
+    bit_offset: 7
+    bit_size: 1
+  - name: VC2START
+    description: Virtual channel 2 start.
+    bit_offset: 10
+    bit_size: 1
+  - name: VC2STOP
+    description: Virtual channel 2 stop.
+    bit_offset: 11
+    bit_size: 1
+  - name: VC3START
+    description: Virtual channel 3 start.
+    bit_offset: 14
+    bit_size: 1
+  - name: VC3STOP
+    description: Virtual channel 3 stop.
+    bit_offset: 15
+    bit_size: 1
+fieldset/ERR1:
+  description: CSI-2 Host error register 1.
+  fields:
+  - name: CRCDTERR
+    description: Data type having a CRC error.
+    bit_offset: 0
+    bit_size: 6
+  - name: CRCVCERR
+    description: Virtual channel having a CRC error.
+    bit_offset: 6
+    bit_size: 2
+  - name: CECCDTERR
+    description: Data type having a corrected ECC error.
+    bit_offset: 8
+    bit_size: 6
+  - name: CECCVCERR
+    description: Virtual channel having a corrected ECC error.
+    bit_offset: 14
+    bit_size: 2
+  - name: IDDTERR
+    description: Data type in error.
+    bit_offset: 16
+    bit_size: 6
+  - name: IDVCERR
+    description: Virtual channel having ID error.
+    bit_offset: 22
+    bit_size: 2
+fieldset/ERR2:
+  description: CSI-2 Host error register 2.
+  fields:
+  - name: SPKTDTERR
+    description: Data type having a short packet error.
+    bit_offset: 0
+    bit_size: 6
+  - name: SPKTVCERR
+    description: Virtual channel having a short packet error.
+    bit_offset: 6
+    bit_size: 2
+  - name: WDVCERR
+    description: Virtual channel having a watchdog error.
+    bit_offset: 16
+    bit_size: 2
+  - name: SYNCVCERR
+    description: Virtual channel having synchronization error.
+    bit_offset: 18
+    bit_size: 2
+fieldset/FCR0:
+  description: CSI-2 Host flag clear register 0.
+  fields:
+  - name: CLB0F
+    description: Clear line/byte counter 0 flag.
+    bit_offset: 0
+    bit_size: 1
+  - name: CLB1F
+    description: Clear line/byte counter 1 flag.
+    bit_offset: 1
+    bit_size: 1
+  - name: CLB2F
+    description: Clear line/byte counter 2 flag.
+    bit_offset: 2
+    bit_size: 1
+  - name: CLB3F
+    description: Clear line/byte counter 3 flag.
+    bit_offset: 3
+    bit_size: 1
+  - name: CTIM0F
+    description: Clear timer 0 flag.
+    bit_offset: 4
+    bit_size: 1
+  - name: CTIM1F
+    description: Clear timer 1 flag.
+    bit_offset: 5
+    bit_size: 1
+  - name: CTIM2F
+    description: Clear timer 2 flag.
+    bit_offset: 6
+    bit_size: 1
+  - name: CTIM3F
+    description: Clear timer 3 flag.
+    bit_offset: 7
+    bit_size: 1
+  - name: CSOF0F
+    description: Clear SOF flag for virtual channel 0.
+    bit_offset: 8
+    bit_size: 1
+  - name: CSOF1F
+    description: Clear SOF flag for virtual channel 1.
+    bit_offset: 9
+    bit_size: 1
+  - name: CSOF2F
+    description: Clear SOF flag for virtual channel 2.
+    bit_offset: 10
+    bit_size: 1
+  - name: CSOF3F
+    description: Clear SOF flag for virtual channel 3.
+    bit_offset: 11
+    bit_size: 1
+  - name: CEOF0F
+    description: Clear EOF flag for virtual channel 0.
+    bit_offset: 12
+    bit_size: 1
+  - name: CEOF1F
+    description: Clear EOF flag for virtual channel 1.
+    bit_offset: 13
+    bit_size: 1
+  - name: CEOF2F
+    description: Clear EOF flag for virtual channel 2.
+    bit_offset: 14
+    bit_size: 1
+  - name: CEOF3F
+    description: Clear EOF flag for virtual channel 3.
+    bit_offset: 15
+    bit_size: 1
+  - name: CSPKTF
+    description: Clear short packet flag.
+    bit_offset: 16
+    bit_size: 1
+  - name: CCCFIFOFF
+    description: Clear clock changer FIFO full flag.
+    bit_offset: 21
+    bit_size: 1
+  - name: CCRCERRF
+    description: Clear CRC error flag.
+    bit_offset: 24
+    bit_size: 1
+  - name: CECCERRF
+    description: Clear ECC error flag.
+    bit_offset: 25
+    bit_size: 1
+  - name: CCECCERRF
+    description: Clear corrected ECC error flag.
+    bit_offset: 26
+    bit_size: 1
+  - name: CIDERRF
+    description: Clear data type ID error flag.
+    bit_offset: 27
+    bit_size: 1
+  - name: CSPKTERRF
+    description: Clear short packet error flag.
+    bit_offset: 28
+    bit_size: 1
+  - name: CWDERRF
+    description: Clear watchdog error flag.
+    bit_offset: 29
+    bit_size: 1
+  - name: CSYNCERRF
+    description: Clear invalid synchronization error flag.
+    bit_offset: 30
+    bit_size: 1
+fieldset/FCR1:
+  description: CSI-2 Host flag clear register 1.
+  fields:
+  - name: CESOTDL0F
+    description: Clear SOT error flag on lane 0.
+    bit_offset: 0
+    bit_size: 1
+  - name: CESOTSYNCDL0F
+    description: Clear SOT synchronization error flag on lane 0.
+    bit_offset: 1
+    bit_size: 1
+  - name: CEESCDL0F
+    description: Clear D-PHY_RX lane 0 escape entry error flag.
+    bit_offset: 2
+    bit_size: 1
+  - name: CESYNCESCDL0F
+    description: Clear D-PHY_RX lane 0 low-power data transmission synchronization error flag.
+    bit_offset: 3
+    bit_size: 1
+  - name: CECTRLDL0F
+    description: Clear D-PHY_RX lane 0 control error flag.
+    bit_offset: 4
+    bit_size: 1
+  - name: CESOTDL1F
+    description: Clear SOT error flag on lane 1.
+    bit_offset: 8
+    bit_size: 1
+  - name: CESOTSYNCDL1F
+    description: Clear SOT synchronization error flag on lane 1.
+    bit_offset: 9
+    bit_size: 1
+  - name: CEESCDL1F
+    description: Clear D-PHY_RX lane 1 escape entry error flag.
+    bit_offset: 10
+    bit_size: 1
+  - name: CESYNCESCDL1F
+    description: Clear D-PHY_RX lane 1 low-power data transmission synchronization error flag.
+    bit_offset: 11
+    bit_size: 1
+  - name: CECTRLDL1F
+    description: Clear D-PHY_RX lane 1 control error flag.
+    bit_offset: 12
+    bit_size: 1
+fieldset/IER0:
+  description: CSI-2 Host interrupt enable register 0.
+  fields:
+  - name: LB0IE
+    description: Line/byte counter 0 interrupt enable.
+    bit_offset: 0
+    bit_size: 1
+  - name: LB1IE
+    description: Line/byte counter 1 interrupt enable.
+    bit_offset: 1
+    bit_size: 1
+  - name: LB2IE
+    description: Line/byte counter 2 interrupt enable.
+    bit_offset: 2
+    bit_size: 1
+  - name: LB3IE
+    description: Line/byte counter 3 interrupt enable.
+    bit_offset: 3
+    bit_size: 1
+  - name: TIM0IE
+    description: Timer 0 interrupt enable.
+    bit_offset: 4
+    bit_size: 1
+  - name: TIM1IE
+    description: Timer 1 interrupt enable.
+    bit_offset: 5
+    bit_size: 1
+  - name: TIM2IE
+    description: Timer 2 interrupt enable.
+    bit_offset: 6
+    bit_size: 1
+  - name: TIM3IE
+    description: Timer 3 interrupt enable.
+    bit_offset: 7
+    bit_size: 1
+  - name: SOF0IE
+    description: SOF for virtual channel 0 interrupt enable.
+    bit_offset: 8
+    bit_size: 1
+  - name: SOF1IE
+    description: SOF for virtual channel 1 interrupt enable.
+    bit_offset: 9
+    bit_size: 1
+  - name: SOF2IE
+    description: SOF for virtual channel 2 interrupt enable.
+    bit_offset: 10
+    bit_size: 1
+  - name: SOF3IE
+    description: SOF for virtual channel 3 interrupt enable.
+    bit_offset: 11
+    bit_size: 1
+  - name: EOF0IE
+    description: EOF for virtual channel 0 interrupt enable.
+    bit_offset: 12
+    bit_size: 1
+  - name: EOF1IE
+    description: EOF for virtual channel 1 interrupt enable.
+    bit_offset: 13
+    bit_size: 1
+  - name: EOF2IE
+    description: EOF for virtual channel 2 interrupt enable.
+    bit_offset: 14
+    bit_size: 1
+  - name: EOF3IE
+    description: EOF for virtual channel 3 interrupt enable.
+    bit_offset: 15
+    bit_size: 1
+  - name: SPKTIE
+    description: Short packet interrupt enable.
+    bit_offset: 16
+    bit_size: 1
+  - name: CCFIFOFIE
+    description: Clock changer FIFO full interrupt enable.
+    bit_offset: 21
+    bit_size: 1
+  - name: CRCERRIE
+    description: CRC error interrupt enable.
+    bit_offset: 24
+    bit_size: 1
+  - name: ECCERRIE
+    description: ECC error interrupt enable.
+    bit_offset: 25
+    bit_size: 1
+  - name: CECCERRIE
+    description: Corrected ECC error interrupt enable.
+    bit_offset: 26
+    bit_size: 1
+  - name: IDERRIE
+    description: Data type ID error interrupt enable.
+    bit_offset: 27
+    bit_size: 1
+  - name: SPKTERRIE
+    description: Short packet error interrupt enable.
+    bit_offset: 28
+    bit_size: 1
+  - name: WDERRIE
+    description: Watchdog error interrupt enable.
+    bit_offset: 29
+    bit_size: 1
+  - name: SYNCERRIE
+    description: Invalid synchronization error interrupt enable.
+    bit_offset: 30
+    bit_size: 1
+fieldset/IER1:
+  description: CSI-2 Host interrupt enable register 1.
+  fields:
+  - name: ESOTDL0IE
+    description: SOT error interrupt enable on lane 0.
+    bit_offset: 0
+    bit_size: 1
+  - name: ESOTSYNCDL0IE
+    description: SOT synchronization interrupt error enable on lane 0.
+    bit_offset: 1
+    bit_size: 1
+  - name: EESCDL0IE
+    description: D-PHY_RX lane 0 escape entry error interrupt enable.
+    bit_offset: 2
+    bit_size: 1
+  - name: ESYNCESCDL0IE
+    description: D-PHY_RX lane 0 low power data transmission synchronization error interrupt enable.
+    bit_offset: 3
+    bit_size: 1
+  - name: ECTRLDL0IE
+    description: D-PHY_RX lane 0 control error interrupt enable.
+    bit_offset: 4
+    bit_size: 1
+  - name: ESOTDL1IE
+    description: SOT error interrupt enable on lane 1.
+    bit_offset: 8
+    bit_size: 1
+  - name: ESOTSYNCDL1IE
+    description: SOT synchronization interrupt error enable on lane 1.
+    bit_offset: 9
+    bit_size: 1
+  - name: EESCDL1IE
+    description: D-PHY_RX lane 1 escape entry error interrupt enable.
+    bit_offset: 10
+    bit_size: 1
+  - name: ESYNCESCDL1IE
+    description: D-PHY_RX lane 1 low-power data transmission synchronization error interrupt enable.
+    bit_offset: 11
+    bit_size: 1
+  - name: ECTRLDL1IE
+    description: D-PHY_RX lane 1 control error interrupt enable.
+    bit_offset: 12
+    bit_size: 1
+fieldset/LB0CFGR:
+  description: CSI-2 Host line byte 0 configuration register.
+  fields:
+  - name: BYTECNT
+    description: Byte counter.
+    bit_offset: 0
+    bit_size: 16
+  - name: LINECNT
+    description: Line counter.
+    bit_offset: 16
+    bit_size: 16
+fieldset/LB1CFGR:
+  description: CSI-2 Host line byte 1 configuration register.
+  fields:
+  - name: BYTECNT
+    description: Byte counter.
+    bit_offset: 0
+    bit_size: 16
+  - name: LINECNT
+    description: Line counter.
+    bit_offset: 16
+    bit_size: 16
+fieldset/LB2CFGR:
+  description: CSI-2 Host line byte 2 configuration register.
+  fields:
+  - name: BYTECNT
+    description: Byte counter.
+    bit_offset: 0
+    bit_size: 16
+  - name: LINECNT
+    description: Line counter.
+    bit_offset: 16
+    bit_size: 16
+fieldset/LB3CFGR:
+  description: CSI-2 Host line byte 3 configuration register.
+  fields:
+  - name: BYTECNT
+    description: Byte counter.
+    bit_offset: 0
+    bit_size: 16
+  - name: LINECNT
+    description: Line counter.
+    bit_offset: 16
+    bit_size: 16
+fieldset/LMCFGR:
+  description: CSI-2 Host lane merger configuration register.
+  fields:
+  - name: LANENB
+    description: Number of lanes.
+    bit_offset: 8
+    bit_size: 3
+  - name: DL0MAP
+    description: Physical mapping of logical data lane 0.
+    bit_offset: 16
+    bit_size: 3
+  - name: DL1MAP
+    description: Physical mapping of logical data lane 1.
+    bit_offset: 20
+    bit_size: 3
+fieldset/PCR:
+  description: CSI-2 Host DPHY_RX control register.
+  fields:
+  - name: PWRDOWN
+    description: Power down.
+    bit_offset: 0
+    bit_size: 1
+  - name: CLEN
+    description: Clock lane enable.
+    bit_offset: 1
+    bit_size: 1
+  - name: DL0EN
+    description: D-PHY_RX data lane 0 enable.
+    bit_offset: 2
+    bit_size: 1
+  - name: DL1EN
+    description: D-PHY_RX data lane 1 enable.
+    bit_offset: 3
+    bit_size: 1
+fieldset/PFCR:
+  description: CSI PHY frequency control register.
+  fields:
+  - name: CCFR
+    description: Configuration clock frequency range selection.
+    bit_offset: 0
+    bit_size: 6
+  - name: HSFR
+    description: PHY high-speed frequency range selection.
+    bit_offset: 8
+    bit_size: 7
+  - name: DLD
+    description: Data lane direction of lane 0.
+    bit_offset: 16
+    bit_size: 1
+fieldset/PMCR:
+  description: CSI PHY mode control register.
+  fields:
+  - name: FRXMDL0
+    description: Force to Rx mode the data lane 0.
+    bit_offset: 0
+    bit_size: 1
+  - name: FRXMDL1
+    description: Force to Rx mode the data lane 1.
+    bit_offset: 1
+    bit_size: 1
+  - name: FTXSMDL0
+    description: Force to Tx Stop mode the data lane 0.
+    bit_offset: 2
+    bit_size: 1
+  - name: DTDL
+    description: Disable turn-around data lane 0.
+    bit_offset: 4
+    bit_size: 1
+  - name: RTDL0
+    description: Turn-around request data lane 0.
+    bit_offset: 8
+    bit_size: 1
+  - name: TUESDL0
+    description: Tx ULP escape-mode data lane 0.
+    bit_offset: 12
+    bit_size: 1
+  - name: TUEXDL0
+    description: Tx ULP exit sequence data lane 0.
+    bit_offset: 16
+    bit_size: 1
+fieldset/PRCR:
+  description: CSI PHY reset control register.
+  fields:
+  - name: PEN
+    description: When set to 0, this bit places the digital section of the D-PHY in the reset state.
+    bit_offset: 1
+    bit_size: 1
+fieldset/PRGITR:
+  description: CSI-2 Host program interrupt register.
+  fields:
+  - name: LB0VC
+    description: Line/byte counter 0 linked to a virtual channel.
+    bit_offset: 0
+    bit_size: 2
+  - name: LB0EN
+    description: Line/byte 0 counter enable.
+    bit_offset: 3
+    bit_size: 1
+  - name: LB1VC
+    description: Line/byte counter 1 linked to a virtual channel.
+    bit_offset: 4
+    bit_size: 2
+  - name: LB1EN
+    description: Line/byte 1 counter enable.
+    bit_offset: 7
+    bit_size: 1
+  - name: LB2VC
+    description: Line/byte counter 2 linked to a virtual channel.
+    bit_offset: 8
+    bit_size: 2
+  - name: LB2EN
+    description: Line/byte 2 counter enable.
+    bit_offset: 11
+    bit_size: 1
+  - name: LB3VC
+    description: Line/byte counter 3 linked to a virtual channel.
+    bit_offset: 12
+    bit_size: 2
+  - name: LB3EN
+    description: Line/byte 3 counter enable.
+    bit_offset: 15
+    bit_size: 1
+  - name: TIM0VC
+    description: TIM0 base time linked to a virtual channel.
+    bit_offset: 16
+    bit_size: 2
+  - name: TIM0EOF
+    description: TIM0 base time starting from the EOF.
+    bit_offset: 18
+    bit_size: 1
+  - name: TIM0EN
+    description: TIM0 base time enable.
+    bit_offset: 19
+    bit_size: 1
+  - name: TIM1VC
+    description: TIM1 base time linked to a virtual channel.
+    bit_offset: 20
+    bit_size: 2
+  - name: TIM1EOF
+    description: TIM1 base time starting from the EOF.
+    bit_offset: 22
+    bit_size: 1
+  - name: TIM1EN
+    description: TIM1 base time enable.
+    bit_offset: 23
+    bit_size: 1
+  - name: TIM2VC
+    description: TIM2 base time linked to a virtual channel.
+    bit_offset: 24
+    bit_size: 2
+  - name: TIM2EOF
+    description: TIM2 base time starting from the EOF.
+    bit_offset: 26
+    bit_size: 1
+  - name: TIM2EN
+    description: TIM2 base time enable.
+    bit_offset: 27
+    bit_size: 1
+  - name: TIM3VC
+    description: TIM3 base time linked to a virtual channel.
+    bit_offset: 28
+    bit_size: 2
+  - name: TIM3EOF
+    description: TIM3 base time starting from the EOF.
+    bit_offset: 30
+    bit_size: 1
+  - name: TIM3EN
+    description: TIM3 base time enable.
+    bit_offset: 31
+    bit_size: 1
+fieldset/PTCR0:
+  description: CSI PHY test control register 0.
+  fields:
+  - name: TCKEN
+    description: Test-interface clock enable for the TDI bus into the PHY.
+    bit_offset: 0
+    bit_size: 1
+  - name: TRSEN
+    description: Test-interface reset enable for the TDI bus into the PHY.
+    bit_offset: 1
+    bit_size: 1
+fieldset/PTCR1:
+  description: CSI PHY test control register 1.
+  fields:
+  - name: TDI
+    description: Test-interface data in.
+    bit_offset: 0
+    bit_size: 8
+  - name: TWM
+    description: Test-interface write mode selector.
+    bit_offset: 16
+    bit_size: 1
+fieldset/PTSR:
+  description: CSI PHY test status register.
+  fields:
+  - name: TDO
+    description: CSI PHY test interface data output bus for read-back and internal probing functionalities.
+    bit_offset: 0
+    bit_size: 8
+fieldset/SPDFR:
+  description: CSI-2 Host short packet data field register.
+  fields:
+  - name: DATAFIELD
+    description: Data field.
+    bit_offset: 0
+    bit_size: 16
+  - name: DATATYPE
+    description: Data type class.
+    bit_offset: 16
+    bit_size: 6
+  - name: VCHANNEL
+    description: Virtual channel.
+    bit_offset: 22
+    bit_size: 2
+fieldset/SR0:
+  description: CSI-2 Host status register 0.
+  fields:
+  - name: LB0F
+    description: Line/byte counter 0 flag.
+    bit_offset: 0
+    bit_size: 1
+  - name: LB1F
+    description: Line/byte counter 1 flag.
+    bit_offset: 1
+    bit_size: 1
+  - name: LB2F
+    description: Line/byte counter 2 flag.
+    bit_offset: 2
+    bit_size: 1
+  - name: LB3F
+    description: Line/byte counter 3 flag.
+    bit_offset: 3
+    bit_size: 1
+  - name: TIM0F
+    description: Timer 0 flag.
+    bit_offset: 4
+    bit_size: 1
+  - name: TIM1F
+    description: Timer 1 flag.
+    bit_offset: 5
+    bit_size: 1
+  - name: TIM2F
+    description: Timer 2 flag.
+    bit_offset: 6
+    bit_size: 1
+  - name: TIM3F
+    description: Timer 3 flag.
+    bit_offset: 7
+    bit_size: 1
+  - name: SOF0F
+    description: SOF flag for virtual channel 0.
+    bit_offset: 8
+    bit_size: 1
+  - name: SOF1F
+    description: SOF flag for virtual channel 1.
+    bit_offset: 9
+    bit_size: 1
+  - name: SOF2F
+    description: SOF flag for virtual channel 2.
+    bit_offset: 10
+    bit_size: 1
+  - name: SOF3F
+    description: SOF flag for virtual channel 3.
+    bit_offset: 11
+    bit_size: 1
+  - name: EOF0F
+    description: EOF flag for virtual channel 0.
+    bit_offset: 12
+    bit_size: 1
+  - name: EOF1F
+    description: EOF flag for virtual channel 1.
+    bit_offset: 13
+    bit_size: 1
+  - name: EOF2F
+    description: EOF flag for virtual channel 2.
+    bit_offset: 14
+    bit_size: 1
+  - name: EOF3F
+    description: EOF flag for virtual channel 3.
+    bit_offset: 15
+    bit_size: 1
+  - name: SPKTF
+    description: Short packet flag.
+    bit_offset: 16
+    bit_size: 1
+  - name: VC0STATEF
+    description: Virtual channel 0 state flag.
+    bit_offset: 17
+    bit_size: 1
+  - name: VC1STATEF
+    description: Virtual channel 1 state flag.
+    bit_offset: 18
+    bit_size: 1
+  - name: VC2STATEF
+    description: Virtual channel 2 state flag.
+    bit_offset: 19
+    bit_size: 1
+  - name: VC3STATEF
+    description: Virtual channel 3 state flag.
+    bit_offset: 20
+    bit_size: 1
+  - name: CCFIFOFF
+    description: Clock changer FIFO full flag.
+    bit_offset: 21
+    bit_size: 1
+  - name: CRCERRF
+    description: CRC error flag.
+    bit_offset: 24
+    bit_size: 1
+  - name: ECCERRF
+    description: ECC error flag.
+    bit_offset: 25
+    bit_size: 1
+  - name: CECCERRF
+    description: Corrected ECC error flag.
+    bit_offset: 26
+    bit_size: 1
+  - name: IDERRF
+    description: Data type ID error flag.
+    bit_offset: 27
+    bit_size: 1
+  - name: SPKTERRF
+    description: Short packet error flag.
+    bit_offset: 28
+    bit_size: 1
+  - name: WDERRF
+    description: Watchdog error flag.
+    bit_offset: 29
+    bit_size: 1
+  - name: SYNCERRF
+    description: Invalid synchronization error flag.
+    bit_offset: 30
+    bit_size: 1
+fieldset/SR1:
+  description: CSI-2 Host status register 1.
+  fields:
+  - name: ESOTDL0F
+    description: SOT error flag on lane 0.
+    bit_offset: 0
+    bit_size: 1
+  - name: ESOTSYNCDL0F
+    description: SOT synchronization error flag on lane 0.
+    bit_offset: 1
+    bit_size: 1
+  - name: EESCDL0F
+    description: D-PHY_RX lane 0 escape entry error flag.
+    bit_offset: 2
+    bit_size: 1
+  - name: ESYNCESCDL0F
+    description: D-PHY_RX lane 0 low-power data transmission synchronization error flag.
+    bit_offset: 3
+    bit_size: 1
+  - name: ECTRLDL0F
+    description: D-PHY_RX lane 0 control error flag.
+    bit_offset: 4
+    bit_size: 1
+  - name: ESOTDL1F
+    description: SOT error flag on lane 1.
+    bit_offset: 8
+    bit_size: 1
+  - name: ESOTSYNCDL1F
+    description: SOT synchronization error flag on lane 1.
+    bit_offset: 9
+    bit_size: 1
+  - name: EESCDL1F
+    description: D-PHY_RX lane 1 escape entry error flag.
+    bit_offset: 10
+    bit_size: 1
+  - name: ESYNCESCDL1F
+    description: D-PHY_RX lane 1 low-power data transmission synchronization error flag.
+    bit_offset: 11
+    bit_size: 1
+  - name: ECTRLDL1F
+    description: D-PHY_RX lane 1 control error flag.
+    bit_offset: 12
+    bit_size: 1
+  - name: ACTDL0F
+    description: D-PHY_RX lane 0 high-speed reception active.
+    bit_offset: 16
+    bit_size: 1
+  - name: SYNCDL0F
+    description: D-PHY_RX lane 0 receiver synchronization observed.
+    bit_offset: 17
+    bit_size: 1
+  - name: SKCALDL0F
+    description: D-PHY_RX lane 0 high-speed skew calibration.
+    bit_offset: 18
+    bit_size: 1
+  - name: STOPDL0F
+    description: D-PHY_RX receiver data lane 0 in stop state.
+    bit_offset: 19
+    bit_size: 1
+  - name: ULPNDL0F
+    description: D-PHY_RX receiver ultra-low-power state (not) active on data lane 0.
+    bit_offset: 20
+    bit_size: 1
+  - name: ACTDL1F
+    description: D-PHY_RX lane 1 high-speed reception active.
+    bit_offset: 22
+    bit_size: 1
+  - name: SYNCDL1F
+    description: D-PHY_RX lane 1 receiver synchronization observed.
+    bit_offset: 23
+    bit_size: 1
+  - name: SKCALDL1F
+    description: D-PHY_RX lane 1 high-speed skew calibration.
+    bit_offset: 24
+    bit_size: 1
+  - name: STOPDL1F
+    description: D-PHY_RX receiver data lane 1 in stop state.
+    bit_offset: 25
+    bit_size: 1
+  - name: ULPNDL1F
+    description: D-PHY_RX receiver ultra-low-power state (not) active on data lane 1.
+    bit_offset: 26
+    bit_size: 1
+  - name: STOPCLF
+    description: D-PHY_RX receiver in stop state for the clock lane.
+    bit_offset: 28
+    bit_size: 1
+  - name: ULPNACTF
+    description: D-PHY_RX receiver ULP state (not) active.
+    bit_offset: 29
+    bit_size: 1
+  - name: ULPNCLF
+    description: D-PHY_RX receiver Ultra-Low power state (not) on clock lane.
+    bit_offset: 30
+    bit_size: 1
+  - name: ACTCLF
+    description: D-PHY_RX receiver clock active flag.
+    bit_offset: 31
+    bit_size: 1
+fieldset/TIM0CFGR:
+  description: CSI-2 Host timer 0 configuration register.
+  fields:
+  - name: COUNT
+    description: Clock cycle counter.
+    bit_offset: 0
+    bit_size: 25
+fieldset/TIM1CFGR:
+  description: CSI-2 Host timer 1 configuration register.
+  fields:
+  - name: COUNT
+    description: Clock cycle counter.
+    bit_offset: 0
+    bit_size: 25
+fieldset/TIM2CFGR:
+  description: CSI-2 Host timer 2 configuration register.
+  fields:
+  - name: COUNT
+    description: Clock cycle counter.
+    bit_offset: 0
+    bit_size: 25
+fieldset/TIM3CFGR:
+  description: CSI-2 Host timer 3 configuration register.
+  fields:
+  - name: COUNT
+    description: Clock cycle counter.
+    bit_offset: 0
+    bit_size: 25
+fieldset/VC0CFGR1:
+  description: CSI-2 Host virtual channel 0 configuration register 1.
+  fields:
+  - name: ALLDT
+    description: All data types enable for the virtual channel x.
+    bit_offset: 0
+    bit_size: 1
+  - name: DT0EN
+    description: Data type 0 enable.
+    bit_offset: 1
+    bit_size: 1
+  - name: DT1EN
+    description: Data type 1 enable.
+    bit_offset: 2
+    bit_size: 1
+  - name: DT2EN
+    description: Data type 2 enable.
+    bit_offset: 3
+    bit_size: 1
+  - name: DT3EN
+    description: Data type 3 enable.
+    bit_offset: 4
+    bit_size: 1
+  - name: DT4EN
+    description: Data type 4 enable.
+    bit_offset: 5
+    bit_size: 1
+  - name: DT5EN
+    description: Data type 5 enable.
+    bit_offset: 6
+    bit_size: 1
+  - name: DT6EN
+    description: Data type 6 enable.
+    bit_offset: 7
+    bit_size: 1
+  - name: CDTFT
+    description: Common format for all data types.
+    bit_offset: 8
+    bit_size: 5
+  - name: DT0
+    description: Data type 0 class selection for virtual channel x.
+    bit_offset: 16
+    bit_size: 6
+  - name: DT0FT
+    description: Data type 0 format.
+    bit_offset: 24
+    bit_size: 5
+fieldset/VC0CFGR2:
+  description: CSI-2 Host virtual channel 0 configuration register 2.
+  fields:
+  - name: DT1
+    description: Data type 1 class selection for virtual channel x.
+    bit_offset: 0
+    bit_size: 6
+  - name: DT1FT
+    description: Data type 1 format.
+    bit_offset: 8
+    bit_size: 5
+  - name: DT2
+    description: Data type 2 class selection for virtual channel x.
+    bit_offset: 16
+    bit_size: 6
+  - name: DT2FT
+    description: Data type 2 format.
+    bit_offset: 24
+    bit_size: 5
+fieldset/VC0CFGR3:
+  description: CSI-2 Host virtual channel 0 configuration register 3.
+  fields:
+  - name: DT3
+    description: Data type 3 class selection for virtual channel x.
+    bit_offset: 0
+    bit_size: 6
+  - name: DT3FT
+    description: Data type 3 format.
+    bit_offset: 8
+    bit_size: 5
+  - name: DT4
+    description: Data type 4 class selection for virtual channel x.
+    bit_offset: 16
+    bit_size: 6
+  - name: DT4FT
+    description: Data type 4 format.
+    bit_offset: 24
+    bit_size: 5
+fieldset/VC0CFGR4:
+  description: CSI-2 Host virtual channel 0 configuration register 4.
+  fields:
+  - name: DT5
+    description: Data type 5 class selection for virtual channel x.
+    bit_offset: 0
+    bit_size: 6
+  - name: DT5FT
+    description: Data type 5 format.
+    bit_offset: 8
+    bit_size: 5
+  - name: DT6
+    description: Data type 6 class selection for virtual channel x.
+    bit_offset: 16
+    bit_size: 6
+  - name: DT6FT
+    description: Data type 6 format.
+    bit_offset: 24
+    bit_size: 5
+fieldset/VC1CFGR1:
+  description: CSI-2 Host virtual channel 1 configuration register 1.
+  fields:
+  - name: ALLDT
+    description: All data types enable for the virtual channel x.
+    bit_offset: 0
+    bit_size: 1
+  - name: DT0EN
+    description: Data type 0 enable.
+    bit_offset: 1
+    bit_size: 1
+  - name: DT1EN
+    description: Data type 1 enable.
+    bit_offset: 2
+    bit_size: 1
+  - name: DT2EN
+    description: Data type 2 enable.
+    bit_offset: 3
+    bit_size: 1
+  - name: DT3EN
+    description: Data type 3 enable.
+    bit_offset: 4
+    bit_size: 1
+  - name: DT4EN
+    description: Data type 4 enable.
+    bit_offset: 5
+    bit_size: 1
+  - name: DT5EN
+    description: Data type 5 enable.
+    bit_offset: 6
+    bit_size: 1
+  - name: DT6EN
+    description: Data type 6 enable.
+    bit_offset: 7
+    bit_size: 1
+  - name: CDTFT
+    description: Common format for all data types.
+    bit_offset: 8
+    bit_size: 5
+  - name: DT0
+    description: Data type 0 class selection for virtual channel x.
+    bit_offset: 16
+    bit_size: 6
+  - name: DT0FT
+    description: Data type 0 format.
+    bit_offset: 24
+    bit_size: 5
+fieldset/VC1CFGR2:
+  description: CSI-2 Host virtual channel 1 configuration register 2.
+  fields:
+  - name: DT1
+    description: Data type 1 class selection for virtual channel x.
+    bit_offset: 0
+    bit_size: 6
+  - name: DT1FT
+    description: Data type 1 format.
+    bit_offset: 8
+    bit_size: 5
+  - name: DT2
+    description: Data type 2 class selection for virtual channel x.
+    bit_offset: 16
+    bit_size: 6
+  - name: DT2FT
+    description: Data type 2 format.
+    bit_offset: 24
+    bit_size: 5
+fieldset/VC1CFGR3:
+  description: CSI-2 Host virtual channel 1 configuration register 3.
+  fields:
+  - name: DT3
+    description: Data type 3 class selection for virtual channel x.
+    bit_offset: 0
+    bit_size: 6
+  - name: DT3FT
+    description: Data type 3 format.
+    bit_offset: 8
+    bit_size: 5
+  - name: DT4
+    description: Data type 4 class selection for virtual channel x.
+    bit_offset: 16
+    bit_size: 6
+  - name: DT4FT
+    description: Data type 4 format.
+    bit_offset: 24
+    bit_size: 5
+fieldset/VC1CFGR4:
+  description: CSI-2 Host virtual channel 1 configuration register 4.
+  fields:
+  - name: DT5
+    description: Data type 5 class selection for virtual channel x.
+    bit_offset: 0
+    bit_size: 6
+  - name: DT5FT
+    description: Data type 5 format.
+    bit_offset: 8
+    bit_size: 5
+  - name: DT6
+    description: Data type 6 class selection for virtual channel x.
+    bit_offset: 16
+    bit_size: 6
+  - name: DT6FT
+    description: Data type 6 format.
+    bit_offset: 24
+    bit_size: 5
+fieldset/VC2CFGR1:
+  description: CSI-2 Host virtual channel 2 configuration register 1.
+  fields:
+  - name: ALLDT
+    description: All data types enable for the virtual channel x.
+    bit_offset: 0
+    bit_size: 1
+  - name: DT0EN
+    description: Data type 0 enable.
+    bit_offset: 1
+    bit_size: 1
+  - name: DT1EN
+    description: Data type 1 enable.
+    bit_offset: 2
+    bit_size: 1
+  - name: DT2EN
+    description: Data type 2 enable.
+    bit_offset: 3
+    bit_size: 1
+  - name: DT3EN
+    description: Data type 3 enable.
+    bit_offset: 4
+    bit_size: 1
+  - name: DT4EN
+    description: Data type 4 enable.
+    bit_offset: 5
+    bit_size: 1
+  - name: DT5EN
+    description: Data type 5 enable.
+    bit_offset: 6
+    bit_size: 1
+  - name: DT6EN
+    description: Data type 6 enable.
+    bit_offset: 7
+    bit_size: 1
+  - name: CDTFT
+    description: Common format for all data types.
+    bit_offset: 8
+    bit_size: 5
+  - name: DT0
+    description: Data type 0 class selection for virtual channel x.
+    bit_offset: 16
+    bit_size: 6
+  - name: DT0FT
+    description: Data type 0 format.
+    bit_offset: 24
+    bit_size: 5
+fieldset/VC2CFGR2:
+  description: CSI-2 Host virtual channel 2 configuration register 2.
+  fields:
+  - name: DT1
+    description: Data type 1 class selection for virtual channel x.
+    bit_offset: 0
+    bit_size: 6
+  - name: DT1FT
+    description: Data type 1 format.
+    bit_offset: 8
+    bit_size: 5
+  - name: DT2
+    description: Data type 2 class selection for virtual channel x.
+    bit_offset: 16
+    bit_size: 6
+  - name: DT2FT
+    description: Data type 2 format.
+    bit_offset: 24
+    bit_size: 5
+fieldset/VC2CFGR3:
+  description: CSI-2 Host virtual channel 2 configuration register 3.
+  fields:
+  - name: DT3
+    description: Data type 3 class selection for virtual channel x.
+    bit_offset: 0
+    bit_size: 6
+  - name: DT3FT
+    description: Data type 3 format.
+    bit_offset: 8
+    bit_size: 5
+  - name: DT4
+    description: Data type 4 class selection for virtual channel x.
+    bit_offset: 16
+    bit_size: 6
+  - name: DT4FT
+    description: Data type 4 format.
+    bit_offset: 24
+    bit_size: 5
+fieldset/VC2CFGR4:
+  description: CSI-2 Host virtual channel 2 configuration register 4.
+  fields:
+  - name: DT5
+    description: Data type 5 class selection for virtual channel x.
+    bit_offset: 0
+    bit_size: 6
+  - name: DT5FT
+    description: Data type 5 format.
+    bit_offset: 8
+    bit_size: 5
+  - name: DT6
+    description: Data type 6 class selection for virtual channel x.
+    bit_offset: 16
+    bit_size: 6
+  - name: DT6FT
+    description: Data type 6 format.
+    bit_offset: 24
+    bit_size: 5
+fieldset/VC3CFGR1:
+  description: CSI-2 Host virtual channel 3 configuration register 1.
+  fields:
+  - name: ALLDT
+    description: All data types enable for the virtual channel x.
+    bit_offset: 0
+    bit_size: 1
+  - name: DT0EN
+    description: Data type 0 enable.
+    bit_offset: 1
+    bit_size: 1
+  - name: DT1EN
+    description: Data type 1 enable.
+    bit_offset: 2
+    bit_size: 1
+  - name: DT2EN
+    description: Data type 2 enable.
+    bit_offset: 3
+    bit_size: 1
+  - name: DT3EN
+    description: Data type 3 enable.
+    bit_offset: 4
+    bit_size: 1
+  - name: DT4EN
+    description: Data type 4 enable.
+    bit_offset: 5
+    bit_size: 1
+  - name: DT5EN
+    description: Data type 5 enable.
+    bit_offset: 6
+    bit_size: 1
+  - name: DT6EN
+    description: Data type 6 enable.
+    bit_offset: 7
+    bit_size: 1
+  - name: CDTFT
+    description: Common format for all data types.
+    bit_offset: 8
+    bit_size: 5
+  - name: DT0
+    description: Data type 0 class selection for virtual channel x.
+    bit_offset: 16
+    bit_size: 6
+  - name: DT0FT
+    description: Data type 0 format.
+    bit_offset: 24
+    bit_size: 5
+fieldset/VC3CFGR2:
+  description: CSI-2 Host virtual channel 3 configuration register 2.
+  fields:
+  - name: DT1
+    description: Data type 1 class selection for virtual channel x.
+    bit_offset: 0
+    bit_size: 6
+  - name: DT1FT
+    description: Data type 1 format.
+    bit_offset: 8
+    bit_size: 5
+  - name: DT2
+    description: Data type 2 class selection for virtual channel x.
+    bit_offset: 16
+    bit_size: 6
+  - name: DT2FT
+    description: Data type 2 format.
+    bit_offset: 24
+    bit_size: 5
+fieldset/VC3CFGR3:
+  description: CSI-2 Host virtual channel 3 configuration register 3.
+  fields:
+  - name: DT3
+    description: Data type 3 class selection for virtual channel x.
+    bit_offset: 0
+    bit_size: 6
+  - name: DT3FT
+    description: Data type 3 format.
+    bit_offset: 8
+    bit_size: 5
+  - name: DT4
+    description: Data type 4 class selection for virtual channel x.
+    bit_offset: 16
+    bit_size: 6
+  - name: DT4FT
+    description: Data type 4 format.
+    bit_offset: 24
+    bit_size: 5
+fieldset/VC3CFGR4:
+  description: CSI-2 Host virtual channel 3 configuration register 4.
+  fields:
+  - name: DT5
+    description: Data type 5 class selection for virtual channel x.
+    bit_offset: 0
+    bit_size: 6
+  - name: DT5FT
+    description: Data type 5 format.
+    bit_offset: 8
+    bit_size: 5
+  - name: DT6
+    description: Data type 6 class selection for virtual channel x.
+    bit_offset: 16
+    bit_size: 6
+  - name: DT6FT
+    description: Data type 6 format.
+    bit_offset: 24
+    bit_size: 5
+fieldset/WDR:
+  description: CSI-2 Host watchdog register.
+  fields:
+  - name: CNT
+    description: Watchdog counter.
+    bit_offset: 0
+    bit_size: 32

--- a/data/registers/dcmipp_v2.yaml
+++ b/data/registers/dcmipp_v2.yaml
@@ -1,0 +1,4787 @@
+block/DCMIPP:
+  description: Digital camera interface pixel pipeline.
+  items:
+  - name: IPGR1
+    description: DCMIPP IPPLUG global register 1.
+    byte_offset: 0
+    fieldset: IPGR1
+  - name: IPGR2
+    description: DCMIPP IPPLUG global register 2.
+    byte_offset: 4
+    fieldset: IPGR2
+  - name: IPGR3
+    description: DCMIPP IPPLUG global register 3.
+    byte_offset: 8
+    fieldset: IPGR3
+  - name: IPGR8
+    description: DCMIPP IPPLUG identification register.
+    byte_offset: 28
+    fieldset: IPGR8
+  - name: IPC1R1
+    description: DCMIPP IPPLUG Clientx register 1.
+    byte_offset: 32
+    fieldset: IPC1R1
+  - name: IPC1R2
+    description: DCMIPP IPPLUG Clientx register 2.
+    byte_offset: 36
+    fieldset: IPC1R2
+  - name: IPC1R3
+    description: DCMIPP IPPLUG Clientx register 3.
+    byte_offset: 40
+    fieldset: IPC1R3
+  - name: IPC2R1
+    description: DCMIPP IPPLUG Clientx register 1.
+    byte_offset: 48
+    fieldset: IPC2R1
+  - name: IPC2R2
+    description: DCMIPP IPPLUG Clientx register 2.
+    byte_offset: 52
+    fieldset: IPC2R2
+  - name: IPC2R3
+    description: DCMIPP IPPLUG Clientx register 3.
+    byte_offset: 56
+    fieldset: IPC2R3
+  - name: IPC3R1
+    description: DCMIPP IPPLUG Clientx register 1.
+    byte_offset: 64
+    fieldset: IPC3R1
+  - name: IPC3R2
+    description: DCMIPP IPPLUG Clientx register 2.
+    byte_offset: 68
+    fieldset: IPC3R2
+  - name: IPC3R3
+    description: DCMIPP IPPLUG Clientx register 3.
+    byte_offset: 72
+    fieldset: IPC3R3
+  - name: IPC4R1
+    description: DCMIPP IPPLUG Clientx register 1.
+    byte_offset: 80
+    fieldset: IPC4R1
+  - name: IPC4R2
+    description: DCMIPP IPPLUG Clientx register 2.
+    byte_offset: 84
+    fieldset: IPC4R2
+  - name: IPC4R3
+    description: DCMIPP IPPLUG Clientx register 3.
+    byte_offset: 88
+    fieldset: IPC4R3
+  - name: IPC5R1
+    description: DCMIPP IPPLUG Clientx register 1.
+    byte_offset: 96
+    fieldset: IPC5R1
+  - name: IPC5R2
+    description: DCMIPP IPPLUG Clientx register 2.
+    byte_offset: 100
+    fieldset: IPC5R2
+  - name: IPC5R3
+    description: DCMIPP IPPLUG Clientx register 3.
+    byte_offset: 104
+    fieldset: IPC5R3
+  - name: PRCR
+    description: DCMIPP parallel interface control register.
+    byte_offset: 260
+    fieldset: PRCR
+  - name: PRESCR
+    description: DCMIPP parallel interface embedded synchronization code register.
+    byte_offset: 264
+    fieldset: PRESCR
+  - name: PRESUR
+    description: DCMIPP parallel interface embedded synchronization unmask register.
+    byte_offset: 268
+    fieldset: PRESUR
+  - name: PRIER
+    description: DCMIPP parallel interface interrupt enable register.
+    byte_offset: 500
+    fieldset: PRIER
+  - name: PRSR
+    description: DCMIPP parallel interface status register.
+    byte_offset: 504
+    fieldset: PRSR
+  - name: PRFCR
+    description: DCMIPP parallel interface interrupt clear register.
+    byte_offset: 508
+    fieldset: PRFCR
+  - name: CMCR
+    description: DCMIPP common configuration register.
+    byte_offset: 516
+    fieldset: CMCR
+  - name: CMFRCR
+    description: DCMIPP common frame counter register.
+    byte_offset: 520
+    fieldset: CMFRCR
+  - name: CMIER
+    description: DCMIPP common interrupt enable register.
+    byte_offset: 1008
+    fieldset: CMIER
+  - name: CMSR1
+    description: DCMIPP common status register 1.
+    byte_offset: 1012
+    fieldset: CMSR1
+  - name: CMSR2
+    description: DCMIPP common status register 2.
+    byte_offset: 1016
+    fieldset: CMSR2
+  - name: CMFCR
+    description: DCMIPP common interrupt clear register.
+    byte_offset: 1020
+    fieldset: CMFCR
+  - name: P0FSCR
+    description: DCMIPP Pipe0 flow selection configuration register.
+    byte_offset: 1028
+    fieldset: P0FSCR
+  - name: P0FCTCR
+    description: DCMIPP Pipe0 flow control configuration register.
+    byte_offset: 1280
+    fieldset: P0FCTCR
+  - name: P0SCSTR
+    description: DCMIPP Pipe0 stat/crop start register.
+    byte_offset: 1284
+    fieldset: P0SCSTR
+  - name: P0SCSZR
+    description: DCMIPP Pipe0 stat/crop size register.
+    byte_offset: 1288
+    fieldset: P0SCSZR
+  - name: P0DCCNTR
+    description: DCMIPP Pipe0 dump counter register.
+    byte_offset: 1456
+    fieldset: P0DCCNTR
+  - name: P0DCLMTR
+    description: DCMIPP Pipe0 dump limit register.
+    byte_offset: 1460
+    fieldset: P0DCLMTR
+  - name: P0PPCR
+    description: DCMIPP Pipe0 pixel packer configuration register.
+    byte_offset: 1472
+    fieldset: P0PPCR
+  - name: P0PPM0AR1
+    description: DCMIPP Pipe0 pixel packer Memory0 address register 1.
+    byte_offset: 1476
+    fieldset: P0PPM0AR1
+  - name: P0PPM0AR2
+    description: DCMIPP Pipe0 pixel packer Memory0 address register 2.
+    byte_offset: 1480
+    fieldset: P0PPM0AR2
+  - name: P0STM0AR
+    description: DCMIPP Pipe0 status Memory0 address register.
+    byte_offset: 1488
+    fieldset: P0STM0AR
+  - name: P0IER
+    description: DCMIPP Pipe0 interrupt enable register.
+    byte_offset: 1524
+    fieldset: P0IER
+  - name: P0SR
+    description: DCMIPP Pipe0 status register.
+    byte_offset: 1528
+    fieldset: P0SR
+  - name: P0FCR
+    description: DCMIPP Pipe0 interrupt clear register.
+    byte_offset: 1532
+    fieldset: P0FCR
+  - name: P0CFSCR
+    description: DCMIPP Pipe0 current flow selection configuration register.
+    byte_offset: 1540
+    fieldset: P0CFSCR
+  - name: P0CFCTCR
+    description: DCMIPP Pipe0 current flow control configuration register.
+    byte_offset: 1792
+    fieldset: P0CFCTCR
+  - name: P0CSCSTR
+    description: DCMIPP Pipe0 current stat/crop start register.
+    byte_offset: 1796
+    fieldset: P0CSCSTR
+  - name: P0CSCSZR
+    description: DCMIPP Pipe0 current stat/crop size register.
+    byte_offset: 1800
+    fieldset: P0CSCSZR
+  - name: P0CPPCR
+    description: DCMIPP Pipe0 current pixel packer configuration register.
+    byte_offset: 1984
+    fieldset: P0CPPCR
+  - name: P0CPPM0AR1
+    description: DCMIPP Pipe0 current pixel packer Memory0 address register 1.
+    byte_offset: 1988
+    fieldset: P0CPPM0AR1
+  - name: P0CPPM0AR2
+    description: DCMIPP Pipe0 current pixel packer Memory0 address register 2.
+    byte_offset: 1992
+    fieldset: P0CPPM0AR2
+  - name: P1FSCR
+    description: DCMIPP Pipe1 flow selection configuration register.
+    byte_offset: 2052
+    fieldset: P1FSCR
+  - name: P1SRCR
+    description: DCMIPP Pipe1 stat removal configuration register.
+    byte_offset: 2080
+    fieldset: P1SRCR
+  - name: P1BPRCR
+    description: DCMIPP Pipe1 bad pixel removal control register.
+    byte_offset: 2084
+    fieldset: P1BPRCR
+  - name: P1BPRSR
+    description: DCMIPP Pipe1 bad pixel removal status register.
+    byte_offset: 2088
+    fieldset: P1BPRSR
+  - name: P1DECR
+    description: DCMIPP Pipe1 decimation register.
+    byte_offset: 2096
+    fieldset: P1DECR
+  - name: P1BLCCR
+    description: DCMIPP Pipe1 black level calibration control register.
+    byte_offset: 2112
+    fieldset: P1BLCCR
+  - name: P1EXCR1
+    description: DCMIPP Pipe1 exposure control register 1.
+    byte_offset: 2116
+    fieldset: P1EXCR1
+  - name: P1EXCR2
+    description: DCMIPP Pipe1 exposure control register 2.
+    byte_offset: 2120
+    fieldset: P1EXCR2
+  - name: P1ST1CR
+    description: DCMIPP Pipe1 statistics1 control register.
+    byte_offset: 2128
+    fieldset: P1ST1CR
+  - name: P1ST2CR
+    description: DCMIPP Pipe1 statistics 2 control register.
+    byte_offset: 2132
+    fieldset: P1ST2CR
+  - name: P1ST3CR
+    description: DCMIPP Pipe1 statistics 3 control register.
+    byte_offset: 2136
+    fieldset: P1ST3CR
+  - name: P1STSTR
+    description: DCMIPP Pipe1 statistics window start register.
+    byte_offset: 2140
+    fieldset: P1STSTR
+  - name: P1STSZR
+    description: DCMIPP Pipe1 statistics window size register.
+    byte_offset: 2144
+    fieldset: P1STSZR
+  - name: P1ST1SR
+    description: DCMIPP Pipe1 statistics 1 status register.
+    byte_offset: 2148
+    fieldset: P1ST1SR
+  - name: P1ST2SR
+    description: DCMIPP Pipe1 statistics 2 status register.
+    byte_offset: 2152
+    fieldset: P1ST2SR
+  - name: P1ST3SR
+    description: DCMIPP Pipe1 statistics 3 status register.
+    byte_offset: 2156
+    fieldset: P1ST3SR
+  - name: P1DMCR
+    description: DCMIPP Pipe1 demosaicing configuration register.
+    byte_offset: 2160
+    fieldset: P1DMCR
+  - name: P1CCCR
+    description: DCMIPP Pipe1 ColorConv configuration register.
+    byte_offset: 2176
+    fieldset: P1CCCR
+  - name: P1CCRR1
+    description: DCMIPP Pipe1 ColorConv red coefficient register 1.
+    byte_offset: 2180
+    fieldset: P1CCRR1
+  - name: P1CCRR2
+    description: DCMIPP Pipe1 ColorConv red coefficient register 2.
+    byte_offset: 2184
+    fieldset: P1CCRR2
+  - name: P1CCGR1
+    description: DCMIPP Pipe1 ColorConv green coefficient register 1.
+    byte_offset: 2188
+    fieldset: P1CCGR1
+  - name: P1CCGR2
+    description: DCMIPP Pipe1 ColorConv green coefficient register 2.
+    byte_offset: 2192
+    fieldset: P1CCGR2
+  - name: P1CCBR1
+    description: DCMIPP Pipex ColorConv blue coefficient register 1.
+    byte_offset: 2196
+    fieldset: P1CCBR1
+  - name: P1CCBR2
+    description: DCMIPP Pipe1 ColorConv blue coefficient register 2.
+    byte_offset: 2200
+    fieldset: P1CCBR2
+  - name: P1CTCR1
+    description: DCMIPP Pipe1 contrast control register 1.
+    byte_offset: 2208
+    fieldset: P1CTCR1
+  - name: P1CTCR2
+    description: DCMIPP Pipe1 contrast control register 2.
+    byte_offset: 2212
+    fieldset: P1CTCR2
+  - name: P1CTCR3
+    description: DCMIPP Pipe1 contrast control register 3.
+    byte_offset: 2216
+    fieldset: P1CTCR3
+  - name: P1FCTCR
+    description: DCMIPP Pipex flow control configuration register.
+    byte_offset: 2304
+    fieldset: P1FCTCR
+  - name: P1CRSTR
+    description: DCMIPP Pipex crop window start register.
+    byte_offset: 2308
+    fieldset: P1CRSTR
+  - name: P1CRSZR
+    description: DCMIPP Pipex crop window size register.
+    byte_offset: 2312
+    fieldset: P1CRSZR
+  - name: P1DCCR
+    description: DCMIPP Pipex decimation register.
+    byte_offset: 2316
+    fieldset: P1DCCR
+  - name: P1DSCR
+    description: DCMIPP Pipex downsize configuration register.
+    byte_offset: 2320
+    fieldset: P1DSCR
+  - name: P1DSRTIOR
+    description: DCMIPP Pipex downsize ratio register.
+    byte_offset: 2324
+    fieldset: P1DSRTIOR
+  - name: P1DSSZR
+    description: DCMIPP Pipex downsize destination size register.
+    byte_offset: 2328
+    fieldset: P1DSSZR
+  - name: P1CMRICR
+    description: DCMIPP Pipex common ROI configuration register.
+    byte_offset: 2336
+    fieldset: P1CMRICR
+  - name: P1RI1CR1
+    description: DCMIPP Pipe1 ROI1 configuration register 1.
+    byte_offset: 2340
+    fieldset: P1RI1CR1
+  - name: P1RI1CR2
+    description: DCMIPP Pipe1 ROI1 configuration register 2.
+    byte_offset: 2344
+    fieldset: P1RI1CR2
+  - name: P1RI2CR1
+    description: DCMIPP Pipe1 ROI2 configuration register 1.
+    byte_offset: 2348
+    fieldset: P1RI2CR1
+  - name: P1RI2CR2
+    description: DCMIPP Pipe1 ROI2 configuration register 2.
+    byte_offset: 2352
+    fieldset: P1RI2CR2
+  - name: P1RI3CR1
+    description: DCMIPP Pipe1 ROI3 configuration register 1.
+    byte_offset: 2356
+    fieldset: P1RI3CR1
+  - name: P1RI3CR2
+    description: DCMIPP Pipe1 ROI3 configuration register 2.
+    byte_offset: 2360
+    fieldset: P1RI3CR2
+  - name: P1RI4CR1
+    description: DCMIPP Pipe1 ROI4 configuration register 1.
+    byte_offset: 2364
+    fieldset: P1RI4CR1
+  - name: P1RI4CR2
+    description: DCMIPP Pipe1 ROI4 configuration register 2.
+    byte_offset: 2368
+    fieldset: P1RI4CR2
+  - name: P1RI5CR1
+    description: DCMIPP Pipe1 ROI5 configuration register 1.
+    byte_offset: 2372
+    fieldset: P1RI5CR1
+  - name: P1RI5CR2
+    description: DCMIPP Pipe1 ROI5 configuration register 2.
+    byte_offset: 2376
+    fieldset: P1RI5CR2
+  - name: P1RI6CR1
+    description: DCMIPP Pipe1 ROI6 configuration register 1.
+    byte_offset: 2380
+    fieldset: P1RI6CR1
+  - name: P1RI6CR2
+    description: DCMIPP Pipe1 ROI6 configuration register 2.
+    byte_offset: 2384
+    fieldset: P1RI6CR2
+  - name: P1RI7CR1
+    description: DCMIPP Pipe1 ROI7 configuration register 1.
+    byte_offset: 2388
+    fieldset: P1RI7CR1
+  - name: P1RI7CR2
+    description: DCMIPP Pipe1 ROI7 configuration register 2.
+    byte_offset: 2392
+    fieldset: P1RI7CR2
+  - name: P1RI8CR1
+    description: DCMIPP Pipe1 ROI8 configuration register 1.
+    byte_offset: 2396
+    fieldset: P1RI8CR1
+  - name: P1RI8CR2
+    description: DCMIPP Pipe1 ROI8 configuration register 2.
+    byte_offset: 2400
+    fieldset: P1RI8CR2
+  - name: P1GMCR
+    description: DCMIPP Pipex gamma configuration register.
+    byte_offset: 2416
+    fieldset: P1GMCR
+  - name: P1YUVCR
+    description: DCMIPP Pipe1 YUVConv configuration register.
+    byte_offset: 2432
+    fieldset: P1YUVCR
+  - name: P1YUVRR1
+    description: DCMIPP Pipe1 YUVConv red coefficient register 1.
+    byte_offset: 2436
+    fieldset: P1YUVRR1
+  - name: P1YUVRR2
+    description: DCMIPP Pipe1 YUVConv red coefficient register 2.
+    byte_offset: 2440
+    fieldset: P1YUVRR2
+  - name: P1YUVGR1
+    description: DCMIPP Pipe1 YUVConv green coefficient register 1.
+    byte_offset: 2444
+    fieldset: P1YUVGR1
+  - name: P1YUVGR2
+    description: DCMIPP Pipe1 YUVConv green coefficient register 2.
+    byte_offset: 2448
+    fieldset: P1YUVGR2
+  - name: P1YUVBR1
+    description: DCMIPP Pipe1 YUVConv blue coefficient register 1.
+    byte_offset: 2452
+    fieldset: P1YUVBR1
+  - name: P1YUVBR2
+    description: DCMIPP Pipe1 YUV blue coefficient register 2.
+    byte_offset: 2456
+    fieldset: P1YUVBR2
+  - name: P1PPCR
+    description: DCMIPP Pipe1 pixel packer configuration register.
+    byte_offset: 2496
+    fieldset: P1PPCR
+  - name: P1PPM0AR1
+    description: DCMIPP Pipe1 pixel packer Memory0 address register 1.
+    byte_offset: 2500
+    fieldset: P1PPM0AR1
+  - name: P1PPM0AR2
+    description: DCMIPP Pipe1 pixel packer Memory0 address register 2.
+    byte_offset: 2504
+    fieldset: P1PPM0AR2
+  - name: P1PPM0PR
+    description: DCMIPP Pipex pixel packer Memory0 pitch register.
+    byte_offset: 2508
+    fieldset: P1PPM0PR
+  - name: P1STM0AR
+    description: DCMIPP Pipex status Memory0 address register.
+    byte_offset: 2512
+    fieldset: P1STM0AR
+  - name: P1PPM1AR1
+    description: DCMIPP Pipex pixel packer Memory1 address register 1.
+    byte_offset: 2516
+    fieldset: P1PPM1AR1
+  - name: P1PPM1AR2
+    description: DCMIPP Pipex pixel packer Memory1 address register 2.
+    byte_offset: 2520
+    fieldset: P1PPM1AR2
+  - name: P1PPM1PR
+    description: DCMIPP Pipex pixel packer Memory1 pitch register.
+    byte_offset: 2524
+    fieldset: P1PPM1PR
+  - name: P1STM1AR
+    description: DCMIPP Pipex status Memory1 address register.
+    byte_offset: 2528
+    fieldset: P1STM1AR
+  - name: P1PPM2AR1
+    description: DCMIPP Pipex pixel packer memory2 address register 1.
+    byte_offset: 2532
+    fieldset: P1PPM2AR1
+  - name: P1PPM2AR2
+    description: DCMIPP Pipex pixel packer memory2 address register 2.
+    byte_offset: 2536
+    fieldset: P1PPM2AR2
+  - name: P1STM2AR
+    description: DCMIPP Pipex status Memory2 address register.
+    byte_offset: 2544
+    fieldset: P1STM2AR
+  - name: P1IER
+    description: DCMIPP Pipe1 interrupt enable register.
+    byte_offset: 2548
+    fieldset: P1IER
+  - name: P1SR
+    description: DCMIPP Pipe1 status register.
+    byte_offset: 2552
+    fieldset: P1SR
+  - name: P1FCR
+    description: DCMIPP Pipe1 interrupt clear register.
+    byte_offset: 2556
+    fieldset: P1FCR
+  - name: P1CFSCR
+    description: DCMIPP Pipe1 current flow selection configuration register.
+    byte_offset: 2564
+    fieldset: P1CFSCR
+  - name: P1CBPRCR
+    description: DCMIPP Pipe1 current bad pixel removal register.
+    byte_offset: 2596
+    fieldset: P1CBPRCR
+  - name: P1CBLCCR
+    description: DCMIPP Pipe1 current black level calibration control register.
+    byte_offset: 2624
+    fieldset: P1CBLCCR
+  - name: P1CEXCR1
+    description: DCMIPP Pipe1 current exposure control register 1.
+    byte_offset: 2628
+    fieldset: P1CEXCR1
+  - name: P1CEXCR2
+    description: DCMIPP Pipe1 current exposure control register 2.
+    byte_offset: 2632
+    fieldset: P1CEXCR2
+  - name: P1CST1CR
+    description: DCMIPP Pipe1 current statistics 1 control register.
+    byte_offset: 2640
+    fieldset: P1CST1CR
+  - name: P1CST2CR
+    description: DCMIPP Pipe1 current statistics 2 control register.
+    byte_offset: 2644
+    fieldset: P1CST2CR
+  - name: P1CST3CR
+    description: DCMIPP Pipe1 current statistics 3 control register.
+    byte_offset: 2648
+    fieldset: P1CST3CR
+  - name: P1CSTSTR
+    description: DCMIPP Pipe1 current statistics window start register.
+    byte_offset: 2652
+    fieldset: P1CSTSTR
+  - name: P1CSTSZR
+    description: DCMIPP Pipe1 current statistics window size register.
+    byte_offset: 2656
+    fieldset: P1CSTSZR
+  - name: P1CCCCR
+    description: DCMIPP Pipe1 current ColorConv configuration register.
+    byte_offset: 2688
+    fieldset: P1CCCCR
+  - name: P1CCCRR1
+    description: DCMIPP Pipe1 current ColorConv red coefficient register 1.
+    byte_offset: 2692
+    fieldset: P1CCCRR1
+  - name: P1CCCRR2
+    description: DCMIPP Pipe1 current ColorConv red coefficient register 2.
+    byte_offset: 2696
+    fieldset: P1CCCRR2
+  - name: P1CCCGR1
+    description: DCMIPP Pipe1 current ColorConv green coefficient register 1.
+    byte_offset: 2700
+    fieldset: P1CCCGR1
+  - name: P1CCCGR2
+    description: DCMIPP Pipe1 current ColorConv green coefficient register 2.
+    byte_offset: 2704
+    fieldset: P1CCCGR2
+  - name: P1CCCBR1
+    description: DCMIPP Pipex current ColorConv blue coefficient register 1.
+    byte_offset: 2708
+    fieldset: P1CCCBR1
+  - name: P1CCCBR2
+    description: DCMIPP Pipe1 current ColorConv blue coefficient register 2.
+    byte_offset: 2712
+    fieldset: P1CCCBR2
+  - name: P1CCTCR1
+    description: DCMIPP Pipe1 current contrast control register 1.
+    byte_offset: 2720
+    fieldset: P1CCTCR1
+  - name: P1CCTCR2
+    description: DCMIPP Pipe1 current contrast control register 2.
+    byte_offset: 2724
+    fieldset: P1CCTCR2
+  - name: P1CCTCR3
+    description: DCMIPP Pipe1 current contrast control register 3.
+    byte_offset: 2728
+    fieldset: P1CCTCR3
+  - name: P1CFCTCR
+    description: DCMIPP Pipex current flow control configuration register.
+    byte_offset: 2816
+    fieldset: P1CFCTCR
+  - name: P1CCRSTR
+    description: DCMIPP Pipex current crop window start register.
+    byte_offset: 2820
+    fieldset: P1CCRSTR
+  - name: P1CCRSZR
+    description: DCMIPP Pipex current crop window size register.
+    byte_offset: 2824
+    fieldset: P1CCRSZR
+  - name: P1CDCCR
+    description: DCMIPP Pipex current decimation register.
+    byte_offset: 2828
+    fieldset: P1CDCCR
+  - name: P1CDSCR
+    description: DCMIPP Pipex current downsize configuration register.
+    byte_offset: 2832
+    fieldset: P1CDSCR
+  - name: P1CDSRTIOR
+    description: DCMIPP Pipex current downsize ratio register.
+    byte_offset: 2836
+    fieldset: P1CDSRTIOR
+  - name: P1CDSSZR
+    description: DCMIPP Pipex current downsize destination size register.
+    byte_offset: 2840
+    fieldset: P1CDSSZR
+  - name: P1CCMRICR
+    description: DCMIPP Pipex current common ROI configuration register.
+    byte_offset: 2848
+    fieldset: P1CCMRICR
+  - name: P1CRI1CR1
+    description: DCMIPP Pipe1 current ROI1 configuration register 1.
+    byte_offset: 2852
+    fieldset: P1CRI1CR1
+  - name: P1CRI1CR2
+    description: DCMIPP Pipe1 current ROI1 configuration register 2.
+    byte_offset: 2856
+    fieldset: P1CRI1CR2
+  - name: P1CRI2CR1
+    description: DCMIPP Pipe1 current ROI2 configuration register 1.
+    byte_offset: 2860
+    fieldset: P1CRI2CR1
+  - name: P1CRI2CR2
+    description: DCMIPP Pipe1 current ROI2 configuration register 2.
+    byte_offset: 2864
+    fieldset: P1CRI2CR2
+  - name: P1CRI3CR1
+    description: DCMIPP Pipe1 current ROI3 configuration register 1.
+    byte_offset: 2868
+    fieldset: P1CRI3CR1
+  - name: P1CRI3CR2
+    description: DCMIPP Pipe1 current ROI3 configuration register 2.
+    byte_offset: 2872
+    fieldset: P1CRI3CR2
+  - name: P1CRI4CR1
+    description: DCMIPP Pipe1 current ROI4 configuration register 1.
+    byte_offset: 2876
+    fieldset: P1CRI4CR1
+  - name: P1CRI4CR2
+    description: DCMIPP Pipe1 current ROI4 configuration register 2.
+    byte_offset: 2880
+    fieldset: P1CRI4CR2
+  - name: P1CRI5CR1
+    description: DCMIPP Pipe1 current ROI5 configuration register 1.
+    byte_offset: 2884
+    fieldset: P1CRI5CR1
+  - name: P1CRI5CR2
+    description: DCMIPP Pipe1 current ROI5 configuration register 2.
+    byte_offset: 2888
+    fieldset: P1CRI5CR2
+  - name: P1CRI6CR1
+    description: DCMIPP Pipe1 current ROI6 configuration register 1.
+    byte_offset: 2892
+    fieldset: P1CRI6CR1
+  - name: P1CRI6CR2
+    description: DCMIPP Pipe1 current ROI6 configuration register 2.
+    byte_offset: 2896
+    fieldset: P1CRI6CR2
+  - name: P1CRI7CR1
+    description: DCMIPP Pipe1 current ROI7 configuration register 1.
+    byte_offset: 2900
+    fieldset: P1CRI7CR1
+  - name: P1CRI7CR2
+    description: DCMIPP Pipe1 current ROI7 configuration register 2.
+    byte_offset: 2904
+    fieldset: P1CRI7CR2
+  - name: P1CRI8CR1
+    description: DCMIPP Pipe1 current ROI8 configuration register 1.
+    byte_offset: 2908
+    fieldset: P1CRI8CR1
+  - name: P1CRI8CR2
+    description: DCMIPP Pipe1 current ROI8 configuration register 2.
+    byte_offset: 2912
+    fieldset: P1CRI8CR2
+  - name: P1CPPCR
+    description: DCMIPP Pipe1 current pixel packer configuration register.
+    byte_offset: 3008
+    fieldset: P1CPPCR
+  - name: P1CPPM0AR1
+    description: DCMIPP Pipe1 current pixel packer Memory0 address register 1.
+    byte_offset: 3012
+    fieldset: P1CPPM0AR1
+  - name: P1CPPM0AR2
+    description: DCMIPP Pipe1 current pixel packer Memory0 address register 2.
+    byte_offset: 3016
+    fieldset: P1CPPM0AR2
+  - name: P1CPPM0PR
+    description: DCMIPP Pipex current pixel packer Memory0 pitch register.
+    byte_offset: 3020
+    fieldset: P1CPPM0PR
+  - name: P1CPPM1AR1
+    description: DCMIPP Pipex current pixel packer Memory1 address register 1.
+    byte_offset: 3028
+    fieldset: P1CPPM1AR1
+  - name: P1CPPM1AR2
+    description: DCMIPP Pipex current pixel packer Memory1 address register 2.
+    byte_offset: 3032
+    fieldset: P1CPPM1AR2
+  - name: P1CPPM1PR
+    description: DCMIPP Pipex current pixel packer Memory1 pitch register.
+    byte_offset: 3036
+    fieldset: P1CPPM1PR
+  - name: P1CPPM2AR1
+    description: DCMIPP Pipex current pixel packer Memory2 address register 1.
+    byte_offset: 3044
+    fieldset: P1CPPM2AR1
+  - name: P1CPPM2AR2
+    description: DCMIPP Pipex current pixel packer Memory2 address register 1.
+    byte_offset: 3048
+    fieldset: P1CPPM2AR2
+  - name: P2FSCR
+    description: DCMIPP Pipe2 flow selection configuration register.
+    byte_offset: 3076
+    fieldset: P2FSCR
+  - name: P2FCTCR
+    description: DCMIPP Pipex flow control configuration register.
+    byte_offset: 3328
+    fieldset: P2FCTCR
+  - name: P2CRSTR
+    description: DCMIPP Pipex crop window start register.
+    byte_offset: 3332
+    fieldset: P2CRSTR
+  - name: P2CRSZR
+    description: DCMIPP Pipex crop window size register.
+    byte_offset: 3336
+    fieldset: P2CRSZR
+  - name: P2DCCR
+    description: DCMIPP Pipex decimation register.
+    byte_offset: 3340
+    fieldset: P2DCCR
+  - name: P2DSCR
+    description: DCMIPP Pipex downsize configuration register.
+    byte_offset: 3344
+    fieldset: P2DSCR
+  - name: P2DSRTIOR
+    description: DCMIPP Pipex downsize ratio register.
+    byte_offset: 3348
+    fieldset: P2DSRTIOR
+  - name: P2DSSZR
+    description: DCMIPP Pipex downsize destination size register.
+    byte_offset: 3352
+    fieldset: P2DSSZR
+  - name: P2CMRICR
+    description: DCMIPP Pipex common ROI configuration register.
+    byte_offset: 3360
+    fieldset: P2CMRICR
+  - name: P2RI1CR1
+    description: DCMIPP Pipe2 ROI1 configuration register 1.
+    byte_offset: 3364
+    fieldset: P2RI1CR1
+  - name: P2RI1CR2
+    description: DCMIPP Pipe2 ROI1 configuration register 2.
+    byte_offset: 3368
+    fieldset: P2RI1CR2
+  - name: P2RI2CR1
+    description: DCMIPP Pipe2 ROI2 configuration register 1.
+    byte_offset: 3372
+    fieldset: P2RI2CR1
+  - name: P2RI2CR2
+    description: DCMIPP Pipe2 ROI2 configuration register 2.
+    byte_offset: 3376
+    fieldset: P2RI2CR2
+  - name: P2RI3CR1
+    description: DCMIPP Pipe2 ROI3 configuration register 1.
+    byte_offset: 3380
+    fieldset: P2RI3CR1
+  - name: P2RI3CR2
+    description: DCMIPP Pipe2 ROI3 configuration register 2.
+    byte_offset: 3384
+    fieldset: P2RI3CR2
+  - name: P2RI4CR1
+    description: DCMIPP Pipe2 ROI4 configuration register 1.
+    byte_offset: 3388
+    fieldset: P2RI4CR1
+  - name: P2RI4CR2
+    description: DCMIPP Pipe2 ROI4 configuration register 2.
+    byte_offset: 3392
+    fieldset: P2RI4CR2
+  - name: P2RI5CR1
+    description: DCMIPP Pipe2 ROI5 configuration register 1.
+    byte_offset: 3396
+    fieldset: P2RI5CR1
+  - name: P2RI5CR2
+    description: DCMIPP Pipe2 ROI5 configuration register 2.
+    byte_offset: 3400
+    fieldset: P2RI5CR2
+  - name: P2RI6CR1
+    description: DCMIPP Pipe2 ROI6 configuration register 1.
+    byte_offset: 3404
+    fieldset: P2RI6CR1
+  - name: P2RI6CR2
+    description: DCMIPP Pipe2 ROI6 configuration register 2.
+    byte_offset: 3408
+    fieldset: P2RI6CR2
+  - name: P2RI7CR1
+    description: DCMIPP Pipe2 ROI7 configuration register 1.
+    byte_offset: 3412
+    fieldset: P2RI7CR1
+  - name: P2RI7CR2
+    description: DCMIPP Pipe2 ROI7 configuration register 2.
+    byte_offset: 3416
+    fieldset: P2RI7CR2
+  - name: P2RI8CR1
+    description: DCMIPP Pipe2 ROI8 configuration register 1.
+    byte_offset: 3420
+    fieldset: P2RI8CR1
+  - name: P2RI8CR2
+    description: DCMIPP Pipe2 ROI8 configuration register 2.
+    byte_offset: 3424
+    fieldset: P2RI8CR2
+  - name: P2GMCR
+    description: DCMIPP Pipex gamma configuration register.
+    byte_offset: 3440
+    fieldset: P2GMCR
+  - name: P2PPCR
+    description: DCMIPP Pipe2 pixel packer configuration register.
+    byte_offset: 3520
+    fieldset: P2PPCR
+  - name: P2PPM0AR1
+    description: DCMIPP Pipe2 pixel packer Memory0 address register 1.
+    byte_offset: 3524
+    fieldset: P2PPM0AR1
+  - name: P2PPM0AR2
+    description: DCMIPP Pipe2 pixel packer Memory0 address register 2.
+    byte_offset: 3528
+    fieldset: P2PPM0AR2
+  - name: P2PPM0PR
+    description: DCMIPP Pipex pixel packer Memory0 pitch register.
+    byte_offset: 3532
+    fieldset: P2PPM0PR
+  - name: P2STM0AR
+    description: DCMIPP Pipex status Memory0 address register.
+    byte_offset: 3536
+    fieldset: P2STM0AR
+  - name: P2IER
+    description: DCMIPP Pipe2 interrupt enable register.
+    byte_offset: 3572
+    fieldset: P2IER
+  - name: P2SR
+    description: DCMIPP Pipe2 status register.
+    byte_offset: 3576
+    fieldset: P2SR
+  - name: P2FCR
+    description: DCMIPP Pipe2 interrupt clear register.
+    byte_offset: 3580
+    fieldset: P2FCR
+  - name: P2CFSCR
+    description: DCMIPP Pipe2 current flow selection configuration register.
+    byte_offset: 3588
+    fieldset: P2CFSCR
+  - name: P2CFCTCR
+    description: DCMIPP Pipex current flow control configuration register.
+    byte_offset: 3840
+    fieldset: P2CFCTCR
+  - name: P2CCRSTR
+    description: DCMIPP Pipex current crop window start register.
+    byte_offset: 3844
+    fieldset: P2CCRSTR
+  - name: P2CCRSZR
+    description: DCMIPP Pipex current crop window size register.
+    byte_offset: 3848
+    fieldset: P2CCRSZR
+  - name: P2CDCCR
+    description: DCMIPP Pipex current decimation register.
+    byte_offset: 3852
+    fieldset: P2CDCCR
+  - name: P2CDSCR
+    description: DCMIPP Pipex current downsize configuration register.
+    byte_offset: 3856
+    fieldset: P2CDSCR
+  - name: P2CDSRTIOR
+    description: DCMIPP Pipex current downsize ratio register.
+    byte_offset: 3860
+    fieldset: P2CDSRTIOR
+  - name: P2CDSSZR
+    description: DCMIPP Pipex current downsize destination size register.
+    byte_offset: 3864
+    fieldset: P2CDSSZR
+  - name: P2CCMRICR
+    description: DCMIPP Pipex current common ROI configuration register.
+    byte_offset: 3872
+    fieldset: P2CCMRICR
+  - name: P2CRI1CR1
+    description: DCMIPP Pipe2 current ROI1 configuration register 1.
+    byte_offset: 3876
+    fieldset: P2CRI1CR1
+  - name: P2CRI1CR2
+    description: DCMIPP Pipe2 current ROI1 configuration register 2.
+    byte_offset: 3880
+    fieldset: P2CRI1CR2
+  - name: P2CRI2CR1
+    description: DCMIPP Pipe2 current ROI2 configuration register 1.
+    byte_offset: 3884
+    fieldset: P2CRI2CR1
+  - name: P2CRI2CR2
+    description: DCMIPP Pipe2 current ROI2 configuration register 2.
+    byte_offset: 3888
+    fieldset: P2CRI2CR2
+  - name: P2CRI3CR1
+    description: DCMIPP Pipe2 current ROI3 configuration register 1.
+    byte_offset: 3892
+    fieldset: P2CRI3CR1
+  - name: P2CRI3CR2
+    description: DCMIPP Pipe2 current ROI3 configuration register 2.
+    byte_offset: 3896
+    fieldset: P2CRI3CR2
+  - name: P2CRI4CR1
+    description: DCMIPP Pipe2 current ROI4 configuration register 1.
+    byte_offset: 3900
+    fieldset: P2CRI4CR1
+  - name: P2CRI4CR2
+    description: DCMIPP Pipe2 current ROI4 configuration register 2.
+    byte_offset: 3904
+    fieldset: P2CRI4CR2
+  - name: P2CRI5CR1
+    description: DCMIPP Pipe2 current ROI5 configuration register 1.
+    byte_offset: 3908
+    fieldset: P2CRI5CR1
+  - name: P2CRI5CR2
+    description: DCMIPP Pipe2 current ROI5 configuration register 2.
+    byte_offset: 3912
+    fieldset: P2CRI5CR2
+  - name: P2CRI6CR1
+    description: DCMIPP Pipe2 current ROI6 configuration register 1.
+    byte_offset: 3916
+    fieldset: P2CRI6CR1
+  - name: P2CRI6CR2
+    description: DCMIPP Pipe2 current ROI6 configuration register 2.
+    byte_offset: 3920
+    fieldset: P2CRI6CR2
+  - name: P2CRI7CR1
+    description: DCMIPP Pipe2 current ROI7 configuration register 1.
+    byte_offset: 3924
+    fieldset: P2CRI7CR1
+  - name: P2CRI7CR2
+    description: DCMIPP Pipe2 current ROI7 configuration register 2.
+    byte_offset: 3928
+    fieldset: P2CRI7CR2
+  - name: P2CRI8CR1
+    description: DCMIPP Pipe2 current ROI8 configuration register 1.
+    byte_offset: 3932
+    fieldset: P2CRI8CR1
+  - name: P2CRI8CR2
+    description: DCMIPP Pipe2 current ROI8 configuration register 2.
+    byte_offset: 3936
+    fieldset: P2CRI8CR2
+  - name: P2CPPCR
+    description: DCMIPP Pipe2 current pixel packer configuration register.
+    byte_offset: 4032
+    fieldset: P2CPPCR
+  - name: P2CPPM0AR1
+    description: DCMIPP Pipe2 current pixel packer Memory0 address register 1.
+    byte_offset: 4036
+    fieldset: P2CPPM0AR1
+  - name: P2CPPM0AR2
+    description: DCMIPP Pipe2 current pixel packer Memory0 address register 2.
+    byte_offset: 4040
+    fieldset: P2CPPM0AR2
+fieldset/CMCR:
+  description: DCMIPP common configuration register.
+  fields:
+  - name: INSEL
+    description: input selection.
+    bit_offset: 0
+    bit_size: 1
+  - name: PSFC
+    description: Pipe selection for the frame counter.
+    bit_offset: 1
+    bit_size: 2
+  - name: CFC
+    description: Clear frame counter.
+    bit_offset: 4
+    bit_size: 1
+  - name: SWAPRB
+    description: Swap R/U and B/V.
+    bit_offset: 7
+    bit_size: 1
+fieldset/CMFCR:
+  description: DCMIPP common interrupt clear register.
+  fields:
+  - name: CATXERRF
+    description: AXI transfer error interrupt status clear.
+    bit_offset: 5
+    bit_size: 1
+  - name: CPRERRF
+    description: Synchronization error interrupt status clear.
+    bit_offset: 6
+    bit_size: 1
+  - name: CP0LINEF
+    description: Multi-line capture complete interrupt status clear.
+    bit_offset: 8
+    bit_size: 1
+  - name: CP0FRAMEF
+    description: Frame capture complete interrupt status clear.
+    bit_offset: 9
+    bit_size: 1
+  - name: CP0VSYNCF
+    description: Vertical synchronization interrupt status clear.
+    bit_offset: 10
+    bit_size: 1
+  - name: CP0LIMITF
+    description: limit interrupt status clear.
+    bit_offset: 14
+    bit_size: 1
+  - name: CP0OVRF
+    description: Overrun interrupt status clear.
+    bit_offset: 15
+    bit_size: 1
+  - name: CP1LINEF
+    description: Multi-line capture complete interrupt status clear.
+    bit_offset: 16
+    bit_size: 1
+  - name: CP1FRAMEF
+    description: Frame capture complete interrupt status clear.
+    bit_offset: 17
+    bit_size: 1
+  - name: CP1VSYNCF
+    description: Vertical synchronization interrupt status clear.
+    bit_offset: 18
+    bit_size: 1
+  - name: CP1OVRF
+    description: Overrun interrupt status clear.
+    bit_offset: 23
+    bit_size: 1
+  - name: CP2LINEF
+    description: Multi-line capture complete interrupt status clear.
+    bit_offset: 24
+    bit_size: 1
+  - name: CP2FRAMEF
+    description: Frame capture complete interrupt status clear.
+    bit_offset: 25
+    bit_size: 1
+  - name: CP2VSYNCF
+    description: Vertical synchronization interrupt status clear.
+    bit_offset: 26
+    bit_size: 1
+  - name: CP2OVRF
+    description: Overrun interrupt status clear.
+    bit_offset: 31
+    bit_size: 1
+fieldset/CMFRCR:
+  description: DCMIPP common frame counter register.
+  fields:
+  - name: FRMCNT
+    description: Frame counter, read-only, loops around.
+    bit_offset: 0
+    bit_size: 32
+fieldset/CMIER:
+  description: DCMIPP common interrupt enable register.
+  fields:
+  - name: ATXERRIE
+    description: AXI transfer error interrupt enable for IPPLUG.
+    bit_offset: 5
+    bit_size: 1
+  - name: PRERRIE
+    description: Limit interrupt enable for the parallel Interface.
+    bit_offset: 6
+    bit_size: 1
+  - name: P0LINEIE
+    description: Multi-line capture complete interrupt enable for Pipe0.
+    bit_offset: 8
+    bit_size: 1
+  - name: P0FRAMEIE
+    description: Frame capture complete interrupt enable for Pipe0.
+    bit_offset: 9
+    bit_size: 1
+  - name: P0VSYNCIE
+    description: Vertical sync interrupt enable for Pipe0.
+    bit_offset: 10
+    bit_size: 1
+  - name: P0LIMITIE
+    description: Limit interrupt enable for Pipe0.
+    bit_offset: 14
+    bit_size: 1
+  - name: P0OVRIE
+    description: Overrun interrupt enable for Pipe0.
+    bit_offset: 15
+    bit_size: 1
+  - name: P1LINEIE
+    description: Multi-line capture complete interrupt status clear for Pipe1.
+    bit_offset: 16
+    bit_size: 1
+  - name: P1FRAMEIE
+    description: Frame capture complete interrupt enable for Pipe1.
+    bit_offset: 17
+    bit_size: 1
+  - name: P1VSYNCIE
+    description: Vertical sync interrupt enable for Pipe1.
+    bit_offset: 18
+    bit_size: 1
+  - name: P1OVRIE
+    description: Overrun interrupt enable for Pipe1.
+    bit_offset: 23
+    bit_size: 1
+  - name: P2LINEIE
+    description: Multi-line capture complete interrupt enable for Pipe2.
+    bit_offset: 24
+    bit_size: 1
+  - name: P2FRAMEIE
+    description: Frame capture complete interrupt enable for Pipe2.
+    bit_offset: 25
+    bit_size: 1
+  - name: P2VSYNCIE
+    description: Vertical sync interrupt enable for Pipe2.
+    bit_offset: 26
+    bit_size: 1
+  - name: P2OVRIE
+    description: Overrun interrupt status enable for Pipe2.
+    bit_offset: 31
+    bit_size: 1
+fieldset/CMSR1:
+  description: DCMIPP common status register 1.
+  fields:
+  - name: PRHSYNC
+    description: This bit gives the state of the HSYNC pin with the correct programmed polarity on the parallel interface if ENABLE bit is set into the DCMIPP_PRCR register and if the pixel clock is received. It is set during the blanking period whatever the polarity selected in HPOL bit of the DCMIPP_PRCR register, and cleared otherwise.
+    bit_offset: 0
+    bit_size: 1
+  - name: PRVSYNC
+    description: This bit gives the state of the VSYNC pin with the correct programmed polarity on the parallel interface if ENABLE bit is set into the DCMIPP_PRCR register and if the pixel clock is received. It is set during the blanking period whatever the polarity selected in VPOL bit of the DCMIPP_PRCR register, and cleared otherwise.
+    bit_offset: 1
+    bit_size: 1
+  - name: P0LSTLINE
+    description: Last line LSB bit, sampled at Frame capture complete event for Pipe0.
+    bit_offset: 8
+    bit_size: 1
+  - name: P0LSTFRM
+    description: Last frame LSB bit, sampled at Frame capture complete event for Pipe0.
+    bit_offset: 9
+    bit_size: 1
+  - name: P0CPTACT
+    description: Active frame capture (active from start-of-frame to frame complete) for Pipe0.
+    bit_offset: 15
+    bit_size: 1
+  - name: P1LSTLINE
+    description: Last line LSB bit, sampled at Frame capture complete event for Pipe1.
+    bit_offset: 16
+    bit_size: 1
+  - name: P1LSTFRM
+    description: Last frame LSB bit, sampled at frame capture complete event for Pipe1.
+    bit_offset: 17
+    bit_size: 1
+  - name: P1CPTACT
+    description: Active frame capture (active from start-of-frame to frame complete) for Pipe1.
+    bit_offset: 23
+    bit_size: 1
+  - name: P2LSTLINE
+    description: Last line LSB bit, sampled at frame capture complete event for Pipe2.
+    bit_offset: 24
+    bit_size: 1
+  - name: P2LSTFRM
+    description: Last frame LSB bit, sampled at frame capture complete event for Pipe2.
+    bit_offset: 25
+    bit_size: 1
+  - name: P2CPTACT
+    description: Active frame capture (active from start-of-frame to frame complete) for Pipe2.
+    bit_offset: 31
+    bit_size: 1
+fieldset/CMSR2:
+  description: DCMIPP common status register 2.
+  fields:
+  - name: ATXERRF
+    description: AXI transfer error interrupt status flag for the IPPLUG.
+    bit_offset: 5
+    bit_size: 1
+  - name: PRERRF
+    description: Synchronization error raw interrupt status for the parallel interface.
+    bit_offset: 6
+    bit_size: 1
+  - name: P0LINEF
+    description: Multi-line capture completed raw interrupt status for Pipe0.
+    bit_offset: 8
+    bit_size: 1
+  - name: P0FRAMEF
+    description: Frame capture completed raw interrupt status for Pipe0.
+    bit_offset: 9
+    bit_size: 1
+  - name: P0VSYNCF
+    description: VSYNC raw interrupt status for Pipe0.
+    bit_offset: 10
+    bit_size: 1
+  - name: P0LIMITF
+    description: Limit raw interrupt status for Pipe0.
+    bit_offset: 14
+    bit_size: 1
+  - name: P0OVRF
+    description: Overrun raw interrupt status for Pipe0.
+    bit_offset: 15
+    bit_size: 1
+  - name: P1LINEF
+    description: Multi-line capture completed raw interrupt status for Pipe1.
+    bit_offset: 16
+    bit_size: 1
+  - name: P1FRAMEF
+    description: Frame capture completed raw interrupt status for Pipe1.
+    bit_offset: 17
+    bit_size: 1
+  - name: P1VSYNCF
+    description: VSYNC raw interrupt status for Pipe1.
+    bit_offset: 18
+    bit_size: 1
+  - name: P1OVRF
+    description: Overrun raw interrupt status for Pipe1.
+    bit_offset: 23
+    bit_size: 1
+  - name: P2LINEF
+    description: Multi-line capture completed raw interrupt status for Pipe2.
+    bit_offset: 24
+    bit_size: 1
+  - name: P2FRAMEF
+    description: Frame capture completed raw interrupt status for Pipe2.
+    bit_offset: 25
+    bit_size: 1
+  - name: P2VSYNCF
+    description: VSYNC raw interrupt status for Pipe2.
+    bit_offset: 26
+    bit_size: 1
+  - name: P2OVRF
+    description: Overrun raw interrupt status for Pipe2.
+    bit_offset: 31
+    bit_size: 1
+fieldset/IPC1R1:
+  description: DCMIPP IPPLUG Clientx register 1.
+  fields:
+  - name: TRAFFIC
+    description: Burst size as power of 2 of 8-byte units.
+    bit_offset: 0
+    bit_size: 3
+  - name: OTR
+    description: Maximum outstanding transactions.
+    bit_offset: 8
+    bit_size: 4
+fieldset/IPC1R2:
+  description: DCMIPP IPPLUG Clientx register 2.
+  fields:
+  - name: SVCMAPPING
+    description: Non-user, must be kept at reset value.
+    bit_offset: 8
+    bit_size: 4
+  - name: WLRU
+    description: Ratio for WLRU[3:0] arbitration.
+    bit_offset: 16
+    bit_size: 4
+fieldset/IPC1R3:
+  description: DCMIPP IPPLUG Clientx register 3.
+  fields:
+  - name: DPREGSTART
+    description: Start word (AXI width = 64 bits) of the FIFO of Clientx.
+    bit_offset: 0
+    bit_size: 10
+  - name: DPREGEND
+    description: End word (AXI width = 64 bits) of the FIFO of Clientx.
+    bit_offset: 16
+    bit_size: 10
+fieldset/IPC2R1:
+  description: DCMIPP IPPLUG Clientx register 1.
+  fields:
+  - name: TRAFFIC
+    description: Burst size as power of 2 of 8-byte units.
+    bit_offset: 0
+    bit_size: 3
+  - name: OTR
+    description: Maximum outstanding transactions.
+    bit_offset: 8
+    bit_size: 4
+fieldset/IPC2R2:
+  description: DCMIPP IPPLUG Clientx register 2.
+  fields:
+  - name: SVCMAPPING
+    description: Non-user, must be kept at reset value.
+    bit_offset: 8
+    bit_size: 4
+  - name: WLRU
+    description: Ratio for WLRU[3:0] arbitration.
+    bit_offset: 16
+    bit_size: 4
+fieldset/IPC2R3:
+  description: DCMIPP IPPLUG Clientx register 3.
+  fields:
+  - name: DPREGSTART
+    description: Start word (AXI width = 64 bits) of the FIFO of Clientx.
+    bit_offset: 0
+    bit_size: 10
+  - name: DPREGEND
+    description: End word (AXI width = 64 bits) of the FIFO of Clientx.
+    bit_offset: 16
+    bit_size: 10
+fieldset/IPC3R1:
+  description: DCMIPP IPPLUG Clientx register 1.
+  fields:
+  - name: TRAFFIC
+    description: Burst size as power of 2 of 8-byte units.
+    bit_offset: 0
+    bit_size: 3
+  - name: OTR
+    description: Maximum outstanding transactions.
+    bit_offset: 8
+    bit_size: 4
+fieldset/IPC3R2:
+  description: DCMIPP IPPLUG Clientx register 2.
+  fields:
+  - name: SVCMAPPING
+    description: Non-user, must be kept at reset value.
+    bit_offset: 8
+    bit_size: 4
+  - name: WLRU
+    description: Ratio for WLRU[3:0] arbitration.
+    bit_offset: 16
+    bit_size: 4
+fieldset/IPC3R3:
+  description: DCMIPP IPPLUG Clientx register 3.
+  fields:
+  - name: DPREGSTART
+    description: Start word (AXI width = 64 bits) of the FIFO of Clientx.
+    bit_offset: 0
+    bit_size: 10
+  - name: DPREGEND
+    description: End word (AXI width = 64 bits) of the FIFO of Clientx.
+    bit_offset: 16
+    bit_size: 10
+fieldset/IPC4R1:
+  description: DCMIPP IPPLUG Clientx register 1.
+  fields:
+  - name: TRAFFIC
+    description: Burst size as power of 2 of 8-byte units.
+    bit_offset: 0
+    bit_size: 3
+  - name: OTR
+    description: Maximum outstanding transactions.
+    bit_offset: 8
+    bit_size: 4
+fieldset/IPC4R2:
+  description: DCMIPP IPPLUG Clientx register 2.
+  fields:
+  - name: SVCMAPPING
+    description: Non-user, must be kept at reset value.
+    bit_offset: 8
+    bit_size: 4
+  - name: WLRU
+    description: Ratio for WLRU[3:0] arbitration.
+    bit_offset: 16
+    bit_size: 4
+fieldset/IPC4R3:
+  description: DCMIPP IPPLUG Clientx register 3.
+  fields:
+  - name: DPREGSTART
+    description: Start word (AXI width = 64 bits) of the FIFO of Clientx.
+    bit_offset: 0
+    bit_size: 10
+  - name: DPREGEND
+    description: End word (AXI width = 64 bits) of the FIFO of Clientx.
+    bit_offset: 16
+    bit_size: 10
+fieldset/IPC5R1:
+  description: DCMIPP IPPLUG Clientx register 1.
+  fields:
+  - name: TRAFFIC
+    description: Burst size as power of 2 of 8-byte units.
+    bit_offset: 0
+    bit_size: 3
+  - name: OTR
+    description: Maximum outstanding transactions.
+    bit_offset: 8
+    bit_size: 4
+fieldset/IPC5R2:
+  description: DCMIPP IPPLUG Clientx register 2.
+  fields:
+  - name: SVCMAPPING
+    description: Non-user, must be kept at reset value.
+    bit_offset: 8
+    bit_size: 4
+  - name: WLRU
+    description: Ratio for WLRU[3:0] arbitration.
+    bit_offset: 16
+    bit_size: 4
+fieldset/IPC5R3:
+  description: DCMIPP IPPLUG Clientx register 3.
+  fields:
+  - name: DPREGSTART
+    description: Start word (AXI width = 64 bits) of the FIFO of Clientx.
+    bit_offset: 0
+    bit_size: 10
+  - name: DPREGEND
+    description: End word (AXI width = 64 bits) of the FIFO of Clientx.
+    bit_offset: 16
+    bit_size: 10
+fieldset/IPGR1:
+  description: DCMIPP IPPLUG global register 1.
+  fields:
+  - name: MEMORYPAGE
+    description: Memory page size, as power of 2 of 64-byte units:.
+    bit_offset: 0
+    bit_size: 3
+  - name: QOS_MODE
+    description: Quality of service.
+    bit_offset: 24
+    bit_size: 1
+fieldset/IPGR2:
+  description: DCMIPP IPPLUG global register 2.
+  fields:
+  - name: PSTART
+    description: Request to lock the IP-Plug, to allow reconfiguration.
+    bit_offset: 0
+    bit_size: 1
+fieldset/IPGR3:
+  description: DCMIPP IPPLUG global register 3.
+  fields:
+  - name: IDLE
+    description: Status of IP-Plug.
+    bit_offset: 0
+    bit_size: 1
+fieldset/IPGR8:
+  description: DCMIPP IPPLUG identification register.
+  fields:
+  - name: DID
+    description: Division identifier (0x14).
+    bit_offset: 0
+    bit_size: 6
+  - name: REVID
+    description: Revision identifier (0x03).
+    bit_offset: 8
+    bit_size: 5
+  - name: ARCHIID
+    description: Architecture identifier (0x04).
+    bit_offset: 16
+    bit_size: 5
+  - name: IPPID
+    description: IP identifier (0xAA).
+    bit_offset: 24
+    bit_size: 8
+fieldset/P0CFCTCR:
+  description: DCMIPP Pipe0 current flow control configuration register.
+  fields:
+  - name: FRATE
+    description: Frame capture rate control.
+    bit_offset: 0
+    bit_size: 2
+  - name: CPTMODE
+    description: Capture mode.
+    bit_offset: 2
+    bit_size: 1
+  - name: CPTREQ
+    description: Capture requested.
+    bit_offset: 3
+    bit_size: 1
+fieldset/P0CFSCR:
+  description: DCMIPP Pipe0 current flow selection configuration register.
+  fields:
+  - name: DTIDA
+    description: Current data type selection ID A.
+    bit_offset: 0
+    bit_size: 6
+  - name: DTIDB
+    description: Current data type selection ID B.
+    bit_offset: 8
+    bit_size: 6
+  - name: DTMODE
+    description: Flow selection mode.
+    bit_offset: 16
+    bit_size: 2
+  - name: VC
+    description: Current flow selection mode.
+    bit_offset: 19
+    bit_size: 2
+  - name: PIPEN
+    description: Current activation of PipeN.
+    bit_offset: 31
+    bit_size: 1
+fieldset/P0CPPCR:
+  description: DCMIPP Pipe0 current pixel packer configuration register.
+  fields:
+  - name: SWAPYUV
+    description: Swaps, within a 32-bit word, byte 0 vs. 1 and byte 2 vs. 3. It corresponds, for YUV422 pixels formats, to swap between UYVY and YUYV.
+    bit_offset: 0
+    bit_size: 1
+  - name: PAD
+    description: 'Current Pad mode for monochrome and raw Bayer 10/12/14 bpp: MSB vs. LSB alignment.'
+    bit_offset: 5
+    bit_size: 1
+  - name: HEADEREN
+    description: Current CSI header dump enable.
+    bit_offset: 6
+    bit_size: 1
+  - name: BSM
+    description: Current Byte select mode.
+    bit_offset: 7
+    bit_size: 2
+  - name: OEBS
+    description: Current odd/even byte select (byte select start).
+    bit_offset: 9
+    bit_size: 1
+  - name: LSM
+    description: Current Line select mode.
+    bit_offset: 10
+    bit_size: 1
+  - name: OELS
+    description: Current odd/even line select (ine select start).
+    bit_offset: 11
+    bit_size: 1
+  - name: LINEMULT
+    description: Current amount of capture completed lines for LINE event and interrupt.
+    bit_offset: 13
+    bit_size: 3
+  - name: DBM
+    description: Double buffer mode.
+    bit_offset: 16
+    bit_size: 1
+fieldset/P0CPPM0AR1:
+  description: DCMIPP Pipe0 current pixel packer Memory0 address register 1.
+  fields:
+  - name: M0A
+    description: Memory0 address.
+    bit_offset: 0
+    bit_size: 32
+fieldset/P0CPPM0AR2:
+  description: DCMIPP Pipe0 current pixel packer Memory0 address register 2.
+  fields:
+  - name: M0A
+    description: Memory0 address.
+    bit_offset: 0
+    bit_size: 32
+fieldset/P0CSCSTR:
+  description: DCMIPP Pipe0 current stat/crop start register.
+  fields:
+  - name: HSTART
+    description: Current horizontal start, from 0 to 4094 words wide.
+    bit_offset: 0
+    bit_size: 12
+  - name: VSTART
+    description: Current vertical start, from 0 to 4094 pixels high.
+    bit_offset: 16
+    bit_size: 12
+fieldset/P0CSCSZR:
+  description: DCMIPP Pipe0 current stat/crop size register.
+  fields:
+  - name: HSIZE
+    description: Current horizontal size, from 0 to 4094 word wide (data 32-bit).
+    bit_offset: 0
+    bit_size: 12
+  - name: VSIZE
+    description: Current vertical size, from 0 to 4094 pixels high.
+    bit_offset: 16
+    bit_size: 12
+  - name: POSNEG
+    description: Current value of the POSNEG bit.
+    bit_offset: 30
+    bit_size: 1
+  - name: ENABLE
+    description: Current value of the ENABLE bit.
+    bit_offset: 31
+    bit_size: 1
+fieldset/P0DCCNTR:
+  description: DCMIPP Pipe0 dump counter register.
+  fields:
+  - name: CNT
+    description: Number of data dumped during the frame.
+    bit_offset: 0
+    bit_size: 26
+fieldset/P0DCLMTR:
+  description: DCMIPP Pipe0 dump limit register.
+  fields:
+  - name: LIMIT
+    description: Maximum number of 32-bit data that can be dumped during a frame, after the crop 2D operation.
+    bit_offset: 0
+    bit_size: 24
+  - name: ENABLE
+    description: None.
+    bit_offset: 31
+    bit_size: 1
+fieldset/P0FCR:
+  description: DCMIPP Pipe0 interrupt clear register.
+  fields:
+  - name: CLINEF
+    description: Multi-line capture complete interrupt status clear.
+    bit_offset: 0
+    bit_size: 1
+  - name: CFRAMEF
+    description: Frame capture complete interrupt status clear.
+    bit_offset: 1
+    bit_size: 1
+  - name: CVSYNCF
+    description: Vertical synchronization interrupt status clear.
+    bit_offset: 2
+    bit_size: 1
+  - name: CLIMITF
+    description: limit interrupt status clear.
+    bit_offset: 6
+    bit_size: 1
+  - name: COVRF
+    description: Overrun interrupt status clear.
+    bit_offset: 7
+    bit_size: 1
+fieldset/P0FCTCR:
+  description: DCMIPP Pipe0 flow control configuration register.
+  fields:
+  - name: FRATE
+    description: Frame capture rate control.
+    bit_offset: 0
+    bit_size: 2
+  - name: CPTMODE
+    description: Capture mode.
+    bit_offset: 2
+    bit_size: 1
+  - name: CPTREQ
+    description: Capture requested.
+    bit_offset: 3
+    bit_size: 1
+fieldset/P0FSCR:
+  description: DCMIPP Pipe0 flow selection configuration register.
+  fields:
+  - name: DTIDA
+    description: Data type selection ID A.
+    bit_offset: 0
+    bit_size: 6
+  - name: DTIDB
+    description: Data type selection ID B.
+    bit_offset: 8
+    bit_size: 6
+  - name: DTMODE
+    description: Flow selection mode.
+    bit_offset: 16
+    bit_size: 2
+  - name: VC
+    description: Flow selection mode.
+    bit_offset: 19
+    bit_size: 2
+  - name: PIPEN
+    description: Activation of PipeN.
+    bit_offset: 31
+    bit_size: 1
+fieldset/P0IER:
+  description: DCMIPP Pipe0 interrupt enable register.
+  fields:
+  - name: LINEIE
+    description: Multi-line capture completed interrupt enable.
+    bit_offset: 0
+    bit_size: 1
+  - name: FRAMEIE
+    description: Frame capture completed interrupt enable.
+    bit_offset: 1
+    bit_size: 1
+  - name: VSYNCIE
+    description: VSYNC interrupt enable.
+    bit_offset: 2
+    bit_size: 1
+  - name: LIMITIE
+    description: Limit interrupt enable.
+    bit_offset: 6
+    bit_size: 1
+  - name: OVRIE
+    description: Overrun interrupt enable.
+    bit_offset: 7
+    bit_size: 1
+fieldset/P0PPCR:
+  description: DCMIPP Pipe0 pixel packer configuration register.
+  fields:
+  - name: SWAPYUV
+    description: Swaps, within a 32-bit word, byte 0-vs-1 and byte 2-vs-3. It corresponds, for YUV422 pixels formats, to swap between UYVY and YUYV.
+    bit_offset: 0
+    bit_size: 1
+  - name: PAD
+    description: 'Pad mode for monochrome and raw Bayer 10/12/14 bpp: MSB vs. LSB alignment.'
+    bit_offset: 5
+    bit_size: 1
+  - name: HEADEREN
+    description: CSI header dump enable.
+    bit_offset: 6
+    bit_size: 1
+  - name: BSM
+    description: Byte select mode.
+    bit_offset: 7
+    bit_size: 2
+  - name: OEBS
+    description: Odd/even byte select (byte select start).
+    bit_offset: 9
+    bit_size: 1
+  - name: LSM
+    description: Line select mode.
+    bit_offset: 10
+    bit_size: 1
+  - name: OELS
+    description: Odd/even line select (line select start).
+    bit_offset: 11
+    bit_size: 1
+  - name: LINEMULT
+    description: Amount of capture completed lines for LINE event and interrupt.
+    bit_offset: 13
+    bit_size: 3
+  - name: DBM
+    description: Double buffer mode.
+    bit_offset: 16
+    bit_size: 1
+fieldset/P0PPM0AR1:
+  description: DCMIPP Pipe0 pixel packer Memory0 address register 1.
+  fields:
+  - name: M0A
+    description: Memory0 address.
+    bit_offset: 0
+    bit_size: 32
+fieldset/P0PPM0AR2:
+  description: DCMIPP Pipe0 pixel packer Memory0 address register 2.
+  fields:
+  - name: M0A
+    description: Memory0 address.
+    bit_offset: 0
+    bit_size: 32
+fieldset/P0SCSTR:
+  description: DCMIPP Pipe0 stat/crop start register.
+  fields:
+  - name: HSTART
+    description: Horizontal start, from 0 to 4094 words wide.
+    bit_offset: 0
+    bit_size: 12
+  - name: VSTART
+    description: Vertical start, from 0 to 4094 pixels high.
+    bit_offset: 16
+    bit_size: 12
+fieldset/P0SCSZR:
+  description: DCMIPP Pipe0 stat/crop size register.
+  fields:
+  - name: HSIZE
+    description: Horizontal size, from 0 to 4094 word wide (data 32-bit).
+    bit_offset: 0
+    bit_size: 12
+  - name: VSIZE
+    description: Vertical size, from 0 to 4094 pixels high.
+    bit_offset: 16
+    bit_size: 12
+  - name: POSNEG
+    description: This bit is set and cleared by software. It has a meaning only if ENABLE bit is set.
+    bit_offset: 30
+    bit_size: 1
+  - name: ENABLE
+    description: This bit is set and cleared by software.
+    bit_offset: 31
+    bit_size: 1
+fieldset/P0SR:
+  description: DCMIPP Pipe0 status register.
+  fields:
+  - name: LINEF
+    description: Multi-line capture completed raw interrupt status.
+    bit_offset: 0
+    bit_size: 1
+  - name: FRAMEF
+    description: Frame capture completed raw interrupt status.
+    bit_offset: 1
+    bit_size: 1
+  - name: VSYNCF
+    description: VSYNC raw interrupt status.
+    bit_offset: 2
+    bit_size: 1
+  - name: LIMITF
+    description: Limit raw interrupt status.
+    bit_offset: 6
+    bit_size: 1
+  - name: OVRF
+    description: Overrun raw interrupt status.
+    bit_offset: 7
+    bit_size: 1
+  - name: LSTLINE
+    description: Last line LSB bit, sampled at frame capture complete event.
+    bit_offset: 16
+    bit_size: 1
+  - name: LSTFRM
+    description: Last frame LSB bit, sampled at frame capture complete event. The information is extracted from the frame data number that can be delivered by the camera through the CSI2 interface.
+    bit_offset: 17
+    bit_size: 1
+  - name: CPTACT
+    description: Capture immediate status.
+    bit_offset: 23
+    bit_size: 1
+fieldset/P0STM0AR:
+  description: DCMIPP Pipe0 status Memory0 address register.
+  fields:
+  - name: M0A
+    description: Memory0 address.
+    bit_offset: 0
+    bit_size: 32
+fieldset/P1BLCCR:
+  description: DCMIPP Pipe1 black level calibration control register.
+  fields:
+  - name: ENABLE
+    description: Black level calibration.
+    bit_offset: 0
+    bit_size: 1
+  - name: BLCB
+    description: Black level calibration - Blue.
+    bit_offset: 8
+    bit_size: 8
+  - name: BLCG
+    description: Black level calibration - Green.
+    bit_offset: 16
+    bit_size: 8
+  - name: BLCR
+    description: Black level calibration - Red.
+    bit_offset: 24
+    bit_size: 8
+fieldset/P1BPRCR:
+  description: DCMIPP Pipe1 bad pixel removal control register.
+  fields:
+  - name: ENABLE
+    description: Bad pixel detection must be enabled only for raw Bayer flows, as it corrupts RGB flows.
+    bit_offset: 0
+    bit_size: 1
+  - name: STRENGTH
+    description: Strength (aggressiveness) of the bad pixel detection.
+    bit_offset: 1
+    bit_size: 3
+fieldset/P1BPRSR:
+  description: DCMIPP Pipe1 bad pixel removal status register.
+  fields:
+  - name: BADCNT
+    description: Amount of detected bad pixels.
+    bit_offset: 0
+    bit_size: 12
+fieldset/P1CBLCCR:
+  description: DCMIPP Pipe1 current black level calibration control register.
+  fields:
+  - name: ENABLE
+    description: For current black level calibration.
+    bit_offset: 0
+    bit_size: 1
+  - name: BLCB
+    description: Current black level calibration - Blue.
+    bit_offset: 8
+    bit_size: 8
+  - name: BLCG
+    description: Current black level calibration - Green.
+    bit_offset: 16
+    bit_size: 8
+  - name: BLCR
+    description: Current black level calibration - Red.
+    bit_offset: 24
+    bit_size: 8
+fieldset/P1CBPRCR:
+  description: DCMIPP Pipe1 current bad pixel removal register.
+  fields:
+  - name: ENABLE
+    description: Current status of enable bit.
+    bit_offset: 0
+    bit_size: 1
+  - name: STRENGTH
+    description: Current strength (aggressiveness) of the bad pixel detection:.
+    bit_offset: 1
+    bit_size: 3
+fieldset/P1CCBR1:
+  description: DCMIPP Pipex ColorConv blue coefficient register 1.
+  fields:
+  - name: BR
+    description: Coefficient row 3 column 1 of the matrix.
+    bit_offset: 0
+    bit_size: 11
+  - name: BG
+    description: Coefficient row 3 column 2 of the matrix.
+    bit_offset: 16
+    bit_size: 11
+fieldset/P1CCBR2:
+  description: DCMIPP Pipe1 ColorConv blue coefficient register 2.
+  fields:
+  - name: BB
+    description: Coefficient row 3 column 3 of the matrix.
+    bit_offset: 0
+    bit_size: 11
+  - name: BA
+    description: Coefficient row 3 of the added column (signed integer value).
+    bit_offset: 16
+    bit_size: 10
+fieldset/P1CCCBR1:
+  description: DCMIPP Pipex current ColorConv blue coefficient register 1.
+  fields:
+  - name: BR
+    description: Current coefficient row 3 column 1 of the matrix.
+    bit_offset: 0
+    bit_size: 11
+  - name: BG
+    description: Current coefficient row 3 column 2 of the matrix.
+    bit_offset: 16
+    bit_size: 11
+fieldset/P1CCCBR2:
+  description: DCMIPP Pipe1 current ColorConv blue coefficient register 2.
+  fields:
+  - name: BB
+    description: Current coefficient row 3 column 3 of the matrix.
+    bit_offset: 0
+    bit_size: 11
+  - name: BA
+    description: Current coefficient row 3 of the added column (signed integer value).
+    bit_offset: 16
+    bit_size: 10
+fieldset/P1CCCCR:
+  description: DCMIPP Pipe1 current ColorConv configuration register.
+  fields:
+  - name: ENABLE
+    description: Current value applied.
+    bit_offset: 0
+    bit_size: 1
+  - name: TYPE
+    description: Output samples type used while CLAMP is activated.
+    bit_offset: 1
+    bit_size: 1
+  - name: CLAMP
+    description: Clamp the output samples.
+    bit_offset: 2
+    bit_size: 1
+fieldset/P1CCCGR1:
+  description: DCMIPP Pipe1 current ColorConv green coefficient register 1.
+  fields:
+  - name: GR
+    description: Current coefficient row 2 column 1 of the matrix.
+    bit_offset: 0
+    bit_size: 11
+  - name: GG
+    description: Current coefficient row 2 column 2 of the matrix.
+    bit_offset: 16
+    bit_size: 11
+fieldset/P1CCCGR2:
+  description: DCMIPP Pipe1 current ColorConv green coefficient register 2.
+  fields:
+  - name: GB
+    description: Current coefficient row 2 column 3 of the matrix.
+    bit_offset: 0
+    bit_size: 11
+  - name: GA
+    description: Current coefficient row 2 of the added column (signed integer value).
+    bit_offset: 16
+    bit_size: 10
+fieldset/P1CCCR:
+  description: DCMIPP Pipe1 ColorConv configuration register.
+  fields:
+  - name: ENABLE
+    description: None.
+    bit_offset: 0
+    bit_size: 1
+  - name: TYPE
+    description: output samples type used while CLAMP is activated.
+    bit_offset: 1
+    bit_size: 1
+  - name: CLAMP
+    description: Clamp the output samples.
+    bit_offset: 2
+    bit_size: 1
+fieldset/P1CCCRR1:
+  description: DCMIPP Pipe1 current ColorConv red coefficient register 1.
+  fields:
+  - name: RR
+    description: Current coefficient row 1 column 1 of the matrix.
+    bit_offset: 0
+    bit_size: 11
+  - name: RG
+    description: Current coefficient row 1 column 2 of the matrix.
+    bit_offset: 16
+    bit_size: 11
+fieldset/P1CCCRR2:
+  description: DCMIPP Pipe1 current ColorConv red coefficient register 2.
+  fields:
+  - name: RB
+    description: Current coefficient row 1 column 3 of the matrix.
+    bit_offset: 0
+    bit_size: 11
+  - name: RA
+    description: Current coefficient row 1 of the added column (signed integer value).
+    bit_offset: 16
+    bit_size: 10
+fieldset/P1CCGR1:
+  description: DCMIPP Pipe1 ColorConv green coefficient register 1.
+  fields:
+  - name: GR
+    description: Coefficient row 2 column 1 of the matrix.
+    bit_offset: 0
+    bit_size: 11
+  - name: GG
+    description: Coefficient row 2 column 2 of the matrix.
+    bit_offset: 16
+    bit_size: 11
+fieldset/P1CCGR2:
+  description: DCMIPP Pipe1 ColorConv green coefficient register 2.
+  fields:
+  - name: GB
+    description: Coefficient row 2 column 3 of the matrix.
+    bit_offset: 0
+    bit_size: 11
+  - name: GA
+    description: Coefficient row 2 of the added column (signed integer value).
+    bit_offset: 16
+    bit_size: 10
+fieldset/P1CCMRICR:
+  description: DCMIPP Pipex current common ROI configuration register.
+  fields:
+  - name: ROILSZ
+    description: Current region of interest line size width.
+    bit_offset: 0
+    bit_size: 2
+  - name: ROI1EN
+    description: Current region of interest 1 enable.
+    bit_offset: 16
+    bit_size: 1
+  - name: ROI2EN
+    description: Current region of interest 2 enable.
+    bit_offset: 17
+    bit_size: 1
+  - name: ROI3EN
+    description: Current region of interest 3 enable.
+    bit_offset: 18
+    bit_size: 1
+  - name: ROI4EN
+    description: Current region of interest 4 enable.
+    bit_offset: 19
+    bit_size: 1
+  - name: ROI5EN
+    description: Current region of interest 5 enable.
+    bit_offset: 20
+    bit_size: 1
+  - name: ROI6EN
+    description: Current region of interest 6 enable.
+    bit_offset: 21
+    bit_size: 1
+  - name: ROI7EN
+    description: Current region of interest 7 enable.
+    bit_offset: 22
+    bit_size: 1
+  - name: ROI8EN
+    description: Current region of interest 8 enable.
+    bit_offset: 23
+    bit_size: 1
+fieldset/P1CCRR1:
+  description: DCMIPP Pipe1 ColorConv red coefficient register 1.
+  fields:
+  - name: RR
+    description: Coefficient row 1 column 1 of the matrix.
+    bit_offset: 0
+    bit_size: 11
+  - name: RG
+    description: Coefficient row 1 column 2 of the matrix.
+    bit_offset: 16
+    bit_size: 11
+fieldset/P1CCRR2:
+  description: DCMIPP Pipe1 ColorConv red coefficient register 2.
+  fields:
+  - name: RB
+    description: Coefficient row 1 column 3 of the matrix.
+    bit_offset: 0
+    bit_size: 11
+  - name: RA
+    description: Coefficient row 1 of the added column (signed integer value).
+    bit_offset: 16
+    bit_size: 10
+fieldset/P1CCRSTR:
+  description: DCMIPP Pipex current crop window start register.
+  fields:
+  - name: HSTART
+    description: Current horizontal start, from 0 to 4094 pixels wide.
+    bit_offset: 0
+    bit_size: 12
+  - name: VSTART
+    description: Current vertical start, from 0 to 4094 pixels high.
+    bit_offset: 16
+    bit_size: 12
+fieldset/P1CCRSZR:
+  description: DCMIPP Pipex current crop window size register.
+  fields:
+  - name: HSIZE
+    description: Current horizontal size, from 0 to 4094 pixels wide.
+    bit_offset: 0
+    bit_size: 12
+  - name: VSIZE
+    description: Current vertical size, from 0 to 4094 pixels high.
+    bit_offset: 16
+    bit_size: 12
+  - name: ENABLE
+    description: Current ENABLE bit value.
+    bit_offset: 31
+    bit_size: 1
+fieldset/P1CCTCR1:
+  description: DCMIPP Pipe1 current contrast control register 1.
+  fields:
+  - name: ENABLE
+    description: Current ENABLE bit value.
+    bit_offset: 0
+    bit_size: 1
+  - name: LUM0
+    description: Current luminance increase for input luminance of 0 (increase is idle with LUMx = 16).
+    bit_offset: 9
+    bit_size: 6
+fieldset/P1CCTCR2:
+  description: DCMIPP Pipe1 current contrast control register 2.
+  fields:
+  - name: LUM4
+    description: Current luminance increase for input luminance of 128 (increase is idle with LUMx = 16).
+    bit_offset: 1
+    bit_size: 6
+  - name: LUM3
+    description: Current luminance increase for input luminance of 96 (increase is idle with LUMx = 16).
+    bit_offset: 9
+    bit_size: 6
+  - name: LUM2
+    description: Current luminance increase for input luminance of 64 (increase is idle with LUMx = 16).
+    bit_offset: 17
+    bit_size: 6
+  - name: LUM1
+    description: Current luminance increase for input luminance of 32 (increase is idle with LUMx = 16).
+    bit_offset: 25
+    bit_size: 6
+fieldset/P1CCTCR3:
+  description: DCMIPP Pipe1 current contrast control register 3.
+  fields:
+  - name: LUM8
+    description: Luminance increase for input luminance of 256 (increase is idle with LUMx = 16).
+    bit_offset: 1
+    bit_size: 6
+  - name: LUM7
+    description: Luminance increase for input luminance of 224 (increase is idle with LUMx = 16).
+    bit_offset: 9
+    bit_size: 6
+  - name: LUM6
+    description: Luminance increase for input luminance of 192 (increase is idle with LUMx = 16).
+    bit_offset: 17
+    bit_size: 6
+  - name: LUM5
+    description: Luminance increase for input luminance of 160 (increase is idle with LUMx = 16).
+    bit_offset: 25
+    bit_size: 6
+fieldset/P1CDCCR:
+  description: DCMIPP Pipex current decimation register.
+  fields:
+  - name: ENABLE
+    description: None.
+    bit_offset: 0
+    bit_size: 1
+  - name: HDEC
+    description: Horizontal decimation ratio.
+    bit_offset: 1
+    bit_size: 2
+  - name: VDEC
+    description: Vertical decimation ratio.
+    bit_offset: 3
+    bit_size: 2
+fieldset/P1CDSCR:
+  description: DCMIPP Pipex current downsize configuration register.
+  fields:
+  - name: HDIV
+    description: Current horizontal division factor, from 128 (8x) to 1023 (1x).
+    bit_offset: 0
+    bit_size: 10
+  - name: VDIV
+    description: Current vertical division factor, from 128 (8x) to 1023 (1x).
+    bit_offset: 16
+    bit_size: 10
+  - name: ENABLE
+    description: Current value of bit ENABLE.
+    bit_offset: 31
+    bit_size: 1
+fieldset/P1CDSRTIOR:
+  description: DCMIPP Pipex current downsize ratio register.
+  fields:
+  - name: HRATIO
+    description: Current horizontal ratio, from 8192 (1x) to 65535 (8x).
+    bit_offset: 0
+    bit_size: 16
+  - name: VRATIO
+    description: Current vertical ratio, from 8192 (1x) to 65535 (8x).
+    bit_offset: 16
+    bit_size: 16
+fieldset/P1CDSSZR:
+  description: DCMIPP Pipex current downsize destination size register.
+  fields:
+  - name: HSIZE
+    description: Current horizontal size, from 0 to 4094 pixels wide.
+    bit_offset: 0
+    bit_size: 12
+  - name: VSIZE
+    description: Current vertical size, from 0 to 4094 pixels high.
+    bit_offset: 16
+    bit_size: 12
+fieldset/P1CEXCR1:
+  description: DCMIPP Pipe1 current exposure control register 1.
+  fields:
+  - name: ENABLE
+    description: for exposure control (multiplication and shift).
+    bit_offset: 0
+    bit_size: 1
+  - name: MULTR
+    description: Current exposure multiplier - Red.
+    bit_offset: 20
+    bit_size: 8
+  - name: SHFR
+    description: Current exposure shift - Red.
+    bit_offset: 28
+    bit_size: 3
+fieldset/P1CEXCR2:
+  description: DCMIPP Pipe1 current exposure control register 2.
+  fields:
+  - name: MULTB
+    description: Current exposure multiplier - Blue.
+    bit_offset: 4
+    bit_size: 8
+  - name: SHFB
+    description: Current exposure shift - Blue.
+    bit_offset: 12
+    bit_size: 3
+  - name: MULTG
+    description: Current exposure multiplier - Green.
+    bit_offset: 20
+    bit_size: 8
+  - name: SHFG
+    description: Current exposure shift - Green.
+    bit_offset: 28
+    bit_size: 3
+fieldset/P1CFCTCR:
+  description: DCMIPP Pipex current flow control configuration register.
+  fields:
+  - name: FRATE
+    description: Frame capture rate control.
+    bit_offset: 0
+    bit_size: 2
+  - name: CPTMODE
+    description: Capture mode.
+    bit_offset: 2
+    bit_size: 1
+  - name: CPTREQ
+    description: Capture requested.
+    bit_offset: 3
+    bit_size: 1
+fieldset/P1CFSCR:
+  description: DCMIPP Pipe1 current flow selection configuration register.
+  fields:
+  - name: DTIDA
+    description: Current data type ID A.
+    bit_offset: 0
+    bit_size: 6
+  - name: DTIDB
+    description: Current data type ID B.
+    bit_offset: 8
+    bit_size: 6
+  - name: DTMODE
+    description: Flow selection mode.
+    bit_offset: 16
+    bit_size: 2
+  - name: PIPEDIFF
+    description: Current differentiates Pipe2 vs. Pipe1.
+    bit_offset: 18
+    bit_size: 1
+  - name: VC
+    description: Current flow selection mode.
+    bit_offset: 19
+    bit_size: 2
+  - name: FDTF
+    description: Current force data type format.
+    bit_offset: 24
+    bit_size: 6
+  - name: FDTFEN
+    description: Current force data type format enable.
+    bit_offset: 30
+    bit_size: 1
+  - name: PIPEN
+    description: Current activation of PipeN.
+    bit_offset: 31
+    bit_size: 1
+fieldset/P1CMRICR:
+  description: DCMIPP Pipex common ROI configuration register.
+  fields:
+  - name: ROILSZ
+    description: Region of interest line size width.
+    bit_offset: 0
+    bit_size: 2
+  - name: ROI1EN
+    description: Region of interest 1 enable.
+    bit_offset: 16
+    bit_size: 1
+  - name: ROI2EN
+    description: Region of interest 2 enable.
+    bit_offset: 17
+    bit_size: 1
+  - name: ROI3EN
+    description: Region of interest 3 enable.
+    bit_offset: 18
+    bit_size: 1
+  - name: ROI4EN
+    description: Region of interest 4 enable.
+    bit_offset: 19
+    bit_size: 1
+  - name: ROI5EN
+    description: Region of interest 5 enable.
+    bit_offset: 20
+    bit_size: 1
+  - name: ROI6EN
+    description: Region of interest 6 enable.
+    bit_offset: 21
+    bit_size: 1
+  - name: ROI7EN
+    description: Region of interest 7 enable.
+    bit_offset: 22
+    bit_size: 1
+  - name: ROI8EN
+    description: Region of interest 8 enable.
+    bit_offset: 23
+    bit_size: 1
+fieldset/P1CPPCR:
+  description: DCMIPP Pipe1 current pixel packer configuration register.
+  fields:
+  - name: FORMAT
+    description: Memory format.
+    bit_offset: 0
+    bit_size: 4
+  - name: SWAPRB
+    description: Swaps R-vs-B components if RGB, and U-vs-V components if YUV.
+    bit_offset: 4
+    bit_size: 1
+  - name: LINEMULT
+    description: Amount of capture completed lines for LINE Event and Interrupt.
+    bit_offset: 13
+    bit_size: 3
+  - name: DBM
+    description: Double buffer mode.
+    bit_offset: 16
+    bit_size: 1
+  - name: LMAWM
+    description: Line multi address wrapping modulo.
+    bit_offset: 17
+    bit_size: 3
+  - name: LMAWE
+    description: Line multi address wrapping enable bit.
+    bit_offset: 20
+    bit_size: 1
+fieldset/P1CPPM0AR1:
+  description: DCMIPP Pipe1 current pixel packer Memory0 address register 1.
+  fields:
+  - name: M0A
+    description: Memory0 address.
+    bit_offset: 0
+    bit_size: 32
+fieldset/P1CPPM0AR2:
+  description: DCMIPP Pipe1 current pixel packer Memory0 address register 2.
+  fields:
+  - name: M0A
+    description: Memory0 address.
+    bit_offset: 0
+    bit_size: 32
+fieldset/P1CPPM0PR:
+  description: DCMIPP Pipex current pixel packer Memory0 pitch register.
+  fields:
+  - name: PITCH
+    description: Current number of bytes between the address of two consecutive lines.
+    bit_offset: 0
+    bit_size: 15
+fieldset/P1CPPM1AR1:
+  description: DCMIPP Pipex current pixel packer Memory1 address register 1.
+  fields:
+  - name: M1A
+    description: Memory1 address.
+    bit_offset: 0
+    bit_size: 32
+fieldset/P1CPPM1AR2:
+  description: DCMIPP Pipex current pixel packer Memory1 address register 2.
+  fields:
+  - name: M1A
+    description: Memory1 address.
+    bit_offset: 0
+    bit_size: 32
+fieldset/P1CPPM1PR:
+  description: DCMIPP Pipex current pixel packer Memory1 pitch register.
+  fields:
+  - name: PITCH
+    description: Current number of bytes between the address of two consecutive lines.
+    bit_offset: 0
+    bit_size: 15
+fieldset/P1CPPM2AR1:
+  description: DCMIPP Pipex current pixel packer Memory2 address register 1.
+  fields:
+  - name: M2A
+    description: Memory 2 address.
+    bit_offset: 0
+    bit_size: 32
+fieldset/P1CPPM2AR2:
+  description: DCMIPP Pipex current pixel packer Memory2 address register 1.
+  fields:
+  - name: M2A
+    description: Memory 2 address.
+    bit_offset: 0
+    bit_size: 32
+fieldset/P1CRI1CR1:
+  description: DCMIPP Pipe1 current ROI1 configuration register 1.
+  fields:
+  - name: HSTART
+    description: Current horizontal start, from 0 to 4094 pixels wide.
+    bit_offset: 0
+    bit_size: 12
+  - name: CLB
+    description: Current color line blue.
+    bit_offset: 12
+    bit_size: 2
+  - name: CLG
+    description: Current color line green.
+    bit_offset: 14
+    bit_size: 2
+  - name: VSTART
+    description: Current vertical start, from 0 to 4094 pixels high.
+    bit_offset: 16
+    bit_size: 12
+  - name: CLR
+    description: Current color line red.
+    bit_offset: 28
+    bit_size: 2
+fieldset/P1CRI1CR2:
+  description: DCMIPP Pipe1 current ROI1 configuration register 2.
+  fields:
+  - name: HSIZE
+    description: Current horizontal size, from 0 to 4094 pixels wide.
+    bit_offset: 0
+    bit_size: 12
+  - name: VSIZE
+    description: Current vertical size, from 0 to 4094 pixels high.
+    bit_offset: 16
+    bit_size: 12
+fieldset/P1CRI2CR1:
+  description: DCMIPP Pipe1 current ROI2 configuration register 1.
+  fields:
+  - name: HSTART
+    description: Current horizontal start, from 0 to 4094 pixels wide.
+    bit_offset: 0
+    bit_size: 12
+  - name: CLB
+    description: Current color line blue.
+    bit_offset: 12
+    bit_size: 2
+  - name: CLG
+    description: Current color line green.
+    bit_offset: 14
+    bit_size: 2
+  - name: VSTART
+    description: Current vertical start, from 0 to 4094 pixels high.
+    bit_offset: 16
+    bit_size: 12
+  - name: CLR
+    description: Current color line red.
+    bit_offset: 28
+    bit_size: 2
+fieldset/P1CRI2CR2:
+  description: DCMIPP Pipe1 current ROI2 configuration register 2.
+  fields:
+  - name: HSIZE
+    description: Current horizontal size, from 0 to 4094 pixels wide.
+    bit_offset: 0
+    bit_size: 12
+  - name: VSIZE
+    description: Current vertical size, from 0 to 4094 pixels high.
+    bit_offset: 16
+    bit_size: 12
+fieldset/P1CRI3CR1:
+  description: DCMIPP Pipe1 current ROI3 configuration register 1.
+  fields:
+  - name: HSTART
+    description: Current horizontal start, from 0 to 4094 pixels wide.
+    bit_offset: 0
+    bit_size: 12
+  - name: CLB
+    description: Current color line blue.
+    bit_offset: 12
+    bit_size: 2
+  - name: CLG
+    description: Current color line green.
+    bit_offset: 14
+    bit_size: 2
+  - name: VSTART
+    description: Current vertical start, from 0 to 4094 pixels high.
+    bit_offset: 16
+    bit_size: 12
+  - name: CLR
+    description: Current color line red.
+    bit_offset: 28
+    bit_size: 2
+fieldset/P1CRI3CR2:
+  description: DCMIPP Pipe1 current ROI3 configuration register 2.
+  fields:
+  - name: HSIZE
+    description: Current horizontal size, from 0 to 4094 pixels wide.
+    bit_offset: 0
+    bit_size: 12
+  - name: VSIZE
+    description: Current vertical size, from 0 to 4094 pixels high.
+    bit_offset: 16
+    bit_size: 12
+fieldset/P1CRI4CR1:
+  description: DCMIPP Pipe1 current ROI4 configuration register 1.
+  fields:
+  - name: HSTART
+    description: Current horizontal start, from 0 to 4094 pixels wide.
+    bit_offset: 0
+    bit_size: 12
+  - name: CLB
+    description: Current color line blue.
+    bit_offset: 12
+    bit_size: 2
+  - name: CLG
+    description: Current color line green.
+    bit_offset: 14
+    bit_size: 2
+  - name: VSTART
+    description: Current vertical start, from 0 to 4094 pixels high.
+    bit_offset: 16
+    bit_size: 12
+  - name: CLR
+    description: Current color line red.
+    bit_offset: 28
+    bit_size: 2
+fieldset/P1CRI4CR2:
+  description: DCMIPP Pipe1 current ROI4 configuration register 2.
+  fields:
+  - name: HSIZE
+    description: Current horizontal size, from 0 to 4094 pixels wide.
+    bit_offset: 0
+    bit_size: 12
+  - name: VSIZE
+    description: Current vertical size, from 0 to 4094 pixels high.
+    bit_offset: 16
+    bit_size: 12
+fieldset/P1CRI5CR1:
+  description: DCMIPP Pipe1 current ROI5 configuration register 1.
+  fields:
+  - name: HSTART
+    description: Current horizontal start, from 0 to 4094 pixels wide.
+    bit_offset: 0
+    bit_size: 12
+  - name: CLB
+    description: Current color line blue.
+    bit_offset: 12
+    bit_size: 2
+  - name: CLG
+    description: Current color line green.
+    bit_offset: 14
+    bit_size: 2
+  - name: VSTART
+    description: Current vertical start, from 0 to 4094 pixels high.
+    bit_offset: 16
+    bit_size: 12
+  - name: CLR
+    description: Current color line red.
+    bit_offset: 28
+    bit_size: 2
+fieldset/P1CRI5CR2:
+  description: DCMIPP Pipe1 current ROI5 configuration register 2.
+  fields:
+  - name: HSIZE
+    description: Current horizontal size, from 0 to 4094 pixels wide.
+    bit_offset: 0
+    bit_size: 12
+  - name: VSIZE
+    description: Current vertical size, from 0 to 4094 pixels high.
+    bit_offset: 16
+    bit_size: 12
+fieldset/P1CRI6CR1:
+  description: DCMIPP Pipe1 current ROI6 configuration register 1.
+  fields:
+  - name: HSTART
+    description: Current horizontal start, from 0 to 4094 pixels wide.
+    bit_offset: 0
+    bit_size: 12
+  - name: CLB
+    description: Current color line blue.
+    bit_offset: 12
+    bit_size: 2
+  - name: CLG
+    description: Current color line green.
+    bit_offset: 14
+    bit_size: 2
+  - name: VSTART
+    description: Current vertical start, from 0 to 4094 pixels high.
+    bit_offset: 16
+    bit_size: 12
+  - name: CLR
+    description: Current color line red.
+    bit_offset: 28
+    bit_size: 2
+fieldset/P1CRI6CR2:
+  description: DCMIPP Pipe1 current ROI6 configuration register 2.
+  fields:
+  - name: HSIZE
+    description: Current horizontal size, from 0 to 4094 pixels wide.
+    bit_offset: 0
+    bit_size: 12
+  - name: VSIZE
+    description: Current vertical size, from 0 to 4094 pixels high.
+    bit_offset: 16
+    bit_size: 12
+fieldset/P1CRI7CR1:
+  description: DCMIPP Pipe1 current ROI7 configuration register 1.
+  fields:
+  - name: HSTART
+    description: Current horizontal start, from 0 to 4094 pixels wide.
+    bit_offset: 0
+    bit_size: 12
+  - name: CLB
+    description: Current color line blue.
+    bit_offset: 12
+    bit_size: 2
+  - name: CLG
+    description: Current color line green.
+    bit_offset: 14
+    bit_size: 2
+  - name: VSTART
+    description: Current vertical start, from 0 to 4094 pixels high.
+    bit_offset: 16
+    bit_size: 12
+  - name: CLR
+    description: Current color line red.
+    bit_offset: 28
+    bit_size: 2
+fieldset/P1CRI7CR2:
+  description: DCMIPP Pipe1 current ROI7 configuration register 2.
+  fields:
+  - name: HSIZE
+    description: Current horizontal size, from 0 to 4094 pixels wide.
+    bit_offset: 0
+    bit_size: 12
+  - name: VSIZE
+    description: Current vertical size, from 0 to 4094 pixels high.
+    bit_offset: 16
+    bit_size: 12
+fieldset/P1CRI8CR1:
+  description: DCMIPP Pipe1 current ROI8 configuration register 1.
+  fields:
+  - name: HSTART
+    description: Current horizontal start, from 0 to 4094 pixels wide.
+    bit_offset: 0
+    bit_size: 12
+  - name: CLB
+    description: Current color line blue.
+    bit_offset: 12
+    bit_size: 2
+  - name: CLG
+    description: Current color line green.
+    bit_offset: 14
+    bit_size: 2
+  - name: VSTART
+    description: Current vertical start, from 0 to 4094 pixels high.
+    bit_offset: 16
+    bit_size: 12
+  - name: CLR
+    description: Current color line red.
+    bit_offset: 28
+    bit_size: 2
+fieldset/P1CRI8CR2:
+  description: DCMIPP Pipe1 current ROI8 configuration register 2.
+  fields:
+  - name: HSIZE
+    description: Current horizontal size, from 0 to 4094 pixels wide.
+    bit_offset: 0
+    bit_size: 12
+  - name: VSIZE
+    description: Current vertical size, from 0 to 4094 pixels high.
+    bit_offset: 16
+    bit_size: 12
+fieldset/P1CRSTR:
+  description: DCMIPP Pipex crop window start register.
+  fields:
+  - name: HSTART
+    description: Horizontal start, from 0 to 4094 pixels wide.
+    bit_offset: 0
+    bit_size: 12
+  - name: VSTART
+    description: Vertical start, from 0 to 4094 pixels high.
+    bit_offset: 16
+    bit_size: 12
+fieldset/P1CRSZR:
+  description: DCMIPP Pipex crop window size register.
+  fields:
+  - name: HSIZE
+    description: Horizontal size, from 0 to 4094 pixels wide. If the value is maintained at 0 when enabling the crop by means of the ENABLE bit, the value is forced internally at 0xFFE, which is the maximum value.
+    bit_offset: 0
+    bit_size: 12
+  - name: VSIZE
+    description: Vertical size, from 0 to 4094 pixels high. If the value is maintained at 0 when enabling the crop thanks to the ENABLE bit, the value is forced internally at 0xFFE, which is the maximum value.
+    bit_offset: 16
+    bit_size: 12
+  - name: ENABLE
+    description: None.
+    bit_offset: 31
+    bit_size: 1
+fieldset/P1CST1CR:
+  description: DCMIPP Pipe1 current statistics 1 control register.
+  fields:
+  - name: ENABLE
+    description: Current enable bit value.
+    bit_offset: 0
+    bit_size: 1
+  - name: BINS
+    description: Current bin definition.
+    bit_offset: 2
+    bit_size: 2
+  - name: SRC
+    description: Current source of statistics.
+    bit_offset: 4
+    bit_size: 3
+  - name: MODE
+    description: Current statistics mode.
+    bit_offset: 7
+    bit_size: 1
+  - name: ACCU
+    description: Current accumulation result, divided by 256.
+    bit_offset: 8
+    bit_size: 24
+fieldset/P1CST2CR:
+  description: DCMIPP Pipe1 current statistics 2 control register.
+  fields:
+  - name: ENABLE
+    description: None.
+    bit_offset: 0
+    bit_size: 1
+  - name: BINS
+    description: Bin definition.
+    bit_offset: 2
+    bit_size: 2
+  - name: SRC
+    description: Statistics source.
+    bit_offset: 4
+    bit_size: 3
+  - name: MODE
+    description: Statistics mode.
+    bit_offset: 7
+    bit_size: 1
+  - name: ACCU
+    description: Accumulation result, divided by 256.
+    bit_offset: 8
+    bit_size: 24
+fieldset/P1CST3CR:
+  description: DCMIPP Pipe1 current statistics 3 control register.
+  fields:
+  - name: ENABLE
+    description: None.
+    bit_offset: 0
+    bit_size: 1
+  - name: BINS
+    description: Current bin definition.
+    bit_offset: 2
+    bit_size: 2
+  - name: SRC
+    description: Statistics source.
+    bit_offset: 4
+    bit_size: 3
+  - name: MODE
+    description: Statistics mode.
+    bit_offset: 7
+    bit_size: 1
+  - name: ACCU
+    description: Accumulation result, divided by 256.
+    bit_offset: 8
+    bit_size: 24
+fieldset/P1CSTSTR:
+  description: DCMIPP Pipe1 current statistics window start register.
+  fields:
+  - name: HSTART
+    description: Current horizontal start, from 0 to 4094 pixels wide.
+    bit_offset: 0
+    bit_size: 12
+  - name: VSTART
+    description: Current vertical start, from 0 to 4094 pixels high.
+    bit_offset: 16
+    bit_size: 12
+fieldset/P1CSTSZR:
+  description: DCMIPP Pipe1 current statistics window size register.
+  fields:
+  - name: HSIZE
+    description: Current horizontal size, from 0 to 4094 pixels wide.
+    bit_offset: 0
+    bit_size: 12
+  - name: VSIZE
+    description: Current vertical size, from 0 to 4094 pixels high.
+    bit_offset: 16
+    bit_size: 12
+  - name: CROPEN
+    description: Current CROPEN bit value.
+    bit_offset: 31
+    bit_size: 1
+fieldset/P1CTCR1:
+  description: DCMIPP Pipe1 contrast control register 1.
+  fields:
+  - name: ENABLE
+    description: None.
+    bit_offset: 0
+    bit_size: 1
+  - name: LUM0
+    description: Luminance increase for input luminance of 0 (increase is idle with LUMx = 16).
+    bit_offset: 9
+    bit_size: 6
+fieldset/P1CTCR2:
+  description: DCMIPP Pipe1 contrast control register 2.
+  fields:
+  - name: LUM4
+    description: Luminance increase for input luminance of 128 (increase is idle with LUMx = 16).
+    bit_offset: 1
+    bit_size: 6
+  - name: LUM3
+    description: Luminance increase for input luminance of 96 (increase is idle with LUMx = 16).
+    bit_offset: 9
+    bit_size: 6
+  - name: LUM2
+    description: Luminance increase for input luminance of 64 (increase is idle with LUMx = 16).
+    bit_offset: 17
+    bit_size: 6
+  - name: LUM1
+    description: Luminance increase for input luminance of 32 (increase is idle with LUMx = 16).
+    bit_offset: 25
+    bit_size: 6
+fieldset/P1CTCR3:
+  description: DCMIPP Pipe1 contrast control register 3.
+  fields:
+  - name: LUM8
+    description: Luminance increase for input luminance of 256 (increase is idle with LUMx = 16).
+    bit_offset: 1
+    bit_size: 6
+  - name: LUM7
+    description: Luminance increase for input luminance of 224 (increase is idle with LUMx = 16).
+    bit_offset: 9
+    bit_size: 6
+  - name: LUM6
+    description: Luminance increase for input luminance of 192 (increase is idle with LUMx = 16).
+    bit_offset: 17
+    bit_size: 6
+  - name: LUM5
+    description: Luminance increase for input luminance of 160 (increase is idle with LUMx = 16).
+    bit_offset: 25
+    bit_size: 6
+fieldset/P1DCCR:
+  description: DCMIPP Pipex decimation register.
+  fields:
+  - name: ENABLE
+    description: None.
+    bit_offset: 0
+    bit_size: 1
+  - name: HDEC
+    description: Horizontal decimation ratio.
+    bit_offset: 1
+    bit_size: 2
+  - name: VDEC
+    description: Vertical decimation ratio.
+    bit_offset: 3
+    bit_size: 2
+fieldset/P1DECR:
+  description: DCMIPP Pipe1 decimation register.
+  fields:
+  - name: ENABLE
+    description: None.
+    bit_offset: 0
+    bit_size: 1
+  - name: HDEC
+    description: Horizontal decimation ratio.
+    bit_offset: 1
+    bit_size: 2
+  - name: VDEC
+    description: Vertical decimation ratio.
+    bit_offset: 3
+    bit_size: 2
+fieldset/P1DMCR:
+  description: DCMIPP Pipe1 demosaicing configuration register.
+  fields:
+  - name: ENABLE
+    description: None.
+    bit_offset: 0
+    bit_size: 1
+  - name: TYPE
+    description: Raw Bayer type.
+    bit_offset: 1
+    bit_size: 2
+  - name: PEAK
+    description: Strength of the peak detection.
+    bit_offset: 16
+    bit_size: 3
+  - name: LINEV
+    description: Strength of the vertical line detection.
+    bit_offset: 20
+    bit_size: 3
+  - name: LINEH
+    description: Strength of the horizontal line detection.
+    bit_offset: 24
+    bit_size: 3
+  - name: EDGE
+    description: Strength of the edge detection.
+    bit_offset: 28
+    bit_size: 3
+fieldset/P1DSCR:
+  description: DCMIPP Pipex downsize configuration register.
+  fields:
+  - name: HDIV
+    description: Horizontal division factor, from 128 (8x) to 1023 (1x).
+    bit_offset: 0
+    bit_size: 10
+  - name: VDIV
+    description: Vertical division factor, from 128 (8x) to 1023 (1x).
+    bit_offset: 16
+    bit_size: 10
+  - name: ENABLE
+    description: None.
+    bit_offset: 31
+    bit_size: 1
+fieldset/P1DSRTIOR:
+  description: DCMIPP Pipex downsize ratio register.
+  fields:
+  - name: HRATIO
+    description: Horizontal ratio, from 8192 (1x) to 65535 (8x).
+    bit_offset: 0
+    bit_size: 16
+  - name: VRATIO
+    description: Vertical ratio, from 8192 (1x) to 65535 (8x).
+    bit_offset: 16
+    bit_size: 16
+fieldset/P1DSSZR:
+  description: DCMIPP Pipex downsize destination size register.
+  fields:
+  - name: HSIZE
+    description: Horizontal size, from 0 to 4094 pixels wide.
+    bit_offset: 0
+    bit_size: 12
+  - name: VSIZE
+    description: Vertical size, from 0 to 4094 pixels high.
+    bit_offset: 16
+    bit_size: 12
+fieldset/P1EXCR1:
+  description: DCMIPP Pipe1 exposure control register 1.
+  fields:
+  - name: ENABLE
+    description: Exposure control (multiplication and shift) of all red, green and blue.
+    bit_offset: 0
+    bit_size: 1
+  - name: MULTR
+    description: Exposure multiplier - Red.
+    bit_offset: 20
+    bit_size: 8
+  - name: SHFR
+    description: Exposure shift - Red.
+    bit_offset: 28
+    bit_size: 3
+fieldset/P1EXCR2:
+  description: DCMIPP Pipe1 exposure control register 2.
+  fields:
+  - name: MULTB
+    description: Exposure multiplier - Blue.
+    bit_offset: 4
+    bit_size: 8
+  - name: SHFB
+    description: Exposure shift - Blue.
+    bit_offset: 12
+    bit_size: 3
+  - name: MULTG
+    description: Exposure multiplier - Green.
+    bit_offset: 20
+    bit_size: 8
+  - name: SHFG
+    description: Exposure shift - Green.
+    bit_offset: 28
+    bit_size: 3
+fieldset/P1FCR:
+  description: DCMIPP Pipe1 interrupt clear register.
+  fields:
+  - name: CLINEF
+    description: Multi-line capture complete interrupt status clear.
+    bit_offset: 0
+    bit_size: 1
+  - name: CFRAMEF
+    description: Frame capture complete interrupt status clear.
+    bit_offset: 1
+    bit_size: 1
+  - name: CVSYNCF
+    description: Vertical synchronization interrupt status clear.
+    bit_offset: 2
+    bit_size: 1
+  - name: COVRF
+    description: Overrun interrupt status clear.
+    bit_offset: 7
+    bit_size: 1
+fieldset/P1FCTCR:
+  description: DCMIPP Pipex flow control configuration register.
+  fields:
+  - name: FRATE
+    description: Frame capture rate control.
+    bit_offset: 0
+    bit_size: 2
+  - name: CPTMODE
+    description: Capture mode.
+    bit_offset: 2
+    bit_size: 1
+  - name: CPTREQ
+    description: Capture requested.
+    bit_offset: 3
+    bit_size: 1
+fieldset/P1FSCR:
+  description: DCMIPP Pipe1 flow selection configuration register.
+  fields:
+  - name: DTIDA
+    description: Data type selection ID A.
+    bit_offset: 0
+    bit_size: 6
+  - name: DTIDB
+    description: Data type selection ID B.
+    bit_offset: 8
+    bit_size: 6
+  - name: DTMODE
+    description: Flow selection mode.
+    bit_offset: 16
+    bit_size: 2
+  - name: PIPEDIFF
+    description: Differentiates Pipe2 from Pipe1.
+    bit_offset: 18
+    bit_size: 1
+  - name: VC
+    description: Flow selection mode.
+    bit_offset: 19
+    bit_size: 2
+  - name: FDTF
+    description: Force Datatype format.
+    bit_offset: 24
+    bit_size: 6
+  - name: FDTFEN
+    description: Force Datatype format enable.
+    bit_offset: 30
+    bit_size: 1
+  - name: PIPEN
+    description: Activation of PipeN.
+    bit_offset: 31
+    bit_size: 1
+fieldset/P1GMCR:
+  description: DCMIPP Pipex gamma configuration register.
+  fields:
+  - name: ENABLE
+    description: None.
+    bit_offset: 0
+    bit_size: 1
+fieldset/P1IER:
+  description: DCMIPP Pipe1 interrupt enable register.
+  fields:
+  - name: LINEIE
+    description: Multi-line capture completed interrupt enable.
+    bit_offset: 0
+    bit_size: 1
+  - name: FRAMEIE
+    description: Frame capture completed interrupt enable.
+    bit_offset: 1
+    bit_size: 1
+  - name: VSYNCIE
+    description: VSYNC interrupt enable.
+    bit_offset: 2
+    bit_size: 1
+  - name: OVRIE
+    description: Overrun interrupt enable.
+    bit_offset: 7
+    bit_size: 1
+fieldset/P1PPCR:
+  description: DCMIPP Pipe1 pixel packer configuration register.
+  fields:
+  - name: FORMAT
+    description: Memory format.
+    bit_offset: 0
+    bit_size: 4
+  - name: SWAPRB
+    description: Swaps R-vs-B components if RGB, and U-vs-V components if YUV.
+    bit_offset: 4
+    bit_size: 1
+  - name: LINEMULT
+    description: Amount of capture completed lines for LINE Event and Interrupt.
+    bit_offset: 13
+    bit_size: 3
+  - name: DBM
+    description: Double buffer mode.
+    bit_offset: 16
+    bit_size: 1
+  - name: LMAWM
+    description: Line multi address wrapping modulo.
+    bit_offset: 17
+    bit_size: 3
+  - name: LMAWE
+    description: Line multi address wrapping enable bit.
+    bit_offset: 20
+    bit_size: 1
+fieldset/P1PPM0AR1:
+  description: DCMIPP Pipe1 pixel packer Memory0 address register 1.
+  fields:
+  - name: M0A
+    description: Memory0 address.
+    bit_offset: 0
+    bit_size: 32
+fieldset/P1PPM0AR2:
+  description: DCMIPP Pipe1 pixel packer Memory0 address register 2.
+  fields:
+  - name: M0A
+    description: Memory0 address.
+    bit_offset: 0
+    bit_size: 32
+fieldset/P1PPM0PR:
+  description: DCMIPP Pipex pixel packer Memory0 pitch register.
+  fields:
+  - name: PITCH
+    description: Number of bytes between the address of two consecutive lines.
+    bit_offset: 0
+    bit_size: 15
+fieldset/P1PPM1AR1:
+  description: DCMIPP Pipex pixel packer Memory1 address register 1.
+  fields:
+  - name: M1A
+    description: Memory1 address.
+    bit_offset: 0
+    bit_size: 32
+fieldset/P1PPM1AR2:
+  description: DCMIPP Pipex pixel packer Memory1 address register 2.
+  fields:
+  - name: M1A
+    description: Memory1 address.
+    bit_offset: 0
+    bit_size: 32
+fieldset/P1PPM1PR:
+  description: DCMIPP Pipex pixel packer Memory1 pitch register.
+  fields:
+  - name: PITCH
+    description: Number of bytes between the address of two consecutive lines.
+    bit_offset: 0
+    bit_size: 15
+fieldset/P1PPM2AR1:
+  description: DCMIPP Pipex pixel packer memory2 address register 1.
+  fields:
+  - name: M2A
+    description: Memory 2 address.
+    bit_offset: 0
+    bit_size: 32
+fieldset/P1PPM2AR2:
+  description: DCMIPP Pipex pixel packer memory2 address register 2.
+  fields:
+  - name: M2A
+    description: Memory 2 address.
+    bit_offset: 0
+    bit_size: 32
+fieldset/P1RI1CR1:
+  description: DCMIPP Pipe1 ROI1 configuration register 1.
+  fields:
+  - name: HSTART
+    description: Horizontal start, from 0 to 4094 pixels wide.
+    bit_offset: 0
+    bit_size: 12
+  - name: CLB
+    description: Color line blue.
+    bit_offset: 12
+    bit_size: 2
+  - name: CLG
+    description: Color line green.
+    bit_offset: 14
+    bit_size: 2
+  - name: VSTART
+    description: Vertical start, from 0 to 4094 pixels high.
+    bit_offset: 16
+    bit_size: 12
+  - name: CLR
+    description: Color line red.
+    bit_offset: 28
+    bit_size: 2
+fieldset/P1RI1CR2:
+  description: DCMIPP Pipe1 ROI1 configuration register 2.
+  fields:
+  - name: HSIZE
+    description: Horizontal size, from 0 to 4094 pixels wide.
+    bit_offset: 0
+    bit_size: 12
+  - name: VSIZE
+    description: Vertical size, from 0 to 4094 pixels high.
+    bit_offset: 16
+    bit_size: 12
+fieldset/P1RI2CR1:
+  description: DCMIPP Pipe1 ROI2 configuration register 1.
+  fields:
+  - name: HSTART
+    description: Horizontal start, from 0 to 4094 pixels wide.
+    bit_offset: 0
+    bit_size: 12
+  - name: CLB
+    description: Color line blue.
+    bit_offset: 12
+    bit_size: 2
+  - name: CLG
+    description: Color line green.
+    bit_offset: 14
+    bit_size: 2
+  - name: VSTART
+    description: Vertical start, from 0 to 4094 pixels high.
+    bit_offset: 16
+    bit_size: 12
+  - name: CLR
+    description: Color line red.
+    bit_offset: 28
+    bit_size: 2
+fieldset/P1RI2CR2:
+  description: DCMIPP Pipe1 ROI2 configuration register 2.
+  fields:
+  - name: HSIZE
+    description: Horizontal size, from 0 to 4094 pixels wide.
+    bit_offset: 0
+    bit_size: 12
+  - name: VSIZE
+    description: Vertical size, from 0 to 4094 pixels high.
+    bit_offset: 16
+    bit_size: 12
+fieldset/P1RI3CR1:
+  description: DCMIPP Pipe1 ROI3 configuration register 1.
+  fields:
+  - name: HSTART
+    description: Horizontal start, from 0 to 4094 pixels wide.
+    bit_offset: 0
+    bit_size: 12
+  - name: CLB
+    description: Color line blue.
+    bit_offset: 12
+    bit_size: 2
+  - name: CLG
+    description: Color line green.
+    bit_offset: 14
+    bit_size: 2
+  - name: VSTART
+    description: Vertical start, from 0 to 4094 pixels high.
+    bit_offset: 16
+    bit_size: 12
+  - name: CLR
+    description: Color line red.
+    bit_offset: 28
+    bit_size: 2
+fieldset/P1RI3CR2:
+  description: DCMIPP Pipe1 ROI3 configuration register 2.
+  fields:
+  - name: HSIZE
+    description: Horizontal size, from 0 to 4094 pixels wide.
+    bit_offset: 0
+    bit_size: 12
+  - name: VSIZE
+    description: Vertical size, from 0 to 4094 pixels high.
+    bit_offset: 16
+    bit_size: 12
+fieldset/P1RI4CR1:
+  description: DCMIPP Pipe1 ROI4 configuration register 1.
+  fields:
+  - name: HSTART
+    description: Horizontal start, from 0 to 4094 pixels wide.
+    bit_offset: 0
+    bit_size: 12
+  - name: CLB
+    description: Color line blue.
+    bit_offset: 12
+    bit_size: 2
+  - name: CLG
+    description: Color line green.
+    bit_offset: 14
+    bit_size: 2
+  - name: VSTART
+    description: Vertical start, from 0 to 4094 pixels high.
+    bit_offset: 16
+    bit_size: 12
+  - name: CLR
+    description: Color line red.
+    bit_offset: 28
+    bit_size: 2
+fieldset/P1RI4CR2:
+  description: DCMIPP Pipe1 ROI4 configuration register 2.
+  fields:
+  - name: HSIZE
+    description: Horizontal size, from 0 to 4094 pixels wide.
+    bit_offset: 0
+    bit_size: 12
+  - name: VSIZE
+    description: Vertical size, from 0 to 4094 pixels high.
+    bit_offset: 16
+    bit_size: 12
+fieldset/P1RI5CR1:
+  description: DCMIPP Pipe1 ROI5 configuration register 1.
+  fields:
+  - name: HSTART
+    description: Horizontal start, from 0 to 4094 pixels wide.
+    bit_offset: 0
+    bit_size: 12
+  - name: CLB
+    description: Color line blue.
+    bit_offset: 12
+    bit_size: 2
+  - name: CLG
+    description: Color line green.
+    bit_offset: 14
+    bit_size: 2
+  - name: VSTART
+    description: Vertical start, from 0 to 4094 pixels high.
+    bit_offset: 16
+    bit_size: 12
+  - name: CLR
+    description: Color line red.
+    bit_offset: 28
+    bit_size: 2
+fieldset/P1RI5CR2:
+  description: DCMIPP Pipe1 ROI5 configuration register 2.
+  fields:
+  - name: HSIZE
+    description: Horizontal size, from 0 to 4094 pixels wide.
+    bit_offset: 0
+    bit_size: 12
+  - name: VSIZE
+    description: Vertical size, from 0 to 4094 pixels high.
+    bit_offset: 16
+    bit_size: 12
+fieldset/P1RI6CR1:
+  description: DCMIPP Pipe1 ROI6 configuration register 1.
+  fields:
+  - name: HSTART
+    description: Horizontal start, from 0 to 4094 pixels wide.
+    bit_offset: 0
+    bit_size: 12
+  - name: CLB
+    description: Color line blue.
+    bit_offset: 12
+    bit_size: 2
+  - name: CLG
+    description: Color line green.
+    bit_offset: 14
+    bit_size: 2
+  - name: VSTART
+    description: Vertical start, from 0 to 4094 pixels high.
+    bit_offset: 16
+    bit_size: 12
+  - name: CLR
+    description: Color line red.
+    bit_offset: 28
+    bit_size: 2
+fieldset/P1RI6CR2:
+  description: DCMIPP Pipe1 ROI6 configuration register 2.
+  fields:
+  - name: HSIZE
+    description: Horizontal size, from 0 to 4094 pixels wide.
+    bit_offset: 0
+    bit_size: 12
+  - name: VSIZE
+    description: Vertical size, from 0 to 4094 pixels high.
+    bit_offset: 16
+    bit_size: 12
+fieldset/P1RI7CR1:
+  description: DCMIPP Pipe1 ROI7 configuration register 1.
+  fields:
+  - name: HSTART
+    description: Horizontal start, from 0 to 4094 pixels wide.
+    bit_offset: 0
+    bit_size: 12
+  - name: CLB
+    description: Color line blue.
+    bit_offset: 12
+    bit_size: 2
+  - name: CLG
+    description: Color line green.
+    bit_offset: 14
+    bit_size: 2
+  - name: VSTART
+    description: Vertical start, from 0 to 4094 pixels high.
+    bit_offset: 16
+    bit_size: 12
+  - name: CLR
+    description: Color line red.
+    bit_offset: 28
+    bit_size: 2
+fieldset/P1RI7CR2:
+  description: DCMIPP Pipe1 ROI7 configuration register 2.
+  fields:
+  - name: HSIZE
+    description: Horizontal size, from 0 to 4094 pixels wide.
+    bit_offset: 0
+    bit_size: 12
+  - name: VSIZE
+    description: Vertical size, from 0 to 4094 pixels high.
+    bit_offset: 16
+    bit_size: 12
+fieldset/P1RI8CR1:
+  description: DCMIPP Pipe1 ROI8 configuration register 1.
+  fields:
+  - name: HSTART
+    description: Horizontal start, from 0 to 4094 pixels wide.
+    bit_offset: 0
+    bit_size: 12
+  - name: CLB
+    description: Color line blue.
+    bit_offset: 12
+    bit_size: 2
+  - name: CLG
+    description: Color line green.
+    bit_offset: 14
+    bit_size: 2
+  - name: VSTART
+    description: Vertical start, from 0 to 4094 pixels high.
+    bit_offset: 16
+    bit_size: 12
+  - name: CLR
+    description: Color line red.
+    bit_offset: 28
+    bit_size: 2
+fieldset/P1RI8CR2:
+  description: DCMIPP Pipe1 ROI8 configuration register 2.
+  fields:
+  - name: HSIZE
+    description: Horizontal size, from 0 to 4094 pixels wide.
+    bit_offset: 0
+    bit_size: 12
+  - name: VSIZE
+    description: Vertical size, from 0 to 4094 pixels high.
+    bit_offset: 16
+    bit_size: 12
+fieldset/P1SR:
+  description: DCMIPP Pipe1 status register.
+  fields:
+  - name: LINEF
+    description: Multi-line capture completed raw interrupt status.
+    bit_offset: 0
+    bit_size: 1
+  - name: FRAMEF
+    description: Frame capture completed raw interrupt status.
+    bit_offset: 1
+    bit_size: 1
+  - name: VSYNCF
+    description: VSYNC raw interrupt status.
+    bit_offset: 2
+    bit_size: 1
+  - name: OVRF
+    description: Overrun raw interrupt status.
+    bit_offset: 7
+    bit_size: 1
+  - name: LSTLINE
+    description: Last line LSB bit, sampled at frame capture complete event.
+    bit_offset: 16
+    bit_size: 1
+  - name: LSTFRM
+    description: Last frame LSB bit, sampled at frame capture complete event. The information is extracted from the frame data number, which can be delivered by the camera through the CSI2 interface.
+    bit_offset: 17
+    bit_size: 1
+  - name: CPTACT
+    description: Capture immediate status.
+    bit_offset: 23
+    bit_size: 1
+fieldset/P1SRCR:
+  description: DCMIPP Pipe1 stat removal configuration register.
+  fields:
+  - name: LASTLINE
+    description: Amount of following lines to keep when CROPEN = 1. If LASTLINE = 0 all pixels after FIRSTLINEDEL are fed through.
+    bit_offset: 0
+    bit_size: 12
+  - name: FIRSTLINEDEL
+    description: Amount of first lines to delete when CROPEN = 1.
+    bit_offset: 12
+    bit_size: 3
+  - name: CROPEN
+    description: Crop line enable.
+    bit_offset: 15
+    bit_size: 1
+fieldset/P1ST1CR:
+  description: DCMIPP Pipe1 statistics1 control register.
+  fields:
+  - name: ENABLE
+    description: None.
+    bit_offset: 0
+    bit_size: 1
+  - name: BINS
+    description: Current bin definition.
+    bit_offset: 2
+    bit_size: 2
+  - name: SRC
+    description: Statistics source.
+    bit_offset: 4
+    bit_size: 3
+  - name: MODE
+    description: Statistics mode.
+    bit_offset: 7
+    bit_size: 1
+fieldset/P1ST1SR:
+  description: DCMIPP Pipe1 statistics 1 status register.
+  fields:
+  - name: ACCU
+    description: Accumulation result, divided by 256.
+    bit_offset: 0
+    bit_size: 24
+fieldset/P1ST2CR:
+  description: DCMIPP Pipe1 statistics 2 control register.
+  fields:
+  - name: ENABLE
+    description: None.
+    bit_offset: 0
+    bit_size: 1
+  - name: BINS
+    description: Bin definition.
+    bit_offset: 2
+    bit_size: 2
+  - name: SRC
+    description: Statistics source.
+    bit_offset: 4
+    bit_size: 3
+  - name: MODE
+    description: Statistics mode.
+    bit_offset: 7
+    bit_size: 1
+fieldset/P1ST2SR:
+  description: DCMIPP Pipe1 statistics 2 status register.
+  fields:
+  - name: ACCU
+    description: accumulation result, divided by 256.
+    bit_offset: 0
+    bit_size: 24
+fieldset/P1ST3CR:
+  description: DCMIPP Pipe1 statistics 3 control register.
+  fields:
+  - name: ENABLE
+    description: None.
+    bit_offset: 0
+    bit_size: 1
+  - name: BINS
+    description: Bin definition.
+    bit_offset: 2
+    bit_size: 2
+  - name: SRC
+    description: Statistics source.
+    bit_offset: 4
+    bit_size: 3
+  - name: MODE
+    description: Statistics mode.
+    bit_offset: 7
+    bit_size: 1
+fieldset/P1ST3SR:
+  description: DCMIPP Pipe1 statistics 3 status register.
+  fields:
+  - name: ACCU
+    description: accumulation result, divided by 256.
+    bit_offset: 0
+    bit_size: 24
+fieldset/P1STM0AR:
+  description: DCMIPP Pipex status Memory0 address register.
+  fields:
+  - name: M0A
+    description: Memory0 address.
+    bit_offset: 0
+    bit_size: 32
+fieldset/P1STM1AR:
+  description: DCMIPP Pipex status Memory1 address register.
+  fields:
+  - name: M1A
+    description: Memory1 address.
+    bit_offset: 0
+    bit_size: 32
+fieldset/P1STM2AR:
+  description: DCMIPP Pipex status Memory2 address register.
+  fields:
+  - name: M2A
+    description: Memory2 address.
+    bit_offset: 0
+    bit_size: 32
+fieldset/P1STSTR:
+  description: DCMIPP Pipe1 statistics window start register.
+  fields:
+  - name: HSTART
+    description: Horizontal start, from 0 to 4094 pixels wide.
+    bit_offset: 0
+    bit_size: 12
+  - name: VSTART
+    description: Vertical start, from 0 to 4094 pixels high.
+    bit_offset: 16
+    bit_size: 12
+fieldset/P1STSZR:
+  description: DCMIPP Pipe1 statistics window size register.
+  fields:
+  - name: HSIZE
+    description: Horizontal size, from 0 to 4094 pixels wide.
+    bit_offset: 0
+    bit_size: 12
+  - name: VSIZE
+    description: Vertical size, from 0 to 4094 pixels high.
+    bit_offset: 16
+    bit_size: 12
+  - name: CROPEN
+    description: None.
+    bit_offset: 31
+    bit_size: 1
+fieldset/P1YUVBR1:
+  description: DCMIPP Pipe1 YUVConv blue coefficient register 1.
+  fields:
+  - name: BR
+    description: Coefficient row 3 column 1 of the matrix.
+    bit_offset: 0
+    bit_size: 11
+  - name: BG
+    description: Coefficient row 3 column 2 of the matrix.
+    bit_offset: 16
+    bit_size: 11
+fieldset/P1YUVBR2:
+  description: DCMIPP Pipe1 YUV blue coefficient register 2.
+  fields:
+  - name: BB
+    description: Coefficient row 3 column 3 of the matrix.
+    bit_offset: 0
+    bit_size: 11
+  - name: BA
+    description: Coefficient row 3 of the added column (signed integer value).
+    bit_offset: 16
+    bit_size: 10
+fieldset/P1YUVCR:
+  description: DCMIPP Pipe1 YUVConv configuration register.
+  fields:
+  - name: ENABLE
+    description: None.
+    bit_offset: 0
+    bit_size: 1
+  - name: TYPE
+    description: Output samples type used while CLAMP is activated.
+    bit_offset: 1
+    bit_size: 1
+  - name: CLAMP
+    description: Clamp the output samples.
+    bit_offset: 2
+    bit_size: 1
+fieldset/P1YUVGR1:
+  description: DCMIPP Pipe1 YUVConv green coefficient register 1.
+  fields:
+  - name: GR
+    description: Coefficient row 2 column 1 of the matrix.
+    bit_offset: 0
+    bit_size: 11
+  - name: GG
+    description: Coefficient row 2 column 2 of the matrix.
+    bit_offset: 16
+    bit_size: 11
+fieldset/P1YUVGR2:
+  description: DCMIPP Pipe1 YUVConv green coefficient register 2.
+  fields:
+  - name: GB
+    description: Coefficient row 2 column 3 of the matrix.
+    bit_offset: 0
+    bit_size: 11
+  - name: GA
+    description: Coefficient row 2 of the added column (signed integer value).
+    bit_offset: 16
+    bit_size: 10
+fieldset/P1YUVRR1:
+  description: DCMIPP Pipe1 YUVConv red coefficient register 1.
+  fields:
+  - name: RR
+    description: Coefficient row 1 column 1 of the matrix.
+    bit_offset: 0
+    bit_size: 11
+  - name: RG
+    description: Coefficient row 1 column 2 of the matrix.
+    bit_offset: 16
+    bit_size: 11
+fieldset/P1YUVRR2:
+  description: DCMIPP Pipe1 YUVConv red coefficient register 2.
+  fields:
+  - name: RB
+    description: Coefficient row 1 column 3 of the matrix.
+    bit_offset: 0
+    bit_size: 11
+  - name: RA
+    description: Coefficient row 1 of the added column (signed integer value).
+    bit_offset: 16
+    bit_size: 10
+fieldset/P2CCMRICR:
+  description: DCMIPP Pipex current common ROI configuration register.
+  fields:
+  - name: ROILSZ
+    description: Current region of interest line size width.
+    bit_offset: 0
+    bit_size: 2
+  - name: ROI1EN
+    description: Current region of interest 1 enable.
+    bit_offset: 16
+    bit_size: 1
+  - name: ROI2EN
+    description: Current region of interest 2 enable.
+    bit_offset: 17
+    bit_size: 1
+  - name: ROI3EN
+    description: Current region of interest 3 enable.
+    bit_offset: 18
+    bit_size: 1
+  - name: ROI4EN
+    description: Current region of interest 4 enable.
+    bit_offset: 19
+    bit_size: 1
+  - name: ROI5EN
+    description: Current region of interest 5 enable.
+    bit_offset: 20
+    bit_size: 1
+  - name: ROI6EN
+    description: Current region of interest 6 enable.
+    bit_offset: 21
+    bit_size: 1
+  - name: ROI7EN
+    description: Current region of interest 7 enable.
+    bit_offset: 22
+    bit_size: 1
+  - name: ROI8EN
+    description: Current region of interest 8 enable.
+    bit_offset: 23
+    bit_size: 1
+fieldset/P2CCRSTR:
+  description: DCMIPP Pipex current crop window start register.
+  fields:
+  - name: HSTART
+    description: Current horizontal start, from 0 to 4094 pixels wide.
+    bit_offset: 0
+    bit_size: 12
+  - name: VSTART
+    description: Current vertical start, from 0 to 4094 pixels high.
+    bit_offset: 16
+    bit_size: 12
+fieldset/P2CCRSZR:
+  description: DCMIPP Pipex current crop window size register.
+  fields:
+  - name: HSIZE
+    description: Current horizontal size, from 0 to 4094 pixels wide.
+    bit_offset: 0
+    bit_size: 12
+  - name: VSIZE
+    description: Current vertical size, from 0 to 4094 pixels high.
+    bit_offset: 16
+    bit_size: 12
+  - name: ENABLE
+    description: Current ENABLE bit value.
+    bit_offset: 31
+    bit_size: 1
+fieldset/P2CDCCR:
+  description: DCMIPP Pipex current decimation register.
+  fields:
+  - name: ENABLE
+    description: None.
+    bit_offset: 0
+    bit_size: 1
+  - name: HDEC
+    description: Horizontal decimation ratio.
+    bit_offset: 1
+    bit_size: 2
+  - name: VDEC
+    description: Vertical decimation ratio.
+    bit_offset: 3
+    bit_size: 2
+fieldset/P2CDSCR:
+  description: DCMIPP Pipex current downsize configuration register.
+  fields:
+  - name: HDIV
+    description: Current horizontal division factor, from 128 (8x) to 1023 (1x).
+    bit_offset: 0
+    bit_size: 10
+  - name: VDIV
+    description: Current vertical division factor, from 128 (8x) to 1023 (1x).
+    bit_offset: 16
+    bit_size: 10
+  - name: ENABLE
+    description: Current value of bit ENABLE.
+    bit_offset: 31
+    bit_size: 1
+fieldset/P2CDSRTIOR:
+  description: DCMIPP Pipex current downsize ratio register.
+  fields:
+  - name: HRATIO
+    description: Current horizontal ratio, from 8192 (1x) to 65535 (8x).
+    bit_offset: 0
+    bit_size: 16
+  - name: VRATIO
+    description: Current vertical ratio, from 8192 (1x) to 65535 (8x).
+    bit_offset: 16
+    bit_size: 16
+fieldset/P2CDSSZR:
+  description: DCMIPP Pipex current downsize destination size register.
+  fields:
+  - name: HSIZE
+    description: Current horizontal size, from 0 to 4094 pixels wide.
+    bit_offset: 0
+    bit_size: 12
+  - name: VSIZE
+    description: Current vertical size, from 0 to 4094 pixels high.
+    bit_offset: 16
+    bit_size: 12
+fieldset/P2CFCTCR:
+  description: DCMIPP Pipex current flow control configuration register.
+  fields:
+  - name: FRATE
+    description: Frame capture rate control.
+    bit_offset: 0
+    bit_size: 2
+  - name: CPTMODE
+    description: Capture mode.
+    bit_offset: 2
+    bit_size: 1
+  - name: CPTREQ
+    description: Capture requested.
+    bit_offset: 3
+    bit_size: 1
+fieldset/P2CFSCR:
+  description: DCMIPP Pipe2 current flow selection configuration register.
+  fields:
+  - name: DTIDA
+    description: Current data type ID.
+    bit_offset: 0
+    bit_size: 6
+  - name: VC
+    description: Current flow selection mode.
+    bit_offset: 19
+    bit_size: 2
+  - name: FDTF
+    description: Current force data type format.
+    bit_offset: 24
+    bit_size: 6
+  - name: FDTFEN
+    description: Current force data type format enable.
+    bit_offset: 30
+    bit_size: 1
+  - name: PIPEN
+    description: Current activation of PipeN.
+    bit_offset: 31
+    bit_size: 1
+fieldset/P2CMRICR:
+  description: DCMIPP Pipex common ROI configuration register.
+  fields:
+  - name: ROILSZ
+    description: Region of interest line size width.
+    bit_offset: 0
+    bit_size: 2
+  - name: ROI1EN
+    description: Region of interest 1 enable.
+    bit_offset: 16
+    bit_size: 1
+  - name: ROI2EN
+    description: Region of interest 2 enable.
+    bit_offset: 17
+    bit_size: 1
+  - name: ROI3EN
+    description: Region of interest 3 enable.
+    bit_offset: 18
+    bit_size: 1
+  - name: ROI4EN
+    description: Region of interest 4 enable.
+    bit_offset: 19
+    bit_size: 1
+  - name: ROI5EN
+    description: Region of interest 5 enable.
+    bit_offset: 20
+    bit_size: 1
+  - name: ROI6EN
+    description: Region of interest 6 enable.
+    bit_offset: 21
+    bit_size: 1
+  - name: ROI7EN
+    description: Region of interest 7 enable.
+    bit_offset: 22
+    bit_size: 1
+  - name: ROI8EN
+    description: Region of interest 8 enable.
+    bit_offset: 23
+    bit_size: 1
+fieldset/P2CPPCR:
+  description: DCMIPP Pipe2 current pixel packer configuration register.
+  fields:
+  - name: FORMAT
+    description: Memory format (only coplanar formats are supported in Pipe2).
+    bit_offset: 0
+    bit_size: 4
+  - name: SWAPRB
+    description: Swaps R-vs-B components if RGB, and if YUV, swaps U-vs-V components.
+    bit_offset: 4
+    bit_size: 1
+  - name: LINEMULT
+    description: Amount of capture completed lines for LINE event and interrupt.
+    bit_offset: 13
+    bit_size: 3
+  - name: DBM
+    description: Double buffer mode.
+    bit_offset: 16
+    bit_size: 1
+  - name: LMAWM
+    description: Line multi address wrapping modulo.
+    bit_offset: 17
+    bit_size: 3
+  - name: LMAWE
+    description: Line multi address wrapping enable bit.
+    bit_offset: 20
+    bit_size: 1
+fieldset/P2CPPM0AR1:
+  description: DCMIPP Pipe2 current pixel packer Memory0 address register 1.
+  fields:
+  - name: M0A
+    description: Memory0 address.
+    bit_offset: 0
+    bit_size: 32
+fieldset/P2CPPM0AR2:
+  description: DCMIPP Pipe2 current pixel packer Memory0 address register 2.
+  fields:
+  - name: M0A
+    description: Memory0 address.
+    bit_offset: 0
+    bit_size: 32
+fieldset/P2CRI1CR1:
+  description: DCMIPP Pipe2 current ROI1 configuration register 1.
+  fields:
+  - name: HSTART
+    description: Current horizontal start, from 0 to 4094 pixels wide.
+    bit_offset: 0
+    bit_size: 12
+  - name: CLB
+    description: Current color line blue.
+    bit_offset: 12
+    bit_size: 2
+  - name: CLG
+    description: Current color line green.
+    bit_offset: 14
+    bit_size: 2
+  - name: VSTART
+    description: Current vertical start, from 0 to 4094 pixels high.
+    bit_offset: 16
+    bit_size: 12
+  - name: CLR
+    description: Current color line red.
+    bit_offset: 28
+    bit_size: 2
+fieldset/P2CRI1CR2:
+  description: DCMIPP Pipe2 current ROI1 configuration register 2.
+  fields:
+  - name: HSIZE
+    description: Current horizontal size, from 0 to 4094 pixels wide.
+    bit_offset: 0
+    bit_size: 12
+  - name: VSIZE
+    description: Current vertical size, from 0 to 4094 pixels high.
+    bit_offset: 16
+    bit_size: 12
+fieldset/P2CRI2CR1:
+  description: DCMIPP Pipe2 current ROI2 configuration register 1.
+  fields:
+  - name: HSTART
+    description: Current horizontal start, from 0 to 4094 pixels wide.
+    bit_offset: 0
+    bit_size: 12
+  - name: CLB
+    description: Current color line blue.
+    bit_offset: 12
+    bit_size: 2
+  - name: CLG
+    description: Current color line green.
+    bit_offset: 14
+    bit_size: 2
+  - name: VSTART
+    description: Current vertical start, from 0 to 4094 pixels high.
+    bit_offset: 16
+    bit_size: 12
+  - name: CLR
+    description: Current color line red.
+    bit_offset: 28
+    bit_size: 2
+fieldset/P2CRI2CR2:
+  description: DCMIPP Pipe2 current ROI2 configuration register 2.
+  fields:
+  - name: HSIZE
+    description: Current horizontal size, from 0 to 4094 pixels wide.
+    bit_offset: 0
+    bit_size: 12
+  - name: VSIZE
+    description: Current vertical size, from 0 to 4094 pixels high.
+    bit_offset: 16
+    bit_size: 12
+fieldset/P2CRI3CR1:
+  description: DCMIPP Pipe2 current ROI3 configuration register 1.
+  fields:
+  - name: HSTART
+    description: Current horizontal start, from 0 to 4094 pixels wide.
+    bit_offset: 0
+    bit_size: 12
+  - name: CLB
+    description: Current color line blue.
+    bit_offset: 12
+    bit_size: 2
+  - name: CLG
+    description: Current color line green.
+    bit_offset: 14
+    bit_size: 2
+  - name: VSTART
+    description: Current vertical start, from 0 to 4094 pixels high.
+    bit_offset: 16
+    bit_size: 12
+  - name: CLR
+    description: Current color line red.
+    bit_offset: 28
+    bit_size: 2
+fieldset/P2CRI3CR2:
+  description: DCMIPP Pipe2 current ROI3 configuration register 2.
+  fields:
+  - name: HSIZE
+    description: Current horizontal size, from 0 to 4094 pixels wide.
+    bit_offset: 0
+    bit_size: 12
+  - name: VSIZE
+    description: Current vertical size, from 0 to 4094 pixels high.
+    bit_offset: 16
+    bit_size: 12
+fieldset/P2CRI4CR1:
+  description: DCMIPP Pipe2 current ROI4 configuration register 1.
+  fields:
+  - name: HSTART
+    description: Current horizontal start, from 0 to 4094 pixels wide.
+    bit_offset: 0
+    bit_size: 12
+  - name: CLB
+    description: Current color line blue.
+    bit_offset: 12
+    bit_size: 2
+  - name: CLG
+    description: Current color line green.
+    bit_offset: 14
+    bit_size: 2
+  - name: VSTART
+    description: Current vertical start, from 0 to 4094 pixels high.
+    bit_offset: 16
+    bit_size: 12
+  - name: CLR
+    description: Current color line red.
+    bit_offset: 28
+    bit_size: 2
+fieldset/P2CRI4CR2:
+  description: DCMIPP Pipe2 current ROI4 configuration register 2.
+  fields:
+  - name: HSIZE
+    description: Current horizontal size, from 0 to 4094 pixels wide.
+    bit_offset: 0
+    bit_size: 12
+  - name: VSIZE
+    description: Current vertical size, from 0 to 4094 pixels high.
+    bit_offset: 16
+    bit_size: 12
+fieldset/P2CRI5CR1:
+  description: DCMIPP Pipe2 current ROI5 configuration register 1.
+  fields:
+  - name: HSTART
+    description: Current horizontal start, from 0 to 4094 pixels wide.
+    bit_offset: 0
+    bit_size: 12
+  - name: CLB
+    description: Current color line blue.
+    bit_offset: 12
+    bit_size: 2
+  - name: CLG
+    description: Current color line green.
+    bit_offset: 14
+    bit_size: 2
+  - name: VSTART
+    description: Current vertical start, from 0 to 4094 pixels high.
+    bit_offset: 16
+    bit_size: 12
+  - name: CLR
+    description: Current color line red.
+    bit_offset: 28
+    bit_size: 2
+fieldset/P2CRI5CR2:
+  description: DCMIPP Pipe2 current ROI5 configuration register 2.
+  fields:
+  - name: HSIZE
+    description: Current horizontal size, from 0 to 4094 pixels wide.
+    bit_offset: 0
+    bit_size: 12
+  - name: VSIZE
+    description: Current vertical size, from 0 to 4094 pixels high.
+    bit_offset: 16
+    bit_size: 12
+fieldset/P2CRI6CR1:
+  description: DCMIPP Pipe2 current ROI6 configuration register 1.
+  fields:
+  - name: HSTART
+    description: Current horizontal start, from 0 to 4094 pixels wide.
+    bit_offset: 0
+    bit_size: 12
+  - name: CLB
+    description: Current color line blue.
+    bit_offset: 12
+    bit_size: 2
+  - name: CLG
+    description: Current color line green.
+    bit_offset: 14
+    bit_size: 2
+  - name: VSTART
+    description: Current vertical start, from 0 to 4094 pixels high.
+    bit_offset: 16
+    bit_size: 12
+  - name: CLR
+    description: Current color line red.
+    bit_offset: 28
+    bit_size: 2
+fieldset/P2CRI6CR2:
+  description: DCMIPP Pipe2 current ROI6 configuration register 2.
+  fields:
+  - name: HSIZE
+    description: Current horizontal size, from 0 to 4094 pixels wide.
+    bit_offset: 0
+    bit_size: 12
+  - name: VSIZE
+    description: Current vertical size, from 0 to 4094 pixels high.
+    bit_offset: 16
+    bit_size: 12
+fieldset/P2CRI7CR1:
+  description: DCMIPP Pipe2 current ROI7 configuration register 1.
+  fields:
+  - name: HSTART
+    description: Current horizontal start, from 0 to 4094 pixels wide.
+    bit_offset: 0
+    bit_size: 12
+  - name: CLB
+    description: Current color line blue.
+    bit_offset: 12
+    bit_size: 2
+  - name: CLG
+    description: Current color line green.
+    bit_offset: 14
+    bit_size: 2
+  - name: VSTART
+    description: Current vertical start, from 0 to 4094 pixels high.
+    bit_offset: 16
+    bit_size: 12
+  - name: CLR
+    description: Current color line red.
+    bit_offset: 28
+    bit_size: 2
+fieldset/P2CRI7CR2:
+  description: DCMIPP Pipe2 current ROI7 configuration register 2.
+  fields:
+  - name: HSIZE
+    description: Current horizontal size, from 0 to 4094 pixels wide.
+    bit_offset: 0
+    bit_size: 12
+  - name: VSIZE
+    description: Current vertical size, from 0 to 4094 pixels high.
+    bit_offset: 16
+    bit_size: 12
+fieldset/P2CRI8CR1:
+  description: DCMIPP Pipe2 current ROI8 configuration register 1.
+  fields:
+  - name: HSTART
+    description: Current horizontal start, from 0 to 4094 pixels wide.
+    bit_offset: 0
+    bit_size: 12
+  - name: CLB
+    description: Current color line blue.
+    bit_offset: 12
+    bit_size: 2
+  - name: CLG
+    description: Current color line green.
+    bit_offset: 14
+    bit_size: 2
+  - name: VSTART
+    description: Current vertical start, from 0 to 4094 pixels high.
+    bit_offset: 16
+    bit_size: 12
+  - name: CLR
+    description: Current color line red.
+    bit_offset: 28
+    bit_size: 2
+fieldset/P2CRI8CR2:
+  description: DCMIPP Pipe2 current ROI8 configuration register 2.
+  fields:
+  - name: HSIZE
+    description: Current horizontal size, from 0 to 4094 pixels wide.
+    bit_offset: 0
+    bit_size: 12
+  - name: VSIZE
+    description: Current vertical size, from 0 to 4094 pixels high.
+    bit_offset: 16
+    bit_size: 12
+fieldset/P2CRSTR:
+  description: DCMIPP Pipex crop window start register.
+  fields:
+  - name: HSTART
+    description: Horizontal start, from 0 to 4094 pixels wide.
+    bit_offset: 0
+    bit_size: 12
+  - name: VSTART
+    description: Vertical start, from 0 to 4094 pixels high.
+    bit_offset: 16
+    bit_size: 12
+fieldset/P2CRSZR:
+  description: DCMIPP Pipex crop window size register.
+  fields:
+  - name: HSIZE
+    description: Horizontal size, from 0 to 4094 pixels wide. If the value is maintained at 0 when enabling the crop by means of the ENABLE bit, the value is forced internally at 0xFFE, which is the maximum value.
+    bit_offset: 0
+    bit_size: 12
+  - name: VSIZE
+    description: Vertical size, from 0 to 4094 pixels high. If the value is maintained at 0 when enabling the crop thanks to the ENABLE bit, the value is forced internally at 0xFFE, which is the maximum value.
+    bit_offset: 16
+    bit_size: 12
+  - name: ENABLE
+    description: None.
+    bit_offset: 31
+    bit_size: 1
+fieldset/P2DCCR:
+  description: DCMIPP Pipex decimation register.
+  fields:
+  - name: ENABLE
+    description: None.
+    bit_offset: 0
+    bit_size: 1
+  - name: HDEC
+    description: Horizontal decimation ratio.
+    bit_offset: 1
+    bit_size: 2
+  - name: VDEC
+    description: Vertical decimation ratio.
+    bit_offset: 3
+    bit_size: 2
+fieldset/P2DSCR:
+  description: DCMIPP Pipex downsize configuration register.
+  fields:
+  - name: HDIV
+    description: Horizontal division factor, from 128 (8x) to 1023 (1x).
+    bit_offset: 0
+    bit_size: 10
+  - name: VDIV
+    description: Vertical division factor, from 128 (8x) to 1023 (1x).
+    bit_offset: 16
+    bit_size: 10
+  - name: ENABLE
+    description: None.
+    bit_offset: 31
+    bit_size: 1
+fieldset/P2DSRTIOR:
+  description: DCMIPP Pipex downsize ratio register.
+  fields:
+  - name: HRATIO
+    description: Horizontal ratio, from 8192 (1x) to 65535 (8x).
+    bit_offset: 0
+    bit_size: 16
+  - name: VRATIO
+    description: Vertical ratio, from 8192 (1x) to 65535 (8x).
+    bit_offset: 16
+    bit_size: 16
+fieldset/P2DSSZR:
+  description: DCMIPP Pipex downsize destination size register.
+  fields:
+  - name: HSIZE
+    description: Horizontal size, from 0 to 4094 pixels wide.
+    bit_offset: 0
+    bit_size: 12
+  - name: VSIZE
+    description: Vertical size, from 0 to 4094 pixels high.
+    bit_offset: 16
+    bit_size: 12
+fieldset/P2FCR:
+  description: DCMIPP Pipe2 interrupt clear register.
+  fields:
+  - name: CLINEF
+    description: Multi-line capture complete interrupt status clear.
+    bit_offset: 0
+    bit_size: 1
+  - name: CFRAMEF
+    description: Frame capture complete interrupt status clear.
+    bit_offset: 1
+    bit_size: 1
+  - name: CVSYNCF
+    description: Vertical synchronization interrupt status clear.
+    bit_offset: 2
+    bit_size: 1
+  - name: COVRF
+    description: Overrun interrupt status clear.
+    bit_offset: 7
+    bit_size: 1
+fieldset/P2FCTCR:
+  description: DCMIPP Pipex flow control configuration register.
+  fields:
+  - name: FRATE
+    description: Frame capture rate control.
+    bit_offset: 0
+    bit_size: 2
+  - name: CPTMODE
+    description: Capture mode.
+    bit_offset: 2
+    bit_size: 1
+  - name: CPTREQ
+    description: Capture requested.
+    bit_offset: 3
+    bit_size: 1
+fieldset/P2FSCR:
+  description: DCMIPP Pipe2 flow selection configuration register.
+  fields:
+  - name: DTIDA
+    description: Data type ID.
+    bit_offset: 0
+    bit_size: 6
+  - name: VC
+    description: Flow selection mode.
+    bit_offset: 19
+    bit_size: 2
+  - name: FDTF
+    description: Force data type format.
+    bit_offset: 24
+    bit_size: 6
+  - name: FDTFEN
+    description: Force data type format enable.
+    bit_offset: 30
+    bit_size: 1
+  - name: PIPEN
+    description: Activation of PipeN.
+    bit_offset: 31
+    bit_size: 1
+fieldset/P2GMCR:
+  description: DCMIPP Pipex gamma configuration register.
+  fields:
+  - name: ENABLE
+    description: None.
+    bit_offset: 0
+    bit_size: 1
+fieldset/P2IER:
+  description: DCMIPP Pipe2 interrupt enable register.
+  fields:
+  - name: LINEIE
+    description: Multi-line capture completed interrupt enable.
+    bit_offset: 0
+    bit_size: 1
+  - name: FRAMEIE
+    description: Frame capture completed interrupt enable.
+    bit_offset: 1
+    bit_size: 1
+  - name: VSYNCIE
+    description: VSYNC interrupt enable.
+    bit_offset: 2
+    bit_size: 1
+  - name: OVRIE
+    description: Overrun interrupt enable.
+    bit_offset: 7
+    bit_size: 1
+fieldset/P2PPCR:
+  description: DCMIPP Pipe2 pixel packer configuration register.
+  fields:
+  - name: FORMAT
+    description: Memory format (only coplanar formats are supported in Pipe2).
+    bit_offset: 0
+    bit_size: 4
+  - name: SWAPRB
+    description: Swaps R-vs-B components if RGB, and if YUV, swaps U-vs-V components.
+    bit_offset: 4
+    bit_size: 1
+  - name: LINEMULT
+    description: Amount of capture completed lines for LINE event and interrupt.
+    bit_offset: 13
+    bit_size: 3
+  - name: DBM
+    description: Double buffer mode.
+    bit_offset: 16
+    bit_size: 1
+  - name: LMAWM
+    description: Line multi address wrapping modulo.
+    bit_offset: 17
+    bit_size: 3
+  - name: LMAWE
+    description: Line multi address wrapping enable bit.
+    bit_offset: 20
+    bit_size: 1
+fieldset/P2PPM0AR1:
+  description: DCMIPP Pipe2 pixel packer Memory0 address register 1.
+  fields:
+  - name: M0A
+    description: Memory0 address.
+    bit_offset: 0
+    bit_size: 32
+fieldset/P2PPM0AR2:
+  description: DCMIPP Pipe2 pixel packer Memory0 address register 2.
+  fields:
+  - name: M0A
+    description: Memory0 address.
+    bit_offset: 0
+    bit_size: 32
+fieldset/P2PPM0PR:
+  description: DCMIPP Pipex pixel packer Memory0 pitch register.
+  fields:
+  - name: PITCH
+    description: Number of bytes between the address of two consecutive lines.
+    bit_offset: 0
+    bit_size: 15
+fieldset/P2RI1CR1:
+  description: DCMIPP Pipe2 ROI1 configuration register 1.
+  fields:
+  - name: HSTART
+    description: Horizontal start, from 0 to 4094 pixels wide.
+    bit_offset: 0
+    bit_size: 12
+  - name: CLB
+    description: Color line blue.
+    bit_offset: 12
+    bit_size: 2
+  - name: CLG
+    description: Color line green.
+    bit_offset: 14
+    bit_size: 2
+  - name: VSTART
+    description: Vertical start, from 0 to 4094 pixels high.
+    bit_offset: 16
+    bit_size: 12
+  - name: CLR
+    description: Color line red.
+    bit_offset: 28
+    bit_size: 2
+fieldset/P2RI1CR2:
+  description: DCMIPP Pipe2 ROI1 configuration register 2.
+  fields:
+  - name: HSIZE
+    description: Horizontal size, from 0 to 4094 pixels wide.
+    bit_offset: 0
+    bit_size: 12
+  - name: VSIZE
+    description: Vertical size, from 0 to 4094 pixels high.
+    bit_offset: 16
+    bit_size: 12
+fieldset/P2RI2CR1:
+  description: DCMIPP Pipe2 ROI2 configuration register 1.
+  fields:
+  - name: HSTART
+    description: Horizontal start, from 0 to 4094 pixels wide.
+    bit_offset: 0
+    bit_size: 12
+  - name: CLB
+    description: Color line blue.
+    bit_offset: 12
+    bit_size: 2
+  - name: CLG
+    description: Color line green.
+    bit_offset: 14
+    bit_size: 2
+  - name: VSTART
+    description: Vertical start, from 0 to 4094 pixels high.
+    bit_offset: 16
+    bit_size: 12
+  - name: CLR
+    description: Color line red.
+    bit_offset: 28
+    bit_size: 2
+fieldset/P2RI2CR2:
+  description: DCMIPP Pipe2 ROI2 configuration register 2.
+  fields:
+  - name: HSIZE
+    description: Horizontal size, from 0 to 4094 pixels wide.
+    bit_offset: 0
+    bit_size: 12
+  - name: VSIZE
+    description: Vertical size, from 0 to 4094 pixels high.
+    bit_offset: 16
+    bit_size: 12
+fieldset/P2RI3CR1:
+  description: DCMIPP Pipe2 ROI3 configuration register 1.
+  fields:
+  - name: HSTART
+    description: Horizontal start, from 0 to 4094 pixels wide.
+    bit_offset: 0
+    bit_size: 12
+  - name: CLB
+    description: Color line blue.
+    bit_offset: 12
+    bit_size: 2
+  - name: CLG
+    description: Color line green.
+    bit_offset: 14
+    bit_size: 2
+  - name: VSTART
+    description: Vertical start, from 0 to 4094 pixels high.
+    bit_offset: 16
+    bit_size: 12
+  - name: CLR
+    description: Color line red.
+    bit_offset: 28
+    bit_size: 2
+fieldset/P2RI3CR2:
+  description: DCMIPP Pipe2 ROI3 configuration register 2.
+  fields:
+  - name: HSIZE
+    description: Horizontal size, from 0 to 4094 pixels wide.
+    bit_offset: 0
+    bit_size: 12
+  - name: VSIZE
+    description: Vertical size, from 0 to 4094 pixels high.
+    bit_offset: 16
+    bit_size: 12
+fieldset/P2RI4CR1:
+  description: DCMIPP Pipe2 ROI4 configuration register 1.
+  fields:
+  - name: HSTART
+    description: Horizontal start, from 0 to 4094 pixels wide.
+    bit_offset: 0
+    bit_size: 12
+  - name: CLB
+    description: Color line blue.
+    bit_offset: 12
+    bit_size: 2
+  - name: CLG
+    description: Color line green.
+    bit_offset: 14
+    bit_size: 2
+  - name: VSTART
+    description: Vertical start, from 0 to 4094 pixels high.
+    bit_offset: 16
+    bit_size: 12
+  - name: CLR
+    description: Color line red.
+    bit_offset: 28
+    bit_size: 2
+fieldset/P2RI4CR2:
+  description: DCMIPP Pipe2 ROI4 configuration register 2.
+  fields:
+  - name: HSIZE
+    description: Horizontal size, from 0 to 4094 pixels wide.
+    bit_offset: 0
+    bit_size: 12
+  - name: VSIZE
+    description: Vertical size, from 0 to 4094 pixels high.
+    bit_offset: 16
+    bit_size: 12
+fieldset/P2RI5CR1:
+  description: DCMIPP Pipe2 ROI5 configuration register 1.
+  fields:
+  - name: HSTART
+    description: Horizontal start, from 0 to 4094 pixels wide.
+    bit_offset: 0
+    bit_size: 12
+  - name: CLB
+    description: Color line blue.
+    bit_offset: 12
+    bit_size: 2
+  - name: CLG
+    description: Color line green.
+    bit_offset: 14
+    bit_size: 2
+  - name: VSTART
+    description: Vertical start, from 0 to 4094 pixels high.
+    bit_offset: 16
+    bit_size: 12
+  - name: CLR
+    description: Color line red.
+    bit_offset: 28
+    bit_size: 2
+fieldset/P2RI5CR2:
+  description: DCMIPP Pipe2 ROI5 configuration register 2.
+  fields:
+  - name: HSIZE
+    description: Horizontal size, from 0 to 4094 pixels wide.
+    bit_offset: 0
+    bit_size: 12
+  - name: VSIZE
+    description: Vertical size, from 0 to 4094 pixels high.
+    bit_offset: 16
+    bit_size: 12
+fieldset/P2RI6CR1:
+  description: DCMIPP Pipe2 ROI6 configuration register 1.
+  fields:
+  - name: HSTART
+    description: Horizontal start, from 0 to 4094 pixels wide.
+    bit_offset: 0
+    bit_size: 12
+  - name: CLB
+    description: Color line blue.
+    bit_offset: 12
+    bit_size: 2
+  - name: CLG
+    description: Color line green.
+    bit_offset: 14
+    bit_size: 2
+  - name: VSTART
+    description: Vertical start, from 0 to 4094 pixels high.
+    bit_offset: 16
+    bit_size: 12
+  - name: CLR
+    description: Color line red.
+    bit_offset: 28
+    bit_size: 2
+fieldset/P2RI6CR2:
+  description: DCMIPP Pipe2 ROI6 configuration register 2.
+  fields:
+  - name: HSIZE
+    description: Horizontal size, from 0 to 4094 pixels wide.
+    bit_offset: 0
+    bit_size: 12
+  - name: VSIZE
+    description: Vertical size, from 0 to 4094 pixels high.
+    bit_offset: 16
+    bit_size: 12
+fieldset/P2RI7CR1:
+  description: DCMIPP Pipe2 ROI7 configuration register 1.
+  fields:
+  - name: HSTART
+    description: Horizontal start, from 0 to 4094 pixels wide.
+    bit_offset: 0
+    bit_size: 12
+  - name: CLB
+    description: Color line blue.
+    bit_offset: 12
+    bit_size: 2
+  - name: CLG
+    description: Color line green.
+    bit_offset: 14
+    bit_size: 2
+  - name: VSTART
+    description: Vertical start, from 0 to 4094 pixels high.
+    bit_offset: 16
+    bit_size: 12
+  - name: CLR
+    description: Color line red.
+    bit_offset: 28
+    bit_size: 2
+fieldset/P2RI7CR2:
+  description: DCMIPP Pipe2 ROI7 configuration register 2.
+  fields:
+  - name: HSIZE
+    description: Horizontal size, from 0 to 4094 pixels wide.
+    bit_offset: 0
+    bit_size: 12
+  - name: VSIZE
+    description: Vertical size, from 0 to 4094 pixels high.
+    bit_offset: 16
+    bit_size: 12
+fieldset/P2RI8CR1:
+  description: DCMIPP Pipe2 ROI8 configuration register 1.
+  fields:
+  - name: HSTART
+    description: Horizontal start, from 0 to 4094 pixels wide.
+    bit_offset: 0
+    bit_size: 12
+  - name: CLB
+    description: Color line blue.
+    bit_offset: 12
+    bit_size: 2
+  - name: CLG
+    description: Color line green.
+    bit_offset: 14
+    bit_size: 2
+  - name: VSTART
+    description: Vertical start, from 0 to 4094 pixels high.
+    bit_offset: 16
+    bit_size: 12
+  - name: CLR
+    description: Color line red.
+    bit_offset: 28
+    bit_size: 2
+fieldset/P2RI8CR2:
+  description: DCMIPP Pipe2 ROI8 configuration register 2.
+  fields:
+  - name: HSIZE
+    description: Horizontal size, from 0 to 4094 pixels wide.
+    bit_offset: 0
+    bit_size: 12
+  - name: VSIZE
+    description: Vertical size, from 0 to 4094 pixels high.
+    bit_offset: 16
+    bit_size: 12
+fieldset/P2SR:
+  description: DCMIPP Pipe2 status register.
+  fields:
+  - name: LINEF
+    description: Multi-line capture completed raw interrupt status.
+    bit_offset: 0
+    bit_size: 1
+  - name: FRAMEF
+    description: Frame capture completed raw interrupt status.
+    bit_offset: 1
+    bit_size: 1
+  - name: VSYNCF
+    description: VSYNC raw interrupt status.
+    bit_offset: 2
+    bit_size: 1
+  - name: OVRF
+    description: Overrun raw interrupt status.
+    bit_offset: 7
+    bit_size: 1
+  - name: LSTLINE
+    description: Last line LSB bit, sampled at frame capture complete event.
+    bit_offset: 16
+    bit_size: 1
+  - name: LSTFRM
+    description: Last frame LSB bit, sampled at frame capture complete event. The information is extracted from the frame data number which can be delivered by the camera through the CSI2 interface.
+    bit_offset: 17
+    bit_size: 1
+  - name: CPTACT
+    description: Capture immediate status.
+    bit_offset: 23
+    bit_size: 1
+fieldset/P2STM0AR:
+  description: DCMIPP Pipex status Memory0 address register.
+  fields:
+  - name: M0A
+    description: Memory0 address.
+    bit_offset: 0
+    bit_size: 32
+fieldset/PRCR:
+  description: DCMIPP parallel interface control register.
+  fields:
+  - name: ESS
+    description: Embedded synchronization select.
+    bit_offset: 4
+    bit_size: 1
+  - name: PCKPOL
+    description: Pixel clock polarity.
+    bit_offset: 5
+    bit_size: 1
+  - name: HSPOL
+    description: Horizontal synchronization polarity.
+    bit_offset: 6
+    bit_size: 1
+  - name: VSPOL
+    description: Vertical synchronization polarity.
+    bit_offset: 7
+    bit_size: 1
+  - name: EDM
+    description: Extended data mode.
+    bit_offset: 10
+    bit_size: 3
+  - name: ENABLE
+    description: Parallel interface enable.
+    bit_offset: 14
+    bit_size: 1
+  - name: FORMAT
+    description: 'Other values: data are captured and output as-is only through the data/dump pipeline (e.g. JPEG or byte input format).'
+    bit_offset: 16
+    bit_size: 8
+  - name: SWAPCYCLES
+    description: Swap data (cycle 0 vs. cycle 1) for pixels received on two cycles.
+    bit_offset: 25
+    bit_size: 1
+  - name: SWAPBITS
+    description: Swap LSB vs. MSB within each received component.
+    bit_offset: 26
+    bit_size: 1
+fieldset/PRESCR:
+  description: DCMIPP parallel interface embedded synchronization code register.
+  fields:
+  - name: FSC
+    description: Frame start delimiter code.
+    bit_offset: 0
+    bit_size: 8
+  - name: LSC
+    description: Line start delimiter code.
+    bit_offset: 8
+    bit_size: 8
+  - name: LEC
+    description: Line end delimiter code.
+    bit_offset: 16
+    bit_size: 8
+  - name: FEC
+    description: Frame end delimiter code.
+    bit_offset: 24
+    bit_size: 8
+fieldset/PRESUR:
+  description: DCMIPP parallel interface embedded synchronization unmask register.
+  fields:
+  - name: FSU
+    description: Frame start delimiter unmask.
+    bit_offset: 0
+    bit_size: 8
+  - name: LSU
+    description: Line start delimiter unmask.
+    bit_offset: 8
+    bit_size: 8
+  - name: LEU
+    description: Line end delimiter unmask.
+    bit_offset: 16
+    bit_size: 8
+  - name: FEU
+    description: Frame end delimiter unmask.
+    bit_offset: 24
+    bit_size: 8
+fieldset/PRFCR:
+  description: DCMIPP parallel interface interrupt clear register.
+  fields:
+  - name: CERRF
+    description: Synchronization error interrupt status clear.
+    bit_offset: 6
+    bit_size: 1
+fieldset/PRIER:
+  description: DCMIPP parallel interface interrupt enable register.
+  fields:
+  - name: ERRIE
+    description: Synchronization error interrupt enable.
+    bit_offset: 6
+    bit_size: 1
+fieldset/PRSR:
+  description: DCMIPP parallel interface status register.
+  fields:
+  - name: ERRF
+    description: Synchronization error raw interrupt status.
+    bit_offset: 6
+    bit_size: 1
+  - name: HSYNC
+    description: This bit gives the state of the HSYNC pin with the correct programmed polarity if ENABLE bit is set into the DCMIPP_PRCR register and if the pixel clock is received. It is set during the blanking period whatever the polarity selected in HPOL bit, and cleared otherwise.
+    bit_offset: 16
+    bit_size: 1
+  - name: VSYNC
+    description: This bit gives the state of the VSYNC pin with the correct programmed polarity if ENABLE bit is set into the DCMIPP_PRCR register and if the pixel clock is received. It is set during the blanking period whatever the polarity selected in VPOL bit, and cleared otherwise.
+    bit_offset: 17
+    bit_size: 1

--- a/data/registers/rcc_n6.yaml
+++ b/data/registers/rcc_n6.yaml
@@ -5371,8 +5371,8 @@ fieldset/APB5ENCR:
           description: LTDC enable.
           bit_offset: 1
           bit_size: 1
-        - name: DCMIENC
-          description: DCMI enable.
+        - name: DCMIPPENC
+          description: DCMIPP enable.
           bit_offset: 2
           bit_size: 1
         - name: GFXTIMENC
@@ -5394,8 +5394,8 @@ fieldset/APB5ENR:
           description: LTDC enable.
           bit_offset: 1
           bit_size: 1
-        - name: DCMIEN
-          description: DCMI enable.
+        - name: DCMIPPEN
+          description: DCMIPP enable.
           bit_offset: 2
           bit_size: 1
         - name: GFXTIMEN
@@ -5417,8 +5417,8 @@ fieldset/APB5ENSR:
           description: LTDC enable.
           bit_offset: 1
           bit_size: 1
-        - name: DCMIENS
-          description: DCMI enable.
+        - name: DCMIPPENS
+          description: DCMIPP enable.
           bit_offset: 2
           bit_size: 1
         - name: GFXTIMENS
@@ -5440,8 +5440,8 @@ fieldset/APB5LPENCR:
           description: LTDC sleep enable.
           bit_offset: 1
           bit_size: 1
-        - name: DCMILPENC
-          description: DCMI sleep enable.
+        - name: DCMIPPLPENC
+          description: DCMIPP sleep enable.
           bit_offset: 2
           bit_size: 1
         - name: GFXTIMLPENC
@@ -5463,8 +5463,8 @@ fieldset/APB5LPENR:
           description: LTDC sleep enable.
           bit_offset: 1
           bit_size: 1
-        - name: DCMILPEN
-          description: DCMI sleep enable.
+        - name: DCMIPPLPEN
+          description: DCMIPP sleep enable.
           bit_offset: 2
           bit_size: 1
         - name: GFXTIMLPEN
@@ -5486,8 +5486,8 @@ fieldset/APB5LPENSR:
           description: LTDC sleep enable.
           bit_offset: 1
           bit_size: 1
-        - name: DCMILPENS
-          description: DCMI sleep enable.
+        - name: DCMIPPLPENS
+          description: DCMIPP sleep enable.
           bit_offset: 2
           bit_size: 1
         - name: GFXTIMLPENS
@@ -5509,8 +5509,8 @@ fieldset/APB5RSTCR:
           description: LTDC reset.
           bit_offset: 1
           bit_size: 1
-        - name: DCMIRSTC
-          description: DCMI reset.
+        - name: DCMIPPRSTC
+          description: DCMIPP reset.
           bit_offset: 2
           bit_size: 1
         - name: GFXTIMRSTC
@@ -5532,8 +5532,8 @@ fieldset/APB5RSTR:
           description: LTDC reset.
           bit_offset: 1
           bit_size: 1
-        - name: DCMIRST
-          description: DCMI reset.
+        - name: DCMIPPRST
+          description: DCMIPP reset.
           bit_offset: 2
           bit_size: 1
         - name: GFXTIMRST
@@ -5555,8 +5555,8 @@ fieldset/APB5RSTSR:
           description: LTDC reset.
           bit_offset: 1
           bit_size: 1
-        - name: DCMIRSTS
-          description: DCMI reset.
+        - name: DCMIPPRSTS
+          description: DCMIPP reset.
           bit_offset: 2
           bit_size: 1
         - name: GFXTIMRSTS
@@ -6091,11 +6091,11 @@ fieldset/CCIPR1:
           bit_offset: 8
           bit_size: 8
           enum: ADCPRE
-        - name: DCMISEL
-          description: Source selection for the DCMI kernel clock.
+        - name: DCMIPPSEL
+          description: Source selection for the DCMIPP kernel clock.
           bit_offset: 20
           bit_size: 2
-          enum: DCMISEL
+          enum: DCMIPPSEL
 fieldset/CCIPR12:
     description: RCC clock configuration for independent peripheral register12.
     fields:
@@ -10641,7 +10641,7 @@ enum/CPUSWS:
         - name: IC1
           description: ic1_ck selected as system clock.
           value: 3
-enum/DCMISEL:
+enum/DCMIPPSEL:
     bit_size: 2
     variants:
         - name: PCLK5

--- a/data/registers/sdmmc_v3.yaml
+++ b/data/registers/sdmmc_v3.yaml
@@ -1,0 +1,648 @@
+block/SDMMC:
+  description: Secure digital input/output MultiMediaCard interface.
+  items:
+  - name: POWER
+    description: SDMMC power control register.
+    byte_offset: 0
+    fieldset: POWER
+  - name: CLKCR
+    description: SDMMC clock control register.
+    byte_offset: 4
+    fieldset: CLKCR
+  - name: ARGR
+    description: SDMMC argument register.
+    byte_offset: 8
+    fieldset: ARGR
+  - name: CMDR
+    description: SDMMC command register.
+    byte_offset: 12
+    fieldset: CMDR
+  - name: RESPCMDR
+    description: SDMMC command response register.
+    byte_offset: 16
+    fieldset: RESPCMDR
+  - name: RESPR
+    description: SDMMC response 1 register.
+    array:
+      len: 4
+      stride: 4
+    byte_offset: 20
+    fieldset: RESPxR
+  - name: DTIMER
+    description: SDMMC data timer register.
+    byte_offset: 36
+    fieldset: DTIMER
+  - name: DLENR
+    description: SDMMC data length register.
+    byte_offset: 40
+    fieldset: DLENR
+  - name: DCTRL
+    description: SDMMC data control register.
+    byte_offset: 44
+    fieldset: DCTRL
+  - name: DCNTR
+    description: SDMMC data counter register.
+    byte_offset: 48
+    fieldset: DCNTR
+  - name: STAR
+    description: SDMMC status register.
+    byte_offset: 52
+    fieldset: STAR
+  - name: ICR
+    description: SDMMC interrupt clear register.
+    byte_offset: 56
+    fieldset: ICR
+  - name: MASKR
+    description: SDMMC mask register.
+    byte_offset: 60
+    fieldset: MASKR
+  - name: ACKTIMER
+    description: SDMMC acknowledgment timer register.
+    byte_offset: 64
+    fieldset: ACKTIMER
+  - name: FIFOTHRR
+    description: SDMMC data FIFO threshold register.
+    byte_offset: 68
+    fieldset: FIFOTHRR
+  - name: IDMACTRLR
+    description: SDMMC DMA control register.
+    byte_offset: 80
+    fieldset: IDMACTRLR
+  - name: IDMABSIZER
+    description: SDMMC IDMA buffer size register.
+    byte_offset: 84
+    fieldset: IDMABSIZER
+  - name: IDMABASER
+    description: SDMMC IDMA buffer base address register.
+    byte_offset: 88
+    fieldset: IDMABASER
+  - name: IDMALAR
+    description: SDMMC IDMA linked list address register.
+    byte_offset: 100
+    fieldset: IDMALAR
+  - name: IDMABAR
+    description: SDMMC IDMA linked list memory base register.
+    byte_offset: 104
+    fieldset: IDMABAR
+  - name: FIFOR
+    description: SDMMC data FIFO registers 0.
+    array:
+      len: 16
+      stride: 4
+    byte_offset: 128
+    fieldset: FIFOR
+fieldset/ACKTIMER:
+  description: SDMMC acknowledgment timer register.
+  fields:
+  - name: ACKTIME
+    description: Boot acknowledgment timeout period.
+    bit_offset: 0
+    bit_size: 25
+fieldset/ARGR:
+  description: SDMMC argument register.
+  fields:
+  - name: CMDARG
+    description: Command argument.
+    bit_offset: 0
+    bit_size: 32
+fieldset/CLKCR:
+  description: SDMMC clock control register.
+  fields:
+  - name: CLKDIV
+    description: Clock divide factor.
+    bit_offset: 0
+    bit_size: 10
+  - name: PWRSAV
+    description: Power saving configuration bit.
+    bit_offset: 12
+    bit_size: 1
+  - name: WIDBUS
+    description: Wide bus mode enable bit.
+    bit_offset: 14
+    bit_size: 2
+  - name: NEGEDGE
+    description: SDMMC_CK dephasing selection bit for data and command.
+    bit_offset: 16
+    bit_size: 1
+  - name: HWFC_EN
+    description: Hardware flow control enable.
+    bit_offset: 17
+    bit_size: 1
+  - name: DDR
+    description: Data rate signaling selection.
+    bit_offset: 18
+    bit_size: 1
+  - name: BUSSPEED
+    description: Bus speed for selection of SDMMC operating modes.
+    bit_offset: 19
+    bit_size: 1
+  - name: SELCLKRX
+    description: Receive clock selection.
+    bit_offset: 20
+    bit_size: 2
+fieldset/CMDR:
+  description: SDMMC command register.
+  fields:
+  - name: CMDINDEX
+    description: Command index.
+    bit_offset: 0
+    bit_size: 6
+  - name: CMDTRANS
+    description: The CPSM treats the command as a data transfer command, stops the interrupt period, and signals DataEnable to the DPSM.
+    bit_offset: 6
+    bit_size: 1
+  - name: CMDSTOP
+    description: The CPSM treats the command as a Stop Transmission command and signals abort to the DPSM.
+    bit_offset: 7
+    bit_size: 1
+  - name: WAITRESP
+    description: Wait for response bits.
+    bit_offset: 8
+    bit_size: 2
+  - name: WAITINT
+    description: CPSM waits for interrupt request.
+    bit_offset: 10
+    bit_size: 1
+  - name: WAITPEND
+    description: CPSM waits for end of data transfer (CmdPend internal signal) from DPSM.
+    bit_offset: 11
+    bit_size: 1
+  - name: CPSMEN
+    description: Command path state machine (CPSM) enable bit.
+    bit_offset: 12
+    bit_size: 1
+  - name: DTHOLD
+    description: Hold new data block transmission and reception in the DPSM.
+    bit_offset: 13
+    bit_size: 1
+  - name: BOOTMODE
+    description: Select the boot mode procedure to be used.
+    bit_offset: 14
+    bit_size: 1
+  - name: BOOTEN
+    description: Enable boot mode procedure.
+    bit_offset: 15
+    bit_size: 1
+  - name: CMDSUSPEND
+    description: The CPSM treats the command as a Suspend or Resume command and signals interrupt period start/end.
+    bit_offset: 16
+    bit_size: 1
+fieldset/DCNTR:
+  description: SDMMC data counter register.
+  fields:
+  - name: DATACOUNT
+    description: Data count value.
+    bit_offset: 0
+    bit_size: 25
+fieldset/DCTRL:
+  description: SDMMC data control register.
+  fields:
+  - name: DTEN
+    description: Data transfer enable bit.
+    bit_offset: 0
+    bit_size: 1
+  - name: DTDIR
+    description: Data transfer direction selection.
+    bit_offset: 1
+    bit_size: 1
+  - name: DTMODE
+    description: Data transfer mode selection.
+    bit_offset: 2
+    bit_size: 2
+  - name: DBLOCKSIZE
+    description: Data block size.
+    bit_offset: 4
+    bit_size: 4
+  - name: RWSTART
+    description: Read Wait start.
+    bit_offset: 8
+    bit_size: 1
+  - name: RWSTOP
+    description: Read Wait stop.
+    bit_offset: 9
+    bit_size: 1
+  - name: RWMOD
+    description: Read Wait mode.
+    bit_offset: 10
+    bit_size: 1
+  - name: SDIOEN
+    description: SD I/O interrupt enable functions.
+    bit_offset: 11
+    bit_size: 1
+  - name: BOOTACKEN
+    description: Enable the reception of the boot acknowledgment.
+    bit_offset: 12
+    bit_size: 1
+  - name: FIFORST
+    description: FIFO reset, flushes any remaining data.
+    bit_offset: 13
+    bit_size: 1
+fieldset/DLENR:
+  description: SDMMC data length register.
+  fields:
+  - name: DATALENGTH
+    description: Data length value.
+    bit_offset: 0
+    bit_size: 25
+fieldset/DTIMER:
+  description: SDMMC data timer register.
+  fields:
+  - name: DATATIME
+    description: Data and R1b busy timeout period.
+    bit_offset: 0
+    bit_size: 32
+fieldset/FIFOR:
+  description: SDMMC data FIFO registers 0.
+  fields:
+  - name: FIFODATA
+    description: Receive and transmit FIFO data.
+    bit_offset: 0
+    bit_size: 32
+fieldset/FIFOTHRR:
+  description: SDMMC data FIFO threshold register.
+  fields:
+  - name: THR
+    description: FIFO threshold.
+    bit_offset: 0
+    bit_size: 4
+fieldset/ICR:
+  description: SDMMC interrupt clear register.
+  fields:
+  - name: CCRCFAILC
+    description: CCRCFAIL flag clear bit.
+    bit_offset: 0
+    bit_size: 1
+  - name: DCRCFAILC
+    description: DCRCFAIL flag clear bit.
+    bit_offset: 1
+    bit_size: 1
+  - name: CTIMEOUTC
+    description: CTIMEOUT flag clear bit.
+    bit_offset: 2
+    bit_size: 1
+  - name: DTIMEOUTC
+    description: DTIMEOUT flag clear bit.
+    bit_offset: 3
+    bit_size: 1
+  - name: TXUNDERRC
+    description: TXUNDERR flag clear bit.
+    bit_offset: 4
+    bit_size: 1
+  - name: RXOVERRC
+    description: RXOVERR flag clear bit.
+    bit_offset: 5
+    bit_size: 1
+  - name: CMDRENDC
+    description: CMDREND flag clear bit.
+    bit_offset: 6
+    bit_size: 1
+  - name: CMDSENTC
+    description: CMDSENT flag clear bit.
+    bit_offset: 7
+    bit_size: 1
+  - name: DATAENDC
+    description: DATAEND flag clear bit.
+    bit_offset: 8
+    bit_size: 1
+  - name: DHOLDC
+    description: DHOLD flag clear bit.
+    bit_offset: 9
+    bit_size: 1
+  - name: DBCKENDC
+    description: DBCKEND flag clear bit.
+    bit_offset: 10
+    bit_size: 1
+  - name: DABORTC
+    description: DABORT flag clear bit.
+    bit_offset: 11
+    bit_size: 1
+  - name: BUSYD0ENDC
+    description: BUSYD0END flag clear bit.
+    bit_offset: 21
+    bit_size: 1
+  - name: SDIOITC
+    description: SDIOIT flag clear bit.
+    bit_offset: 22
+    bit_size: 1
+  - name: ACKFAILC
+    description: ACKFAIL flag clear bit.
+    bit_offset: 23
+    bit_size: 1
+  - name: ACKTIMEOUTC
+    description: ACKTIMEOUT flag clear bit.
+    bit_offset: 24
+    bit_size: 1
+  - name: VSWENDC
+    description: VSWEND flag clear bit.
+    bit_offset: 25
+    bit_size: 1
+  - name: CKSTOPC
+    description: CKSTOP flag clear bit.
+    bit_offset: 26
+    bit_size: 1
+  - name: IDMATEC
+    description: IDMA transfer error clear bit.
+    bit_offset: 27
+    bit_size: 1
+  - name: IDMABTCC
+    description: IDMA buffer transfer complete clear bit.
+    bit_offset: 28
+    bit_size: 1
+fieldset/IDMABAR:
+  description: SDMMC IDMA linked list memory base register.
+  fields:
+  - name: IDMABA
+    description: Word aligned Linked list memory base address.
+    bit_offset: 2
+    bit_size: 30
+fieldset/IDMABASER:
+  description: SDMMC IDMA buffer base address register.
+  fields:
+  - name: IDMABASE
+    description: Buffer memory base address bits [31:2], must be word aligned (bit [1:0] are always 0 and read only).
+    bit_offset: 0
+    bit_size: 32
+fieldset/IDMABSIZER:
+  description: SDMMC IDMA buffer size register.
+  fields:
+  - name: IDMABNDT
+    description: Number of bytes per buffer.
+    bit_offset: 6
+    bit_size: 11
+fieldset/IDMACTRLR:
+  description: SDMMC DMA control register.
+  fields:
+  - name: IDMAEN
+    description: IDMA enable.
+    bit_offset: 0
+    bit_size: 1
+  - name: IDMABMODE
+    description: Buffer mode selection.
+    bit_offset: 1
+    bit_size: 1
+fieldset/IDMALAR:
+  description: SDMMC IDMA linked list address register.
+  fields:
+  - name: IDMALA
+    description: Word aligned linked list item address offset.
+    bit_offset: 2
+    bit_size: 14
+  - name: ABR
+    description: Acknowledge linked list buffer ready.
+    bit_offset: 29
+    bit_size: 1
+  - name: ULS
+    description: Update SDMMC_IDMABSIZE from the next linked list when in linked list mode (SDMMC_IDMACTRLR.IDMABMODE select linked list mode and ULA = 1).
+    bit_offset: 30
+    bit_size: 1
+  - name: ULA
+    description: Update SDMMC_IDMALAR from linked list when in linked list mode (SDMMC_IDMACTRLR.IDMABMODE select linked list mode).
+    bit_offset: 31
+    bit_size: 1
+fieldset/MASKR:
+  description: SDMMC mask register.
+  fields:
+  - name: CCRCFAILIE
+    description: Command CRC fail interrupt enable.
+    bit_offset: 0
+    bit_size: 1
+  - name: DCRCFAILIE
+    description: Data CRC fail interrupt enable.
+    bit_offset: 1
+    bit_size: 1
+  - name: CTIMEOUTIE
+    description: Command timeout interrupt enable.
+    bit_offset: 2
+    bit_size: 1
+  - name: DTIMEOUTIE
+    description: Data timeout interrupt enable.
+    bit_offset: 3
+    bit_size: 1
+  - name: TXUNDERRIE
+    description: Tx FIFO underrun error interrupt enable.
+    bit_offset: 4
+    bit_size: 1
+  - name: RXOVERRIE
+    description: Rx FIFO overrun error interrupt enable.
+    bit_offset: 5
+    bit_size: 1
+  - name: CMDRENDIE
+    description: Command response received interrupt enable.
+    bit_offset: 6
+    bit_size: 1
+  - name: CMDSENTIE
+    description: Command sent interrupt enable.
+    bit_offset: 7
+    bit_size: 1
+  - name: DATAENDIE
+    description: Data end interrupt enable.
+    bit_offset: 8
+    bit_size: 1
+  - name: DHOLDIE
+    description: Data hold interrupt enable.
+    bit_offset: 9
+    bit_size: 1
+  - name: DBCKENDIE
+    description: Data block end interrupt enable.
+    bit_offset: 10
+    bit_size: 1
+  - name: DABORTIE
+    description: Data transfer aborted interrupt enable.
+    bit_offset: 11
+    bit_size: 1
+  - name: TXFIFOHEIE
+    description: Tx FIFO half empty interrupt enable.
+    bit_offset: 14
+    bit_size: 1
+  - name: RXFIFOHFIE
+    description: Rx FIFO half full interrupt enable.
+    bit_offset: 15
+    bit_size: 1
+  - name: RXFIFOFIE
+    description: Rx FIFO full interrupt enable.
+    bit_offset: 17
+    bit_size: 1
+  - name: TXFIFOEIE
+    description: Tx FIFO empty interrupt enable.
+    bit_offset: 18
+    bit_size: 1
+  - name: BUSYD0ENDIE
+    description: BUSYD0END interrupt enable.
+    bit_offset: 21
+    bit_size: 1
+  - name: SDIOITIE
+    description: SDIO mode interrupt received interrupt enable.
+    bit_offset: 22
+    bit_size: 1
+  - name: ACKFAILIE
+    description: Acknowledgment Fail interrupt enable.
+    bit_offset: 23
+    bit_size: 1
+  - name: ACKTIMEOUTIE
+    description: Acknowledgment timeout interrupt enable.
+    bit_offset: 24
+    bit_size: 1
+  - name: VSWENDIE
+    description: Voltage switch critical timing section completion interrupt enable.
+    bit_offset: 25
+    bit_size: 1
+  - name: CKSTOPIE
+    description: Voltage Switch clock stopped interrupt enable.
+    bit_offset: 26
+    bit_size: 1
+  - name: IDMABTCIE
+    description: IDMA buffer transfer complete interrupt enable.
+    bit_offset: 28
+    bit_size: 1
+fieldset/POWER:
+  description: SDMMC power control register.
+  fields:
+  - name: PWRCTRL
+    description: SDMMC state control bits.
+    bit_offset: 0
+    bit_size: 2
+  - name: VSWITCH
+    description: Voltage switch sequence start.
+    bit_offset: 2
+    bit_size: 1
+  - name: VSWITCHEN
+    description: Voltage switch procedure enable.
+    bit_offset: 3
+    bit_size: 1
+  - name: DIRPOL
+    description: Data and command direction signals polarity selection.
+    bit_offset: 4
+    bit_size: 1
+fieldset/RESPCMDR:
+  description: SDMMC command response register.
+  fields:
+  - name: RESPCMD
+    description: Response command index.
+    bit_offset: 0
+    bit_size: 6
+fieldset/RESPxR:
+  description: SDMMC response 1 register.
+  fields:
+  - name: CARDSTATUS
+    description: Card status according table below.
+    bit_offset: 0
+    bit_size: 32
+fieldset/STAR:
+  description: SDMMC status register.
+  fields:
+  - name: CCRCFAIL
+    description: Command response received (CRC check failed).
+    bit_offset: 0
+    bit_size: 1
+  - name: DCRCFAIL
+    description: Data block sent/received (CRC check failed).
+    bit_offset: 1
+    bit_size: 1
+  - name: CTIMEOUT
+    description: Command response timeout.
+    bit_offset: 2
+    bit_size: 1
+  - name: DTIMEOUT
+    description: Data timeout.
+    bit_offset: 3
+    bit_size: 1
+  - name: TXUNDERR
+    description: Transmit FIFO underrun error (masked by hardware when IDMA is enabled).
+    bit_offset: 4
+    bit_size: 1
+  - name: RXOVERR
+    description: Received FIFO overrun error (masked by hardware when IDMA is enabled).
+    bit_offset: 5
+    bit_size: 1
+  - name: CMDREND
+    description: Command response received (CRC check passed, or no CRC).
+    bit_offset: 6
+    bit_size: 1
+  - name: CMDSENT
+    description: Command sent (no response required).
+    bit_offset: 7
+    bit_size: 1
+  - name: DATAEND
+    description: Data transfer ended correctly.
+    bit_offset: 8
+    bit_size: 1
+  - name: DHOLD
+    description: Data transfer Hold.
+    bit_offset: 9
+    bit_size: 1
+  - name: DBCKEND
+    description: Data block sent/received.
+    bit_offset: 10
+    bit_size: 1
+  - name: DABORT
+    description: Data transfer aborted by CMD12.
+    bit_offset: 11
+    bit_size: 1
+  - name: DPSMACT
+    description: Data path state machine active, i.e. not in Idle state.
+    bit_offset: 12
+    bit_size: 1
+  - name: CPSMACT
+    description: Command path state machine active, i.e. not in Idle state.
+    bit_offset: 13
+    bit_size: 1
+  - name: TXFIFOHE
+    description: Transmit FIFO half empty.
+    bit_offset: 14
+    bit_size: 1
+  - name: RXFIFOHF
+    description: Receive FIFO half full.
+    bit_offset: 15
+    bit_size: 1
+  - name: TXFIFOF
+    description: Transmit FIFO full.
+    bit_offset: 16
+    bit_size: 1
+  - name: RXFIFOF
+    description: Receive FIFO full.
+    bit_offset: 17
+    bit_size: 1
+  - name: TXFIFOE
+    description: Transmit FIFO empty.
+    bit_offset: 18
+    bit_size: 1
+  - name: RXFIFOE
+    description: Receive FIFO empty.
+    bit_offset: 19
+    bit_size: 1
+  - name: BUSYD0
+    description: Inverted value of SDMMC_D0 line (Busy), sampled at the end of a CMD response and a second time 2 SDMMC_CK cycles after the CMD response.
+    bit_offset: 20
+    bit_size: 1
+  - name: BUSYD0END
+    description: end of SDMMC_D0 Busy following a CMD response detected.
+    bit_offset: 21
+    bit_size: 1
+  - name: SDIOIT
+    description: SDIO interrupt received.
+    bit_offset: 22
+    bit_size: 1
+  - name: ACKFAIL
+    description: Boot acknowledgment received (boot acknowledgment check fail).
+    bit_offset: 23
+    bit_size: 1
+  - name: ACKTIMEOUT
+    description: Boot acknowledgment timeout.
+    bit_offset: 24
+    bit_size: 1
+  - name: VSWEND
+    description: Voltage switch critical timing section completion.
+    bit_offset: 25
+    bit_size: 1
+  - name: CKSTOP
+    description: SDMMC_CK stopped in Voltage switch procedure.
+    bit_offset: 26
+    bit_size: 1
+  - name: IDMATE
+    description: IDMA transfer error.
+    bit_offset: 27
+    bit_size: 1
+  - name: IDMABTC
+    description: IDMA buffer transfer complete.
+    bit_offset: 28
+    bit_size: 1

--- a/stm32-data-gen/src/interrupts.rs
+++ b/stm32-data-gen/src/interrupts.rs
@@ -313,6 +313,12 @@ impl ChipInterrupts {
 
                 let peri_names: Vec<_> = parts[2]
                     .split(',')
+                    // On STM32N6 the cube NVIC XML attributes the CSI IRQ to the
+                    // DCMIPP peripheral (`CSI_IRQn:Y:DCMIPP:HAL_DCMIPP_CSI_IRQHandler:`)
+                    // because ST HAL routes it through `HAL_DCMIPP_CSI_IRQHandler`.
+                    // The silicon has a distinct CSI block; re-attribute the IRQ
+                    // to its owning peripheral so embassy drivers can bind CSI::GLOBAL.
+                    .map(|x| if x == "DCMIPP" && name == "CSI" { "CSI" } else { x })
                     .map(|x| if x == "USB_DRD_FS" { "USB" } else { x })
                     .map(|x| if x == "XPI1" { "XSPI1" } else { x })
                     .map(|x| if x == "XPI2" { "XSPI2" } else { x })
@@ -644,9 +650,9 @@ fn valid_signals(peri: &str, chip_name: &str) -> Vec<String> {
     // Special chip-specific signal mappings
     // Format: (peripheral_prefix, chip_pattern, signals)
     const CHIP_SPECIFIC_SIGNALS: &[(&str, &str, &[&str])] = &[
-        // DCMIPP signals: STM32N6 supports CSI, others only basic signals
-        ("DCMIPP", "STM32N6", &["GLOBAL", "CSI"]),
-        ("DCMIPP", "*", &["GLOBAL"]), // Default for all other DCMIPP devices
+        // DCMIPP: only the GLOBAL interrupt belongs here. The separate CSI IRQ
+        // (STM32N6) is attributed to the CSI peripheral instead.
+        ("DCMIPP", "*", &["GLOBAL"]),
         // LTDC signals: STM32N6 has separate LTDC_UP and LTDC_LO interrupts; all others have a single LTDC IRQ
         ("LTDC", "STM32N6", &["ER", "LO", "UP"]),
         ("LTDC", "*", &["ER", "LO"]),

--- a/stm32-data-gen/src/perimap.rs
+++ b/stm32-data-gen/src/perimap.rs
@@ -396,6 +396,7 @@ pub static PERIMAP: RegexMap<(&str, &str, &str)> = RegexMap::new(&[
     ("STM32WB.*:CRS:.*", ("crs", "v1", "CRS")),
     (".*SDMMC:sdmmc2_v1_0.*", ("sdmmc", "v2", "SDMMC")),
     (".*SDMMC:sdmmc2_v2_1.*", ("sdmmc", "v2", "SDMMC")),
+    (".*SDMMC:sdmmc2_v3_0.*", ("sdmmc", "v3", "SDMMC")),
     ("STM32C0.*:PWR:.*", ("pwr", "c0", "PWR")),
     ("STM32G0.*:PWR:.*", ("pwr", "g0", "PWR")),
     ("STM32G4.*:PWR:.*", ("pwr", "g4", "PWR")),

--- a/stm32-data-gen/src/perimap.rs
+++ b/stm32-data-gen/src/perimap.rs
@@ -727,8 +727,10 @@ pub static PERIMAP: RegexMap<(&str, &str, &str)> = RegexMap::new(&[
     ("STM32WBA.*:COMP[12]:.*", ("comp", "u5", "COMP")),
     ("STM32F373.*:COMP[12]:.*", ("comp", "f3_v1", "COMP")),
     (r".*:.*:DCACHE:.*", ("dcache", "v1", "DCACHE")),
-    ("STM32(L4|U5|H5|H7[23AB]).*:PSSI:.*", ("pssi", "v1", "PSSI")),
+    ("STM32(L4|U5|H5|H7[23AB]|N6).*:PSSI:.*", ("pssi", "v1", "PSSI")),
     ("STM32H7[RS].*:PSSI:.*", ("pssi", "v1_h7rs", "PSSI")),
+    (".*:CSI:v1_0.*", ("csi", "v1", "CSI")),
+    (".*:DCMIPP:cci_v2_0.*", ("dcmipp", "v2", "DCMIPP")),
     (".*:.*:DTS:.*", ("dts", "v1", "DTS")),
     // HDMI_CEC for F1
     (".*:HDMI_CEC:hdmi_cec_v1_1", ("cec", "v1", "CEC")),

--- a/stm32-data-gen/src/rcc.rs
+++ b/stm32-data-gen/src/rcc.rs
@@ -295,8 +295,8 @@ impl ParsedRccs {
         peri_name: &str,
     ) -> Option<stm32_data_serde::chip::core::peripheral::Rcc> {
         const FALLBACKS: &[(&str, &[&str])] = &[
-            ("DCMI", &["DCMI_PSSI"]),
-            ("PSSI", &["DCMI_PSSI"]),
+            ("DCMI", &["DCMI_PSSI", "PSSI"]),
+            ("PSSI", &["DCMI_PSSI", "DCMI"]),
             ("FDCAN1", &["FDCAN12"]),
             ("FDCAN2", &["FDCAN12"]),
             ("ADC", &["ADC1", "ADCDAC"]),

--- a/transforms/CSI.yaml
+++ b/transforms/CSI.yaml
@@ -1,0 +1,15 @@
+transforms:
+  # Strip useless "CSI_" prefix from register and fieldset names.
+  - !RenameRegisters
+    block: .*
+    from: ^CSI_(.*)$
+    to: $1
+  - !Rename
+    from: ^CSI_(.*)$
+    to: $1
+    type: Fieldset
+
+  # The SVD uses "B_0x0" / "B_0x1" variant names which don't generate
+  # useful Rust enums. Drop them all and let the driver work with raw ints.
+  - !DeleteEnums
+    from: .*

--- a/transforms/DCMIPP.yaml
+++ b/transforms/DCMIPP.yaml
@@ -1,0 +1,15 @@
+transforms:
+  # Strip useless "DCMIPP_" prefix from register and fieldset names.
+  - !RenameRegisters
+    block: .*
+    from: ^DCMIPP_(.*)$
+    to: $1
+  - !Rename
+    from: ^DCMIPP_(.*)$
+    to: $1
+    type: Fieldset
+
+  # The SVD uses "B_0x0" / "B_0x1" variant names which don't generate
+  # useful Rust enums. Drop them all and let the driver work with raw ints.
+  - !DeleteEnums
+    from: .*

--- a/transforms/SDMMC.yaml
+++ b/transforms/SDMMC.yaml
@@ -1,0 +1,46 @@
+transforms:
+  # Strip useless "SDMMC_" prefix from register and fieldset names.
+  - !RenameRegisters
+    block: .*
+    from: ^SDMMC_(.*)$
+    to: $1
+  - !Rename
+    from: ^SDMMC_(.*)$
+    to: $1
+    type: Fieldset
+
+  # Rename block SDMMC1 -> SDMMC (instance number is meaningless).
+  - !Rename
+    from: ^SDMMC1$
+    to: SDMMC
+    type: Block
+
+  # Array-ify the four response registers.
+  - !MergeFieldsets
+    from: RESP\d+R
+    to: RESPxR
+    main: RESP1R
+  - !MakeRegisterArray
+    blocks: .*
+    from: RESP\d+R
+    to: RESPR
+
+  # Array-ify the 16 FIFO data registers (contiguous 32-bit words).
+  - !MergeFieldsets
+    from: FIFOR\d+
+    to: FIFOR
+    main: FIFOR0
+  - !MakeRegisterArray
+    blocks: .*
+    from: FIFOR\d+
+    to: FIFOR
+
+  # Drop useless enums (SVD uses unhelpful B_0x0/B_0x1 variant names).
+  # DeleteUselessEnums only catches the cases that already have meaningful
+  # names (enabled/disabled etc.), so we explicitly list the single-bit
+  # boolean-style fields here.
+  # The SDMMC SVD exports enums with generic "B_0x0" / "B_0x1" variant names
+  # that carry no useful information. Drop them all; the v1 / v2 YAMLs also
+  # have no enums and the embassy driver accesses the fields as raw integers.
+  - !DeleteEnums
+    from: .*


### PR DESCRIPTION
# STM32N6: SDMMC, MIPI CSI-2, DCMIPP, and RCC fixes

Adds the missing peripherals for SD-card, MIPI camera, and camera-pipeline support on STM32N6, plus two related RCC fixes.

## SDMMC v3 (`sdmmc2_v3_0_Cube`)

N6's SDMMC isn't register-compatible with the existing `sdmmc/v2`: the IDMA block is redesigned.
Core state-machine registers (POWER, CLKCR, CMDR, DCTRL, STAR, ICR, MASKR, ACKTIMER, IDMACTRLR, FIFOR) are unchanged.

Adds `data/registers/sdmmc_v3.yaml`, `transforms/SDMMC.yaml`, and the perimap rule.

## MIPI CSI-2 and DCMIPP

- `data/registers/csi_v1.yaml` (46 regs) + `transforms/CSI.yaml`, perimap `CSI:v1_0 → csi/v1`.
- `data/registers/dcmipp_v2.yaml` (240 regs) + `transforms/DCMIPP.yaml`, perimap `DCMIPP:cci_v2_0 → dcmipp/v2`. Named `v2` to match ST's cube IP version; `dcmipp_v1` is left reserved for the distinct H7RS variant (not in this PR).
- PSSI perimap regex extended to include N6 (`pssi_v1.yaml` already fits; cube version `cci_v3_0_Cube` same as H5).

## RCC fixes

**Revert DCMIPP→DCMI rename in `rcc_n6.yaml`.**  This restores the original names and adds the missing `CCIPR1.DCMIPPSEL` (kernel-clock mux).

**Extend the `DCMI`/`PSSI` fallback table** in `stm32-data-gen/src/rcc.rs`:

Comments in Code were generated with Claude to have them more descriptive.