### PR TITLE
STM32N6: fix DLYB layout — use dlybsd_v1 instead of dlyb/v1

### DIFF
--- a/data/extra/STM32N6.yaml
+++ b/data/extra/STM32N6.yaml
@@ -104,20 +104,21 @@ peripherals:
       version: n6
       block: RISAF
   # SDMMC DLL delay blocks. Not declared as IPs in cube DB (same situation as
-  # on STM32H5/H7/U5), so we wire them in here. The N6 SVD names them DLYBSD
-  # with a different field layout, but the CMSIS device header (DLYB_TypeDef
-  # in stm32n657xx.h) shows the same CR/CFGR layout as on every other STM32
-  # with this block — we trust the header here. Same naming convention as
-  # data/extra/STM32H7.yaml and data/extra/STM32H5[67]x.yaml.
+  # on STM32H5/H7/U5), so we wire them in here. N6 uses a redesigned
+  # tap-select DLL (RM0486 §31.5) with a programming model that's
+  # incompatible with the older sampler-length DLYB used on H7/H5/U5/U3 —
+  # see data/registers/dlybsd_v1.yaml. Instance names match the H7/U5
+  # naming convention so embassy-stm32 driver code can reach the same
+  # peripheral by the same name across families.
   - name: DLYB_SDMMC1
     address: 0x48028000
     registers:
-      kind: dlyb
+      kind: dlybsd
       version: v1
-      block: DLYB
+      block: DLYBSD
   - name: DLYB_SDMMC2
     address: 0x48026C00
     registers:
-      kind: dlyb
+      kind: dlybsd
       version: v1
-      block: DLYB
+      block: DLYBSD

--- a/data/registers/dlybsd_v1.yaml
+++ b/data/registers/dlybsd_v1.yaml
@@ -1,0 +1,45 @@
+block/DLYBSD:
+  description: DLYBSD address block description.
+  items:
+  - name: CFG
+    description: Delay block SDMMC DLL configuration.
+    byte_offset: 0
+    fieldset: CFG
+  - name: STATUS
+    description: Delay block SDMMC DLL status.
+    byte_offset: 4
+    fieldset: STATUS
+fieldset/CFG:
+  description: Delay block SDMMC DLL configuration.
+  fields:
+  - name: SDMMC_DLL_EN
+    description: DLL enable.
+    bit_offset: 0
+    bit_size: 1
+  - name: SDMMC_RX_TAP_SEL
+    description: selection of RX delay.
+    bit_offset: 1
+    bit_size: 6
+  - name: SDMMC_DLL_BYP_EN
+    description: DLL configuration.
+    bit_offset: 16
+    bit_size: 1
+  - name: SDMMC_DLL_BYP_CMD
+    description: Bypass command.
+    bit_offset: 17
+    bit_size: 5
+  - name: SDMMC_DLL_ANTIGLITCH_EN
+    description: Antiglitch logic enabled when 1.
+    bit_offset: 22
+    bit_size: 1
+fieldset/STATUS:
+  description: Delay block SDMMC DLL status.
+  fields:
+  - name: SDMMC_DLL_LOCK
+    description: SDMMC DLL lock.
+    bit_offset: 0
+    bit_size: 1
+  - name: SDMMC_RX_TAP_SEL_ACK
+    description: SDMMC RX delay selection acknowledge.
+    bit_offset: 1
+    bit_size: 1

--- a/transforms/DLYBSD.yaml
+++ b/transforms/DLYBSD.yaml
@@ -1,0 +1,14 @@
+transforms:
+  # Strip the "DLYBSD_" prefix from register and fieldset names.
+  - !RenameRegisters
+    block: .*
+    from: ^DLYBSD_(.*)$
+    to: $1
+  - !Rename
+    from: ^DLYBSD_(.*)$
+    to: $1
+    type: Fieldset
+
+  # Drop the SVD's generic B_0x0/B_0x1 placeholder enums.
+  - !DeleteEnums
+    from: .*


### PR DESCRIPTION
Fix on top of #782. I got the DLYB peripheral wrong: I trusted
`DLYB_TypeDef` in `stm32n657xx.h` and reused the existing `dlyb/v1`
(H7-era sampler-length block with `CR`/`CFGR`/`SEN`/`LNG`/`UNIT`).

It turns out RM0486 §31.5 describes a completely redesigned tap-select
DLL — `DLYBSD_CFG`/`DLYBSD_STATUS` with `SDMMC_DLL_EN`, `SDMMC_RX_TAP_SEL`
(32 taps, not 16 phases), `SDMMC_DLL_BYP_*`, `SDMMC_DLL_ANTIGLITCH_EN`,
`SDMMC_DLL_LOCK`, `SDMMC_RX_TAP_SEL_ACK`.

This adds `data/registers/dlybsd_v1.yaml` and `transforms/DLYBSD.yaml`
and flips the two N6 entries in `data/extra/STM32N6.yaml` to
`kind: dlybsd, version: v1, block: DLYBSD`.