### PR TITLE
fix(stm32g4): correct ADC2 differential INN signal assignments for channels 12-14

### DIFF
--- a/data/extra/STM32G4.yaml
+++ b/data/extra/STM32G4.yaml
@@ -226,10 +226,10 @@ peripherals:
       signal: INN11
     - pin: IN13
       signal: INN12
-    - pin: IN13
-      signal: INN14
     - pin: IN14
-      signal: INN15
+      signal: INN13
+    - pin: IN15
+      signal: INN14
   - name: ADC3
     pins:
     - pin: IN2


### PR DESCRIPTION
The MCU XML for STM32G4 has INN signal numbers shifted by +2 for ADC2 channels 12-15. Per RM0440 Figure 85 (ADC2 connectivity diagram), each channel N's INN is the same physical pin as channel N+1's INP:
  - IN13 (PA5)  = INN12  [unchanged]
  - IN14 (PB11) = INN13  [was incorrectly INN15]
  - IN15 (PB15) = INN14  [was missing; IN13 was wrongly listed as INN14]