### PR TITLE
Fix WBA65/U5 PWR register bugs and clean up generic enum names

### DIFF
--- a/data/registers/comp_u5.yaml
+++ b/data/registers/comp_u5.yaml
@@ -145,9 +145,9 @@ enum/WindowMode:
 enum/WindowOut:
   bit_size: 1
   variants:
-  - name: COMP1_VALUE
+  - name: Comp1Value
     description: Comparator 1 value.
     value: 0
-  - name: COMP1_VALUE XOR COMP2_VALUE
+  - name: Comp1XorComp2Value
     description: Comparator 1 value XOR comparator 2 value (required for window mode).
     value: 1

--- a/data/registers/dbgmcu_n6.yaml
+++ b/data/registers/dbgmcu_n6.yaml
@@ -56,137 +56,23 @@ block/DBGMCU:
 fieldset/AHB1FZ1:
   description: DBGMCU AHB1 peripheral freeze register.
   fields:
-  - name: DBG_GPDMA1_CH0_STOP
+  - name: DBG_GPDMA1_STOP
     description: GPDMA1_CHn suspend in debug.
     bit_offset: 0
     bit_size: 1
-  - name: DBG_GPDMA1_CH1_STOP
-    description: GPDMA1_CHn suspend in debug.
-    bit_offset: 1
-    bit_size: 1
-  - name: DBG_GPDMA1_CH2_STOP
-    description: GPDMA1_CHn suspend in debug.
-    bit_offset: 2
-    bit_size: 1
-  - name: DBG_GPDMA1_CH3_STOP
-    description: GPDMA1_CHn suspend in debug.
-    bit_offset: 3
-    bit_size: 1
-  - name: DBG_GPDMA1_CH4_STOP
-    description: GPDMA1_CHn suspend in debug.
-    bit_offset: 4
-    bit_size: 1
-  - name: DBG_GPDMA1_CH5_STOP
-    description: GPDMA1_CHn suspend in debug.
-    bit_offset: 5
-    bit_size: 1
-  - name: DBG_GPDMA1_CH6_STOP
-    description: GPDMA1_CHn suspend in debug.
-    bit_offset: 6
-    bit_size: 1
-  - name: DBG_GPDMA1_CH7_STOP
-    description: GPDMA1_CHn suspend in debug.
-    bit_offset: 7
-    bit_size: 1
-  - name: DBG_GPDMA1_CH8_STOP
-    description: GPDMA1_CHn suspend in debug.
-    bit_offset: 8
-    bit_size: 1
-  - name: DBG_GPDMA1_CH9_STOP
-    description: GPDMA1_CHn suspend in debug.
-    bit_offset: 9
-    bit_size: 1
-  - name: DBG_GPDMA1_CH10_STOP
-    description: GPDMA1_CHn suspend in debug.
-    bit_offset: 10
-    bit_size: 1
-  - name: DBG_GPDMA1_CH11_STOP
-    description: GPDMA1_CHn suspend in debug.
-    bit_offset: 11
-    bit_size: 1
-  - name: DBG_GPDMA1_CH12_STOP
-    description: GPDMA1_CHn suspend in debug.
-    bit_offset: 12
-    bit_size: 1
-  - name: DBG_GPDMA1_CH13_STOP
-    description: GPDMA1_CHn suspend in debug.
-    bit_offset: 13
-    bit_size: 1
-  - name: DBG_GPDMA1_CH14_STOP
-    description: GPDMA1_CHn suspend in debug.
-    bit_offset: 14
-    bit_size: 1
-  - name: DBG_GPDMA1_CH15_STOP
-    description: GPDMA1_CHn suspend in debug.
-    bit_offset: 15
-    bit_size: 1
+    array:
+      len: 16
+      stride: 1
 fieldset/AHB5FZ1:
   description: DBGMCU AHB5 peripheral freeze register.
   fields:
-  - name: DBG_HPDMA1_CH0_STOP
+  - name: DBG_HPDMA1_STOP
     description: HPDMA3_CHn suspend in debug.
     bit_offset: 0
     bit_size: 1
-  - name: DBG_HPDMA1_CH1_STOP
-    description: HPDMA3_CHn suspend in debug.
-    bit_offset: 1
-    bit_size: 1
-  - name: DBG_HPDMA1_CH2_STOP
-    description: HPDMA3_CHn suspend in debug.
-    bit_offset: 2
-    bit_size: 1
-  - name: DBG_HPDMA1_CH3_STOP
-    description: HPDMA3_CHn suspend in debug.
-    bit_offset: 3
-    bit_size: 1
-  - name: DBG_HPDMA1_CH4_STOP
-    description: HPDMA3_CHn suspend in debug.
-    bit_offset: 4
-    bit_size: 1
-  - name: DBG_HPDMA1_CH5_STOP
-    description: HPDMA3_CHn suspend in debug.
-    bit_offset: 5
-    bit_size: 1
-  - name: DBG_HPDMA1_CH6_STOP
-    description: HPDMA3_CHn suspend in debug.
-    bit_offset: 6
-    bit_size: 1
-  - name: DBG_HPDMA1_CH7_STOP
-    description: HPDMA3_CHn suspend in debug.
-    bit_offset: 7
-    bit_size: 1
-  - name: DBG_HPDMA1_CH8_STOP
-    description: HPDMA3_CHn suspend in debug.
-    bit_offset: 8
-    bit_size: 1
-  - name: DBG_HPDMA1_CH9_STOP
-    description: HPDMA3_CHn suspend in debug.
-    bit_offset: 9
-    bit_size: 1
-  - name: DBG_HPDMA1_CH10_STOP
-    description: HPDMA3_CHn suspend in debug.
-    bit_offset: 10
-    bit_size: 1
-  - name: DBG_HPDMA1_CH11_STOP
-    description: HPDMA3_CHn suspend in debug.
-    bit_offset: 11
-    bit_size: 1
-  - name: DBG_HPDMA1_CH12_STOP
-    description: HPDMA3_CHn suspend in debug.
-    bit_offset: 12
-    bit_size: 1
-  - name: DBG_HPDMA1_CH13_STOP
-    description: HPDMA3_CHn suspend in debug.
-    bit_offset: 13
-    bit_size: 1
-  - name: DBG_HPDMA1_CH14_STOP
-    description: HPDMA3_CHn suspend in debug.
-    bit_offset: 14
-    bit_size: 1
-  - name: DBG_HPDMA1_CH15_STOP
-    description: HPDMA3_CHn suspend in debug.
-    bit_offset: 15
-    bit_size: 1
+    array:
+      len: 16
+      stride: 1
   - name: NPU_DBG_FREEZE
     description: NPU stop in debug mode.
     bit_offset: 16

--- a/data/registers/dbgmcu_u3.yaml
+++ b/data/registers/dbgmcu_u3.yaml
@@ -1,384 +1,343 @@
 block/DBGMCU:
