### PR TITLE
fix(stm32g4): correct ADC4/ADC5 differential INN signal assignments for cahnnels 12-13

### DIFF
--- a/data/extra/STM32G4.yaml
+++ b/data/extra/STM32G4.yaml
@@ -280,10 +280,8 @@ peripherals:
       signal: INN11
     - pin: IN13
       signal: INN12
-    - pin: IN13
-      signal: INN14
     - pin: IN14
-      signal: INN15
+      signal: INN13
     - pin: IN15
       signal: INN14
     - pin: IN16
@@ -306,10 +304,8 @@ peripherals:
       signal: INN11
     - pin: IN13
       signal: INN12
-    - pin: IN13
-      signal: INN14
     - pin: IN14
-      signal: INN15
+      signal: INN13
     - pin: IN15
       signal: INN14
     - pin: IN16


### PR DESCRIPTION
IN13 was listed twice in the extra pin data for both ADC4 and ADC5, once correctly as INN12, and again incorrectly as INN14. This caused the INN13 entry (IN14) to be missing entirely, while INN14 was shifted to point at IN13 instead of IN15 (which was already correct).

The result was that impl_adc_pair! was never generated for channels 12 and 13 on ADC4 and ADC5, making differential mode unavailable for those channel pairs despite the hardware supporting it.