### PR TITLE
Add TIM peripherals for N6

### DIFF
--- a/stm32-data-gen/src/perimap.rs
+++ b/stm32-data-gen/src/perimap.rs
@@ -528,18 +528,35 @@ pub static PERIMAP: RegexMap<(&str, &str, &str)> = RegexMap::new(&[
     // AN4013 Table 4: STM32Gx/Hx/Ux/Wx (and Cx) serials
     // timer_v2 for STM32Gx/Hx/Ux/Wx (and Cx) serials
     ("STM32(U5|U3).*:TIM(3|4):.*", ("timer", "v2", "TIM_GP32")),
-    ("STM32(G4|H5|U0|U3|U5|WBA).*:TIM(1|8|20):.*", ("timer", "v2", "TIM_ADV")),
+    ("STM32N6.*:TIM4:.*", ("timer", "v2", "TIM_GP32")),
     (
-        "STM32(G4|H5|U0|U3|U5|WBA).*:TIM(2|5|23|24):.*",
+        "STM32(G4|H5|N6|U0|U3|U5|WBA).*:TIM(1|8|20):.*",
+        ("timer", "v2", "TIM_ADV"),
+    ),
+    (
+        "STM32(G4|H5|N6|U0|U3|U5|WBA).*:TIM(2|5|23|24):.*",
         ("timer", "v2", "TIM_GP32"),
     ),
     ("STM32(G4|H5|U0|U3|U5|WBA).*:TIM(3|4):.*", ("timer", "v2", "TIM_GP16")),
-    ("STM32(G4|H5|U0|U3|U5|WBA).*:TIM(6|7):.*", ("timer", "v2", "TIM_BASIC")),
-    ("STM32(G4|H5|U0|U3|U5|WBA).*:TIM(13|14):.*", ("timer", "v2", "TIM_1CH")),
-    ("STM32(G4|H5|U0|U3|U5|WBA).*:TIM12:.*", ("timer", "v2", "TIM_2CH")),
-    ("STM32(G4|H5|U0|U3|U5|WBA).*:TIM15:.*", ("timer", "v2", "TIM_2CH_CMP")),
+    ("STM32N6.*:TIM3:.*", ("timer", "v2", "TIM_GP16")),
     (
-        "STM32(G4|H5|U0|U3|U5|WBA).*:TIM(16|17):.*",
+        "STM32(G4|H5|N6|U0|U3|U5|WBA).*:TIM(6|7|18):.*",
+        ("timer", "v2", "TIM_BASIC"),
+    ),
+    (
+        "STM32(G4|H5|N6|U0|U3|U5|WBA).*:TIM(10|13|14):.*",
+        ("timer", "v2", "TIM_1CH"),
+    ),
+    (
+        "STM32(G4|H5|N6|U0|U3|U5|WBA).*:TIM(9|12):.*",
+        ("timer", "v2", "TIM_2CH"),
+    ),
+    (
+        "STM32(G4|H5|N6|U0|U3|U5|WBA).*:TIM15:.*",
+        ("timer", "v2", "TIM_2CH_CMP"),
+    ),
+    (
+        "STM32(G4|H5|N6|U0|U3|U5|WBA).*:TIM(16|17):.*",
         ("timer", "v2", "TIM_1CH_CMP"),
     ),
     ("STM32G4.*:HRTIM1:.*", ("hrtim", "v2", "HRTIM")),
@@ -568,7 +585,6 @@ pub static PERIMAP: RegexMap<(&str, &str, &str)> = RegexMap::new(&[
     ("STM32WB0[59].*:TIM2:.*", ("timer", "v3", "TIM_GP32")),
     ("STM32WB0[67].*:TIM1:.*", ("timer", "v3", "TIM_GP32")),
     ("STM32[CGHUW].*:HRTIM1?:.*", ("hrtim", "v1", "HRTIM")),
-    ("STM32N6.*:TIM9:.*", ("timer", "v3", "TIM_2CH")),
     // LPTIM for STM32Gx/Hx/Ux/Wx (and Cx) serials
     ("STM32U0.*:LPTIM.*:.*", ("lptim", "v2b", "LPTIM")),
     ("STM32(H5|U3|U5|WBA).*:LPTIM[12356]:.*", ("lptim", "v2a", "LPTIM")),


### PR DESCRIPTION
All credit goes to @william-spinelli . This just remerges those changes after they were reverted

Original PR: https://github.com/embassy-rs/stm32-data/pull/806