-    description: DBGMCU Address block.
-    items:
-        - name: IDCODE
-          byte_offset: 0
-          access: Read
-          fieldset: IDCODE
-        - name: CR
-          description: DBGMCU configuration register.
-          byte_offset: 4
-          fieldset: CR
-        - name: APB1LFZR
-          description: DBGMCU APB1L peripheral freeze register.
-          byte_offset: 8
-          fieldset: APB1LFZR
-        - name: APB1HFZR
-          description: DBGMCU APB1H peripheral freeze register.
-          byte_offset: 12
-          fieldset: APB1HFZR
-        - name: APB2FZR
-          description: DBGMCU APB2 peripheral freeze register.
-          byte_offset: 16
-          fieldset: APB2FZR
-        - name: APB3FZR
-          description: DBGMCU APB3 peripheral freeze register.
-          byte_offset: 20
-          fieldset: APB3FZR
-        - name: AHB1FZR
-          description: DBGMCU AHB1 peripheral freeze register.
-          byte_offset: 32
-          fieldset: AHB1FZR
-        - name: DBGMCU_SR
-          description: DBGMCU status register.
-          byte_offset: 252
-          access: Read
-          fieldset: DBGMCU_SR
-        - name: DBGMCU_DBG_AUTH_HOST
-          description: DBGMCU debug host authentication register.
-          byte_offset: 256
-          access: Write
-          fieldset: DBGMCU_DBG_AUTH_HOST
-        - name: DBGMCU_DBG_AUTH_DEVICE
-          description: DBGMCU debug device authentication register.
-          byte_offset: 260
-          access: Read
-          fieldset: DBGMCU_DBG_AUTH_DEVICE
-        - name: PIDR4
-          description: DBGMCU CoreSight peripheral identity register 4.
-          byte_offset: 4048
-          access: Read
-          fieldset: PIDR4
-        - name: PIDR0
-          description: DBGMCU CoreSight peripheral identity register 0.
-          byte_offset: 4064
-          access: Read
-          fieldset: PIDR0
-        - name: PIDR1
-          description: DBGMCU CoreSight peripheral identity register 1.
-          byte_offset: 4068
-          access: Read
-          fieldset: PIDR1
-        - name: PIDR2
-          description: DBGMCU CoreSight peripheral identity register 2.
-          byte_offset: 4072
-          access: Read
-          fieldset: PIDR2
-        - name: PIDR3
-          description: DBGMCU CoreSight peripheral identity register 3.
-          byte_offset: 4076
-          access: Read
-          fieldset: PIDR3
-        - name: CIDR0
-          description: DBGMCU CoreSight component identity register 0.
-          byte_offset: 4080
-          access: Read
-          fieldset: CIDR0
-        - name: CIDR1
-          description: DBGMCU CoreSight component identity register 1.
-          byte_offset: 4084
-          access: Read
-          fieldset: CIDR1
-        - name: CIDR2
-          description: DBGMCU CoreSight component identity register 2.
-          byte_offset: 4088
-          access: Read
-          fieldset: CIDR2
-        - name: CIDR3
-          description: DBGMCU CoreSight component identity register 3.
-          byte_offset: 4092
-          access: Read
-          fieldset: CIDR3
-fieldset/AHB1FZR:
-    description: DBGMCU AHB1 peripheral freeze register.
-    fields:
-        - name: DBG_GPDMA0_STOP
-          description: "None 0: normal operation. GPDMA channel 0 continues to operate while CPU is in debug mode. 1: stop in debug. GPDMA channel 0 is frozen while CPU is in debug mode."
-          bit_offset: 0
-          bit_size: 1
-        - name: DBG_GPDMA1_STOP
-          description: "None 0: normal operation. GPDMA channel 1 continues to operate while CPU is in debug mode. 1: stop in debug. GPDMA channel 1 is frozen while CPU is in debug mode."
-          bit_offset: 1
-          bit_size: 1
-        - name: DBG_GPDMA2_STOP
-          description: "None 0: normal operation. GPDMA channel 2 continues to operate while CPU is in debug mode. 1: stop in debug. GPDMA channel 2 is frozen while CPU is in debug mode."
-          bit_offset: 2
-          bit_size: 1
-        - name: DBG_GPDMA3_STOP
-          description: "None 0: normal operation. GPDMA channel 3 continues to operate while CPU is in debug mode. 1: stop in debug. GPDMA channel 3 is frozen while CPU is in debug mode."
-          bit_offset: 3
-          bit_size: 1
-        - name: DBG_GPDMA4_STOP
-          description: "None 0: normal operation. GPDMA channel 4 continues to operate while CPU is in debug mode. 1: stop in debug. GPDMA channel 4 is frozen while CPU is in debug mode."
-          bit_offset: 4
-          bit_size: 1
-        - name: DBG_GPDMA5_STOP
-          description: "None 0: normal operation. GPDMA channel 5 continues to operate while CPU is in debug mode. 1: stop in debug. GPDMA channel 5 is frozen while CPU is in debug mode."
-          bit_offset: 5
-          bit_size: 1
-        - name: DBG_GPDMA6_STOP
-          description: "None 0: normal operation. GPDMA channel 6 continues to operate while CPU is in debug mode. 1: stop in debug. GPDMA channel 6 is frozen while CPU is in debug mode."
-          bit_offset: 6
-          bit_size: 1
-        - name: DBG_GPDMA7_STOP
-          description: "None 0: normal operation. GPDMA channel 7 continues to operate while CPU is in debug mode. 1: stop in debug. GPDMA channel 7 is frozen while CPU is in debug mode."
-          bit_offset: 7
-          bit_size: 1
-        - name: DBG_GPDMA8_STOP
-          description: "None 0: normal operation. GPDMA channel 8 continues to operate while CPU is in debug mode. 1: stop in debug. GPDMA channel 8 is frozen while CPU is in debug mode."
-          bit_offset: 8
-          bit_size: 1
-        - name: DBG_GPDMA9_STOP
-          description: "None 0: normal operation. GPDMA channel 9 continues to operate while CPU is in debug mode. 1: stop in debug. GPDMA channel 9 is frozen while CPU is in debug mode."
-          bit_offset: 9
-          bit_size: 1
-        - name: DBG_GPDMA10_STOP
-          description: "None 0: normal operation. GPDMA channel 10 continues to operate while CPU is in debug mode. 1: stop in debug. GPDMA channel 10 is frozen while CPU is in debug mode."
-          bit_offset: 10
-          bit_size: 1
-        - name: DBG_GPDMA11_STOP
-          description: "None 0: normal operation. GPDMA channel 11 continues to operate while CPU is in debug mode. 1: stop in debug. GPDMA channel 11 is frozen while CPU is in debug mode."
-          bit_offset: 11
-          bit_size: 1
-fieldset/APB1HFZR:
-    description: DBGMCU APB1H peripheral freeze register.
-    fields:
-        - name: DBG_LPTIM2_STOP
-          description: "None 0: normal operation. LPTIM2 continues to operate while CPU is in debug mode. 1: stop in debug. LPTIM2 is frozen while CPU is in debug mode."
-          bit_offset: 5
-          bit_size: 1
-fieldset/APB1LFZR:
-    description: DBGMCU APB1L peripheral freeze register.
-    fields:
-        - name: DBG_TIM2_STOP
-          description: "None 0: normal operation. TIM2 continues to operate while CPU is in debug mode. 1: stop in debug. TIM2 is frozen while CPU is in debug mode."
-          bit_offset: 0
-          bit_size: 1
-        - name: DBG_TIM3_STOP
-          description: "None 0: normal operation. TIM3 continues to operate while CPU is in debug mode. 1: stop in debug. TIM3 is frozen while CPU is in debug mode."
-          bit_offset: 1
-          bit_size: 1
-        - name: DBG_TIM4_STOP
-          description: "None 0: normal operation. TIM4 continues to operate while CPU is in debug mode. 1: stop in debug. TIM4 is frozen while CPU is in debug mode."
-          bit_offset: 2
-          bit_size: 1
-        - name: DBG_TIM6_STOP
-          description: "None 0: normal operation. TIM6 continues to operate while CPU is in debug mode. 1: stop in debug. TIM6 is frozen while CPU is in debug mode."
-          bit_offset: 4
-          bit_size: 1
-        - name: DBG_TIM7_STOP
-          description: "None 0: normal operation. TIM7 continues to operate while CPU is in debug mode. 1: stop in debug. TIM7 is frozen while CPU is in debug mode."
-          bit_offset: 5
-          bit_size: 1
-        - name: DBG_WWDG_STOP
-          description: "None 0: normal operation. WWDG continues to operate while CPU is in debug mode. 1: stop in debug. WWDG is frozen while CPU is in debug mode."
-          bit_offset: 11
-          bit_size: 1
-        - name: DBG_IWDG_STOP
-          description: "None 0: normal operation. IWDG continues to operate while CPU is in debug mode. 1: stop in debug. IWDG is frozen while CPU is in debug mode."
-          bit_offset: 12
-          bit_size: 1
-        - name: DBG_I2C1_STOP
-          description: "None 0: normal operation. I2C1 SMBUS timeout continues to operate while CPU is in debug mode. 1: stop in debug. I2C1 SMBUS timeout is frozen while CPU is in debug mode."
-          bit_offset: 21
-          bit_size: 1
-        - name: DBG_I2C2_STOP
-          description: "None 0: normal operation. I2C2 SMBUS timeout continues to operate while CPU is in debug mode. 1: stop in debug. I2C2 SMBUS timeout is frozen while CPU is in debug mode."
-          bit_offset: 22
-          bit_size: 1
-        - name: DBG_I3C1_STOP
-          description: "None 0: normal operation. I3C1 timeout continues to operate while CPU is in debug mode. 1: stop in debug. I3C1 timeout is frozen while CPU is in debug mode."
-          bit_offset: 23
-          bit_size: 1
-        - name: DBG_RTC_STOP
-          description: "None 0: normal operation. RTC continues to operate while CPU is in debug mode. 1: stop in debug. RTC is frozen while CPU is in debug mode."
-          bit_offset: 30
-          bit_size: 1
-fieldset/APB2FZR:
-    description: DBGMCU APB2 peripheral freeze register.
-    fields:
-        - name: DBG_TIM1_STOP
-          description: "None 0: normal operation. TIM1 continues to operate while CPU is in debug mode. 1: stop in debug. TIM1 is frozen while CPU is in debug mode."
-          bit_offset: 11
-          bit_size: 1
-        - name: DBG_TIM15_STOP
-          description: "None 0: normal operation. TIM15 continues to operate while CPU is in debug mode. 1: stop in debug. TIM15 is frozen while CPU is in debug mode."
-          bit_offset: 16
-          bit_size: 1
-        - name: DBG_TIM16_STOP
-          description: "None 0: normal operation. TIM16 continues to operate while CPU is in debug mode. 1: stop in debug. TIM16 is frozen while CPU is in debug mode."
-          bit_offset: 17
-          bit_size: 1
-        - name: DBG_TIM17_STOP
-          description: "None 0: normal operation. TIM17 continues to operate while CPU is in debug mode. 1: stop in debug. TIM17 is frozen while CPU is in debug mode."
-          bit_offset: 18
-          bit_size: 1
-        - name: DBG_I3C2_STOP
-          description: "None 0: normal operation. I3C2 timeout continues to operate while CPU is in debug mode. 1: stop in debug. I3C2 timeout is frozen while CPU is in debug mode."
-          bit_offset: 27
-          bit_size: 1
-fieldset/APB3FZR:
-    description: DBGMCU APB3 peripheral freeze register.
-    fields:
-        - name: DBG_I2C3_STOP
-          description: "None 0: normal operation. I2C3 continues to operate while CPU is in debug mode. 1: stop in debug. I2C3 is frozen while CPU is in debug mode."
-          bit_offset: 10
-          bit_size: 1
-        - name: DBG_LPTIM1_STOP
-          description: "None 0: normal operation. LPTIM1 continues to operate while CPU is in debug mode. 1: stop in debug. LPTIM1 is frozen while CPU is in debug mode."
-          bit_offset: 17
-          bit_size: 1
-        - name: DBG_LPTIM3_STOP
-          description: "None 0: normal operation. LPTIM3 continues to operate while CPU is in debug mode. 1: stop in debug. LPTIM3 is frozen while CPU is in debug mode."
-          bit_offset: 18
-          bit_size: 1
-        - name: DBG_LPTIM4_STOP
-          description: "None 0: normal operation. LPTIM4 continues to operate while CPU is in debug mode. 1: stop in debug. LPTIM4 is frozen while CPU is in debug mode."
-          bit_offset: 19
-          bit_size: 1
-fieldset/CIDR0:
-    description: DBGMCU CoreSight component identity register 0.
-    fields:
-        - name: PREAMBLE
-          description: "None 0x0D: common identification value."
-          bit_offset: 0
-          bit_size: 8
-fieldset/CIDR1:
-    description: DBGMCU CoreSight component identity register 1.
-    fields:
-        - name: PREAMBLE
-          description: "None 0x0: common identification value."
-          bit_offset: 0
-          bit_size: 4
-        - name: CLASS
-          description: "None 0xF: Non-CoreSight component."
-          bit_offset: 4
-          bit_size: 4
-fieldset/CIDR2:
-    description: DBGMCU CoreSight component identity register 2.
-    fields:
-        - name: PREAMBLE
-          description: "None 0x05: common identification value."
-          bit_offset: 0
-          bit_size: 8
-fieldset/CIDR3:
-    description: DBGMCU CoreSight component identity register 3.
-    fields:
-        - name: PREAMBLE
-          description: "None 0xB1: common identification value."
-          bit_offset: 0
-          bit_size: 8
-fieldset/CR:
+  description: DBGMCU Address block.
+  items:
+  - name: IDCODE
+    byte_offset: 0
+    access: Read
+    fieldset: IDCODE
+  - name: CR
     description: DBGMCU configuration register.
