### PR TITLE
rcc_wba: add LSI variant to RADIOSTSEL enum

### DIFF
--- a/data/registers/rcc_wba.yaml
+++ b/data/registers/rcc_wba.yaml
@@ -3195,6 +3195,9 @@ enum/RADIOSTSEL:
   - name: LSE
     description: LSE oscillator clock selected
     value: 1
+  - name: LSI
+    description: LSI oscillator clock selected
+    value: 2
   - name: HSE
     description: HSE oscillator clock divided by 1000 selected
     value: 3


### PR DESCRIPTION
## Summary

- Adds `LSI` (value `0x2`) to the `enum/RADIOSTSEL` definition in `data/registers/rcc_wba.yaml`
- The WBA65 SVD correctly documents this value as "LSI oscillator clock selected"; the WBA52 SVD incorrectly marks it as "Reserved"
- The embassy-stm32-wpan binding layer (`ll_sys_sleep_clock_source_selection`) already handles this value as the LSI/RCO sleep timer source — the metapac was the only place it was unnamed

## Motivation

On STM32WBA boards without an LSE crystal, the BLE radio sleep timer must use LSI. Without this variant, users had to write `mux::Radiostsel::_RESERVED_2` as a workaround. With this fix, `mux::Radiostsel::Lsi` is available and a clean `Config::new_wpan_lsi()` constructor can be added to embassy-stm32.

## References

- WBA65 SVD: `BDCR.RADIOSTSEL` bit 0x2 = "LSI oscillator clock selected"
- WBA52 SVD: same bit incorrectly described as "Reserved"
- RM0530 (STM32WBA52) §7.4.27 `RCC_BDCR` register confirms LSI is a valid RADIOSTSEL option