### PR TITLE
Fix GPU2D RCC field names and missing completion interrupt on N6/H7RS

### DIFF
--- a/data/registers/rcc_h7rs.yaml
+++ b/data/registers/rcc_h7rs.yaml
@@ -693,8 +693,8 @@ fieldset/AHB5ENR:
     description: GFXMMU peripheral clock enable Set and reset by software.
     bit_offset: 19
     bit_size: 1
-  - name: GPUEN
-    description: GPU peripheral clock enable Set and reset by software.
+  - name: GPU2DEN
+    description: GPU2D peripheral clock enable Set and reset by software.
     bit_offset: 20
     bit_size: 1
 fieldset/AHB5LPENR:
@@ -740,8 +740,8 @@ fieldset/AHB5LPENR:
     description: GFXMMU low-power peripheral clock enable Set and reset by software.
     bit_offset: 19
     bit_size: 1
-  - name: GPULPEN
-    description: GPU low-power peripheral clock enable Set and reset by software.
+  - name: GPU2DLPEN
+    description: GPU2D low-power peripheral clock enable Set and reset by software.
     bit_offset: 20
     bit_size: 1
   - name: DTCM1LPEN
@@ -799,8 +799,8 @@ fieldset/AHB5RSTR:
     description: GFXMMU block reset Set and reset by software.
     bit_offset: 19
     bit_size: 1
-  - name: GPURST
-    description: GPU block reset Set and reset by software.
+  - name: GPU2DRST
+    description: GPU2D block reset Set and reset by software.
     bit_offset: 20
     bit_size: 1
 fieldset/AHBPERCKSELR:

--- a/data/registers/rcc_n6.yaml
+++ b/data/registers/rcc_n6.yaml
@@ -2024,8 +2024,8 @@ fieldset/AHB5ENCR:
     description: GFXMMU enable.
     bit_offset: 19
     bit_size: 1
-  - name: GPUENC
-    description: GPU enable.
+  - name: GPU2DENC
+    description: GPU2D enable.
     bit_offset: 20
     bit_size: 1
   - name: ETH1MACENC
@@ -2135,8 +2135,8 @@ fieldset/AHB5ENR:
     description: GFXMMU enable.
     bit_offset: 19
     bit_size: 1
-  - name: GPUEN
-    description: GPU enable.
+  - name: GPU2DEN
+    description: GPU2D enable.
     bit_offset: 20
     bit_size: 1
   - name: ETH1MACEN
@@ -2246,8 +2246,8 @@ fieldset/AHB5ENSR:
     description: GFXMMU enable.
     bit_offset: 19
     bit_size: 1
-  - name: GPUENS
-    description: GPU enable.
+  - name: GPU2DENS
+    description: GPU2D enable.
     bit_offset: 20
     bit_size: 1
   - name: ETH1MACENS
@@ -2357,8 +2357,8 @@ fieldset/AHB5LPENCR:
     description: GFXMMU sleep enable.
     bit_offset: 19
     bit_size: 1
-  - name: GPULPENC
-    description: GPU sleep enable.
+  - name: GPU2DLPENC
+    description: GPU2D sleep enable.
     bit_offset: 20
     bit_size: 1
   - name: ETH1MACLPENC
@@ -2468,8 +2468,8 @@ fieldset/AHB5LPENR:
     description: GFXMMU sleep enable.
     bit_offset: 19
     bit_size: 1
-  - name: GPULPEN
-    description: GPU sleep enable.
+  - name: GPU2DLPEN
+    description: GPU2D sleep enable.
     bit_offset: 20
     bit_size: 1
   - name: ETH1MACLPEN
@@ -2579,8 +2579,8 @@ fieldset/AHB5LPENSR:
     description: GFXMMU sleep enable.
     bit_offset: 19
     bit_size: 1
-  - name: GPULPENS
-    description: GPU sleep enable.
+  - name: GPU2DLPENS
+    description: GPU2D sleep enable.
     bit_offset: 20
     bit_size: 1
   - name: ETH1MACLPENS
