### PR TITLE
Add SPI support for stm32c5

### DIFF
--- a/stm32-data-gen/src/perimap.rs
+++ b/stm32-data-gen/src/perimap.rs
@@ -146,6 +146,7 @@ const PERIMAP: &[(&str, (&str, &str, &str))] = &[
     ("STM32H7[RS].*:SPI:.*", ("spi", "v5_i2s", "SPI")),
     ("STM32H7.*:SPI:.*", ("spi", "v4_i2s", "SPI")),
     ("STM32H5.*:SPI:.*", ("spi", "v5_i2s", "SPI")),
+    ("STM32C5.*:SPI:.*", ("spi", "v5_i2s", "SPI")),
     ("STM32N6.*:SPI:.*", ("spi", "v5", "SPI")),
     ("STM32U3.*:SPI:.*", ("spi", "v6", "SPI")),
     ("STM32U5.*:SPI:.*", ("spi", "v6", "SPI")),


### PR DESCRIPTION
Adds stm32c5 SPI definition in perimap.rs with the same configuration as the H5.

Tested via embassy-stm32 with a smt32c562re nucleo board and a LPS27HHW sensor