### PR TITLE
i2c: add WUPEN flag

### DIFF
--- a/data/registers/i2c_v2.yaml
+++ b/data/registers/i2c_v2.yaml
@@ -105,6 +105,10 @@ fieldset/CR1:
     description: Clock stretching disable
     bit_offset: 17
     bit_size: 1
+  - name: WUPEN
+    description: Wakeup from STOP enable
+    bit_offset: 18
+    bit_size: 1
   - name: GCEN
     description: General call enable
     bit_offset: 19

--- a/data/registers/i2c_v3.yaml
+++ b/data/registers/i2c_v3.yaml
@@ -105,6 +105,10 @@ fieldset/CR1:
     description: Clock stretching disable
     bit_offset: 17
     bit_size: 1
+  - name: WUPEN
+    description: Wakeup from STOP enable
+    bit_offset: 18
+    bit_size: 1
   - name: GCEN
     description: General call enable
     bit_offset: 19


### PR DESCRIPTION
Add the `WUPEN` bit to `i2c_v2` and `i2c_v3` to support waking from STOP mode.

Running a check against the SVD files showed that:
* All `i2c_v3` SVDs have this bit.
* Some `i2c_v2` SVDs have this bit marked as reserved.
* Some `i2c_v2` SVDs include this bit, but the actual peripheral instance doesn't support the functionality.

The reference manual says that if it is not supported it will always read 0.

Maintaining metadata on which specific instances support wake-up seems like a huge task, so this commit only adds the register definition.