### PR TITLE
EXTI things should not be :Y:

### DIFF
--- a/stm32-data-gen/src/package.rs
+++ b/stm32-data-gen/src/package.rs
@@ -927,7 +927,8 @@ fn build_interrupts(f: &interrupts::File, exti_map: &HashMap<String, String>) ->
                 .iter()
                 .map(|p| exti_map.get(&p.name).unwrap_or(&p.name).clone());
 
-            irq.name.clone() + "_IRQn" + ":Y:" + &peripherals.join(",") + "::"
+            let t = if irq.name.starts_with("EXTI") { ":EXTI:" } else { ":Y:" };
+            irq.name.clone() + "_IRQn" + t + &peripherals.join(",") + "::"
         })
         .collect()
 }


### PR DESCRIPTION
The goal with this is to fix the EXTI peripheral's interrupts not getting populated