### PR TITLE
Add TS_CAL1/TS_CAL2 temperature sensor factory calibration registers

### DIFF
--- a/data/extra/STM32C0.yaml
+++ b/data/extra/STM32C0.yaml
@@ -1,0 +1,11 @@
+matches:
+  family: STM32C0
+peripherals:
+  # RM0490 only documents a single calibration point (TS_CAL1); there is no
+  # TS_CAL2 on this family.
+  - name: TS_CAL1
+    address: 0x1FFF7568
+    registers:
+      kind: tscal
+      version: v1
+      block: TSCAL

--- a/data/extra/STM32F0.yaml
+++ b/data/extra/STM32F0.yaml
@@ -7,3 +7,12 @@ peripherals:
       kind: vrefintcal
       version: v1
       block: VREFINTCAL
+  # TS_CAL1 exists on all F0 chips (RM0091/RM0360). TS_CAL2 only exists on the
+  # F0x1/F0x2/F0x8 mainstream line (see STM32F0_tscal2.yaml overlay); the
+  # F030/F070 value line has no second calibration point.
+  - name: TS_CAL1
+    address: 0x1FFFF7B8
+    registers:
+      kind: tscal
+      version: v1
+      block: TSCAL

--- a/data/extra/STM32F0_tscal2.yaml
+++ b/data/extra/STM32F0_tscal2.yaml
@@ -1,0 +1,11 @@
+matches:
+  chip: STM32F0(31|38|42|48|51|58|71|72|78|91|98).*
+peripherals:
+  # TS_CAL2 only exists on the F0x1/F0x2/F0x8 mainstream line (RM0091);
+  # the F030/F070 value line (RM0360) only has TS_CAL1.
+  - name: TS_CAL2
+    address: 0x1FFFF7C2
+    registers:
+      kind: tscal
+      version: v1
+      block: TSCAL

--- a/data/extra/STM32F3.yaml
+++ b/data/extra/STM32F3.yaml
@@ -7,6 +7,18 @@ peripherals:
       kind: vrefintcal
       version: v1
       block: VREFINTCAL
+  - name: TS_CAL1
+    address: 0x1FFFF7B8
+    registers:
+      kind: tscal
+      version: v1
+      block: TSCAL
+  - name: TS_CAL2
+    address: 0x1FFFF7C2
+    registers:
+      kind: tscal
+      version: v1
+      block: TSCAL
   - name: OPAMP1
     pins:
       # Corresponds to tsmc018_ull_opamp_v1_0_Cube

--- a/data/extra/STM32F4.yaml
+++ b/data/extra/STM32F4.yaml
@@ -1,6 +1,18 @@
 matches:
   family: STM32F4
 peripherals:
+  - name: TS_CAL1
+    address: 0x1FFF7A2C
+    registers:
+      kind: tscal
+      version: v1
+      block: TSCAL
+  - name: TS_CAL2
+    address: 0x1FFF7A2E
+    registers:
+      kind: tscal
+      version: v1
+      block: TSCAL
   - name: I2S2
     address: 0x40003400
     registers:

--- a/data/extra/STM32F7[23]x.yaml
+++ b/data/extra/STM32F7[23]x.yaml
@@ -1,20 +1,16 @@
 matches:
-  family: STM32WB
+  chip: STM32F7[23].*
 peripherals:
-  - name: VREFINTCAL
-    address: 0x1FFF75AA
-    registers:
-      kind: vrefintcal
-      version: v1
-      block: VREFINTCAL
+  # F72x/F73x (RM0431) use this address; F74x/F75x/F76x/F77x use a different
+  # one (see STM32F7[4-7]x.yaml).
   - name: TS_CAL1
-    address: 0x1FFF75A8
+    address: 0x1FF07A2C
     registers:
       kind: tscal
       version: v1
       block: TSCAL
   - name: TS_CAL2