-    fields:
-        - name: DBG_STOP
-          description: "All clocks are disabled automatically in Stop mode. All active clocks and oscillators continue to run during Stop mode, allowing full debug capability. On exit from Stop mode, the clock settings are set to the Stop mode exit state. 0: normal operation 1: automatic clock stop disabled."
-          bit_offset: 1
-          bit_size: 1
-        - name: DBG_STANDBY
-          description: "All clocks are disabled and the core powered down automatically in Standby mode. All active clocks and oscillators continue to run during Standby mode, and the core supply is maintained, allowing full debug capability. On exit from Standby mode, a system reset is performed. 0: normal operation 1: automatic clock stop/power down disabled."
-          bit_offset: 2
-          bit_size: 1
-        - name: TRACE_IOEN
-          description: "None 0: disabled-trace pins not assigned 1: enabled-trace pins assigned according to the value of TRACE_MODE field."
-          bit_offset: 4
-          bit_size: 1
-        - name: TRACE_EN
-          description: "This bit enables the trace port clock, TRACECK. 0: disabled 1: enabled."
-          bit_offset: 5
-          bit_size: 1
-        - name: TRACE_MODE
-          description: "None 0x0: trace pins assigned for asynchronous mode (TRACESWO) 0x1: trace pins assigned for synchronous mode with a port width of 1 (TRACECK, TRACED0) 0x2: trace pins assigned for synchronous mode with a port width of 2 ((TRACECK, TRACED0-1) 0x3: trace pins assigned for synchronous mode with a port width of 4 ((TRACECK, TRACED0-3)."
-          bit_offset: 6
-          bit_size: 2
-fieldset/DBGMCU_DBG_AUTH_DEVICE:
-    description: DBGMCU debug device authentication register.
-    fields:
-        - name: AUTH_ID
-          description: Device specific ID used for RDP regression.
-          bit_offset: 0
-          bit_size: 32
-fieldset/DBGMCU_DBG_AUTH_HOST:
-    description: DBGMCU debug host authentication register.
-    fields:
-        - name: AUTH_KEY
-          description: The device specific 64-bit authentication key (OEM key) must be written to this register (in two successive 32-bit writes, least significant word first) to permit RDP regression. Writing a wrong key locks access to the device and prevent code execution from the Flash memory.
-          bit_offset: 0
-          bit_size: 32
-fieldset/IDCODE:
-    description: DBGMCU identity code register.
-    fields:
-        - name: DEV_ID
-          description: "None 0x454: STM32U375/385."
-          bit_offset: 0
-          bit_size: 12
-        - name: REV_ID
-          description: "None 0x0001: revision A."
-          bit_offset: 16
-          bit_size: 16
-fieldset/PIDR0:
-    description: DBGMCU CoreSight peripheral identity register 0.
-    fields:
-        - name: PARTNUM
-          description: "None 0x00: DBGMCU part number."
-          bit_offset: 0
-          bit_size: 8
-fieldset/PIDR1:
-    description: DBGMCU CoreSight peripheral identity register 1.
-    fields:
-        - name: PARTNUM
-          description: "None 0x0: DBGMCU part number."
-          bit_offset: 0
-          bit_size: 4
-        - name: JEP106ID
-          description: "None 0x0: STMicroelectronics JEDEC code."
-          bit_offset: 4
-          bit_size: 4
-fieldset/PIDR2:
-    description: DBGMCU CoreSight peripheral identity register 2.
-    fields:
-        - name: JEP106ID
-          description: "None 0x2: STMicroelectronics JEDEC code."
-          bit_offset: 0
-          bit_size: 3
-        - name: JEDEC
-          description: "None 0x1: designer identification specified by JEDEC."
-          bit_offset: 3
-          bit_size: 1
-        - name: REVISION
-          description: "None 0x0: r0p0."
-          bit_offset: 4
-          bit_size: 4
-fieldset/PIDR3:
-    description: DBGMCU CoreSight peripheral identity register 3.
-    fields:
-        - name: CMOD
-          description: "None 0x0: no customer modifications."
-          bit_offset: 0
-          bit_size: 4
-        - name: REVAND
-          description: "None 0x0: no metal fix."
-          bit_offset: 4
-          bit_size: 4
-fieldset/PIDR4:
-    description: DBGMCU CoreSight peripheral identity register 4.
-    fields:
-        - name: JEP106CON
-          description: "None 0x0: STMicroelectronics JEDEC code."
-          bit_offset: 0
-          bit_size: 4
-        - name: SIZE
-          description: "None 0x0: The register file occupies a single 4-Kbyte region."
-          bit_offset: 4
-          bit_size: 4
-fieldset/DBGMCU_SR:
+    byte_offset: 4
+    fieldset: CR
+  - name: APB1LFZR
+    description: DBGMCU APB1L peripheral freeze register.
+    byte_offset: 8
+    fieldset: APB1LFZR
+  - name: APB1HFZR
+    description: DBGMCU APB1H peripheral freeze register.
+    byte_offset: 12
+    fieldset: APB1HFZR
+  - name: APB2FZR
+    description: DBGMCU APB2 peripheral freeze register.
+    byte_offset: 16
+    fieldset: APB2FZR
+  - name: APB3FZR
+    description: DBGMCU APB3 peripheral freeze register.
+    byte_offset: 20
+    fieldset: APB3FZR
+  - name: AHB1FZR
+    description: DBGMCU AHB1 peripheral freeze register.
+    byte_offset: 32
+    fieldset: AHB1FZR
+  - name: DBGMCU_SR
     description: DBGMCU status register.
