### PR TITLE
STM32U5: Update PWR_CR1 fields, add PWR_CR4 and PWR_CR5

### DIFF
--- a/data/registers/pwr_u5.yaml
+++ b/data/registers/pwr_u5.yaml
@@ -13,6 +13,14 @@ block/PWR:
     description: control register 3
     byte_offset: 8
     fieldset: CR3
+  - name: CR4
+    description: control register 4
+    byte_offset: 0xA8
+    fieldset: CR4
+  - name: CR5
+    description: control register 5
+    byte_offset: 0xAC
+    fieldset: CR5
   - name: VOSR
     description: voltage scaling register
     byte_offset: 12
@@ -183,6 +191,21 @@ fieldset/CR1:
     bit_offset: 11
     bit_size: 1
     enum: SRAMPD
+  - name: SRAM5PD
+    description: "SRAM5 power down\r This bit is used to reduce the consumption by powering off the SRAM5."
+    bit_offset: 12
+    bit_size: 1
+    enum: SRAMPD
+  - name: SRAM6PD
+    description: "SRAM6 power down\r This bit is used to reduce the consumption by powering off the SRAM6."
+    bit_offset: 13
+    bit_size: 1
+    enum: SRAMPD
+  - name: FORCE_USBPWR
+    description: "OTG_HS PHY power maintained during Stop 2, Stop 3, and Standby low-power modes."
+    bit_offset: 15
+    bit_size: 1
+    enum: FORCE_USBPWR
 fieldset/CR2:
   description: control register 2
   fields:
@@ -500,6 +523,187 @@ fieldset/VOSR:
     description: OTG_HS VDD11USB disable
     bit_offset: 21
     bit_size: 1