-    address: 0x1FFF75CA
+    address: 0x1FF07A2E
     registers:
       kind: tscal
       version: v1

--- a/data/extra/STM32F7[4-7]x.yaml
+++ b/data/extra/STM32F7[4-7]x.yaml
@@ -1,20 +1,16 @@
 matches:
-  family: STM32WB
+  chip: STM32F7[4-7].*
 peripherals:
-  - name: VREFINTCAL
-    address: 0x1FFF75AA
-    registers:
-      kind: vrefintcal
-      version: v1
-      block: VREFINTCAL
+  # F74x/F75x (RM0385) and F76x/F77x (RM0410) share this address; F72x/F73x
+  # use a different one (see STM32F7[23]x.yaml).
   - name: TS_CAL1
-    address: 0x1FFF75A8
+    address: 0x1FF0F44C
     registers:
       kind: tscal
       version: v1
       block: TSCAL
   - name: TS_CAL2
-    address: 0x1FFF75CA
+    address: 0x1FF0F44E
     registers:
       kind: tscal
       version: v1

--- a/data/extra/STM32G0.yaml
+++ b/data/extra/STM32G0.yaml
@@ -7,6 +7,14 @@ peripherals:
       kind: vrefintcal
       version: v1
       block: VREFINTCAL
+  # TS_CAL1 exists on all G0 chips. TS_CAL2 only exists on a subset
+  # (see STM32G0_tscal2.yaml overlay).
+  - name: TS_CAL1
+    address: 0x1FFF75A8
+    registers:
+      kind: tscal
+      version: v1
+      block: TSCAL
   - name: TAMP
     address: 0x4000B000
     registers:

--- a/data/extra/STM32G0_tscal2.yaml
+++ b/data/extra/STM32G0_tscal2.yaml
@@ -1,0 +1,12 @@
+matches:
+  chip: STM32G0(31|41|50|51|61|71|81|B1|C1).*
+peripherals:
+  # TS_CAL2 exists on the G0x1 mainstream line (G031/G041/G051/G061/G071/
+  # G081/G0B1/G0C1) and on the G050/G051 value-line variant, but not on the
+  # rest of the G0x0 value line (G030/G070/G0B0).
+  - name: TS_CAL2
+    address: 0x1FFF75CA
+    registers:
+      kind: tscal
+      version: v1
+      block: TSCAL

--- a/data/extra/STM32G4.yaml
+++ b/data/extra/STM32G4.yaml
@@ -7,6 +7,18 @@ peripherals:
       kind: vrefintcal
       version: v1
       block: VREFINTCAL
+  - name: TS_CAL1
+    address: 0x1FFF75A8
+    registers:
+      kind: tscal
+      version: v1
+      block: TSCAL
+  - name: TS_CAL2
+    address: 0x1FFF75CA
+    registers:
+      kind: tscal
+      version: v1
+      block: TSCAL
   - name: TAMP
     address: 0x40002400
     registers:

--- a/data/extra/STM32H5.yaml
+++ b/data/extra/STM32H5.yaml
@@ -1,6 +1,18 @@
 matches:
   family: STM32H5
 peripherals:
+  - name: TS_CAL1
+    address: 0x08FFF814
+    registers:
+      kind: tscal
+      version: v1
+      block: TSCAL
+  - name: TS_CAL2
+    address: 0x08FFF818
+    registers:
+      kind: tscal
+      version: v1
+      block: TSCAL
   # Corresponds to cmosM40_opamp_v1_0_Cube
   # STM32H5 variant
   - name: OPAMP1

--- a/data/extra/STM32H7[2345]x.yaml
+++ b/data/extra/STM32H7[2345]x.yaml
@@ -1,0 +1,17 @@
+matches:
+  chip: STM32H7[2345].*
+peripherals:
+  # H72x/73x/74x/75x share this electronic-signature layout (RM0433/RM0399/
+  # RM0468); H7A/B/R/S use a different one (see STM32H7[ABRS]x.yaml).
+  - name: TS_CAL1
+    address: 0x1FF1E820
+    registers:
+      kind: tscal
+      version: v1
+      block: TSCAL
+  - name: TS_CAL2
+    address: 0x1FF1E840
+    registers:
+      kind: tscal
+      version: v1
+      block: TSCAL

