### PR TITLE
dma: normalize C5 ADC GLOBAL signals to ADC instances

### DIFF
--- a/stm32-data-gen/src/package.rs
+++ b/stm32-data-gen/src/package.rs
@@ -870,11 +870,17 @@ fn build_dma(f: &dma::File, dma_map: &DmaMap, chip_name: &str) -> ChipDma {
                 continue;
             };
 
+            let signal = if interconnect.instance.starts_with("ADC") && signal_id.eq_ignore_ascii_case("global") {
+                interconnect.instance.clone()
+            } else {
+                signal_id.to_uppercase()
+            };
+
             peripherals
                 .entry(interconnect.instance.clone())
                 .or_default()
                 .push(peripheral::DmaChannel {
-                    signal: signal_id.to_uppercase(),
+                    signal,
                     dma: Some(instance.name.clone()),
                     channel: None,
                     dmamux: None,


### PR DESCRIPTION
STM32C5 package DMA metadata reports ADC DMA signals as `GLOBAL`, while equivalent ADC DMA signals on other families use the ADC instance name (`ADC1`, `ADC2`, etc.).

This prevents embassy-stm32 from generating the existing `RxDma<ADCx>` implementations.

Normalize ADC `GLOBAL` signals to their peripheral instance names when parsing package DMA metadata.