### PR TITLE
C5: Add flash info

### DIFF
--- a/stm32-data-gen/src/memory.rs
+++ b/stm32-data-gen/src/memory.rs
@@ -429,6 +429,7 @@ struct FlashInfo {
 #[allow(clippy::identity_op)]
 const FLASH_INFO: &[(&str, &[FlashInfo])] = &[
     ("STM32C0.*",               &[FlashInfo{ erase_value: 0xFF, write_size:  8, erase_size: &[(  2*1024, 0)] }]),
+    ("STM32C5.*",               &[FlashInfo{ erase_value: 0xFF, write_size: 16, erase_size: &[(  8*1024, 0)] }]),
     ("STM32F030.C",             &[FlashInfo{ erase_value: 0xFF, write_size:  4, erase_size: &[(  2*1024, 0)] }]),
     ("STM32F070.6",             &[FlashInfo{ erase_value: 0xFF, write_size:  4, erase_size: &[(  1*1024, 0)] }]),
     ("STM32F0[79].*",           &[FlashInfo{ erase_value: 0xFF, write_size:  4, erase_size: &[(  2*1024, 0)] }]),


### PR DESCRIPTION
RM0522:

<img width="1616" height="592" alt="image" src="https://github.com/user-attachments/assets/2612b2df-ccc0-42ac-84a0-2022a6a1be12" />
and this also mentions 2kB
<img width="1616" height="584" alt="image" src="https://github.com/user-attachments/assets/1ab6d0e2-468e-459a-a3c5-9c65240abcb0" />

**Edit:** Oh, 2kB is for EDATA