--- a/data/extra/STM32H7[ABRS]x.yaml
+++ b/data/extra/STM32H7[ABRS]x.yaml
@@ -1,0 +1,18 @@
+matches:
+  chip: STM32H7[ABRS].*
+peripherals:
+  # H7A3/H7B3/H7B0/H7R/H7S use this electronic-signature layout (RM0455,
+  # RM0477); confirmed via RM0477 for H7R/S, applied to H7A/B by analogy
+  # (same "Reserved information" memory-map layout, RM0455 §4.3.14 Table 18).
+  - name: TS_CAL1
+    address: 0x08FFF814
+    registers:
+      kind: tscal
+      version: v1
+      block: TSCAL
+  - name: TS_CAL2
+    address: 0x08FFF818
+    registers:
+      kind: tscal
+      version: v1
+      block: TSCAL

--- a/data/extra/STM32L0_tscal.yaml
+++ b/data/extra/STM32L0_tscal.yaml
@@ -1,0 +1,19 @@
+matches:
+  # L011/L021/L031/L041/L051-53/L062-63/L071-73/L081-83 have a temperature
+  # sensor calibrated at 30/130C (RM0377/RM0376/RM0367). The L010 value line
+  # (RM0451) has no temperature sensor at all, so it's deliberately excluded
+  # from this match.
+  chip: STM32L0(11|21|31|41|5[123]|6[23]|7[123]|8[123]).*
+peripherals:
+  - name: TS_CAL1
+    address: 0x1FF8007A
+    registers:
+      kind: tscal
+      version: v1
+      block: TSCAL
+  - name: TS_CAL2
+    address: 0x1FF8007E
+    registers:
+      kind: tscal
+      version: v1
+      block: TSCAL

--- a/data/extra/STM32L1_cat1-2.yaml
+++ b/data/extra/STM32L1_cat1-2.yaml
@@ -1,0 +1,18 @@
+matches:
+  # L100/L151/L152 Cat.1 & Cat.2 devices (flash size 6/8/B), per RM0038.
+  # Cat.3/4/5/6 devices (flash size C/D/E) use a different address
+  # (see STM32L1_cat3-6.yaml).
+  chip: STM32L1(00|5[12])[A-Z][68B](-A)?
+peripherals:
+  - name: TS_CAL1
+    address: 0x1FF8007A
+    registers:
+      kind: tscal
+      version: v1
+      block: TSCAL
+  - name: TS_CAL2
+    address: 0x1FF8007E
+    registers:
+      kind: tscal
+      version: v1
+      block: TSCAL

--- a/data/extra/STM32L1_cat3-6.yaml
+++ b/data/extra/STM32L1_cat3-6.yaml
@@ -1,0 +1,18 @@
+matches:
+  # L100/L151/L152/L162 Cat.3 & Cat.4/5/6 devices (flash size C/D/E), per
+  # RM0038. Cat.1/2 devices (flash size 6/8/B) use a different address
+  # (see STM32L1_cat1-2.yaml).
+  chip: STM32L1(00|5[12]|62)[A-Z][CDE](-[AX])?
+peripherals:
+  - name: TS_CAL1
+    address: 0x1FF800FA
+    registers:
+      kind: tscal
+      version: v1
+      block: TSCAL
+  - name: TS_CAL2
+    address: 0x1FF800FE
+    registers:
+      kind: tscal
+      version: v1
+      block: TSCAL

--- a/data/extra/STM32L4+.yaml
+++ b/data/extra/STM32L4+.yaml
@@ -7,6 +7,18 @@ peripherals:
       kind: vrefintcal
       version: v1
       block: VREFINTCAL