-    fields:
-        - name: AP_PRESENT
-          description: "Bit n=0: APn absent Bit n=1: APn present."
-          bit_offset: 0
-          bit_size: 16
-        - name: AP_ENABLED
-          description: "Bit n=0: APn locked Bit n=1: APn enabled."
-          bit_offset: 16
-          bit_size: 16
+    byte_offset: 252
+    access: Read
+    fieldset: DBGMCU_SR
+  - name: DBGMCU_DBG_AUTH_HOST
+    description: DBGMCU debug host authentication register.
+    byte_offset: 256
+    access: Write
+    fieldset: DBGMCU_DBG_AUTH_HOST
+  - name: DBGMCU_DBG_AUTH_DEVICE
+    description: DBGMCU debug device authentication register.
+    byte_offset: 260
+    access: Read
+    fieldset: DBGMCU_DBG_AUTH_DEVICE
+  - name: PIDR4
+    description: DBGMCU CoreSight peripheral identity register 4.
+    byte_offset: 4048
+    access: Read
+    fieldset: PIDR4
+  - name: PIDR0
+    description: DBGMCU CoreSight peripheral identity register 0.
+    byte_offset: 4064
+    access: Read
+    fieldset: PIDR0
+  - name: PIDR1
+    description: DBGMCU CoreSight peripheral identity register 1.
+    byte_offset: 4068
+    access: Read
+    fieldset: PIDR1
+  - name: PIDR2
+    description: DBGMCU CoreSight peripheral identity register 2.
+    byte_offset: 4072
+    access: Read
+    fieldset: PIDR2
+  - name: PIDR3
+    description: DBGMCU CoreSight peripheral identity register 3.
+    byte_offset: 4076
+    access: Read
+    fieldset: PIDR3
+  - name: CIDR0
+    description: DBGMCU CoreSight component identity register 0.
+    byte_offset: 4080
+    access: Read
+    fieldset: CIDR0
+  - name: CIDR1
+    description: DBGMCU CoreSight component identity register 1.
+    byte_offset: 4084
+    access: Read
+    fieldset: CIDR1
+  - name: CIDR2
+    description: DBGMCU CoreSight component identity register 2.
+    byte_offset: 4088
+    access: Read
+    fieldset: CIDR2
+  - name: CIDR3
+    description: DBGMCU CoreSight component identity register 3.
+    byte_offset: 4092
+    access: Read
+    fieldset: CIDR3
+fieldset/AHB1FZR:
+  description: DBGMCU AHB1 peripheral freeze register.
+  fields:
+  - name: DBG_GPDMA_STOP
+    description: 'None 0: normal operation. GPDMA channel y continues to operate while CPU is in debug mode. 1: stop in debug. GPDMA channel y is frozen while CPU is in debug mode.'
+    bit_offset: 0
+    bit_size: 1
+    array:
+      len: 12
+      stride: 1
+fieldset/APB1HFZR:
+  description: DBGMCU APB1H peripheral freeze register.
+  fields:
+  - name: DBG_LPTIM2_STOP
+    description: 'None 0: normal operation. LPTIM2 continues to operate while CPU is in debug mode. 1: stop in debug. LPTIM2 is frozen while CPU is in debug mode.'
+    bit_offset: 5
+    bit_size: 1
+fieldset/APB1LFZR:
+  description: DBGMCU APB1L peripheral freeze register.
+  fields:
+  - name: DBG_TIM2_STOP
+    description: 'None 0: normal operation. TIM2 continues to operate while CPU is in debug mode. 1: stop in debug. TIM2 is frozen while CPU is in debug mode.'
+    bit_offset: 0
+    bit_size: 1
+  - name: DBG_TIM3_STOP
+    description: 'None 0: normal operation. TIM3 continues to operate while CPU is in debug mode. 1: stop in debug. TIM3 is frozen while CPU is in debug mode.'
+    bit_offset: 1
+    bit_size: 1
+  - name: DBG_TIM4_STOP
+    description: 'None 0: normal operation. TIM4 continues to operate while CPU is in debug mode. 1: stop in debug. TIM4 is frozen while CPU is in debug mode.'
+    bit_offset: 2
+    bit_size: 1
+  - name: DBG_TIM6_STOP
+    description: 'None 0: normal operation. TIM6 continues to operate while CPU is in debug mode. 1: stop in debug. TIM6 is frozen while CPU is in debug mode.'
+    bit_offset: 4
+    bit_size: 1
+  - name: DBG_TIM7_STOP
+    description: 'None 0: normal operation. TIM7 continues to operate while CPU is in debug mode. 1: stop in debug. TIM7 is frozen while CPU is in debug mode.'
+    bit_offset: 5
+    bit_size: 1
+  - name: DBG_WWDG_STOP
+    description: 'None 0: normal operation. WWDG continues to operate while CPU is in debug mode. 1: stop in debug. WWDG is frozen while CPU is in debug mode.'
+    bit_offset: 11
+    bit_size: 1
+  - name: DBG_IWDG_STOP
+    description: 'None 0: normal operation. IWDG continues to operate while CPU is in debug mode. 1: stop in debug. IWDG is frozen while CPU is in debug mode.'
+    bit_offset: 12
+    bit_size: 1
+  - name: DBG_I2C1_STOP
+    description: 'None 0: normal operation. I2C1 SMBUS timeout continues to operate while CPU is in debug mode. 1: stop in debug. I2C1 SMBUS timeout is frozen while CPU is in debug mode.'
+    bit_offset: 21
+    bit_size: 1
+  - name: DBG_I2C2_STOP
+    description: 'None 0: normal operation. I2C2 SMBUS timeout continues to operate while CPU is in debug mode. 1: stop in debug. I2C2 SMBUS timeout is frozen while CPU is in debug mode.'
+    bit_offset: 22
+    bit_size: 1
+  - name: DBG_I3C1_STOP
+    description: 'None 0: normal operation. I3C1 timeout continues to operate while CPU is in debug mode. 1: stop in debug. I3C1 timeout is frozen while CPU is in debug mode.'
+    bit_offset: 23
+    bit_size: 1
+  - name: DBG_RTC_STOP
+    description: 'None 0: normal operation. RTC continues to operate while CPU is in debug mode. 1: stop in debug. RTC is frozen while CPU is in debug mode.'
+    bit_offset: 30
+    bit_size: 1
+fieldset/APB2FZR:
+  description: DBGMCU APB2 peripheral freeze register.
+  fields:
+  - name: DBG_TIM1_STOP
+    description: 'None 0: normal operation. TIM1 continues to operate while CPU is in debug mode. 1: stop in debug. TIM1 is frozen while CPU is in debug mode.'
+    bit_offset: 11
+    bit_size: 1
+  - name: DBG_TIM15_STOP
+    description: 'None 0: normal operation. TIM15 continues to operate while CPU is in debug mode. 1: stop in debug. TIM15 is frozen while CPU is in debug mode.'
+    bit_offset: 16
+    bit_size: 1
+  - name: DBG_TIM16_STOP
+    description: 'None 0: normal operation. TIM16 continues to operate while CPU is in debug mode. 1: stop in debug. TIM16 is frozen while CPU is in debug mode.'
+    bit_offset: 17
+    bit_size: 1
+  - name: DBG_TIM17_STOP
+    description: 'None 0: normal operation. TIM17 continues to operate while CPU is in debug mode. 1: stop in debug. TIM17 is frozen while CPU is in debug mode.'
+    bit_offset: 18
+    bit_size: 1
+  - name: DBG_I3C2_STOP
+    description: 'None 0: normal operation. I3C2 timeout continues to operate while CPU is in debug mode. 1: stop in debug. I3C2 timeout is frozen while CPU is in debug mode.'
+    bit_offset: 27
+    bit_size: 1
+fieldset/APB3FZR:
+  description: DBGMCU APB3 peripheral freeze register.
+  fields:
+  - name: DBG_I2C3_STOP
+    description: 'None 0: normal operation. I2C3 continues to operate while CPU is in debug mode. 1: stop in debug. I2C3 is frozen while CPU is in debug mode.'
+    bit_offset: 10
+    bit_size: 1
+  - name: DBG_LPTIM1_STOP
+    description: 'None 0: normal operation. LPTIM1 continues to operate while CPU is in debug mode. 1: stop in debug. LPTIM1 is frozen while CPU is in debug mode.'
+    bit_offset: 17
+    bit_size: 1
+  - name: DBG_LPTIM3_STOP
+    description: 'None 0: normal operation. LPTIM3 continues to operate while CPU is in debug mode. 1: stop in debug. LPTIM3 is frozen while CPU is in debug mode.'
+    bit_offset: 18
+    bit_size: 1
+  - name: DBG_LPTIM4_STOP
+    description: 'None 0: normal operation. LPTIM4 continues to operate while CPU is in debug mode. 1: stop in debug. LPTIM4 is frozen while CPU is in debug mode.'
+    bit_offset: 19
+    bit_size: 1
+fieldset/CIDR0:
+  description: DBGMCU CoreSight component identity register 0.
+  fields:
+  - name: PREAMBLE
+    description: 'None 0x0D: common identification value.'
+    bit_offset: 0
+    bit_size: 8
+fieldset/CIDR1:
+  description: DBGMCU CoreSight component identity register 1.
+  fields:
+  - name: PREAMBLE
+    description: 'None 0x0: common identification value.'
+    bit_offset: 0
+    bit_size: 4
+  - name: CLASS
+    description: 'None 0xF: Non-CoreSight component.'
+    bit_offset: 4
+    bit_size: 4
+fieldset/CIDR2:
+  description: DBGMCU CoreSight component identity register 2.
+  fields:
+  - name: PREAMBLE
+    description: 'None 0x05: common identification value.'
+    bit_offset: 0
+    bit_size: 8
+fieldset/CIDR3:
+  description: DBGMCU CoreSight component identity register 3.
+  fields:
+  - name: PREAMBLE
+    description: 'None 0xB1: common identification value.'
+    bit_offset: 0
+    bit_size: 8
+fieldset/CR:
+  description: DBGMCU configuration register.
+  fields:
+  - name: DBG_STOP
+    description: 'All clocks are disabled automatically in Stop mode. All active clocks and oscillators continue to run during Stop mode, allowing full debug capability. On exit from Stop mode, the clock settings are set to the Stop mode exit state. 0: normal operation 1: automatic clock stop disabled.'
+    bit_offset: 1
+    bit_size: 1
+  - name: DBG_STANDBY
+    description: 'All clocks are disabled and the core powered down automatically in Standby mode. All active clocks and oscillators continue to run during Standby mode, and the core supply is maintained, allowing full debug capability. On exit from Standby mode, a system reset is performed. 0: normal operation 1: automatic clock stop/power down disabled.'
+    bit_offset: 2
+    bit_size: 1
+  - name: TRACE_IOEN
+    description: 'None 0: disabled-trace pins not assigned 1: enabled-trace pins assigned according to the value of TRACE_MODE field.'
+    bit_offset: 4
+    bit_size: 1
+  - name: TRACE_EN
+    description: 'This bit enables the trace port clock, TRACECK. 0: disabled 1: enabled.'
+    bit_offset: 5
+    bit_size: 1
+  - name: TRACE_MODE
+    description: 'None 0x0: trace pins assigned for asynchronous mode (TRACESWO) 0x1: trace pins assigned for synchronous mode with a port width of 1 (TRACECK, TRACED0) 0x2: trace pins assigned for synchronous mode with a port width of 2 ((TRACECK, TRACED0-1) 0x3: trace pins assigned for synchronous mode with a port width of 4 ((TRACECK, TRACED0-3).'
+    bit_offset: 6
+    bit_size: 2
+fieldset/DBGMCU_DBG_AUTH_DEVICE:
+  description: DBGMCU debug device authentication register.
+  fields:
+  - name: AUTH_ID
+    description: Device specific ID used for RDP regression.
+    bit_offset: 0
+    bit_size: 32
+fieldset/DBGMCU_DBG_AUTH_HOST:
+  description: DBGMCU debug host authentication register.
+  fields:
+  - name: AUTH_KEY
+    description: The device specific 64-bit authentication key (OEM key) must be written to this register (in two successive 32-bit writes, least significant word first) to permit RDP regression. Writing a wrong key locks access to the device and prevent code execution from the Flash memory.
+    bit_offset: 0
+    bit_size: 32
+fieldset/DBGMCU_SR:
+  description: DBGMCU status register.
+  fields:
+  - name: AP_PRESENT
+    description: 'Bit n=0: APn absent Bit n=1: APn present.'
+    bit_offset: 0
+    bit_size: 16
+  - name: AP_ENABLED
+    description: 'Bit n=0: APn locked Bit n=1: APn enabled.'
+    bit_offset: 16
+    bit_size: 16
+fieldset/IDCODE:
+  description: DBGMCU identity code register.
+  fields:
+  - name: DEV_ID
+    description: 'None 0x454: STM32U375/385.'
+    bit_offset: 0
+    bit_size: 12
+  - name: REV_ID
+    description: 'None 0x0001: revision A.'
+    bit_offset: 16
+    bit_size: 16
+fieldset/PIDR0:
+  description: DBGMCU CoreSight peripheral identity register 0.
+  fields:
+  - name: PARTNUM
+    description: 'None 0x00: DBGMCU part number.'
+    bit_offset: 0
+    bit_size: 8
+fieldset/PIDR1:
+  description: DBGMCU CoreSight peripheral identity register 1.
+  fields:
+  - name: PARTNUM
+    description: 'None 0x0: DBGMCU part number.'
+    bit_offset: 0
+    bit_size: 4
+  - name: JEP106ID
+    description: 'None 0x0: STMicroelectronics JEDEC code.'
+    bit_offset: 4
+    bit_size: 4
+fieldset/PIDR2:
+  description: DBGMCU CoreSight peripheral identity register 2.
+  fields:
+  - name: JEP106ID
+    description: 'None 0x2: STMicroelectronics JEDEC code.'
+    bit_offset: 0
+    bit_size: 3
+  - name: JEDEC
+    description: 'None 0x1: designer identification specified by JEDEC.'
+    bit_offset: 3
+    bit_size: 1
+  - name: REVISION
+    description: 'None 0x0: r0p0.'
+    bit_offset: 4
+    bit_size: 4
+fieldset/PIDR3:
+  description: DBGMCU CoreSight peripheral identity register 3.
+  fields:
+  - name: CMOD
+    description: 'None 0x0: no customer modifications.'
+    bit_offset: 0
+    bit_size: 4
+  - name: REVAND
+    description: 'None 0x0: no metal fix.'
+    bit_offset: 4
+    bit_size: 4
+fieldset/PIDR4:
+  description: DBGMCU CoreSight peripheral identity register 4.
+  fields:
+  - name: JEP106CON
+    description: 'None 0x0: STMicroelectronics JEDEC code.'
+    bit_offset: 0
+    bit_size: 4
+  - name: SIZE
+    description: 'None 0x0: The register file occupies a single 4-Kbyte region.'
+    bit_offset: 4
+    bit_size: 4

