### PR TITLE
fix LPTIM variant mapping

### DIFF
--- a/stm32-data-gen/src/perimap.rs
+++ b/stm32-data-gen/src/perimap.rs
@@ -553,6 +553,8 @@ const PERIMAP: &[(&str, (&str, &str, &str))] = &[
     ("STM32L.*:TIM(16|17):.*", ("timer", "v1", "TIM_1CH_CMP")),
     // LPTIM for STM32Lx
     ("STM32L5.*:LPTIM.*:.*", ("lptim", "v1c", "LPTIM")),
+    // These L4 parts include the repetition counter and update-event flags.
+    ("STM32L4(P5|Q5|12|22).*:LPTIM.*:.*", ("lptim", "v1c", "LPTIM")),
     ("STM32L4[PQRS].*:LPTIM.*:.*", ("lptim", "v1b", "LPTIM")),
     ("STM32L4[^PQRS].*:LPTIM.*:.*", ("lptim", "v1a", "LPTIM")),
     ("STM32L0.*:LPTIM.*:.*", ("lptim", "v1", "LPTIM")),


### PR DESCRIPTION
I'm currently working on a project using the STM32L4P5 and its LPTIM is mapped to the wrong variant. During research I noticed a few other parts that are also incorrectly mapped to the v1b variant instead of the v1c.