+fieldset/CR4:
+  description: control register 4
+  fields:
+  - name: SRAM1PDS4
+    description: SRAM1 page 4 (64 Kbytes) power-down in Stop modes (Stop 0, 1, 2, 3)
+    bit_offset: 0
+    bit_size: 1
+    enum: PDS
+  - name: SRAM1PDS5
+    description: SRAM1 page 5 (64 Kbytes) power-down in Stop modes (Stop 0, 1, 2, 3)
+    bit_offset: 1
+    bit_size: 1
+    enum: PDS
+  - name: SRAM1PDS6
+    description: SRAM1 page 6 (64 Kbytes) power-down in Stop modes (Stop 0, 1, 2, 3)
+    bit_offset: 2
+    bit_size: 1
+    enum: PDS
+  - name: SRAM1PDS7
+    description: SRAM1 page 7 (64 Kbytes) power-down in Stop modes (Stop 0, 1, 2, 3)
+    bit_offset: 3
+    bit_size: 1
+    enum: PDS
+  - name: SRAM1PDS8
+    description: SRAM1 page 8 (64 Kbytes) power-down in Stop modes (Stop 0, 1, 2, 3)
+    bit_offset: 4
+    bit_size: 1
+    enum: PDS
+  - name: SRAM1PDS9
+    description: SRAM1 page 9 (64 Kbytes) power-down in Stop modes (Stop 0, 1, 2, 3)
+    bit_offset: 5
+    bit_size: 1
+    enum: PDS
+  - name: SRAM1PDS10
+    description: SRAM1 page 10 (64 Kbytes) power-down in Stop modes (Stop 0, 1, 2, 3)
+    bit_offset: 6
+    bit_size: 1
+    enum: PDS
+  - name: SRAM1PDS11
+    description: SRAM1 page 11 (64 Kbytes) power-down in Stop modes (Stop 0, 1, 2, 3)
+    bit_offset: 7
+    bit_size: 1
+    enum: PDS
+  - name: SRAM1PDS12
+    description: SRAM1 page 12 (64 Kbytes) power-down in Stop modes (Stop 0, 1, 2, 3)
+    bit_offset: 8
+    bit_size: 1
+    enum: PDS
+  - name: SRAM3PDS9
+    description: SRAM3 page 9 (64 Kbytes) power-down in Stop modes (Stop 0, 1, 2, 3)
+    bit_offset: 10
+    bit_size: 1
+    enum: PDS
+  - name: SRAM3PDS10
+    description: SRAM3 page 10 (64 Kbytes) power-down in Stop modes (Stop 0, 1, 2, 3)
+    bit_offset: 11
+    bit_size: 1
+    enum: PDS
+  - name: SRAM3PDS11
+    description: SRAM3 page 11 (64 Kbytes) power-down in Stop modes (Stop 0, 1, 2, 3)
+    bit_offset: 12
+    bit_size: 1
+    enum: PDS
+  - name: SRAM3PDS12
+    description: SRAM3 page 12 (64 Kbytes) power-down in Stop modes (Stop 0, 1, 2, 3)
+    bit_offset: 13
+    bit_size: 1
+    enum: PDS
+  - name: SRAM3PDS13
+    description: SRAM3 page 13 (64 Kbytes) power-down in Stop modes (Stop 0, 1, 2, 3)
+    bit_offset: 14
+    bit_size: 1
+    enum: PDS
+  - name: SRAM5PDS1
+    description: SRAM5 page 1 (64 Kbytes) power-down in Stop modes (Stop 0, 1, 2, 3)
+    bit_offset: 16
+    bit_size: 1
+    enum: PDS
+  - name: SRAM5PDS2
+    description: SRAM5 page 2 (64 Kbytes) power-down in Stop modes (Stop 0, 1, 2, 3)
+    bit_offset: 17
+    bit_size: 1
+    enum: PDS
+  - name: SRAM5PDS3
+    description: SRAM5 page 3 (64 Kbytes) power-down in Stop modes (Stop 0, 1, 2, 3)
+    bit_offset: 18
+    bit_size: 1
+    enum: PDS
+  - name: SRAM5PDS4
+    description: SRAM5 page 4 (64 Kbytes) power-down in Stop modes (Stop 0, 1, 2, 3)
+    bit_offset: 19
+    bit_size: 1
+    enum: PDS
+  - name: SRAM5PDS5
+    description: SRAM5 page 5 (64 Kbytes) power-down in Stop modes (Stop 0, 1, 2, 3)
+    bit_offset: 20
+    bit_size: 1
+    enum: PDS
+  - name: SRAM5PDS6
+    description: SRAM5 page 6 (64 Kbytes) power-down in Stop modes (Stop 0, 1, 2, 3)
+    bit_offset: 21
+    bit_size: 1
+    enum: PDS
+  - name: SRAM5PDS7
+    description: SRAM5 page 7 (64 Kbytes) power-down in Stop modes (Stop 0, 1, 2, 3)
+    bit_offset: 22
+    bit_size: 1
+    enum: PDS
+  - name: SRAM5PDS8
+    description: SRAM5 page 8 (64 Kbytes) power-down in Stop modes (Stop 0, 1, 2, 3)
+    bit_offset: 23
+    bit_size: 1
+    enum: PDS
+  - name: SRAM5PDS9
+    description: SRAM5 page 9 (64 Kbytes) power-down in Stop modes (Stop 0, 1, 2, 3)
+    bit_offset: 24
+    bit_size: 1
+    enum: PDS
+  - name: SRAM5PDS10
+    description: SRAM5 page 10 (64 Kbytes) power-down in Stop modes (Stop 0, 1, 2, 3)
+    bit_offset: 25
+    bit_size: 1
+    enum: PDS
+  - name: SRAM5PDS11
+    description: SRAM5 page 11 (64 Kbytes) power-down in Stop modes (Stop 0, 1, 2, 3)
+    bit_offset: 26
+    bit_size: 1
+    enum: PDS
+  - name: SRAM5PDS12
+    description: SRAM5 page 12 (64 Kbytes) power-down in Stop modes (Stop 0, 1, 2, 3)
+    bit_offset: 27
+    bit_size: 1
+    enum: PDS
+  - name: SRAM5PDS13
+    description: SRAM5 page 13 (64 Kbytes) power-down in Stop modes (Stop 0, 1, 2, 3)
+    bit_offset: 28
+    bit_size: 1
+    enum: PDS
+fieldset/CR5:
+  description: control register 5
+  fields:
+  - name: SRAM6PDS1
+    description: SRAM6 page 1 (64 Kbytes) power-down in Stop modes (Stop 0, 1, 2, 3)
+    bit_offset: 0
+    bit_size: 1
+    enum: PDS
+  - name: SRAM6PDS2
+    description: SRAM6 page 2 (64 Kbytes) power-down in Stop modes (Stop 0, 1, 2, 3)
+    bit_offset: 1
+    bit_size: 1
+    enum: PDS
+  - name: SRAM6PDS3
+    description: SRAM6 page 3 (64 Kbytes) power-down in Stop modes (Stop 0, 1, 2, 3)
+    bit_offset: 2
+    bit_size: 1
+    enum: PDS
+  - name: SRAM6PDS4
+    description: SRAM6 page 4 (64 Kbytes) power-down in Stop modes (Stop 0, 1, 2, 3)
+    bit_offset: 3
+    bit_size: 1
+    enum: PDS
+  - name: SRAM6PDS5
+    description: SRAM6 page 5 (64 Kbytes) power-down in Stop modes (Stop 0, 1, 2, 3)
+    bit_offset: 4
+    bit_size: 1
+    enum: PDS
+  - name: SRAM6PDS6
+    description: SRAM6 page 6 (64 Kbytes) power-down in Stop modes (Stop 0, 1, 2, 3)
+    bit_offset: 5
+    bit_size: 1
+    enum: PDS
+  - name: SRAM6PDS7
+    description: SRAM6 page 7 (64 Kbytes) power-down in Stop modes (Stop 0, 1, 2, 3)
+    bit_offset: 6
+    bit_size: 1
+    enum: PDS
+  - name: SRAM6PDS8
+    description: SRAM6 page 8 (64 Kbytes) power-down in Stop modes (Stop 0, 1, 2, 3)
+    bit_offset: 7
+    bit_size: 1
+    enum: PDS
 fieldset/WUCR1:
   description: wakeup control register 1
   fields:
