### PR TITLE
Fix ADC12_COMMON base address for STM32U5

### DIFF
--- a/stm32-data-gen/src/generator.rs
+++ b/stm32-data-gen/src/generator.rs
@@ -779,6 +779,12 @@ fn resolve_peri_addr(chip_name: &str, pname: &str, defines: &header::Defines) ->
         }
     }
 
+    if pname == "ADC12_COMMON" && chip_name.starts_with("STM32U5") {
+        // The ADC12_COMMON address is incorrect in the headers for STM32U5.
+        // It is defined as 0x42048308 but should be 0x42048300 according to RM0456.
+        return Some(0x42048300);
+    }
+
     if let Some(cap) = regex!(r"^FDCANRAM(?P<idx>[0-9]+)$").captures(pname) {
         defines.get_peri_addr("FDCANRAM").map(|addr| {
             let h7_non_rs_re = Regex::new(r"STM32H7[0-9AB].*").unwrap();


### PR DESCRIPTION
# Fix ADC12_COMMON base address for STM32U5 series

## Description
This PR addresses an issue where the `ADC12_COMMON` base address for the STM32U5 series is incorrectly defined in the ST header files (`stm32u5XXxx.h`) as `0x42048308`. According to the official STM32U5 Reference Manual (RM0456), page 146 and page 1368 (sections 33.7.1 and 33.7.2), the correct base address is `0x42048300` (master ADC base address + `0x300`).

This incorrect address mapping prevents the usage of VREF/VBAT/TEMPSENSOR in the ADC1 peripheral. 

The fix overrides the address during the generation phase specifically for `ADC12_COMMON` in the `STM32U5` family.

## Fix Details
- Modified `resolve_peri_addr` in `stm32-data-gen/src/generator.rs` to catch `ADC12_COMMON` on `STM32U5` chips and hardcode the base address to `0x42048300`.

Closes #624.
