### PR TITLE
Add TIM peripherals for N6

### DIFF
--- a/stm32-data-gen/src/perimap.rs
+++ b/stm32-data-gen/src/perimap.rs
@@ -527,18 +527,35 @@ pub static PERIMAP: RegexMap<(&str, &str, &str)> = RegexMap::new(&[
     // AN4013 Table 4: STM32Gx/Hx/Ux/Wx (and Cx) serials
     // timer_v2 for STM32Gx/Hx/Ux/Wx (and Cx) serials
     ("STM32(U5|U3).*:TIM(3|4):.*", ("timer", "v2", "TIM_GP32")),
-    ("STM32(G4|H5|U0|U3|U5|WBA).*:TIM(1|8|20):.*", ("timer", "v2", "TIM_ADV")),
+    ("STM32N6.*:TIM4:.*", ("timer", "v2", "TIM_GP32")),
     (
-        "STM32(G4|H5|U0|U3|U5|WBA).*:TIM(2|5|23|24):.*",
+        "STM32(G4|H5|N6|U0|U3|U5|WBA).*:TIM(1|8|20):.*",
+        ("timer", "v2", "TIM_ADV"),
+    ),
+    (
+        "STM32(G4|H5|N6|U0|U3|U5|WBA).*:TIM(2|5|23|24):.*",
         ("timer", "v2", "TIM_GP32"),
     ),
     ("STM32(G4|H5|U0|U3|U5|WBA).*:TIM(3|4):.*", ("timer", "v2", "TIM_GP16")),
-    ("STM32(G4|H5|U0|U3|U5|WBA).*:TIM(6|7):.*", ("timer", "v2", "TIM_BASIC")),
-    ("STM32(G4|H5|U0|U3|U5|WBA).*:TIM(13|14):.*", ("timer", "v2", "TIM_1CH")),
-    ("STM32(G4|H5|U0|U3|U5|WBA).*:TIM12:.*", ("timer", "v2", "TIM_2CH")),
-    ("STM32(G4|H5|U0|U3|U5|WBA).*:TIM15:.*", ("timer", "v2", "TIM_2CH_CMP")),
+    ("STM32N6.*:TIM3:.*", ("timer", "v2", "TIM_GP16")),
     (
-        "STM32(G4|H5|U0|U3|U5|WBA).*:TIM(16|17):.*",
+        "STM32(G4|H5|N6|U0|U3|U5|WBA).*:TIM(6|7|18):.*",
+        ("timer", "v2", "TIM_BASIC"),
+    ),
+    (
+        "STM32(G4|H5|N6|U0|U3|U5|WBA).*:TIM(10|13|14):.*",
+        ("timer", "v2", "TIM_1CH"),
+    ),
+    (
+        "STM32(G4|H5|N6|U0|U3|U5|WBA).*:TIM(9|12):.*",
+        ("timer", "v2", "TIM_2CH"),
+    ),
+    (
+        "STM32(G4|H5|N6|U0|U3|U5|WBA).*:TIM15:.*",
+        ("timer", "v2", "TIM_2CH_CMP"),
+    ),
+    (
+        "STM32(G4|H5|N6|U0|U3|U5|WBA).*:TIM(16|17):.*",
         ("timer", "v2", "TIM_1CH_CMP"),
     ),
     ("STM32G4.*:HRTIM1:.*", ("hrtim", "v2", "HRTIM")),
@@ -567,7 +584,6 @@ pub static PERIMAP: RegexMap<(&str, &str, &str)> = RegexMap::new(&[
     ("STM32WB0[59].*:TIM2:.*", ("timer", "v3", "TIM_GP32")),
     ("STM32WB0[67].*:TIM1:.*", ("timer", "v3", "TIM_GP32")),
     ("STM32[CGHUW].*:HRTIM1?:.*", ("hrtim", "v1", "HRTIM")),
-    ("STM32N6.*:TIM9:.*", ("timer", "v3", "TIM_2CH")),
     // LPTIM for STM32Gx/Hx/Ux/Wx (and Cx) serials
     ("STM32U0.*:LPTIM.*:.*", ("lptim", "v2b", "LPTIM")),
     ("STM32(H5|U3|U5|WBA).*:LPTIM[12356]:.*", ("lptim", "v2a", "LPTIM")),


### PR DESCRIPTION
Add all timers available on N6 and use timer_v2 instead of timer_v3

Based on the references in the technical manual and in ST XML files it looks to me that the timer should be v2 instead of v3

From `STM32N657X0HxQ.xml`
```
<IP ConfigFile="TIM-STM32N6xx" InstanceName="TIM1" Name="TIM1_8N6" Version="gptimer2_v4_x_Cube">
```

This look more similar to e.g. `STM32U5G7VJTx.xml` which is `timer_v2.yaml`
```
<IP ConfigFile="TIM-STM32U5xx" InstanceName="TIM1" Name="TIM1_8U5" Version="gptimer2_v4_x_Cube">
```

than to e.g. `STM32H723VEHx.xml` which is `timer_v3.yaml`
```
<IP ConfigFile="TIM-STM32H7xx" InstanceName="TIM1" Name="TIM1_8H7" Version="gptimer2_v3_x_Cube"/>
```

Additionally the analysis of the data generated with `./d extract-all TIM1` seems to confirm this.  For example in `n657.yaml` i find the following register entry 
```
  - name: TIM1_DCR
    description: TIM1 DMA control register.
    byte_offset: 988
    fieldset: TIM1_DCR
```

This is in line with `timer_v2.yaml`
```
  - name: DCR
    description: DMA control register
    byte_offset: 988
    fieldset: DCR_1CH_CMP
```

And not with `timer_v3.yaml`
```
  - name: DCR
    description: DMA control register
    byte_offset: 72
    fieldset: DCR_1CH_CMP
```

The register map in N6 TRM confirms this

<img width="736" height="171" alt="image" src="https://github.com/user-attachments/assets/403533db-926d-4163-ae61-6f376f25da29" />