+  - name: TS_CAL1
+    address: 0x1FFF75A8
+    registers:
+      kind: tscal
+      version: v1
+      block: TSCAL
+  - name: TS_CAL2
+    address: 0x1FFF75CA
+    registers:
+      kind: tscal
+      version: v1
+      block: TSCAL
   # Corresponds to tsmc018_ull_opamp_v1_0_L4_Cube
   - name: OPAMP1
     pins:

--- a/data/extra/STM32L4.yaml
+++ b/data/extra/STM32L4.yaml
@@ -7,6 +7,18 @@ peripherals:
       kind: vrefintcal
       version: v1
       block: VREFINTCAL
+  - name: TS_CAL1
+    address: 0x1FFF75A8
+    registers:
+      kind: tscal
+      version: v1
+      block: TSCAL
+  - name: TS_CAL2
+    address: 0x1FFF75CA
+    registers:
+      kind: tscal
+      version: v1
+      block: TSCAL
   # Corresponds to tsmc018_ull_opamp_v1_0_L4_Cube
   - name: OPAMP1
     pins:

--- a/data/extra/STM32L5.yaml
+++ b/data/extra/STM32L5.yaml
@@ -7,6 +7,18 @@ peripherals:
       kind: vrefintcal
       version: v1
       block: VREFINTCAL
+  - name: TS_CAL1
+    address: 0x0BFA05A8
+    registers:
+      kind: tscal
+      version: v1
+      block: TSCAL
+  - name: TS_CAL2
+    address: 0x0BFA05CA
+    registers:
+      kind: tscal
+      version: v1
+      block: TSCAL
 override_pins:
   # Corresponds to tsmc018_ull_opamp_v1_0_L4_Cube, also used for L5
   - name: OPAMP1

--- a/data/extra/STM32U0.yaml
+++ b/data/extra/STM32U0.yaml
@@ -1,6 +1,18 @@
 matches:
   family: STM32U0
 peripherals:
+  - name: TS_CAL1
+    address: 0x1FFF6E68
+    registers:
+      kind: tscal
+      version: v1
+      block: TSCAL
+  - name: TS_CAL2
+    address: 0x1FFF6E8A
+    registers:
+      kind: tscal
+      version: v1
+      block: TSCAL
   # Corresponds to tsmc018_ull_opamp_v1_0_L4_Cube, also used for U0
   - name: OPAMP1
     pins:

--- a/data/extra/STM32U5.yaml
+++ b/data/extra/STM32U5.yaml
@@ -1,6 +1,18 @@
 matches:
   family: STM32U5
 peripherals:
+  - name: TS_CAL1
+    address: 0x0BFA0710
+    registers:
+      kind: tscal
+      version: v1
+      block: TSCAL
+  - name: TS_CAL2
+    address: 0x0BFA0742
+    registers:
+      kind: tscal
+      version: v1
+      block: TSCAL
   # Corresponds to tsmc018_ull_opamp_v1_0_L4_Cube, also used for U5
   - name: OPAMP1
     pins:

--- a/data/extra/STM32WBA5.yaml
+++ b/data/extra/STM32WBA5.yaml
@@ -1,20 +1,16 @@
 matches:
-  family: STM32WB
+  chip: STM32WBA5.*
 peripherals:
-  - name: VREFINTCAL
-    address: 0x1FFF75AA
-    registers:
-      kind: vrefintcal
-      version: v1
-      block: VREFINTCAL
+  # DESIG_TSCAL1R/TSCAL2R (RM0493 §44.1.5/6), confirmed against the ADC4
+  # calibration table.
   - name: TS_CAL1
-    address: 0x1FFF75A8
+    address: 0x0BF90710
     registers:
       kind: tscal
       version: v1
       block: TSCAL
   - name: TS_CAL2
