### PR TITLE
usart_v4: Add SLVEN bit in CR2

### DIFF
--- a/data/registers/usart_v4.yaml
+++ b/data/registers/usart_v4.yaml
@@ -216,6 +216,10 @@ fieldset/CR1:
 fieldset/CR2:
   description: Control register 2
   fields:
+  - name: SLVEN
+    description: Synchronous slave mode enable
+    bit_offset: 0
+    bit_size: 1
   - name: ADDM
     description: 7-bit Address Detection/4-bit Address Detection
     bit_offset: 4


### PR DESCRIPTION
I checked the existence of this bit against the STM32H723 reference manual (RM0468).