### PR TITLE
gen: use allocated regex map

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -521,6 +521,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-map"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc94b2749dbd8491e23d917a1c6403862cd4393af822df6d3d1637625c6a3401"
+dependencies = [
+ "regex",
+]
+
+[[package]]
 name = "regex-syntax"
 version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -611,6 +620,7 @@ dependencies = [
  "rayon",
  "ref_thread_local",
  "regex",
+ "regex-map",
  "serde",
  "serde_json",
  "serde_yaml",

--- a/stm32-data-gen/Cargo.toml
+++ b/stm32-data-gen/Cargo.toml
@@ -27,3 +27,4 @@ pretty_env_logger = "0.5.0"
 clap = { version = "4.6", features = ["derive"] }
 itertools = "0.14.0"
 env_logger = "0.10.2"
+regex-map = "0.1.0"

--- a/stm32-data-gen/src/chips.rs
+++ b/stm32-data-gen/src/chips.rs
@@ -1,8 +1,8 @@
 use std::collections::HashMap;
-
-use util::RegexSet;
+use std::sync::LazyLock;
 
 use super::*;
+use crate::util::new_regex_set;
 
 pub mod xml {
     use serde::Deserialize;
@@ -149,24 +149,26 @@ pub fn parse_groups(filter: &Option<String>) -> Result<(HashMap<String, Chip>, V
     ))
 }
 
