### PR TITLE
deps: upgrade defmt to 1.x in stm32-metapac

### DIFF
--- a/stm32-metapac-gen/res/Cargo.toml
+++ b/stm32-metapac-gen/res/Cargo.toml
@@ -50,7 +50,7 @@ flavors = [
 [dependencies]
 cortex-m = "0.7.6"
 cortex-m-rt = { version = ">=0.6.15,<0.8", optional = true }
-defmt = { version = "0.3.0", optional = true }
+defmt = { version = "1.0.0", optional = true }
 
 [features]
 default = ["pac"]


### PR DESCRIPTION
While going through duplicate dependencies for my project with cargo-deny, I noticed stm32-metapac was the only thing in the tree that still depends on defmt 0.3.100. Since 0.3.100 just re-exports defmt 1.x, and the wire format hasn't changed since defmt 0.3.4, this shouldn't be a breaking change.