### PR TITLE
STM32N6: Add VENC and DLYB_SDMMC1/2 peripherals

### DIFF
--- a/data/extra/STM32N6.yaml
+++ b/data/extra/STM32N6.yaml
@@ -103,3 +103,21 @@ peripherals:
       kind: risaf
       version: n6
       block: RISAF
+  # SDMMC DLL delay blocks. Not declared as IPs in cube DB (same situation as
+  # on STM32H5/H7/U5), so we wire them in here. The N6 SVD names them DLYBSD
+  # with a different field layout, but the CMSIS device header (DLYB_TypeDef
+  # in stm32n657xx.h) shows the same CR/CFGR layout as on every other STM32
+  # with this block — we trust the header here. Same naming convention as
+  # data/extra/STM32H7.yaml and data/extra/STM32H5[67]x.yaml.
+  - name: DLYB_SDMMC1
+    address: 0x48028000
+    registers:
+      kind: dlyb
+      version: v1
+      block: DLYB
+  - name: DLYB_SDMMC2
+    address: 0x48026C00
+    registers:
+      kind: dlyb
+      version: v1
+      block: DLYB

--- a/data/registers/venc_v1.yaml
+++ b/data/registers/venc_v1.yaml
@@ -1,0 +1,17 @@
+block/VENC:
+  description: Video encoder.
+  items:
+  - name: SWREG
+    description: VENC ID register.
+    array:
+      len: 499
+      stride: 4
+    byte_offset: 0
+    fieldset: SWREG
+fieldset/SWREG:
+  description: VENC ID register.
+  fields:
+  - name: SWREG_FIELD
+    description: Interrupt register (all format mode).
+    bit_offset: 0
+    bit_size: 32

--- a/stm32-data-gen/src/perimap.rs
+++ b/stm32-data-gen/src/perimap.rs
@@ -736,6 +736,7 @@ pub static PERIMAP: RegexMap<(&str, &str, &str)> = RegexMap::new(&[
     ("STM32H7[RS].*:PSSI:.*", ("pssi", "v1_h7rs", "PSSI")),
     (".*:CSI:v1_0.*", ("csi", "v1", "CSI")),
     (".*:DCMIPP:cci_v2_0.*", ("dcmipp", "v2", "DCMIPP")),
+    (".*:VENC:venc1_v1_0.*", ("venc", "v1", "VENC")),
     (".*:.*:DTS:.*", ("dts", "v1", "DTS")),
     // HDMI_CEC for F1
     (".*:HDMI_CEC:hdmi_cec_v1_1", ("cec", "v1", "CEC")),

--- a/transforms/VENC.yaml
+++ b/transforms/VENC.yaml
@@ -1,0 +1,27 @@
+transforms:
+  # Strip the "VENC_" prefix from register and fieldset names.
+  - !RenameRegisters
+    block: .*
+    from: ^VENC_(.*)$
+    to: $1
+  - !Rename
+    from: ^VENC_(.*)$
+    to: $1
+    type: Fieldset
+
+  # The SVD describes the VENC programming interface as SWREG0..SWREG354 —
+  # a single 32-bit-wide register file at sequential offsets, with each
+  # SWREGn declared individually. Collapse them into one SWREG[355] array.
+  - !MergeFieldsets
+    from: SWREG\d+
+    to: SWREG
+    main: SWREG0
+  - !MakeRegisterArray
+    blocks: .*
+    from: SWREG\d+
+    to: SWREG
+    mode: Holey
+
+  # Drop unhelpful enums (SVD uses B_0x0/B_0x1 placeholder variants).
+  - !DeleteEnums
+    from: .*


### PR DESCRIPTION
Follow-up to #779.

- **VENC** (H.264/JPEG encoder)
- **DLYB_SDMMC1/2**: Looks different when looking at the svd but headers match existing peripheral. Added old dlyb to N6 from H7.

Disclosure: as always, code comments were writte/enhanced by claude.