--- a/data/registers/dbgmcu_u5.yaml
+++ b/data/registers/dbgmcu_u5.yaml
@@ -97,89 +97,23 @@ block/DBGMCU:
 fieldset/AHB1FZR:
   description: Debug MCU AHB1 peripheral freeze register
   fields:
-  - name: DBG_GPDMA0_STOP
-    description: GPDMA channel 0 stop in debug
+  - name: DBG_GPDMA_STOP
+    description: GPDMA channel y stop in debug
     bit_offset: 0
     bit_size: 1
-  - name: DBG_GPDMA1_STOP
-    description: GPDMA channel 1 stop in debug
-    bit_offset: 1
-    bit_size: 1
-  - name: DBG_GPDMA2_STOP
-    description: GPDMA channel 2 stop in debug
-    bit_offset: 2
-    bit_size: 1
-  - name: DBG_GPDMA3_STOP
-    description: GPDMA channel 3 stop in debug
-    bit_offset: 3
-    bit_size: 1
-  - name: DBG_GPDMA4_STOP
-    description: GPDMA channel 4 stop in debug
-    bit_offset: 4
-    bit_size: 1
-  - name: DBG_GPDMA5_STOP
-    description: GPDMA channel 5 stop in debug
-    bit_offset: 5
-    bit_size: 1
-  - name: DBG_GPDMA6_STOP
-    description: GPDMA channel 6 stop in debug
-    bit_offset: 6
-    bit_size: 1
-  - name: DBG_GPDMA7_STOP
-    description: GPDMA channel 7 stop in debug
-    bit_offset: 7
-    bit_size: 1
-  - name: DBG_GPDMA8_STOP
-    description: GPDMA channel 8 stop in debug
-    bit_offset: 8
-    bit_size: 1
-  - name: DBG_GPDMA9_STOP
-    description: GPDMA channel 9 stop in debug
-    bit_offset: 9
-    bit_size: 1
-  - name: DBG_GPDMA10_STOP
-    description: GPDMA channel 10 stop in debug
-    bit_offset: 10
-    bit_size: 1
-  - name: DBG_GPDMA11_STOP
-    description: GPDMA channel 11 stop in debug
-    bit_offset: 11
-    bit_size: 1
-  - name: DBG_GPDMA12_STOP
-    description: GPDMA channel 12 stop in debug
-    bit_offset: 12
-    bit_size: 1
-  - name: DBG_GPDMA13_STOP
-    description: GPDMA channel 13 stop in debug
-    bit_offset: 13
-    bit_size: 1
-  - name: DBG_GPDMA14_STOP
-    description: GPDMA channel 14 stop in debug
-    bit_offset: 14
-    bit_size: 1
-  - name: DBG_GPDMA15_STOP
-    description: GPDMA channel 15 stop in debug
-    bit_offset: 15
-    bit_size: 1
+    array:
+      len: 16
+      stride: 1
 fieldset/AHB3FZR:
   description: Debug MCU AHB3 peripheral freeze register
   fields:
-  - name: DBG_LPDMA0_STOP
-    description: LPDMA channel 0 stop in debug
+  - name: DBG_LPDMA_STOP
+    description: LPDMA channel y stop in debug
     bit_offset: 0
     bit_size: 1
-  - name: DBG_LPDMA1_STOP
-    description: LPDMA channel 1 stop in debug
-    bit_offset: 1
-    bit_size: 1
-  - name: DBG_LPDMA2_STOP
-    description: LPDMA channel 2 stop in debug
-    bit_offset: 2
-    bit_size: 1
-  - name: DBG_LPDMA3_STOP
-    description: LPDMA channel 3 stop in debug
-    bit_offset: 3
-    bit_size: 1
+    array:
+      len: 4
+      stride: 1
 fieldset/APB1HFZR:
   description: Debug MCU APB1H peripheral freeze register
   fields:

--- a/data/registers/dbgmcu_wba.yaml
+++ b/data/registers/dbgmcu_wba.yaml
@@ -84,38 +84,13 @@ block/DBGMCU:
 fieldset/AHB1FZR:
   description: AHB1 peripheral freeze register
   fields:
-  - name: DBG_GPDMA1_CH0_STOP
-    description: "GPDMA 1 channel 0 stop in CPU debug\r Write access can be protected by GPDMA_SECCFGR.SEC0."
+  - name: DBG_GPDMA1_CH_STOP
+    description: "GPDMA 1 channel y stop in CPU debug\r Write access can be protected by GPDMA_SECCFGR.SECy."
     bit_offset: 0
     bit_size: 1
-  - name: DBG_GPDMA1_CH1_STOP
-    description: "GPDMA 1 channel 1 stop in CPU debug\r Write access can be protected by GPDMA_SECCFGR.SEC1."
-    bit_offset: 1
-    bit_size: 1
-  - name: DBG_GPDMA1_CH2_STOP
-    description: "GPDMA 1 channel 2 stop in CPU debug\r Write access can be protected by GPDMA_SECCFGR.SEC2."
-    bit_offset: 2
-    bit_size: 1
-  - name: DBG_GPDMA1_CH3_STOP
-    description: "GPDMA 1 channel 3 stop in CPU debug\r Write access can be protected by GPDMA_SECCFGR.SEC3."
-    bit_offset: 3
-    bit_size: 1
-  - name: DBG_GPDMA1_CH4_STOP
-    description: "GPDMA 1 channel 4 stop in CPU debug\r Write access can be protected by GPDMA_SECCFGR.SEC4."
-    bit_offset: 4
-    bit_size: 1
-  - name: DBG_GPDMA1_CH5_STOP
-    description: "GPDMA 1 channel 5 stop in CPU debug\r Write access can be protected by GPDMA_SECCFGR.SEC5."
-    bit_offset: 5
-    bit_size: 1
-  - name: DBG_GPDMA1_CH6_STOP
-    description: "GPDMA 1 channel 6 stop in CPU debug\r Write access can be protected by GPDMA_SECCFGR.SEC6."
-    bit_offset: 6
-    bit_size: 1
-  - name: DBG_GPDMA1_CH7_STOP
-    description: "GPDMA 1 channel 7 stop in CPU debug\r Write access can be protected by GPDMA_SECCFGR.SEC7."
-    bit_offset: 7
-    bit_size: 1
+    array:
+      len: 8
+      stride: 1
 fieldset/APB1HFZR:
   description: APB1H peripheral freeze register
   fields:

--- a/data/registers/flash_u5.yaml
+++ b/data/registers/flash_u5.yaml
@@ -2895,12 +2895,12 @@ enum/CODE_OP:
 enum/RDP:
   bit_size: 8
   variants:
-  - name: B_0x55
+  - name: Level0_5
     description: Level 0.5 (readout protection not active, only non-secure debug access is possible). Only available when TrustZone is active (TZEN=1)
     value: 85
-  - name: B_0xAA
+  - name: Level0
     description: Level 0 (readout protection not active)
     value: 170
-  - name: B_0xCC
+  - name: Level2
     description: Level 2 (chip readout protection active)
     value: 204

--- a/data/registers/flash_wba.yaml
+++ b/data/registers/flash_wba.yaml
@@ -742,12 +742,12 @@ enum/CODE_OP:
 enum/RDP:
   bit_size: 8
   variants:
-  - name: B_0x55
+  - name: Level0_5
     description: Level 0.5 (readout protection not active, only non-secure debug access is possible). Only available when TrustZone is active (TZEN=1)
     value: 85
-  - name: B_0xAA
+  - name: Level0
     description: Level 0 (readout protection not active)
     value: 170