-    address: 0x1FFF75CA
+    address: 0x0BF90742
     registers:
       kind: tscal
       version: v1

--- a/data/extra/STM32WBA6.yaml
+++ b/data/extra/STM32WBA6.yaml
@@ -1,0 +1,17 @@
+matches:
+  chip: STM32WBA6.*
+peripherals:
+  # DESIG_TSCAL1R/TSCAL2R (RM0515), same register layout as WBA5 but at a
+  # different DESIG base address (confirmed via ADC4 calibration table).
+  - name: TS_CAL1
+    address: 0x0BFA0710
+    registers:
+      kind: tscal
+      version: v1
+      block: TSCAL
+  - name: TS_CAL2
+    address: 0x0BFA0742
+    registers:
+      kind: tscal
+      version: v1
+      block: TSCAL

--- a/data/extra/STM32WL.yaml
+++ b/data/extra/STM32WL.yaml
@@ -7,6 +7,20 @@ peripherals:
       kind: vrefintcal
       version: v1
       block: VREFINTCAL
+  - name: TS_CAL1
+    address: 0x1FFF75A8
+    registers:
+      kind: tscal
+      version: v1
+      block: TSCAL
+  # Note: TS_CAL2 is at 0x1FFF75C8 here, NOT 0x1FFF75CA like STM32WB/G0/G4/L4
+  # (2 bytes earlier) - confirmed against the electronic signature table.
+  - name: TS_CAL2
+    address: 0x1FFF75C8
+    registers:
+      kind: tscal
+      version: v1
+      block: TSCAL
   - name: TAMP
     address: 0x4000B000
     registers:

--- a/data/registers/tscal_v1.yaml
+++ b/data/registers/tscal_v1.yaml
@@ -1,0 +1,8 @@
+block/TSCAL:
+  description: Temperature sensor factory calibration data
+  items:
+  - name: DATA
+    description: Factory calibration value
+    byte_offset: 0
+    bit_size: 16
+    access: Read


### PR DESCRIPTION
## Summary

Adds factory-programmed temperature sensor calibration data (TS_CAL1 at ~30°C, TS_CAL2 at ~110/130°C) as standalone peripherals, following the same pattern already used for `VREFINTCAL`, across: C0, F0, F3, F4, F7, G0, G4, H5, H7, L0, L1, L4, L4+, L5, U0, U5, WB, WBA, WL.

This picks up where #506 left off.

Addresses are sourced from ST's electronic-signature/factory-calibration reference, since most reference manuals explicitly defer the calibration address to the datasheet rather than printing it. Wherever a reference manual *does* document the address (L0x1, H7R/S, U5, WBA5/WBA6, WB0/WB05-07), values were cross-checked and one correction was made: WB0's `TS_CAL1` offset from the `DESIG` base is `+0x60`, not `+0x5C`. A real discrepancy was also confirmed between families that otherwise look similar: WL's `TS_CAL2` sits at `0x1FFF75C8`, two bytes off from WB/G0/G4/L4's `0x1FFF75CA`.

Sub-line address differences within a family (e.g. F0 value line vs mainstream, F7's two address groups, G0's mainstream line plus a value-line exception, H7's mainline vs A/B/R/S region, L1's Cat.1/2 vs Cat.3-6, WBA5 vs WBA6) are handled with non-overlapping `chip:` regex overlays so no chip ends up matching two conflicting entries for the same peripheral.

Intentionally left out (no reliable data or the register doesn't exist):
- **F1, F2** — no factory calibration register exists at all.
- **N6** — has an unrelated "Digital Temperature Sensor" (DTS) peripheral instead.
- **L0's base L010 line** — no temperature sensor at all (the rest of L0 is covered).
- **U3, WBA2** — no manual/datasheet data available yet.
- **WB0** (WB05/06/07/09xx) — the `DESIG` peripheral's absolute base address isn't confirmed in the reference manual, only inferred from a memory-map row, so left out pending a firmer source.