-static NOPELIST: RegexSet = RegexSet::new(&[
-    // Not supported, not planned unless someone wants to do it.
-    "STM32MP.*",
-    // "STM32N6.*",
-    "STM32G41[14].*",
-    "STM32G4.*xZ",
-    "STM32WL3.*",
-    // Does not exist in ST website. No datasheet, no RM.
-    "STM32GBK.*",
-    "STM32L485.*",
-    // STM32WxM modules. These are based on a chip that's supported on its own,
-    // not sure why we want a separate target for it.
-    "STM32WL5M.*",
-    "STM32WB1M.*",
-    "STM32WB3M.*",
-    "STM32WB5M.*",
-    "STM32WBA5M.*",
-]);
+static NOPELIST: LazyLock<regex::RegexSet> = LazyLock::new(|| {
+    new_regex_set([
+        // Not supported, not planned unless someone wants to do it.
+        "STM32MP.*",
+        // "STM32N6.*",
+        "STM32G41[14].*",
+        "STM32G4.*xZ",
+        "STM32WL3.*",
+        // Does not exist in ST website. No datasheet, no RM.
+        "STM32GBK.*",
+        "STM32L485.*",
+        // STM32WxM modules. These are based on a chip that's supported on its own,
+        // not sure why we want a separate target for it.
+        "STM32WL5M.*",
+        "STM32WB1M.*",
+        "STM32WB3M.*",
+        "STM32WB5M.*",
+        "STM32WBA5M.*",
+    ])
+});
 
 fn parse_group(
     f: std::path::PathBuf,
@@ -175,7 +177,7 @@ fn parse_group(
 ) -> anyhow::Result<()> {
     let ff = f.file_name().unwrap().to_string_lossy();
 
-    if NOPELIST.contains(ff.split('.').next().unwrap()) {
+    if NOPELIST.is_match(ff.split('.').next().unwrap()) {
         return Ok(());
     }
 

--- a/stm32-data-gen/src/dma.rs
+++ b/stm32-data-gen/src/dma.rs
@@ -6,6 +6,7 @@ use rayon::prelude::*;
 use stm32_data_serde::chip::core::peripheral::RemapInfo;
 
 use crate::normalize_peris::normalize_peri_name;
+use crate::perimap::Perimap;
 use crate::util::HashMapFns;
 
 mod xml {
@@ -309,7 +310,7 @@ fn build_remap_info_f0_bdma_v1() -> HashMap<RemapKey, Vec<RemapInfo>> {
 }
 
 impl DmaChannels {
-    pub fn parse() -> anyhow::Result<Self> {
+    pub fn parse(perimap: &Perimap) -> anyhow::Result<Self> {
         let f0_bdma_v1_remap = build_remap_info_f0_bdma_v1();
         let f3_remap = build_remap_info_f3();
 
@@ -345,8 +346,7 @@ impl DmaChannels {
                     &f3_remap
                 } else {
                     // apply only to F0 devices having bdma_v1
-                    if let Some((kind, version, _)) = crate::perimap::PERIMAP.get(format!("{}:DMA", &ff[..9]).as_str())
-                    {
+                    if let Some((kind, version, _)) = perimap.get(format!("{}:DMA", &ff[..9]).as_str()) {
                         if ff.starts_with("STM32F0") && *kind == "bdma" && *version == "v1" {
                             &f0_bdma_v1_remap
                         } else {

--- a/stm32-data-gen/src/generator.rs
+++ b/stm32-data-gen/src/generator.rs
@@ -1,17 +1,20 @@
 use std::collections::hash_map::Entry;
 use std::collections::{BTreeSet, HashMap, HashSet};
+use std::sync::LazyLock;
 
 use gpio_af::pin_sort_key;
 use log::warn;
-use perimap::PERIMAP;
+#[cfg(feature = "rayon")]
+use rayon::prelude::*;
 use regex::Regex;
 use stm32_data_serde::chip::core::peripheral::{Pin, Trigger};
-use util::RegexMap;
 
 use super::*;
 use crate::chips::{Chip, ChipGroup};
 use crate::gpio_af::parse_signal_name;
 use crate::normalize_peris::normalize_peri_name;
+use crate::perimap::Perimap;
+use crate::util::new_regex_map;
 
 #[derive(serde::Deserialize)]
 struct ExtraMatches {
@@ -52,7 +55,10 @@ pub fn dump_all_chips(
     chip_groups: Vec<ChipGroup>,
     headers: header::Headers,
     af: gpio_af::Af,
+    perimap: Perimap,
+    stop_modes: low_power::ChipStopModes,
     triggers: trigger::Triggers,
+    chip_memories: memory::ChipMemories,
     blocks: HashMap<String, HashSet<String>>,
     chip_interrupts: interrupts::ChipInterrupts,
     peripheral_to_clock: rcc::ParsedRccs,
@@ -65,41 +71,29 @@ pub fn dump_all_chips(
     let extras = load_extras();
 
     #[cfg(feature = "rayon")]
-    {
-        use rayon::prelude::*;
+    let iter = chip_groups.into_par_iter();
 
-        chip_groups.into_par_iter().try_for_each(|group| {
-            process_group(
-                group,
-                &headers,
-                &af,
-                &triggers,
-                &blocks,
-                &chip_interrupts,
-                &peripheral_to_clock,
-                &dma_channels,
-                &chips,
-                &docs,
-                &extras,
-            )
-        })
-    }
     #[cfg(not(feature = "rayon"))]
-    {
-        chip_groups.into_iter().try_for_each(|group| {
-            process_group(
-                group,
-                &headers,
-                &af,
-                &chip_interrupts,
-                &peripheral_to_clock,
-                &dma_channels,
-                &chips,
-                &docs,
-                &extras,
-            )
-        })
-    }
+    let iter = chip_groups.into_iter();
+
+    iter.try_for_each(|group| {
+        process_group(
+            group,
+            &headers,
+            &af,
+            &perimap,
+            &stop_modes,
+            &triggers,
+            &chip_memories,
+            &blocks,
+            &chip_interrupts,
+            &peripheral_to_clock,
+            &dma_channels,
+            &chips,
+            &docs,
+            &extras,
+        )
+    })
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -107,7 +101,10 @@ fn process_group(
     group: ChipGroup,
     headers: &header::Headers,
     af: &gpio_af::Af,
+    perimap: &Perimap,
+    stop_modes: &low_power::ChipStopModes,
     triggers: &trigger::Triggers,
+    chip_memories: &memory::ChipMemories,
     blocks: &HashMap<String, HashSet<String>>,
     chip_interrupts: &interrupts::ChipInterrupts,
     peripheral_to_clock: &rcc::ParsedRccs,
@@ -118,7 +115,7 @@ fn process_group(
 ) -> Result<(), anyhow::Error> {
     let chip_name = group.chip_names[0].clone();
     let rcc_kind = group.ips.values().find(|x| x.name == "RCC").unwrap().version.clone();
-    let rcc_block = *PERIMAP
+    let rcc_block = perimap
         .get(&format!("{chip_name}:RCC:{rcc_kind}"))
         .unwrap_or_else(|| panic!("could not get rcc for {} (kind: {})", &chip_name, &rcc_kind));
     let h = if let Some(h) = group.headers.iter().filter_map(|h| headers.get(h)).next() {
@@ -156,11 +153,13 @@ fn process_group(
                 h,
                 &chip_name,
                 &group,
+                &perimap,
+                &stop_modes,
                 &triggers,
                 &blocks,
                 chip_interrupts,
                 peripheral_to_clock,
-                rcc_block,
+                *rcc_block,
                 chip_af,
                 dma_channels,
                 extras,
@@ -170,7 +169,7 @@ fn process_group(
     let cores = cores?;
 
     for chip_name in &group.chip_names {
-        process_chip(chips, chip_name, h, docs, &group, &cores)?;
+        process_chip(chips, &chip_memories, chip_name, h, docs, &group, &cores)?;
     }
 
     Ok(())
@@ -182,6 +181,8 @@ fn process_core(
     h: &header::ParsedHeader,
     chip_name: &str,
     group: &ChipGroup,
+    perimap: &Perimap,
+    stop_modes: &low_power::ChipStopModes,
     triggers: &trigger::Triggers,
     blocks: &HashMap<String, HashSet<String>>,
     chip_interrupts: &interrupts::ChipInterrupts,
@@ -197,6 +198,8 @@ fn process_core(
     let mut peripherals = create_peripherals_for_chip(
         chip_name,
         group,
+        perimap,
+        stop_modes,
         triggers,
         blocks,
         peripheral_to_clock,
@@ -259,6 +262,8 @@ fn process_core(
 fn create_peripherals_for_chip(
     chip_name: &str,
     group: &ChipGroup,
+    perimap: &Perimap,
+    stop_modes: &low_power::ChipStopModes,
     triggers: &trigger::Triggers,
     blocks: &HashMap<String, HashSet<String>>,
     peripheral_to_clock: &rcc::ParsedRccs,
@@ -278,7 +283,7 @@ fn create_peripherals_for_chip(
         let addr = resolve_peri_addr(chip_name, &pname, defines);
         let Some(address) = addr else { continue };
 
-        let perimap = PERIMAP.get(&format!("{chip_name}:{pname}:{pkind}"));
+        let perimap = perimap.get(&format!("{chip_name}:{pname}:{pkind}"));
         let registers = if let Some(&block) = perimap {
             Some(stm32_data_serde::chip::core::peripheral::Registers {
                 kind: block.0.to_string(),
@@ -320,7 +325,7 @@ fn create_peripherals_for_chip(
             .match_peri_clock(rcc_block.1, &pname)
             .or_else(syscfg_for_comp)
         {
-            if let Some(stop_mode_info) = low_power::peripheral_stop_mode_info(chip_name, &pname) {
+            if let Some(stop_mode_info) = stop_modes.peripheral_stop_mode_info(chip_name, &pname) {
                 rcc_info.stop_mode = stop_mode_info;
             }
             Some(rcc_info)
@@ -1011,11 +1016,13 @@ fn extract_relevant_dma_channels(
 ) -> Vec<stm32_data_serde::chip::core::DmaChannels> {
     // The dma_channels[xx] is generic for multiple chips. The current chip may have less DMAs,
     // so we have to filter it.
-    static DMA_CHANNEL_COUNTS: RegexMap<usize> = RegexMap::new(&[
-        ("STM32F0[37]0.*:DMA1", 5),
-        ("STM32G4[34]1.*:DMA1", 6),
-        ("STM32G4[34]1.*:DMA2", 6),
-    ]);
+    static DMA_CHANNEL_COUNTS: LazyLock<regex_map::RegexMap<usize>> = LazyLock::new(|| {
+        new_regex_map([
+            ("STM32F0[37]0.*:DMA1", 5),
+            ("STM32G4[34]1.*:DMA1", 6),
+            ("STM32G4[34]1.*:DMA2", 6),
+        ])
+    });
     let have_peris: HashSet<_> = peripherals.iter().map(|p| p.name.clone()).collect();
     let dma_channels = dmas
         .iter()
@@ -1024,6 +1031,7 @@ fn extract_relevant_dma_channels(
         .filter(|ch| {
             DMA_CHANNEL_COUNTS
                 .get(&format!("{}:{}", chip_name, ch.dma))
+                .next()
                 .map_or_else(|| true, |&v| usize::from(ch.channel) < v)
         })
         .collect::<Vec<_>>();
@@ -1068,6 +1076,7 @@ fn associate_peripherals_dma_channels(
 
 fn process_chip(
     chips: &HashMap<String, Chip>,
+    chip_memories: &memory::ChipMemories,
     chip_name: &str,
     _h: &header::ParsedHeader,
     docs: &docs::Docs,
@@ -1083,7 +1092,7 @@ fn process_chip(
         die: group.die.clone(),
         device_id: u16::from_str_radix(&group.die[3..], 16).unwrap(),
         packages: chip.packages.clone(),
-        memory: memory::get(chip_name),
+        memory: chip_memories.get(chip_name),
         docs,
         cores: cores.to_vec(),
     };

--- a/stm32-data-gen/src/interrupts.rs
+++ b/stm32-data-gen/src/interrupts.rs
@@ -1,4 +1,5 @@
 use std::collections::{HashMap, HashSet};
+use std::sync::LazyLock;
 use std::thread;
 
 use anyhow::anyhow;
@@ -7,7 +8,7 @@ use log::*;
 use crate::chips::ChipGroup;
 use crate::normalize_peris::normalize_peri_name;
 use crate::regex;
-use crate::util::RegexMap;
+use crate::util::new_regex_map;
 
 mod xml {
     use serde::Deserialize;
@@ -824,21 +825,27 @@ fn trim_trailing_digits(input: &str) -> &str {
 }
 
 fn pick_nvic(chip_name: &str, core_name: &str) -> String {
-    static PICK_NVIC: RegexMap<&str> = RegexMap::new(&[
-        // Exception 1: Multicore: NVIC1 is the first core, NVIC2 is the second. We have to pick the right one.
-        ("STM32H7(45|47|55|57).*:cm7", "NVIC1"),
-        ("STM32H7(45|47|55|57).*:cm4", "NVIC2"),
-        ("STM32WL5.*:cm4", "NVIC1"),
-        ("STM32WL5.*:cm0p", "NVIC2"),
-        // Exception 2: TrustZone: NVIC1 is Secure mode, NVIC2 is NonSecure mode. For now, we pick the NonSecure one.
-        ("STM32(L5|U3|U5|H5[2367]|WBA5[245]|WBA6[2345]).*", "NVIC2"),
-        // Exception 3: NVICs are split for "bootloader" and "application", not sure what that means?
-        ("STM32H7[RS].*", "NVIC2"),
-        // Exception 4: NVICS are split for bootloader NVIC, secure NVIC1 and non-secure NVIC2.
-        ("STM32N6.*", "NVIC2"),
-        // catch-all: Most chips have a single NVIC, named "NVIC"
-        (".*", "NVIC"),
-    ]);
+    static PICK_NVIC: LazyLock<regex_map::RegexMap<&str>> = LazyLock::new(|| {
+        new_regex_map([
+            // Exception 1: Multicore: NVIC1 is the first core, NVIC2 is the second. We have to pick the right one.
+            ("STM32H7(45|47|55|57).*:cm7", "NVIC1"),
+            ("STM32H7(45|47|55|57).*:cm4", "NVIC2"),
+            ("STM32WL5.*:cm4", "NVIC1"),
+            ("STM32WL5.*:cm0p", "NVIC2"),
+            // Exception 2: TrustZone: NVIC1 is Secure mode, NVIC2 is NonSecure mode. For now, we pick the NonSecure one.
+            ("STM32(L5|U3|U5|H5[2367]|WBA5[245]|WBA6[2345]).*", "NVIC2"),
+            // Exception 3: NVICs are split for "bootloader" and "application", not sure what that means?
+            ("STM32H7[RS].*", "NVIC2"),
+            // Exception 4: NVICS are split for bootloader NVIC, secure NVIC1 and non-secure NVIC2.
+            ("STM32N6.*", "NVIC2"),
+            // catch-all: Most chips have a single NVIC, named "NVIC"
+            (".*", "NVIC"),
+        ])
+    });
 
-    PICK_NVIC.must_get(&format!("{chip_name}:{core_name}")).to_string()
+    PICK_NVIC
+        .get(&format!("{chip_name}:{core_name}"))
+        .next()
+        .unwrap()
+        .to_string()
 }

--- a/stm32-data-gen/src/low_power.rs
+++ b/stm32-data-gen/src/low_power.rs
@@ -1,70 +1,80 @@
 use stm32_data_serde::chip::core::peripheral::rcc::StopMode;
 
-use crate::util::RegexMap;
+use crate::util::new_regex_map;
 
-/// Get the stop mode limit for a peripheral based on the MCU and peripheral name.
-/// Determines the lowest possible stop mode when a peripheral is enabled.
-///
-/// Parameters:
-/// - mcu_name: the full name of the MCU (e.g., "STM32WB55RG")
-/// - peripheral: the name of the peripheral (e.g., "USART1")
-pub(crate) fn peripheral_stop_mode_info(mcu_name: &str, peripheral: &str) -> Option<StopMode> {
-    /// Regexmap where the key is mcu_name:peripheral and the value is the stop mode.
-    /// Example: STM32WB55RG:USART1 -> StopMode::Stop2
-    #[rustfmt::skip]
-    static STOP_MODE_OVERRIDE_RULES: RegexMap<StopMode> = RegexMap::new(&[
-        (r"^STM32WB55.*:LPTIM1", StopMode::Standby),
-        (r"^STM32WB55.*:USART1", StopMode::Stop2),
-        (r"^STM32WB55.*:LPUART1", StopMode::Standby),
-        (r"^STM32WB55.*:I2C1", StopMode::Stop2),
-        (r"^STM32WB55.*:I2C3", StopMode::Standby),
-        (r"^STM32WLE5.*:LPUART1", StopMode::Standby),
-        (r"^STM32WLE5.*:I2C1", StopMode::Stop2),
-        (r"^STM32WLE5.*:I2C2", StopMode::Stop2),
-        (r"^STM32WLE5.*:I2C3", StopMode::Standby),
-        (r"^STM32WLE5.*:LPTIM1", StopMode::Standby),
-        (r"^STM32WLE5.*:SUBGHZSPI", StopMode::Stop2),
-        (r"^STM32WLE5.*:ADC1", StopMode::Stop2),
+pub struct ChipStopModes {
+    map: regex_map::RegexMap<StopMode>,
+}
 
-        (r"^STM32WL55.*:LPUART1", StopMode::Standby),
-        (r"^STM32WL55.*:I2C1", StopMode::Stop2),
-        (r"^STM32WL55.*:I2C2", StopMode::Stop2),
-        (r"^STM32WL55.*:I2C3", StopMode::Standby),
-        (r"^STM32WL55.*:LPTIM1", StopMode::Standby),
-        (r"^STM32WL55.*:SUBGHZSPI", StopMode::Stop2),
-        (r"^STM32WL55.*:ADC1", StopMode::Stop2),
-        (r"^STM32WL55.*:IPCC", StopMode::Standby),
-        (r"^STM32WL55.*:HSEM", StopMode::Stop2),
+impl ChipStopModes {
+    pub fn new() -> Self {
+        /// Regexmap where the key is mcu_name:peripheral and the value is the stop mode.
+        /// Example: STM32WB55RG:USART1 -> StopMode::Stop2
+        #[rustfmt::skip]
+        const STOP_MODE_OVERRIDE_RULES: &[(&str, StopMode)]= &[
+            (r"^STM32WB55.*:LPTIM1", StopMode::Standby),
+            (r"^STM32WB55.*:USART1", StopMode::Stop2),
+            (r"^STM32WB55.*:LPUART1", StopMode::Standby),
+            (r"^STM32WB55.*:I2C1", StopMode::Stop2),
+            (r"^STM32WB55.*:I2C3", StopMode::Standby),
+            (r"^STM32WLE5.*:LPUART1", StopMode::Standby),
+            (r"^STM32WLE5.*:I2C1", StopMode::Stop2),
+            (r"^STM32WLE5.*:I2C2", StopMode::Stop2),
+            (r"^STM32WLE5.*:I2C3", StopMode::Standby),
+            (r"^STM32WLE5.*:LPTIM1", StopMode::Standby),
+            (r"^STM32WLE5.*:SUBGHZSPI", StopMode::Stop2),
+            (r"^STM32WLE5.*:ADC1", StopMode::Stop2),
 
-        // STM32WBA series - from RM0515 Table 90
-        // Stop2-capable (Standby in StopMode terms): overrides generic .*:LP.* rule for LPUART1/LPTIM1
-        (r"^STM32WBA.*:LPUART1", StopMode::Standby),
-        (r"^STM32WBA.*:LPTIM1",  StopMode::Standby),
-        (r"^STM32WBA.*:I2C3",    StopMode::Standby),
-        (r"^STM32WBA.*:SPI3",    StopMode::Standby),
-        // Stop1-capable only: USART1/2/3, I2C1, SPI1, ADC4, COMP1/2
-        (r"^STM32WBA.*:USART\d", StopMode::Stop2),
-        (r"^STM32WBA.*:I2C\d",   StopMode::Stop2),
-        (r"^STM32WBA.*:SPI\d",   StopMode::Stop2),
-        (r"^STM32WBA.*:ADC4",    StopMode::Stop2),
-        (r"^STM32WBA.*:COMP\d",  StopMode::Stop2),
-        // GPDMA1 is Stop0-only (BAM wakeup) — default Stop1 is correct, no entry needed
+            (r"^STM32WL55.*:LPUART1", StopMode::Standby),
+            (r"^STM32WL55.*:I2C1", StopMode::Stop2),
+            (r"^STM32WL55.*:I2C2", StopMode::Stop2),
+            (r"^STM32WL55.*:I2C3", StopMode::Standby),
+            (r"^STM32WL55.*:LPTIM1", StopMode::Standby),
+            (r"^STM32WL55.*:SUBGHZSPI", StopMode::Stop2),
+            (r"^STM32WL55.*:ADC1", StopMode::Stop2),
+            (r"^STM32WL55.*:IPCC", StopMode::Standby),
+            (r"^STM32WL55.*:HSEM", StopMode::Stop2),
 
-        (r"^STM32U3.*:GPDMA.*", StopMode::Stop2),
-        (r"^STM32U3.*:LPDMA.*", StopMode::Standby),
-        (r"^STM32U5.*:GPDMA.*", StopMode::Stop2),
-        (r"^STM32U5.*:LPDMA.*", StopMode::Standby),
+            // STM32WBA series - from RM0515 Table 90
+            // Stop2-capable (Standby in StopMode terms): overrides generic .*:LP.* rule for LPUART1/LPTIM1
+            (r"^STM32WBA.*:LPUART1", StopMode::Standby),
+            (r"^STM32WBA.*:LPTIM1",  StopMode::Standby),
+            (r"^STM32WBA.*:I2C3",    StopMode::Standby),
+            (r"^STM32WBA.*:SPI3",    StopMode::Standby),
+            // Stop1-capable only: USART1/2/3, I2C1, SPI1, ADC4, COMP1/2
+            (r"^STM32WBA.*:USART\d", StopMode::Stop2),
+            (r"^STM32WBA.*:I2C\d",   StopMode::Stop2),
+            (r"^STM32WBA.*:SPI\d",   StopMode::Stop2),
+            (r"^STM32WBA.*:ADC4",    StopMode::Stop2),
+            (r"^STM32WBA.*:COMP\d",  StopMode::Stop2),
+            // GPDMA1 is Stop0-only (BAM wakeup) — default Stop1 is correct, no entry needed
 
-        // __ATTENTION__: Keep these rules at the bottom to grant precedence to the more specific rules above
-        // Every peripheral with LP prefix is assumed to be able enter up to Stop1 mode
-        (r".*:LP.*", StopMode::Stop2),
-        // The RTC peripheral is assumed to be able to enter up to Stop2 mode
-        (r".*:RTC", StopMode::Standby),
-    ]);
+            (r"^STM32U3.*:GPDMA.*", StopMode::Stop2),
+            (r"^STM32U3.*:LPDMA.*", StopMode::Standby),
+            (r"^STM32U5.*:GPDMA.*", StopMode::Stop2),
+            (r"^STM32U5.*:LPDMA.*", StopMode::Standby),
 
-    STOP_MODE_OVERRIDE_RULES
-        .get(&format!("{mcu_name}:{peripheral}"))
-        .cloned()
+            // __ATTENTION__: Keep these rules at the bottom to grant precedence to the more specific rules above
+            // Every peripheral with LP prefix is assumed to be able enter up to Stop1 mode
+            (r".*:LP.*", StopMode::Stop2),
+            // The RTC peripheral is assumed to be able to enter up to Stop2 mode
+            (r".*:RTC", StopMode::Standby),
+        ];
+
+        Self {
+            map: new_regex_map(STOP_MODE_OVERRIDE_RULES.iter().map(|(k, v)| (*k, v.clone()))),
+        }
+    }
+
+    /// Get the stop mode limit for a peripheral based on the MCU and peripheral name.
+    /// Determines the lowest possible stop mode when a peripheral is enabled.
+    ///
+    /// Parameters:
+    /// - mcu_name: the full name of the MCU (e.g., "STM32WB55RG")
+    /// - peripheral: the name of the peripheral (e.g., "USART1")
+    pub(crate) fn peripheral_stop_mode_info(&self, mcu_name: &str, peripheral: &str) -> Option<StopMode> {
+        self.map.get(&format!("{mcu_name}:{peripheral}")).next().cloned()
+    }
 }
 
 #[cfg(test)]
@@ -73,21 +83,26 @@ mod tests {
 
     #[test]
     fn test_get_peripheral_stop_mode_info() {
+        let chip_stop_modes = ChipStopModes::new();
+
         // MCU independent rule for RTC
-        assert_eq!(peripheral_stop_mode_info("my-test-mcu", "RTC"), Some(StopMode::Standby));
+        assert_eq!(
+            chip_stop_modes.peripheral_stop_mode_info("my-test-mcu", "RTC"),
+            Some(StopMode::Standby)
+        );
 
         // No rule for this but starting with LP prefix, so assumed to be Stop2
         assert_eq!(
-            peripheral_stop_mode_info("my-test-mcu", "LPTIM2"),
+            chip_stop_modes.peripheral_stop_mode_info("my-test-mcu", "LPTIM2"),
             Some(StopMode::Stop2)
         );
 
         // MCU independent rule for RTC. Must match RTC exactly
-        assert_eq!(peripheral_stop_mode_info("my-test-mcu", "RTC1"), None);
+        assert_eq!(chip_stop_modes.peripheral_stop_mode_info("my-test-mcu", "RTC1"), None);
 
         // Rule covering all STM32WB55 for LPTIM1
         assert_eq!(
-            peripheral_stop_mode_info("STM32WB55RG", "LPTIM1"),
+            chip_stop_modes.peripheral_stop_mode_info("STM32WB55RG", "LPTIM1"),
             Some(StopMode::Standby)
         );
     }

--- a/stm32-data-gen/src/main.rs
+++ b/stm32-data-gen/src/main.rs
@@ -136,7 +136,10 @@ fn main() -> anyhow::Result<()> {
 
     let mut stopwatch = Stopwatch::new();
 
+    let perimap = perimap::Perimap::new();
+    let stop_modes = low_power::ChipStopModes::new();
     let triggers = trigger::Triggers::new();
+    let chip_memories = memory::ChipMemories::new();
 
     stopwatch.section("Removing build directory");
 
@@ -161,7 +164,7 @@ fn main() -> anyhow::Result<()> {
     let docs = docs::Docs::parse()?;
 
     // stopwatch.section("Parsing DMA");
-    let mut dma_channels = dma::DmaChannels::parse()?;
+    let mut dma_channels = dma::DmaChannels::parse(&perimap)?;
 
     // stopwatch.section("Parsing GPIO AF");
     let mut af = gpio_af::Af::parse()?;
@@ -185,7 +188,10 @@ fn main() -> anyhow::Result<()> {
         chip_groups,
         headers,
         af,
+        perimap,
+        stop_modes,
         triggers,
+        chip_memories,
         registers.blocks,
         chip_interrupts,
         peripheral_to_clock,

--- a/stm32-data-gen/src/memory.rs
+++ b/stm32-data-gen/src/memory.rs
@@ -1,8 +1,9 @@
 use stm32_data_serde::chip::Memory;
 use stm32_data_serde::chip::memory::{self, Access, Settings};
 
-use crate::util::RegexMap;
+use crate::util::new_regex_map;
 
+#[derive(Clone)]
 struct Mem {
     name: &'static str,
     address: u32,
@@ -72,7 +73,7 @@ macro_rules! mem {
 }
 
 #[rustfmt::skip]
-static MEMS: RegexMap<&[&[Mem]]> = RegexMap::new(&[
+const MEMS: &[(&str, &[&[Mem]])] = &[
     // C0
     ("STM32C01..4",                  &[mem!(BANK_1 { 0x08000000 16 }, SRAM { 0x20000000 6 })]),
     ("STM32C01..6",                  &[mem!(BANK_1 { 0x08000000 32 }, SRAM { 0x20000000 6 })]),
@@ -410,8 +411,9 @@ static MEMS: RegexMap<&[&[Mem]]> = RegexMap::new(&[
     ("STM32WL[5E]..8",               &[mem!(BANK_1 { 0x08000000 64 },  SRAM1 { 0x20000000 10 }, SRAM2 { 0x20002800 10 })]),
     ("STM32WL[5E]..B",               &[mem!(BANK_1 { 0x08000000 128 }, SRAM1 { 0x20000000 24 }, SRAM2 { 0x20006000 24 })]),
     ("STM32WL[5E]..C",               &[mem!(BANK_1 { 0x08000000 256 }, SRAM1 { 0x20000000 32 }, SRAM2 { 0x20008000 32 })]),
-]);
+];
 
+#[derive(Clone)]
 struct FlashInfo {
     write_size: u32,
     erase_size: &'static [(u32, u32)],
@@ -421,7 +423,7 @@ struct FlashInfo {
 
 #[rustfmt::skip]
 #[allow(clippy::identity_op)]
-static FLASH_INFO: RegexMap<&[FlashInfo]> = RegexMap::new(&[
+const FLASH_INFO: &[(&str, &[FlashInfo])] = &[
     ("STM32C0.*",               &[FlashInfo{ erase_value: 0xFF, write_size:  8, erase_size: &[(  2*1024, 0)] }]),
     ("STM32F030.C",             &[FlashInfo{ erase_value: 0xFF, write_size:  4, erase_size: &[(  2*1024, 0)] }]),
     ("STM32F070.6",             &[FlashInfo{ erase_value: 0xFF, write_size:  4, erase_size: &[(  1*1024, 0)] }]),
@@ -481,27 +483,80 @@ static FLASH_INFO: RegexMap<&[FlashInfo]> = RegexMap::new(&[
     ("STM32WB.*",               &[FlashInfo{ erase_value: 0xFF, write_size:  8, erase_size: &[(  4*1024, 0)] }]),
     ("STM32WL.*",               &[FlashInfo{ erase_value: 0xFF, write_size:  8, erase_size: &[(  2*1024, 0)] }]),
     ("STM32.*",                 &[FlashInfo{ erase_value: 0xFF, write_size:  8, erase_size: &[(  2*1024, 0)] }]),
-]);
+];
 
-pub fn get(chip: &str) -> Vec<Vec<Memory>> {
-    let mems_variations = *MEMS.must_get(chip);
-    let flash_variations = FLASH_INFO.must_get(chip);
+pub struct ChipMemories {
+    mems: regex_map::RegexMap<Vec<Vec<Mem>>>,
+    flash_info: regex_map::RegexMap<Vec<FlashInfo>>,
+}
 
-    assert_eq!(
-        mems_variations.len(),
-        flash_variations.len(),
-        "All memory variants must be present in both the mems and the flash info: {chip}"
-    );
+impl ChipMemories {
+    pub fn new() -> Self {
+        Self {
+            mems: new_regex_map(MEMS.iter().map(|(k, v)| (k, v.iter().map(|x| x.to_vec()).collect()))),
+            flash_info: new_regex_map(FLASH_INFO.iter().map(|(k, v)| (k, v.to_vec()))),
+        }
+    }
 
-    mems_variations
-        .into_iter()
-        .zip(flash_variations.into_iter())
-        .map(|(mems, flash)| {
-            let mut res = Vec::new();
+    pub fn get(&self, chip: &str) -> Vec<Vec<Memory>> {
+        let mems_variations = self.mems.get(chip).next().unwrap();
+        let flash_variations = self.flash_info.get(chip).next().unwrap();
 
-            for mem in *mems {
-                if mem.name.starts_with("BANK") {
-                    if flash.erase_size.len() == 1 || mem.size <= flash.erase_size[0].0 * flash.erase_size[0].1 {
+        assert_eq!(
+            mems_variations.len(),
+            flash_variations.len(),
+            "All memory variants must be present in both the mems and the flash info: {chip}"
+        );
+
+        mems_variations
+            .into_iter()
+            .zip(flash_variations.into_iter())
+            .map(|(mems, flash)| {
+                let mut res = Vec::new();
+
+                for mem in mems {
+                    if mem.name.starts_with("BANK") {
+                        if flash.erase_size.len() == 1 || mem.size <= flash.erase_size[0].0 * flash.erase_size[0].1 {
+                            res.push(Memory {
+                                name: mem.name.to_string(),
+                                address: mem.address,
+                                size: mem.size,
+                                kind: memory::Kind::Flash,
+                                settings: Some(Settings {
+                                    write_size: flash.write_size,
+                                    erase_size: flash.erase_size[0].0,
+                                    erase_value: flash.erase_value,
+                                }),
+                                access: mem.access,
+                            });
+                        } else {
+                            let mut offs = 0;
+                            for (i, &(erase_size, count)) in flash.erase_size.iter().enumerate() {
+                                if offs >= mem.size {
+                                    break;
+                                }
+                                let left = mem.size - offs;
+                                let mut size = left;
+                                if i != flash.erase_size.len() - 1 {
+                                    size = size.min(erase_size * count);
+                                }
+                                #[allow(clippy::redundant_field_names)]
+                                res.push(Memory {
+                                    name: format!("{}_REGION_{}", mem.name, i + 1),
+                                    address: mem.address + offs,
+                                    size: size,
+                                    kind: memory::Kind::Flash,
+                                    settings: Some(Settings {
+                                        write_size: flash.write_size,
+                                        erase_size: erase_size,
+                                        erase_value: flash.erase_value,
+                                    }),
+                                    access: mem.access,
+                                });
+                                offs += size;
+                            }
+                        }
+                    } else if mem.name == "OTP" {
                         res.push(Memory {
                             name: mem.name.to_string(),
                             address: mem.address,
@@ -509,79 +564,40 @@ pub fn get(chip: &str) -> Vec<Vec<Memory>> {
                             kind: memory::Kind::Flash,
                             settings: Some(Settings {
                                 write_size: flash.write_size,
-                                erase_size: flash.erase_size[0].0,
+                                erase_size: 0,
                                 erase_value: flash.erase_value,
                             }),
                             access: mem.access,
                         });
+                    } else if mem.name.starts_with("EEPROM") {
+                        res.push(Memory {
+                            name: mem.name.to_string(),
+                            address: mem.address,
+                            size: mem.size,
+                            kind: memory::Kind::Eeprom,
+                            settings: None,
+                            access: mem.access,
+                        });
                     } else {
-                        let mut offs = 0;
-                        for (i, &(erase_size, count)) in flash.erase_size.iter().enumerate() {
-                            if offs >= mem.size {
-                                break;
-                            }
-                            let left = mem.size - offs;
-                            let mut size = left;
-                            if i != flash.erase_size.len() - 1 {
-                                size = size.min(erase_size * count);
-                            }
-                            #[allow(clippy::redundant_field_names)]
-                            res.push(Memory {
-                                name: format!("{}_REGION_{}", mem.name, i + 1),
-                                address: mem.address + offs,
-                                size: size,
-                                kind: memory::Kind::Flash,
-                                settings: Some(Settings {
-                                    write_size: flash.write_size,
-                                    erase_size: erase_size,
-                                    erase_value: flash.erase_value,
-                                }),
-                                access: mem.access,
-                            });
-                            offs += size;
+                        let mut kind = memory::Kind::Ram;
+                        if mem.name.contains("FLASH") || mem.name.contains("AXIICP") {
+                            kind = memory::Kind::Flash;
                         }
+                        res.push(Memory {
+                            name: mem.name.to_string(),
+                            address: mem.address,
+                            size: mem.size,
+                            kind,
+                            settings: None,
+                            access: mem.access,
+                        });
                     }
-                } else if mem.name == "OTP" {
-                    res.push(Memory {
-                        name: mem.name.to_string(),
-                        address: mem.address,
-                        size: mem.size,
-                        kind: memory::Kind::Flash,
-                        settings: Some(Settings {
-                            write_size: flash.write_size,
-                            erase_size: 0,
-                            erase_value: flash.erase_value,
-                        }),
-                        access: mem.access,
-                    });
-                } else if mem.name.starts_with("EEPROM") {
-                    res.push(Memory {
-                        name: mem.name.to_string(),
-                        address: mem.address,
-                        size: mem.size,
-                        kind: memory::Kind::Eeprom,
-                        settings: None,
-                        access: mem.access,
-                    });
-                } else {
-                    let mut kind = memory::Kind::Ram;
-                    if mem.name.contains("FLASH") || mem.name.contains("AXIICP") {
-                        kind = memory::Kind::Flash;
-                    }
-                    res.push(Memory {
-                        name: mem.name.to_string(),
-                        address: mem.address,
-                        size: mem.size,
-                        kind,
-                        settings: None,
-                        access: mem.access,
-                    });
                 }
-            }
 
-            res.sort_by_key(|m| (m.address, m.name.clone()));
+                res.sort_by_key(|m| (m.address, m.name.clone()));
 
-            res
-        })
-        .collect()
+                res
+            })
+            .collect()
+    }
 }

--- a/stm32-data-gen/src/package.rs
+++ b/stm32-data-gen/src/package.rs
@@ -16,7 +16,7 @@ use crate::gpio_af::{Af, clean_pin, pin_matches};
 use crate::interrupts::ChipInterrupts;
 use crate::package::schema::pinout::Characteristics;
 use crate::package::schema::{dma, exti, interrupts, peripherals, pinout};
-use crate::util::{EntryFns, HashMapFns, RegexMap};
+use crate::util::{EntryFns, HashMapFns, new_regex_map};
 
 #[derive(Serialize, Deserialize)]
 pub struct Package {
@@ -995,24 +995,26 @@ impl PackageDirectory {
     }
 }
 
-struct DmaMap<'a> {
-    dma_map: HashMap<&'a str, HashMap<String, u8>>,
-    regex_map: RegexMap<'a, &'a str>,
+struct DmaMap {
+    dma_files: Vec<HashMap<String, u8>>,
+    regex_map: regex_map::RegexMap<usize>,
 }
 
-impl<'a> DmaMap<'a> {
-    pub fn new(map: &'a [(&'a str, &'a str)]) -> anyhow::Result<Self> {
+impl DmaMap {
+    pub fn new(map: &[(&str, &str)]) -> anyhow::Result<Self> {
+        let (keys, values): (Vec<_>, Vec<_>) = map.iter().map(|(k, v)| (*k, *v)).unzip();
+
         Ok(Self {
-            dma_map: map
+            dma_files: values
                 .iter()
-                .map(|(_, f)| Ok((*f, load_dma_mux(f)?)))
+                .map(|f| Ok(load_dma_mux(*f)?))
                 .collect::<anyhow::Result<_>>()?,
-            regex_map: RegexMap::new(map),
+            regex_map: new_regex_map(keys.iter().enumerate().map(|(k, v)| (*v, k))),
         })
     }
 
     pub fn get(&self, key: &str) -> Option<&HashMap<String, u8>> {
-        self.dma_map.get(self.regex_map.get(key)?)
+        Some(&self.dma_files[*self.regex_map.get(key).next()?])
     }
 }
 

--- a/stm32-data-gen/src/perimap.rs
+++ b/stm32-data-gen/src/perimap.rs
@@ -1,6 +1,6 @@
-use crate::util::RegexMap;
+use crate::util::new_regex_map;
 
-pub static PERIMAP: RegexMap<(&str, &str, &str)> = RegexMap::new(&[
+const PERIMAP: &[(&str, (&str, &str, &str))] = &[
     // GTZC - TrustZone Security Controller
     ("STM32H503.*:GTZC:.*", ("gtzc", "h503", "GTZC1")),
     ("STM32H5[2367].*:GTZC:.*", ("gtzc", "v1", "GTZC1_TZSC")),
@@ -790,4 +790,20 @@ pub static PERIMAP: RegexMap<(&str, &str, &str)> = RegexMap::new(&[
     (".*:XSPI[12]:XSPI:xspi_v2_1H7RS*", ("xspi", "v1", "XSPI")),
     (".*:XSPIM:XSPIM:xspi_v2_1H7RS*", ("xspim", "v1", "XSPIM")),
     ("STM32H7.*:MDMA:.*", ("mdma", "v1", "MDMA")),
-]);
+];
+
+pub struct Perimap {
+    map: regex_map::RegexMap<(&'static str, &'static str, &'static str)>,
+}
+
+impl Perimap {
+    pub fn new() -> Self {
+        Self {
+            map: new_regex_map(PERIMAP.iter().map(|(k, v)| (*k, *v))),
+        }
+    }
+
+    pub fn get(&self, pattern: &str) -> Option<&(&'static str, &'static str, &'static str)> {
+        self.map.get(pattern).next()
+    }
+}

--- a/stm32-data-gen/src/trigger.rs
+++ b/stm32-data-gen/src/trigger.rs
@@ -2,22 +2,23 @@ use std::collections::{HashMap, HashSet};
 
 use regex::Regex;
 
-use crate::util::RegexMap;
+use crate::util::new_regex_map;
 
+#[derive(Clone)]
 pub struct Trigger {
     pub signal: &'static str,
     pub source: &'static str,
 }
 
 pub struct Triggers {
-    map: &'static RegexMap<'static, &'static [Trigger]>,
+    map: regex_map::RegexMap<Vec<Trigger>>,
 }
 
 impl Triggers {
     pub fn new() -> Self {
         /// Regexmap where the key is mcu_name:peripheral and the value is the trigger list.
         #[rustfmt::skip]
-        static PERIPHERAL_TRIGGER_RULES: RegexMap<&'static [Trigger]> = RegexMap::new(&[
+        const PERIPHERAL_TRIGGER_RULES: &[(&str, &'static [Trigger])] = &[
             (r"^STM32F0.*:DAC.*", &[
                 Trigger {signal: "DAC_CHX_TRG0", source: "TIM6_TRGO"},
                 Trigger {signal: "DAC_CHX_TRG1", source: "TIM3_TRGO"},
@@ -884,11 +885,11 @@ impl Triggers {
                 Trigger {signal: "DAC_CHX_TRG13", source: "LPTIM3_TRGO"},
                 Trigger {signal: "DAC_CHX_TRG14", source: "EXTI9_TRG"},
             ]),
-        ]);
+        ];
 
         let trigger_expr = Regex::new(r"(?m)(.+?)(\d+)").unwrap();
 
-        for (expr, triggers) in PERIPHERAL_TRIGGER_RULES.get_map() {
+        for (expr, triggers) in PERIPHERAL_TRIGGER_RULES {
             let mut trigger_sets: HashMap<String, HashSet<&str>> = HashMap::new();
 
             for trigger in *triggers {
@@ -905,7 +906,7 @@ impl Triggers {
         }
 
         Self {
-            map: &PERIPHERAL_TRIGGER_RULES,
+            map: new_regex_map(PERIPHERAL_TRIGGER_RULES.iter().map(|(k, v)| (k, v.to_vec()))),
         }
     }
 
@@ -915,7 +916,7 @@ impl Triggers {
     /// Parameters:
     /// - mcu_name: the full name of the MCU (e.g., "STM32WB55RG")
     /// - peripheral: the name of the peripheral (e.g., "USART1")
-    pub fn peripheral_trigger_info(&self, mcu_name: &str, peripheral: &str) -> Option<&'static [Trigger]> {
-        self.map.get(&format!("{mcu_name}:{peripheral}")).map(|v| &**v)
+    pub fn peripheral_trigger_info(&self, mcu_name: &str, peripheral: &str) -> Option<&[Trigger]> {
+        self.map.get(&format!("{mcu_name}:{peripheral}")).next().map(|v| &**v)
     }
 }

--- a/stm32-data-gen/src/util.rs
+++ b/stm32-data-gen/src/util.rs
@@ -2,7 +2,6 @@ use std::collections::HashMap;
 use std::collections::hash_map::Entry;
 use std::hash::Hash;
 use std::ptr;
-use std::sync::{Mutex, OnceLock};
 
 pub trait HashMapFns<K: Eq + Hash, V> {
     fn try_insert_stable(&mut self, key: K, value: V) -> Result<(), ()>;
@@ -54,74 +53,18 @@ impl<'a, K: Eq + Hash + 'a, V: 'a> EntryFns<'a, K, V> for Entry<'a, K, V> {
     }
 }
 
-struct RegexMapState {
-    regexes: regex::RegexSet,
-    cache: Mutex<HashMap<String, Option<usize>>>,
+pub fn new_regex_map<I, S, V>(items: I) -> regex_map::RegexMap<V>
+where
+    I: IntoIterator<Item = (S, V)>,
+    S: AsRef<str>,
+{
+    regex_map::RegexMap::new(items.into_iter().map(|(k, v)| (format!("^{}$", k.as_ref()), v)))
 }
 
-impl RegexMapState {
-    fn get(&self, key: &str) -> Option<usize> {
-        if let Some(&val) = self.cache.lock().unwrap().get(key) {
-            return val;
-        }
-
-        let val = self.regexes.matches(key).iter().next();
-        let key = key.to_string();
-
-        self.cache.lock().unwrap().insert(key, val);
-
-        val
-    }
-}
-
-pub struct RegexMap<'a, T> {
-    map: &'a [(&'a str, T)],
-    state: OnceLock<RegexMapState>,
-}
-
-impl<'a, T> RegexMap<'a, T> {
-    pub const fn new(map: &'a [(&'a str, T)]) -> Self {
-        Self {
-            map,
-            state: OnceLock::new(),
-        }
-    }
-
-    pub const fn get_map(&self) -> &'a [(&'a str, T)] {
-        self.map
-    }
-
-    pub fn get(&self, key: &str) -> Option<&'a T> {
-        self.state
-            .get_or_init(|| RegexMapState {
-                regexes: regex::RegexSet::new(self.map.iter().map(|(k, _)| format!("^{k}$"))).unwrap(),
-                cache: Mutex::new(HashMap::new()),
-            })
-            .get(key)
-            .map(|i| &self.map[i].1)
-    }
-
-    #[track_caller]
-    pub fn must_get(&self, key: &str) -> &T {
-        let Some(res) = self.get(key) else {
-            panic!("no regexmap for key '{key}'")
-        };
-        res
-    }
-}
-
-pub struct RegexSet<'a> {
-    map: RegexMap<'a, ()>,
-}
-
-impl<'a> RegexSet<'a> {
-    pub const fn new(map: &'a [&'a str]) -> Self {
-        Self {
-            map: RegexMap::new(unsafe { std::mem::transmute::<&[&str], &[(&str, ())]>(map) }),
-        }
-    }
-
-    pub fn contains(&self, key: &str) -> bool {
-        self.map.get(key).is_some()
-    }
+pub fn new_regex_set<I, S>(items: I) -> regex::RegexSet
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<str>,
+{
+    regex::RegexSet::new(items.into_iter().map(|k| format!("^{}$", k.as_ref()))).unwrap()
 }


### PR DESCRIPTION
uses an allocated map, which is cleaner than the static map with the lifetimes.