-  - name: B_0xCC
+  - name: Level2
     description: Level 2 (chip readout protection active)
     value: 204

--- a/data/registers/pwr_u5.yaml
+++ b/data/registers/pwr_u5.yaml
@@ -127,7 +127,6 @@ fieldset/BDCR2:
     description: VBAT charging enable
     bit_offset: 0
     bit_size: 1
-    enum: VBE
   - name: VBRS
     description: VBAT charging resistor selection
     bit_offset: 1
@@ -732,42 +731,42 @@ fieldset/WUCR3:
     description: "Wakeup pin WKUP1 selection\r This field must be configured when WUPEN1 = 0."
     bit_offset: 0
     bit_size: 2
-    enum: WUSEL
+    enum: WUSEL1
   - name: WUSEL2
     description: "Wakeup pin WKUP2 selection\r This field must be configured when WUPEN2 = 0."
     bit_offset: 2
     bit_size: 2
-    enum: WUSEL
+    enum: WUSEL2
   - name: WUSEL3
     description: "Wakeup pin WKUP3 selection\r This field must be configured when WUPEN3 = 0."
     bit_offset: 4
     bit_size: 2
-    enum: WUSEL
+    enum: WUSEL3
   - name: WUSEL4
     description: "Wakeup pin WKUP4 selection\r This field must be configured when WUPEN4 = 0."
     bit_offset: 6
     bit_size: 2
-    enum: WUSEL
+    enum: WUSEL4
   - name: WUSEL5
     description: "Wakeup pin WKUP5 selection\r This field must be configured when WUPEN5 = 0."
     bit_offset: 8
     bit_size: 2
-    enum: WUSEL
+    enum: WUSEL5
   - name: WUSEL6
     description: "Wakeup pin WKUP6 selection\r This field must be configured when WUPEN6 = 0."
     bit_offset: 10
     bit_size: 2
-    enum: WUSEL
+    enum: WUSEL6
   - name: WUSEL7
     description: "Wakeup pin WKUP7 selection\r This field must be configured when WUPEN7 = 0."
     bit_offset: 12
     bit_size: 2
-    enum: WUSEL
+    enum: WUSEL7
   - name: WUSEL8
     description: "Wakeup pin WKUP8 selection\r This field must be configured when WUPEN8 = 0."
     bit_offset: 14
     bit_size: 2
-    enum: WUSEL
+    enum: WUSEL8
 fieldset/WUSCR:
   description: wakeup status clear register
   fields:
@@ -934,10 +933,10 @@ enum/REGSEL:
 enum/SRAMFWU:
   bit_size: 1
   variants:
-  - name: B_0x0
+  - name: LowPower
     description: SRAM4 enters low-power mode in Stop 0, 1 and 2 modes (source biasing for lower-power consumption).
     value: 0
-  - name: B_0x1
+  - name: Normal
     description: SRAM4 remains in normal mode in Stop 0, 1 and 2 modes (higher consumption but no SRAM4 wakeup time).
     value: 1
 enum/SRAMPD:
@@ -952,46 +951,37 @@ enum/SRAMPD:
 enum/TEMPH:
   bit_size: 1
   variants:
-  - name: B_0x0
+  - name: Below
     description: Temperature < high threshold
     value: 0
-  - name: B_0x1
+  - name: AboveOrEqual
     description: Temperature ≥ high threshold
     value: 1
 enum/TEMPL:
   bit_size: 1
   variants:
-  - name: B_0x0
+  - name: Above
     description: Temperature > low threshold
     value: 0
-  - name: B_0x1
+  - name: BelowOrEqual
     description: Temperature ≤ low threshold
     value: 1
 enum/VBATH:
   bit_size: 1
   variants:
-  - name: B_0x0
+  - name: Below
     description: Backup domain voltage level < high threshold
     value: 0
-  - name: B_0x1
+  - name: AboveOrEqual
     description: Backup domain voltage level ≥ high threshold
-    value: 1
-enum/VBE:
-  bit_size: 1
-  variants:
-  - name: B_0x0
-    description: VBAT battery charging disabled
-    value: 0
-  - name: B_0x1
-    description: VBAT battery charging enabled
     value: 1
 enum/VBRS:
   bit_size: 1
   variants:
-  - name: B_0x0
+  - name: R5kOhm
     description: Charge VBAT through a 5 kΩ resistor
     value: 0
-  - name: B_0x1
+  - name: R1_5kOhm
     description: Charge VBAT through a 1.5 kΩ resistor
     value: 1
 enum/VOS:
@@ -1018,20 +1008,125 @@ enum/WUPP:
   - name: Low
     description: Detection on low level (falling edge)
     value: 1
-enum/WUSEL:
+enum/WUSEL1:
   bit_size: 2
   variants:
-  - name: B_0x0
-    description: WKUP7_0
+  - name: PA0
+    description: WKUP1 sourced from PA0
     value: 0
-  - name: B_0x1
-    description: WKUP7_1
+  - name: PB2
+    description: WKUP1 sourced from PB2
     value: 1
-  - name: B_0x2
-    description: WKUP7_2
+  - name: PE4
+    description: WKUP1 sourced from PE4
     value: 2
-  - name: B_0x3
-    description: WKUP7_3
+  - name: Reserved
+    description: Reserved
+    value: 3
+enum/WUSEL2:
+  bit_size: 2
+  variants:
+  - name: PA4
+    description: WKUP2 sourced from PA4
+    value: 0
+  - name: PC13
+    description: WKUP2 sourced from PC13
+    value: 1
+  - name: PE5
+    description: WKUP2 sourced from PE5
+    value: 2
+  - name: Reserved
+    description: Reserved
+    value: 3
+enum/WUSEL3:
+  bit_size: 2
+  variants:
+  - name: PE6
+    description: WKUP3 sourced from PE6
+    value: 0
+  - name: PA1
+    description: WKUP3 sourced from PA1
+    value: 1
+  - name: PB6
+    description: WKUP3 sourced from PB6
+    value: 2
+  - name: Reserved
+    description: Reserved
+    value: 3
+enum/WUSEL4:
+  bit_size: 2
+  variants:
+  - name: PA2
+    description: WKUP4 sourced from PA2
+    value: 0
+  - name: PB1
+    description: WKUP4 sourced from PB1
+    value: 1
+  - name: PB7
+    description: WKUP4 sourced from PB7
+    value: 2
+  - name: Reserved
+    description: Reserved
+    value: 3
+enum/WUSEL5:
+  bit_size: 2
+  variants:
+  - name: PC5
+    description: WKUP5 sourced from PC5
+    value: 0
+  - name: PA3
+    description: WKUP5 sourced from PA3
+    value: 1
+  - name: PB8
+    description: WKUP5 sourced from PB8
+    value: 2
+  - name: EarlyIwdg
+    description: WKUP5 sourced from the early IWDG interrupt
+    value: 3
+enum/WUSEL6:
+  bit_size: 2
+  variants:
+  - name: PB5
+    description: WKUP6 sourced from PB5
+    value: 0
+  - name: PA5
+    description: WKUP6 sourced from PA5
+    value: 1
+  - name: PE7
+    description: WKUP6 sourced from PE7
+    value: 2
+  - name: Rtc
+    description: WKUP6 sourced from RTC_ALRA_S, RTC_ALRB_S, RTC_WUT_S, or RTC_TS_S
+    value: 3
+enum/WUSEL7:
+  bit_size: 2
+  variants:
+  - name: PB15
+    description: WKUP7 sourced from PB15
+    value: 0
+  - name: PA6
+    description: WKUP7 sourced from PA6
+    value: 1
+  - name: PE8
+    description: WKUP7 sourced from PE8
+    value: 2
+  - name: Rtc
+    description: WKUP7 sourced from RTC_ALRA, RTC_ALRB, RTC_WUT, or RTC_TS
+    value: 3
+enum/WUSEL8:
+  bit_size: 2
+  variants:
+  - name: PF2
+    description: WKUP8 sourced from PF2
+    value: 0
+  - name: PA7
+    description: WKUP8 sourced from PA7
+    value: 1
+  - name: PB10
+    description: WKUP8 sourced from PB10
+    value: 2
+  - name: Tamp
+    description: WKUP8 sourced from TAMP
     value: 3
 enum/FORCE_USBPWR:
   bit_size: 1

--- a/data/registers/pwr_wba.yaml
+++ b/data/registers/pwr_wba.yaml
@@ -144,12 +144,12 @@ fieldset/CR2:
     description: OTG SRAM power-down in Stop modes.
     bit_offset: 11
     bit_size: 1
-    enum: PRAMPDS
+    enum: SRAMPDS
   - name: PKARAMPDS
     description: PKA SRAM power-down in Stop modes.
     bit_offset: 12
     bit_size: 1
-    enum: PKARAMPDS
+    enum: SRAMPDS
   - name: FLASHFWU
     description: "Flash memory fast wakeup from Stop modes (Stop 0, 1)\r This bit is used to obtain the best trade-off between low-power consumption and wakeup time when exiting the Stop 0 or Stop 1 modes.\r When this bit is set, the Flash memory remains in normal mode in Stop 0 and Stop 1 modes, which offers a faster startup time with higher consumption."
     bit_offset: 14
@@ -167,12 +167,10 @@ fieldset/CR3:
     description: Fast soft start
     bit_offset: 2
     bit_size: 1
-    enum: FSTEN
   - name: DIVCLP
-    description: Low power mode regulator clock division.
+    description: "Low power mode regulator clock division.\r 000: Low power regulator clock not divided\r Others: Low power regulator clock divided by 2^DIVCLP"
     bit_offset: 4
     bit_size: 3
-    enum: DIVCLP
   - name: SELREP
     description: Low power mode regulator replica selection.
     bit_offset: 8