@@ -2678,8 +2678,8 @@ fieldset/AHB5RSTCR:
     description: GFXMMU reset.
     bit_offset: 19
     bit_size: 1
-  - name: GPURSTC
-    description: GPU reset.
+  - name: GPU2DRSTC
+    description: GPU2D reset.
     bit_offset: 20
     bit_size: 1
   - name: SYSCFGOTGHSPHY1RSTC
@@ -2773,8 +2773,8 @@ fieldset/AHB5RSTR:
     description: GFXMMU reset.
     bit_offset: 19
     bit_size: 1
-  - name: GPURST
-    description: GPU reset.
+  - name: GPU2DRST
+    description: GPU2D reset.
     bit_offset: 20
     bit_size: 1
   - name: SYSCFGOTGHSPHY1RST
@@ -2868,8 +2868,8 @@ fieldset/AHB5RSTSR:
     description: GFXMMU reset.
     bit_offset: 19
     bit_size: 1
-  - name: GPURSTS
-    description: GPU reset.
+  - name: GPU2DRSTS
+    description: GPU2D reset.
     bit_offset: 20
     bit_size: 1
   - name: SYSCFGOTGHSPHY1RSTS

--- a/stm32-data-gen/src/interrupts.rs
+++ b/stm32-data-gen/src/interrupts.rs
@@ -753,7 +753,7 @@ impl InterruptSignals {
             ("USB1_OTG_HS", &["GLOBAL", "EP1_OUT", "EP1_IN", "WKUP"]),
             ("USB2_OTG_HS", &["GLOBAL", "EP1_OUT", "EP1_IN", "WKUP"]),
             ("USB", &["LP", "HP", "WKUP", "USBH", "OHCI", "EHCI"]),
-            ("GPU2D", &["ER"]),
+            ("GPU2D", &["GLOBAL", "ER"]),
             ("SAI", &["A", "B"]),
             ("ADF", &["FLT0"]),
             ("RAMECC", &["ECC"]),


### PR DESCRIPTION
## Summary
- **RCC field names**: `rcc_n6.yaml`/`rcc_h7rs.yaml`'s `AHB5ENR`/`AHB5RSTR`/`AHB5LPENR` fields for GPU2D's clock enable/reset were transcribed as `GPUEN`/`GPURST`/`GPULPEN` (one letter short of the real bit names), so `stm32-data-gen`'s RCC matcher — which derives a peripheral's clock/reset info by stripping the `EN`/`RST` suffix and looking up the peripheral name directly — never matched "GPU" to peripheral "GPU2D". No `rcc` info was ever generated for GPU2D on these families, despite `JPEG`/`DMA2D` on the same `AHB5` bus working correctly. Verified against RM0486 (STM32N647/657) and RM0477 (STM32H7R/S): both name the bits `GPU2DEN`/`GPU2DRST`/`GPU2DLPEN` at bit 20 of the respective registers.
- **Missing completion interrupt**: `stm32-data-gen/src/interrupts.rs`'s `IRQ_SIGNALS_MAP` only listed `("GPU2D", &["ER"])`, but the raw NVIC XML (and both reference manuals) show two distinct vectors: `GPU2D_IRQn` (command-list-complete, "GPU2D global interrupt") and `GPU2D_ER_IRQn` (error). Since `"ER"` was the only recognized signal, the bare `GPU2D_IRQn` vector fanned out to it too, collided with `GPU2D_ER_IRQn` under the same signal bucket, and the dedup logic silently discarded the completion vector in favor of `GPU2D_ER` — for every chip family with GPU2D, not just N6/H7RS. Fixed by adding `"GLOBAL"` alongside `"ER"`, the same pattern already used for other two-vector peripherals (`USB_OTG_FS`, `MDIOS`, `ETH`, `GTZC`, `WWDG`).