### PR TITLE
stm32c5: add CRC register mapping

### DIFF
--- a/stm32-data-gen/src/perimap.rs
+++ b/stm32-data-gen/src/perimap.rs
@@ -424,6 +424,7 @@ const PERIMAP: &[(&str, (&str, &str, &str))] = &[
     ("STM32H5.*:CRS:.*", ("crs", "v1", "CRS")),
     ("STM32H7.*:CRS:.*", ("crs", "v1", "CRS")),
     ("STM32WB.*:CRS:.*", ("crs", "v1", "CRS")),
+    ("STM32C5.*:CRS:.*", ("crs", "v1", "CRS")),
     (".*SDMMC:sdmmc2_v1_0.*", ("sdmmc", "v2", "SDMMC")),
     (".*SDMMC:sdmmc2_v2_1.*", ("sdmmc", "v2", "SDMMC")),
     (".*SDMMC:sdmmc2_v3_0.*", ("sdmmc", "v3", "SDMMC")),

--- a/stm32-data-gen/src/perimap.rs
+++ b/stm32-data-gen/src/perimap.rs
@@ -702,7 +702,7 @@ const PERIMAP: &[(&str, (&str, &str, &str))] = &[
     ("STM32N6.*:CRC:.*", ("crc", "v3", "CRC")),
     ("STM32WB0.*:CRC:.*", ("crc", "v3", "CRC")),
     ("STM32W[BL].*:CRC:.*", ("crc", "v3", "CRC")),
-    ("STM32C[0].*:CRC:.*", ("crc", "v3", "CRC")),
+    ("STM32C[05].*:CRC:.*", ("crc", "v3", "CRC")),
     ("STM32U[035].*:CRC:.*", ("crc", "v3", "CRC")),
     (".*:LCD:lcdc1_v1.0.*", ("lcd", "v1", "LCD")),
     (".*:LCD:lcdc1_v1.2.*", ("lcd", "v2", "LCD")),


### PR DESCRIPTION
Add STM32C5 CRC peripherals to the existing crc_v3 register mapping.

The STM32C5 CRC register layout matches crc_v3, including DR, IDR, CR, INIT and POL offsets and fields.

<img width="1372" height="1188" alt="图片" src="https://github.com/user-attachments/assets/9a80dcd8-ba84-4c41-bf51-32a16222c4c1" />
