### PR TITLE
STM32U0: LPTIMs don't block Stop 2

### DIFF
--- a/stm32-data-gen/src/low_power.rs
+++ b/stm32-data-gen/src/low_power.rs
@@ -54,6 +54,9 @@ impl ChipStopModes {
             (r"^STM32U5.*:GPDMA.*", StopMode::Stop2),
             (r"^STM32U5.*:LPDMA.*", StopMode::Standby),
 
+            // STM32U0 series - from RM0503 Table 22: all LPTIMs functional in Stop 2
+            (r"^STM32U0.*:LPTIM\d", StopMode::Standby),
+
             // __ATTENTION__: Keep these rules at the bottom to grant precedence to the more specific rules above
             // Every peripheral with LP prefix is assumed to be able enter up to Stop1 mode
             (r".*:LP.*", StopMode::Stop2),
@@ -103,6 +106,12 @@ mod tests {
         // Rule covering all STM32WB55 for LPTIM1
         assert_eq!(
             chip_stop_modes.peripheral_stop_mode_info("STM32WB55RG", "LPTIM1"),
+            Some(StopMode::Standby)
+        );
+
+        // U0 LPTIMs run in Stop 2; the specific rule must beat the generic LP rule
+        assert_eq!(
+            chip_stop_modes.peripheral_stop_mode_info("STM32U083RC", "LPTIM1"),
             Some(StopMode::Standby)
         );
     }


### PR DESCRIPTION
All U0 LPTIMs are functional in Stop 2 (RM0503 Rev 4 Table 22), but the generic `.*:LP.*` rule marks them `Stop2`, so under embassy's `low-power` feature an enabled LPTIM pins the chip at Stop 1. Give them the same `Standby` override WB55/WL55/WBA LPTIM1 already have.

Verified on a NUCLEO-U083RC: 3.4 µA idle at Stop 1 vs 1.6 µA at Stop 2 with an LSI-clocked LPTIM1 PWM running.