### PR TITLE
h5: make extsel not an array

### DIFF
--- a/data/registers/adc_h5.yaml
+++ b/data/registers/adc_h5.yaml
@@ -144,10 +144,7 @@ fieldset/CFGR:
   - name: EXTSEL
     description: 'External trigger selection for regular group These bits select the external event used to trigger the start of conversion of a regular group: ... Note: The software is allowed to write these bits only when ADSTART = 0 (which ensures that no regular conversion is ongoing).'
     bit_offset: 5
-    bit_size: 1
-    array:
-      len: 5
-      stride: 1
+    bit_size: 5
   - name: EXTEN
     description: 'External trigger enable and polarity selection for regular channels These bits are set and cleared by software to select the external trigger polarity and enable the trigger of a regular group. Note: The software is allowed to write these bits only when ADSTART = 0 (which ensures that no regular conversion is ongoing).'
     bit_offset: 10


### PR DESCRIPTION
Modified to match other ADCs, such that it can be used here:
https://github.com/embassy-rs/embassy/blob/0a10a97a98916a41106e14473854234987745560/embassy-stm32/src/adc/v3.rs#L254