@@ -181,7 +179,6 @@ fieldset/CR3:
     description: V11 feedback switch enable (non user bit).
     bit_offset: 15
     bit_size: 1
-    enum: V11FBSW
 fieldset/DBPCR:
   description: disable Backup domain register.
   fields:
@@ -237,7 +234,6 @@ fieldset/RADIOSCR:
     description: 2.4 GHz RADIO encryption function operating mode
     bit_offset: 3
     bit_size: 1
-    enum: ENCMODE
   - name: RFVDDHPA
     description: "2.4 GHz RADIO VDDHPA control word.\r Bits [3:0] see Table 81: PA output power table format for definition.\r Bit [4] rf_event."
     bit_offset: 8
@@ -266,12 +262,10 @@ fieldset/S2RETR:
     description: "PTA output signals Stop 2 mode retention enable\r Access can be secured by GTZC_TZSC PTACONVSEC. When secure, a non-secure read/write access is RAZ/WI. It does not generate an illegal access interrupt. This bit can be protected against unprivileged access when secure with SPRIV or when non-secure with NSPRIV."
     bit_offset: 0
     bit_size: 1
-    enum: PTASREN
   - name: PTASR
     description: "PTA interface output signals state retention in Stop 2 mode active\r Access can be secured by GTZC_TZSC PTACONVSEC. When secure, a non-secure read/write access is RAZ/WI. It does not generate an illegal access interrupt. This bit can be protected against unprivileged access when secure with SPRIV or when non-secure with NSPRIV."
     bit_offset: 16
     bit_size: 1
-    enum: PTASR
 fieldset/SECCFGR:
   description: security configuration register.
   fields:
@@ -286,17 +280,14 @@ fieldset/SECCFGR:
     description: Low-power modes secure protection
     bit_offset: 12
     bit_size: 1
-    enum: LPMSEC
   - name: VDMSEC
     description: Voltage detection secure protection
     bit_offset: 13
     bit_size: 1
-    enum: VDMSEC
   - name: VBSEC
     description: Backup domain secure protection
     bit_offset: 14
     bit_size: 1
-    enum: VBSEC
 fieldset/SR:
   description: status register.
   fields:
@@ -312,7 +303,6 @@ fieldset/SR:
     description: "Standby flag\r This bit is set by hardware when the device enters the Standby mode and the CPU restart from its reset vector. It’s cleared by writing 1 to the CSSF bit, or by a power-on reset. It is not cleared by the system reset."
     bit_offset: 2
     bit_size: 1
-    enum: SBF
   - name: STOP2F
     description: Stop 2 mode peripherals power down flag.
     bit_offset: 3
@@ -333,12 +323,10 @@ fieldset/SVMCR:
     description: VDDUSB supply valid.
     bit_offset: 28
     bit_size: 1
-    enum: USV
   - name: IO2SV
     description: VDDIO2 supply valid.
     bit_offset: 29
     bit_size: 1
-    enum: IO2SV
 fieldset/SVMSR:
   description: supply voltage monitoring status register.
   fields:
@@ -346,7 +334,7 @@ fieldset/SVMSR:
     description: Regulator selection.
     bit_offset: 1
     bit_size: 1
-    enum: REGS
+    enum: REGSEL
   - name: PVDO
     description: Programmable voltage detector output
     bit_offset: 4
@@ -356,7 +344,6 @@ fieldset/SVMSR:
     description: Voltage level ready for currently used VOS
     bit_offset: 15
     bit_size: 1
-    enum: ACTVOSRDY
   - name: ACTVOS
     description: "VOS currently applied to V<sub>CORE</sub>\r This field provides the last VOS value."
     bit_offset: 16
@@ -422,14 +409,46 @@ fieldset/WUCR2:
 fieldset/WUCR3:
   description: wake-up control register 3.
   fields:
-  - name: WUSEL
-    description: "Wakeup and interrupt pin WKUPX selection\r This field must be configured when WUPENX = 0.\r Access can be secured by WUPXSEC. When secure, a non-secure read/write access is RAZ/WI. It does not generate an illegal access interrupt. This bit can be protected against unprivileged access when secure with SPRIV or when non-secure with NSPRIV."
+  - name: WUSEL1
+    description: "Wakeup and interrupt pin WKUP1 selection\r This field must be configured when WUPEN1 = 0.\r Access can be secured by WUP1SEC. When secure, a non-secure read/write access is RAZ/WI. It does not generate an illegal access interrupt. This bit can be protected against unprivileged access when secure with SPRIV or when non-secure with NSPRIV."
     bit_offset: 0
     bit_size: 2
-    array:
-      len: 8
-      stride: 2
-    enum: WUSEL
+    enum: WUSEL1
+  - name: WUSEL2
+    description: "Wakeup and interrupt pin WKUP2 selection\r This field must be configured when WUPEN2 = 0.\r Access can be secured by WUP2SEC. When secure, a non-secure read/write access is RAZ/WI. It does not generate an illegal access interrupt. This bit can be protected against unprivileged access when secure with SPRIV or when non-secure with NSPRIV."
+    bit_offset: 2
+    bit_size: 2
+    enum: WUSEL2
+  - name: WUSEL3
+    description: "Wakeup and interrupt pin WKUP3 selection\r This field must be configured when WUPEN3 = 0.\r Access can be secured by WUP3SEC. When secure, a non-secure read/write access is RAZ/WI. It does not generate an illegal access interrupt. This bit can be protected against unprivileged access when secure with SPRIV or when non-secure with NSPRIV."
+    bit_offset: 4
+    bit_size: 2
+    enum: WUSEL3
+  - name: WUSEL4
+    description: "Wakeup and interrupt pin WKUP4 selection\r This field must be configured when WUPEN4 = 0.\r Access can be secured by WUP4SEC. When secure, a non-secure read/write access is RAZ/WI. It does not generate an illegal access interrupt. This bit can be protected against unprivileged access when secure with SPRIV or when non-secure with NSPRIV."
+    bit_offset: 6
+    bit_size: 2
+    enum: WUSEL4
+  - name: WUSEL5
+    description: "Wakeup and interrupt pin WKUP5 selection\r This field must be configured when WUPEN5 = 0.\r Access can be secured by WUP5SEC. When secure, a non-secure read/write access is RAZ/WI. It does not generate an illegal access interrupt. This bit can be protected against unprivileged access when secure with SPRIV or when non-secure with NSPRIV."
+    bit_offset: 8
+    bit_size: 2
+    enum: WUSEL5
+  - name: WUSEL6
+    description: "Wakeup and interrupt pin WKUP6 selection\r This field must be configured when WUPEN6 = 0.\r Access can be secured by WUP6SEC. When secure, a non-secure read/write access is RAZ/WI. It does not generate an illegal access interrupt. This bit can be protected against unprivileged access when secure with SPRIV or when non-secure with NSPRIV."
+    bit_offset: 10
+    bit_size: 2
+    enum: WUSEL6
+  - name: WUSEL7
+    description: "Wakeup and interrupt pin WKUP7 selection\r This field must be configured when WUPEN7 = 0.\r Access can be secured by WUP7SEC. When secure, a non-secure read/write access is RAZ/WI. It does not generate an illegal access interrupt. This bit can be protected against unprivileged access when secure with SPRIV or when non-secure with NSPRIV."
+    bit_offset: 12
+    bit_size: 2
+    enum: WUSEL7
+  - name: WUSEL8
+    description: "Wakeup and interrupt pin WKUP8 selection\r This field must be configured when WUPEN8 = 0.\r Access can be secured by WUP8SEC. When secure, a non-secure read/write access is RAZ/WI. It does not generate an illegal access interrupt. This bit can be protected against unprivileged access when secure with SPRIV or when non-secure with NSPRIV."
+    bit_offset: 14
+    bit_size: 2
+    enum: WUSEL8
 fieldset/WUSCR:
   description: wake-up status clear register.
   fields:
@@ -459,30 +478,6 @@ enum/ACTVOS:
   - name: Range1
     description: Range 1 (highest frequency)
     value: 1
-enum/ACTVOSRDY:
-  bit_size: 1
-  variants:
-  - name: B_0x0
-    description: VsubCORE/sub is above or below the current voltage scaling provided by ACTVOS.
-    value: 0
-  - name: B_0x1
-    description: VsubCORE /subis equal to the current voltage scaling provided by ACTVOS.
-    value: 1
-enum/DIVCLP:
-  bit_size: 3
-  variants:
-  - name: B_0x0
-    description: Low power regulator clock not divided.
-    value: 0
-enum/ENCMODE:
-  bit_size: 1
-  variants:
-  - name: B_0x0
-    description: 2.4 GHz RADIO encryption function disabled.
-    value: 0
-  - name: B_0x1
-    description: 2.4 GHz RADIO encryption function enabled.
-    value: 1
 enum/FLASHFWU:
   bit_size: 1
   variants:
@@ -491,15 +486,6 @@ enum/FLASHFWU:
     value: 0
   - name: Normal
     description: Flash memory remains in normal mode in Stop 0 and Stop 1 modes (faster wakeup time).
-    value: 1
-enum/FSTEN:
-  bit_size: 1
-  variants:
-  - name: B_0x0
-    description: LDO fast startup disabled (limited inrush current).
-    value: 0
-  - name: B_0x1
-    description: LDO fast startup enabled.
     value: 1
 enum/ICRAMPDS:
   bit_size: 1
@@ -510,15 +496,6 @@ enum/ICRAMPDS:
   - name: NotRetained
     description: ICACHE SRAM content lost in Stop modes
     value: 1
-enum/IO2SV:
-  bit_size: 1
-  variants:
-  - name: B_0x0
-    description: VDDIO2 not supplied, electrical and logical isolation enabled.
-    value: 0
-  - name: B_0x1
-    description: VDDIO2 supply present, electrical and logical isolation disabled.
-    value: 1
 enum/LPMS:
   bit_size: 3
   variants:
