### PR TITLE
Fix the RIMC register count to allow setting the VENC configuration

### DIFF
--- a/data/registers/rifsc_n6.yaml
+++ b/data/registers/rifsc_n6.yaml
@@ -34,7 +34,7 @@ block/RIFSC:
     description: RIFSC RIMC master attribute register.
     byte_offset: 0xC10
     array:
-      len: 12
+      len: 13
       stride: 4
     fieldset: RIMC_ATTR
   - name: PPSR


### PR DESCRIPTION
As described in the reference manual (RM0486), page 250:

| Master index | Master name |
|--------------|-------------|
| 0            | Trace (ETR) |
| 1            | NPU         |
| 2            | SDMMC1      |
| 3            | SDMMC2      |
| 4            | OTG1        |
| 5            | OTG2        |
| 6            | ETH1        |
| 7            | GPU         |
| 8            | DMA2D       |
| 9            | DCMIPP      |
| 10           | LTDC_L1     |
| 11           | LTDC_L2     |
| 12           | VENC        |