@@ -829,3 +1033,12 @@ enum/WUSEL:
   - name: B_0x3
     description: WKUP7_3
     value: 3
+enum/FORCE_USBPWR:
+  bit_size: 1
+  variants:
+  - name: NotMaintained
+    description: OTG_HS PHY power is not maintained during low-power modes
+    value: 0
+  - name: Maintained
+    description: OTG_HS PHY power is maintained during low-power modes
+    value: 1


### PR DESCRIPTION
This PR updates the STM32U5 PWR register definitions to align with RM0456 Reference Manual (Chapter 10, Power control (PWR)):

### Changes

1. **PWR_CR1** (Section 10.10.1) - Added new fields:
   - `SRAM5PD` (bit 12) – SRAM5 power down control (Page 444/3653)
   - `SRAM6PD` (bit 13) – SRAM6 power down control (Page 443/3653)
   - `FORCE_USBPWR` (bit 15) – OTG_HS PHY power maintained during Stop 2, Stop 3, and Standby low-power modes (Page 443/3653, Section 10.10.1)

2. **PWR_CR4** (new, offset 0xA8, Section 10.10.41, Page 447/3653) – Added fields for SRAM page power-down in Stop modes:
   - SRAM1 pages 4-12 (bits 8:0)
   - SRAM3 pages 9-13 (bits 14:10)
   - SRAM5 pages 1-13 (bits 28:16)
   - Reference: Pages 447-478/3653 (offset 0xA8 description)

3. **PWR_CR5** (new, offset 0xAC, Section 10.10.42) – Added fields:
   - SRAM6 pages 1-8 (bits 7:0) – power-down in all Stop modes
   - Reference: Page 478/3653 (offset 0xAC description)

### New Enum
- `FORCE_USBPWR` – Controls OTG_HS PHY power retention during low-power modes (Page 443/3653, Section 10.10.1):
  - `NotMaintained` (0): PHY power not maintained
  - `Maintained` (1): PHY power maintained