@@ -528,15 +505,15 @@ enum/LPMS:
   - name: Stop1
     description: Stop 1 mode
     value: 1
-enum/LPMSEC:
-  bit_size: 1
-  variants:
-  - name: B_0x0
-    description: CR1, CR2 and CSSF in the SR can be read and written with secure or non-secure access.
-    value: 0
-  - name: B_0x1
-    description: CR1, CR2, and CSSF in the SR can be read and written only with secure access.
-    value: 1
+  - name: Stop2
+    description: Stop 2 mode
+    value: 2
+  - name: Standby0
+    description: Standby mode
+    value: 4
+  - name: Standby1
+    description: Standby mode
+    value: 5
 enum/MODE:
   bit_size: 2
   variants:
@@ -546,50 +523,20 @@ enum/MODE:
   - name: Sleep
     description: 2.4 GHz RADIO sleep mode
     value: 1
+  - name: Active0
+    description: 2.4 GHz RADIO active mode
+    value: 2
+  - name: Active1
+    description: 2.4 GHz RADIO active mode
+    value: 3
 enum/PHYMODE:
   bit_size: 1
   variants:
-  - name: B_0x0
+  - name: Sleep
     description: 2.4 GHz RADIO Sleep mode.
     value: 0
-  - name: B_0x1
+  - name: Standby
     description: 2.4 GHz RADIO Standby mode.
-    value: 1
-enum/PKARAMPDS:
-  bit_size: 1
-  variants:
-  - name: B_0x0
-    description: PKA SRAM content retained in Stop modes.
-    value: 0
-  - name: B_0x1
-    description: PKA SRAM content lost in Stop modes.
-    value: 1
-enum/PRAMPDS:
-  bit_size: 1
-  variants:
-  - name: B_0x0
-    description: OTG SRAM content retained in Stop modes.
-    value: 0
-  - name: B_0x1
-    description: OTG SRAM content lost in Stop modes.
-    value: 1
-enum/PTASR:
-  bit_size: 1
-  variants:
-  - name: B_0x0
-    description: Cleared by software, writing 0.
-    value: 0
-  - name: B_0x1
-    description: Set by hardware when Stop 2 mode PTA retention is enabled in PTASREN and Stop 2 mode is entered.
-    value: 1
-enum/PTASREN:
-  bit_size: 1
-  variants:
-  - name: B_0x0
-    description: PTA output signals Stop 2 retention feature disabled.
-    value: 0
-  - name: B_0x1
-    description: PTA output signals Stop 2 retention feature enabled.
     value: 1
 enum/PVDLS:
   bit_size: 3
@@ -630,38 +577,20 @@ enum/PVDO:
 enum/REGPASEL:
   bit_size: 1
   variants:
-  - name: B_0x0
+  - name: Fixed
     description: VDDRFPA pin selected as regulator REG_VDDHPA input supply.
     value: 0
-  - name: B_0x1
+  - name: Auto
     description: regulator REG_VDDHPA input supply selection between VDDRFPA and VDD11, dependent on requested regulated output voltage.
-    value: 1
-enum/REGS:
-  bit_size: 1
-  variants:
-  - name: B_0x0
-    description: LDO selected.
-    value: 0
-  - name: B_0x1
-    description: SMPS selected.
     value: 1
 enum/REGSEL:
   bit_size: 1
   variants:
-  - name: B_0x0
+  - name: LDO
     description: LDO selected.
     value: 0
-  - name: B_0x1
+  - name: SMPS
     description: SMPS selected.
-    value: 1
-enum/SBF:
-  bit_size: 1
-  variants:
-  - name: B_0x0
-    description: The device did not enter Standby mode.
-    value: 0
-  - name: B_0x1
-    description: The device entered Standby mode.
     value: 1
 enum/SRAM1PDS567:
   bit_size: 1
@@ -681,42 +610,6 @@ enum/SRAMPDS:
   - name: PoweredOff
     description: SRAM1 content lost in Stop modes
     value: 1
-enum/USV:
-  bit_size: 1
-  variants:
-  - name: B_0x0
-    description: VDDUSB not supplied, electrical and logical isolation enabled.
-    value: 0
-  - name: B_0x1
-    description: VDDUSB supply present, electrical and logical isolation disabled.
-    value: 1
-enum/V11FBSW:
-  bit_size: 1
-  variants:
-  - name: B_0x0
-    description: V11 feedback fixed before Epod.
-    value: 0
-  - name: B_0x1
-    description: V11 feedback switch enabled:.
-    value: 1
-enum/VBSEC:
-  bit_size: 1
-  variants:
-  - name: B_0x0
-    description: DBPCR can be read and written with secure or non-secure access.
-    value: 0
-  - name: B_0x1
-    description: DBPCR can be read and written only with secure access.
-    value: 1
-enum/VDMSEC:
-  bit_size: 1
-  variants:
-  - name: B_0x0
-    description: SVMCR and CR3 can be read and written with secure or non-secure access.
-    value: 0
-  - name: B_0x1
-    description: SVMCR and CR3 can be read and written only with secure access.
-    value: 1
 enum/VOS:
   bit_size: 1
   variants:
@@ -735,18 +628,84 @@ enum/WUPP:
   - name: Low
     description: Detection on low level (falling edge)
     value: 1
-enum/WUSEL:
+enum/WUSEL1:
   bit_size: 2
   variants:
-  - name: B_0x0
-    description: reserved
+  - name: WKUP1_0
+    description: WKUP1_0
     value: 0
-  - name: B_0x1
+  - name: WKUP1_1
+    description: WKUP1_1
+    value: 1
+enum/WUSEL2:
+  bit_size: 2
+  variants:
+  - name: WKUP2_0
+    description: WKUP2_0
+    value: 0
+  - name: WKUP2_1
+    description: WKUP2_1
+    value: 1
+enum/WUSEL3:
+  bit_size: 2
+  variants:
+  - name: WKUP3_1
     description: WKUP3_1
     value: 1
-  - name: B_0x2
+  - name: WKUP3_2
     description: WKUP3_2
     value: 2
-  - name: B_0x3
-    description: reserved
+enum/WUSEL4:
+  bit_size: 2
+  variants:
+  - name: WKUP4_0
+    description: WKUP4_0
+    value: 0
+  - name: WKUP4_1
+    description: WKUP4_1
+    value: 1
+enum/WUSEL5:
+  bit_size: 2
+  variants:
+  - name: WKUP5_1
+    description: WKUP5_1
+    value: 1
+  - name: WKUP5_2
+    description: WKUP5_2
+    value: 2
+enum/WUSEL6:
+  bit_size: 2
+  variants:
+  - name: WKUP6_0
+    description: WKUP6_0
+    value: 0
+  - name: WKUP6_1
+    description: WKUP6_1
+    value: 1
+  - name: WKUP6_3
+    description: WKUP6_3 (internal source, does not generate a WKUP interrupt)
+    value: 3
+enum/WUSEL7:
+  bit_size: 2
+  variants:
+  - name: WKUP7_0
+    description: WKUP7_0
+    value: 0
+  - name: WKUP7_1
+    description: WKUP7_1
+    value: 1
+  - name: WKUP7_3
+    description: WKUP7_3 (internal source, does not generate a WKUP interrupt)
+    value: 3
+enum/WUSEL8:
+  bit_size: 2
+  variants:
+  - name: WKUP8_1
+    description: WKUP8_1
+    value: 1
+  - name: WKUP8_2
+    description: WKUP8_2
+    value: 2
+  - name: WKUP8_3
+    description: WKUP8_3 (internal source, does not generate a WKUP interrupt)
     value: 3

--- a/data/registers/ramcfg_wba.yaml
+++ b/data/registers/ramcfg_wba.yaml
@@ -165,15 +165,15 @@ fieldset/M2WPR2:
 enum/ID:
   bit_size: 4
   variants:
-  - name: B_0x2
+  - name: Cpu
     description: parity error detected on CPU access.
     value: 2
-  - name: B_0x3
+  - name: Debugger
     description: parity error detected on Debugger access.
     value: 3
-  - name: B_0x6
-    description: parity error detected on DMA master port o access.
+  - name: DmaPort0
+    description: parity error detected on DMA master port 0 access.
     value: 6
-  - name: B_0x7
+  - name: DmaPort1
     description: parity error detected on DMA master port 1 access.
     value: 7


### PR DESCRIPTION
## Summary

- **PWR_CR1.LPMS** on WBA65 was missing the `Stop2` (2) and `Standby` (4/5) enum values — only `Stop0`/`Stop1` decoded
- **WUCR3's per-pin `WUSELx` fields** (WBA and U5) all shared a single generic enum copy-pasted from one pin's meaning. Split into per-pin enums:
  - WBA: named after the SVD's per-pin enumeratedValues (WKUPn_x, internal sources, reserved gaps)
  - U5: named after the actual GPIO/internal-signal source documented in RM0456 Table 97
- **Generic `B_0x0`/`B_0x1`/... enum names** cleaned up across `pwr_wba`, `ramcfg_wba`, `flash_wba`
- **`comp_u5.yaml`**: fixed an enum variant literally named `COMP1_VALUE XOR COMP2_VALUE` (contains a space — not a valid Rust identifier).
- **DBGMCU per-channel DMA freeze bits** (`DBG_GPDMA<n>_STOP` / `DBG_HPDMA<n>_STOP`) converted from N separate fields into array fields, for `dbgmcu_u5`, `dbgmcu_n6`, `dbgmcu_u3`, `dbgmcu_wba` — matching the shape `dbgmcu_h5` already used for the same IP block

`comp_u5.yaml`/`rtc_v3_u5.yaml` are also used by WBA chips per `perimap.rs`, so WBA builds were checked wherever a U5-named file changed.