### PR TITLE
uid: fix uid for L0 and L1

### DIFF
--- a/data/registers/uid_l0.yaml
+++ b/data/registers/uid_l0.yaml
@@ -1,0 +1,12 @@
+block/UID:
+  description: Device Factory programmed 96-bit unique device identifier
+  items:
+  - name: UID
+    description: Factory programmed 96-bit unique device identifier word 0
+    array:
+      offsets:
+      - 0
+      - 4
+      - 20
+    byte_offset: 0
+    access: Read

--- a/stm32-data-gen/src/perimap.rs
+++ b/stm32-data-gen/src/perimap.rs
@@ -706,6 +706,7 @@ const PERIMAP: &[(&str, (&str, &str, &str))] = &[
     (".*:LCD:lcdc1_v1.2.*", ("lcd", "v2", "LCD")),
     (".*:LCD:lcdc1_v1.3.*", ("lcd", "v2", "LCD")),
     (".*:LCD:lcdc1_v1.4.*", ("lcd", "v2", "LCD")),
+    ("STM32L[01].*:UID:.*", ("uid", "l0", "UID")),
     (".*:UID:.*", ("uid", "v1", "UID")),
     ("STM32WBA.*:DESIG:.*", ("desig", "wba", "DESIG")),
     ("STM32H5.*:UCPD:.*", ("ucpd", "h5", "UCPD")),


### PR DESCRIPTION
## Problem

From issue #800.
The UID block is modelled as a contiguous array for every chip. On STM32L0 and STM32L1 the third word is at 0x14 instead of 0x08.

Closes #800.

## Fix

Add uid_l0.yaml for L0 and L1

```rs
("STM32L[01].*:UID:.*", ("uid", "l0", "UID")),
(".*:UID:.*",           ("uid", "v1", "UID")),
```

I scan through all reference manuals of STM32 (67 pdfs latest version, with the help of LLM),
confirming that the only chip families that have this weird offset are L0 and L1.

| RM     | Section | Family    | Base                     | Offsets            |
|--------|---------|-----------|--------------------------|--------------------|
| RM0038 | 31.2    | STM32L1   | 0x1FF80050 / 0x1FF800D0  | 0x00 / 0x04 / 0x14 |
| RM0367 | 34.2    | STM32L0x3 | 0x1FF80050               | 0x00 / 0x04 / 0x14 |
| RM0376 | 33.2    | STM32L0x2 | 0x1FF80050               | 0x00 / 0x04 / 0x14 |
| RM0377 | 28.2    | STM32L0x1 | 0x1FF80050               | 0x00 / 0x04 / 0x14 |
| RM0451 | 25.2    | STM32L0x0 | 0x1FF80050               | 0x00 / 0x04 / 0x14 |
