### PR TITLE
stm32c5: add hash register mapping

### DIFF
--- a/data/registers/ccb_v2.yaml
+++ b/data/registers/ccb_v2.yaml
@@ -1,0 +1,51 @@
+block/CCB:
+  description: Coupling and chaining bridge
+  items:
+  - name: CR
+    description: CCB control register
+    byte_offset: 0
+    fieldset: CR
+  - name: SR
+    description: CCB status register
+    byte_offset: 4
+    access: Read
+    fieldset: SR
+  - name: REFTAGR
+    description: CCB reference tag register
+    array:
+      len: 4
+      stride: 4
+    byte_offset: 16
+fieldset/CR:
+  description: CCB control register
+  fields:
+  - name: CCOP
+    description: Coupling and chaining operation
+    bit_offset: 0
+    bit_size: 8
+  - name: IPRST
+    description: CCB reset
+    bit_offset: 31
+    bit_size: 1
+fieldset/SR:
+  description: CCB status register
+  fields:
+  - name: OPSTEP
+    description: Operation step
+    bit_offset: 0
+    bit_size: 5
+  - name: OPERR
+    description: Operation error
+    bit_offset: 8
+    bit_size: 6
+  - name: BUSY
+    description: CCB busy
+    bit_offset: 16
+    bit_size: 1
+  - name: TAMP_EVT
+    description: Tamper event flag
+    bit_offset: 24
+    bit_size: 1
+    array:
+      len: 6
+      stride: 1

--- a/data/registers/dac_v8.yaml
+++ b/data/registers/dac_v8.yaml
@@ -1,0 +1,367 @@
+block/DAC:
+  description: Digital-to-analog converter
+  items:
+  - name: CR
+    description: control register
+    byte_offset: 0
+    fieldset: CR
+  - name: SWTRIGR
+    description: software trigger register
+    byte_offset: 4
+    access: Write
+    fieldset: SWTRIGR
+  - name: DHR12R
+    description: channel 12-bit right-aligned data holding register
+    array:
+      len: 2
+      stride: 12
+    byte_offset: 8
+    fieldset: DHR12R
+  - name: DHR12L
+    description: channel 12-bit left-aligned data holding register
+    array:
+      len: 2
+      stride: 12
+    byte_offset: 12
+    fieldset: DHR12L
+  - name: DHR8R
+    description: channel 8-bit right-aligned data holding register
+    array:
+      len: 2
+      stride: 12
+    byte_offset: 16
+    fieldset: DHR8R
+  - name: DHR12RD
+    description: dual 12-bit right-aligned data holding register
+    byte_offset: 32
+    fieldset: DHR12RD
+  - name: DHR12LD
+    description: dual 12-bit left aligned data holding register
+    byte_offset: 36
+    fieldset: DHR12LD
+  - name: DHR8RD
+    description: dual 8-bit right aligned data holding register
+    byte_offset: 40
+    fieldset: DHR8RD
+  - name: DOR
+    description: channel data output register
+    array:
+      len: 2
+      stride: 4
+    byte_offset: 44
+    access: Read
+    fieldset: DOR
+  - name: SR
+    description: status register
+    byte_offset: 52
+    fieldset: SR
+  - name: CCR
+    description: calibration control register
+    byte_offset: 56
+    fieldset: CCR
+  - name: MCR
+    description: mode control register
+    byte_offset: 60
+    fieldset: MCR
+  - name: SHSR
+    description: sample and hold sample time register
+    array:
+      len: 2
+      stride: 4
+    byte_offset: 64
+    fieldset: SHSR
+  - name: SHHR
+    description: sample and hold hold time register
+    byte_offset: 72
+    fieldset: SHHR
+  - name: SHRR
+    description: sample and hold refresh time register
+    byte_offset: 76
+    fieldset: SHRR
+fieldset/CCR:
+  description: calibration control register
+  fields:
+  - name: OTRIM
+    description: channel offset trimming value
+    bit_offset: 0
+    bit_size: 5
+    array:
+      len: 2
+      stride: 16
+fieldset/CR:
+  description: control register
+  fields:
+  - name: EN
+    description: channel enable
+    bit_offset: 0
+    bit_size: 1
+    array:
+      len: 2
+      stride: 16
+  - name: TEN
+    description: channel trigger enable
+    bit_offset: 1
+    bit_size: 1
+    array:
+      len: 2
+      stride: 16
+  - name: TSEL
+    description: channel trigger selection
+    bit_offset: 2
+    bit_size: 4
+    array:
+      len: 2
+      stride: 16
+  - name: WAVE
+    description: channel noise/triangle wave generation enable
+    bit_offset: 6
+    bit_size: 2
+    array:
+      len: 2
+      stride: 16
+    enum: WAVE
+  - name: MAMP
+    description: channel mask/amplitude selector
+    bit_offset: 8
+    bit_size: 4
+    array:
+      len: 2
+      stride: 16
+  - name: DMAEN
+    description: channel DMA enable
+    bit_offset: 12
+    bit_size: 1
+    array:
+      len: 2
+      stride: 16
+  - name: DMAUDRIE
+    description: channel DMA Underrun Interrupt enable
+    bit_offset: 13
+    bit_size: 1
+    array:
+      len: 2
+      stride: 16
+  - name: CEN
+    description: DAC channel calibration enable
+    bit_offset: 14
+    bit_size: 1
+    array:
+      len: 2
+      stride: 16
+fieldset/DHR12L:
+  description: channel 12-bit left-aligned data holding register
+  fields:
+  - name: DHR
+    description: channel 12-bit left-aligned data
+    bit_offset: 4
+    bit_size: 12
+  - name: DHRB
+    description: channel 12-bit left-aligned data B
+    bit_offset: 20
+    bit_size: 12
+fieldset/DHR12LD:
+  description: dual 12-bit left aligned data holding register
+  fields:
+  - name: DHR
+    description: channel 12-bit left-aligned data
+    bit_offset: 4
+    bit_size: 12
+    array:
+      len: 2
+      stride: 16
+fieldset/DHR12R:
+  description: channel 12-bit right-aligned data holding register
+  fields:
+  - name: DHR
+    description: channel 12-bit right-aligned data
+    bit_offset: 0
+    bit_size: 12
+  - name: DHRB
+    description: channel 12-bit right-aligned data B
+    bit_offset: 16
+    bit_size: 12
+fieldset/DHR12RD:
+  description: dual 12-bit right-aligned data holding register
+  fields:
+  - name: DHR
+    description: channel 12-bit right-aligned data
+    bit_offset: 0
+    bit_size: 12
+    array:
+      len: 2
+      stride: 16
+fieldset/DHR8R:
+  description: channel 8-bit right-aligned data holding register
+  fields:
+  - name: DHR
+    description: channel 8-bit right-aligned data
+    bit_offset: 0
+    bit_size: 8
+  - name: DHRB
+    description: channel 8-bit right-aligned data B
+    bit_offset: 8
+    bit_size: 8
+fieldset/DHR8RD:
+  description: dual 8-bit right aligned data holding register
+  fields:
+  - name: DHR
+    description: channel 8-bit right-aligned data
+    bit_offset: 0
+    bit_size: 8
+    array:
+      len: 2
+      stride: 8
+fieldset/DOR:
+  description: channel data output register
+  fields:
+  - name: DOR
+    description: channel data output
+    bit_offset: 0
+    bit_size: 12
+  - name: DORB
+    description: channel data output B
+    bit_offset: 16
+    bit_size: 12
+fieldset/MCR:
+  description: mode control register
+  fields:
+  - name: MODE
+    description: DAC channel mode
+    bit_offset: 0
+    bit_size: 3
+    array:
+      len: 2
+      stride: 16
+    enum: MODE
+  - name: DMADOUBLE
+    description: channel DMA double data mode.
+    bit_offset: 8
+    bit_size: 1
+    array:
+      len: 2
+      stride: 16
+  - name: SINFORMAT
+    description: enable signed format for DAC channel
+    bit_offset: 9
+    bit_size: 1
+    array:
+      len: 2
+      stride: 16
+  - name: HFSEL
+    description: high frequency interface mode selection
+    bit_offset: 13
+    bit_size: 3
+fieldset/SHHR:
+  description: sample and hold hold time register
+  fields:
+  - name: THOLD
+    description: channel hold time
+    bit_offset: 0
+    bit_size: 10
+    array:
+      len: 2
+      stride: 16
+fieldset/SHRR:
+  description: sample and hold refresh time register
+  fields:
+  - name: TREFRESH
+    description: channel refresh time
+    bit_offset: 0
+    bit_size: 8
+    array:
+      len: 2
+      stride: 16
+fieldset/SHSR:
+  description: sample and hold sample time register
+  fields:
+  - name: TSAMPLE
+    description: channel sample time
+    bit_offset: 0
+    bit_size: 10
+fieldset/SR:
+  description: status register
+  fields:
+  - name: DACRDY
+    description: channel ready status bit
+    bit_offset: 11
+    bit_size: 1
+    array:
+      len: 2
+      stride: 16
+  - name: DORSTAT
+    description: channel output register status bit
+    bit_offset: 12
+    bit_size: 1
+    array:
+      len: 2
+      stride: 16
+  - name: DMAUDR
+    description: channel DMA underrun flag
+    bit_offset: 13
+    bit_size: 1
+    array:
+      len: 2
+      stride: 16
+  - name: CAL_FLAG
+    description: channel calibration offset status
+    bit_offset: 14
+    bit_size: 1
+    array:
+      len: 2
+      stride: 16
+  - name: BWST
+    description: channel busy writing sample time flag
+    bit_offset: 15
+    bit_size: 1
+    array:
+      len: 2
+      stride: 16
+fieldset/SWTRIGR:
+  description: software trigger register
+  fields:
+  - name: SWTRIG
+    description: channel software trigger
+    bit_offset: 0
+    bit_size: 1
+    array:
+      len: 2
+      stride: 1
+enum/MODE:
+  bit_size: 3
+  variants:
+  - name: NORMAL_EXT_BUFEN
+    description: Normal mode, external pin only, buffer enabled
+    value: 0
+  - name: NORMAL_EXT_INT_BUFEN
+    description: Normal mode, external pin and internal peripherals, buffer enabled
+    value: 1
+  - name: NORMAL_EXT_BUFDIS
+    description: Normal mode, external pin only, buffer disabled
+    value: 2
+  - name: NORMAL_INT_BUFDIS
+    description: Normal mode, internal peripherals only, buffer disabled
+    value: 3
+  - name: SAMPHOLD_EXT_BUFEN
+    description: Sample and hold mode, external pin only, buffer enabled
+    value: 4
+  - name: SAMPHOLD_EXT_INT_BUFEN
+    description: Sample and hold mode, external pin and internal peripherals, buffer enabled
+    value: 5
+  - name: SAMPHOLD_EXT_INT_BUFDIS
+    description: Sample and hold mode, external pin and internal peripherals, buffer disabled
+    value: 6
+  - name: SAMPHOLD_INT_BUFDIS
+    description: Sample and hold mode, internal peripherals only, buffer disabled
+    value: 7
+enum/WAVE:
+  bit_size: 2
+  variants:
+  - name: Disabled
+    description: Wave generation disabled
+    value: 0
+  - name: Noise
+    description: Noise wave generation enabled
+    value: 1
+  - name: Triangle
+    description: Triangle wave generation enabled
+    value: 2

--- a/data/registers/dac_v9.yaml
+++ b/data/registers/dac_v9.yaml
@@ -1,0 +1,250 @@
+block/DAC:
+  description: Digital-to-analog converter
+  items:
+  - name: CR
+    description: control register
+    byte_offset: 0
+    fieldset: CR
+  - name: SWTRIGR
+    description: software trigger register
+    byte_offset: 4
+    access: Write
+    fieldset: SWTRIGR
+  - name: DHR12R
+    description: channel 12-bit right-aligned data holding register
+    byte_offset: 8
+    fieldset: DHR12R
+  - name: DHR12L
+    description: channel 12-bit left-aligned data holding register
+    byte_offset: 12
+    fieldset: DHR12L
+  - name: DHR8R
+    description: channel 8-bit right-aligned data holding register
+    byte_offset: 16
+    fieldset: DHR8R
+  - name: DOR
+    description: channel data output register
+    byte_offset: 44
+    access: Read
+    fieldset: DOR
+  - name: SR
+    description: status register
+    byte_offset: 52
+    fieldset: SR
+  - name: CCR
+    description: calibration control register
+    byte_offset: 56
+    fieldset: CCR
+  - name: MCR
+    description: mode control register
+    byte_offset: 60
+    fieldset: MCR
+  - name: SHSR
+    description: sample and hold sample time register
+    byte_offset: 64
+    fieldset: SHSR
+  - name: SHHR
+    description: sample and hold hold time register
+    byte_offset: 72
+    fieldset: SHHR
+  - name: SHRR
+    description: sample and hold refresh time register
+    byte_offset: 76
+    fieldset: SHRR
+fieldset/CCR:
+  description: calibration control register
+  fields:
+  - name: OTRIM
+    description: channel offset trimming value
+    bit_offset: 0
+    bit_size: 5
+fieldset/CR:
+  description: control register
+  fields:
+  - name: EN
+    description: channel enable
+    bit_offset: 0
+    bit_size: 1
+  - name: TEN
+    description: channel trigger enable
+    bit_offset: 1
+    bit_size: 1
+  - name: TSEL
+    description: channel trigger selection
+    bit_offset: 2
+    bit_size: 4
+  - name: WAVE
+    description: channel noise/triangle wave generation enable
+    bit_offset: 6
+    bit_size: 2
+    enum: WAVE
+  - name: MAMP
+    description: channel mask/amplitude selector
+    bit_offset: 8
+    bit_size: 4
+  - name: DMAEN
+    description: channel DMA enable
+    bit_offset: 12
+    bit_size: 1
+  - name: DMAUDRIE
+    description: channel DMA Underrun Interrupt enable
+    bit_offset: 13
+    bit_size: 1
+  - name: CEN
+    description: DAC channel calibration enable
+    bit_offset: 14
+    bit_size: 1
+fieldset/DHR12L:
+  description: channel 12-bit left-aligned data holding register
+  fields:
+  - name: DHR
+    description: channel 12-bit left-aligned data
+    bit_offset: 4
+    bit_size: 12
+  - name: DHRB
+    description: channel 12-bit left-aligned data B
+    bit_offset: 20
+    bit_size: 12
+fieldset/DHR12R:
+  description: channel 12-bit right-aligned data holding register
+  fields:
+  - name: DHR
+    description: channel 12-bit right-aligned data
+    bit_offset: 0
+    bit_size: 12
+  - name: DHRB
+    description: channel 12-bit right-aligned data B
+    bit_offset: 16
+    bit_size: 12
+fieldset/DHR8R:
+  description: channel 8-bit right-aligned data holding register
+  fields:
+  - name: DHR
+    description: channel 8-bit right-aligned data
+    bit_offset: 0
+    bit_size: 8
+  - name: DHRB
+    description: channel 8-bit right-aligned data B
+    bit_offset: 8
+    bit_size: 8
+fieldset/DOR:
+  description: channel data output register
+  fields:
+  - name: DOR
+    description: channel data output
+    bit_offset: 0
+    bit_size: 12
+  - name: DORB
+    description: channel data output B
+    bit_offset: 16
+    bit_size: 12
+fieldset/MCR:
+  description: mode control register
+  fields:
+  - name: MODE
+    description: DAC channel mode
+    bit_offset: 0
+    bit_size: 3
+    enum: MODE
+  - name: DMADOUBLE
+    description: channel DMA double data mode.
+    bit_offset: 8
+    bit_size: 1
+  - name: SINFORMAT
+    description: enable signed format for DAC channel
+    bit_offset: 9
+    bit_size: 1
+  - name: HFSEL
+    description: high frequency interface mode selection
+    bit_offset: 13
+    bit_size: 3
+fieldset/SHHR:
+  description: sample and hold hold time register
+  fields:
+  - name: THOLD
+    description: channel hold time
+    bit_offset: 0
+    bit_size: 10
+fieldset/SHRR:
+  description: sample and hold refresh time register
+  fields:
+  - name: TREFRESH
+    description: channel refresh time
+    bit_offset: 0
+    bit_size: 8
+fieldset/SHSR:
+  description: sample and hold sample time register
+  fields:
+  - name: TSAMPLE
+    description: channel sample time
+    bit_offset: 0
+    bit_size: 10
+fieldset/SR:
+  description: status register
+  fields:
+  - name: DACRDY
+    description: channel ready status bit
+    bit_offset: 11
+    bit_size: 1
+  - name: DORSTAT
+    description: channel output register status bit
+    bit_offset: 12
+    bit_size: 1
+  - name: DMAUDR
+    description: channel DMA underrun flag
+    bit_offset: 13
+    bit_size: 1
+  - name: CAL_FLAG
+    description: channel calibration offset status
+    bit_offset: 14
+    bit_size: 1
+  - name: BWST
+    description: channel busy writing sample time flag
+    bit_offset: 15
+    bit_size: 1
+fieldset/SWTRIGR:
+  description: software trigger register
+  fields:
+  - name: SWTRIG
+    description: channel software trigger
+    bit_offset: 0
+    bit_size: 1
+enum/MODE:
+  bit_size: 3
+  variants:
+  - name: NORMAL_EXT_BUFEN
+    description: Normal mode, external pin only, buffer enabled
+    value: 0
+  - name: NORMAL_EXT_INT_BUFEN
+    description: Normal mode, external pin and internal peripherals, buffer enabled
+    value: 1
+  - name: NORMAL_EXT_BUFDIS
+    description: Normal mode, external pin only, buffer disabled
+    value: 2
+  - name: NORMAL_INT_BUFDIS
+    description: Normal mode, internal peripherals only, buffer disabled
+    value: 3
+  - name: SAMPHOLD_EXT_BUFEN
+    description: Sample and hold mode, external pin only, buffer enabled
+    value: 4
+  - name: SAMPHOLD_EXT_INT_BUFEN
+    description: Sample and hold mode, external pin and internal peripherals, buffer enabled
+    value: 5
+  - name: SAMPHOLD_EXT_INT_BUFDIS
+    description: Sample and hold mode, external pin and internal peripherals, buffer disabled
+    value: 6
+  - name: SAMPHOLD_INT_BUFDIS
+    description: Sample and hold mode, internal peripherals only, buffer disabled
+    value: 7
+enum/WAVE:
+  bit_size: 2
+  variants:
+  - name: Disabled
+    description: Wave generation disabled
+    value: 0
+  - name: Noise
+    description: Noise wave generation enabled
+    value: 1
+  - name: Triangle
+    description: Triangle wave generation enabled
+    value: 2

--- a/data/registers/hash_c5.yaml
+++ b/data/registers/hash_c5.yaml
@@ -1,0 +1,135 @@
+block/HASH:
+  description: Hash processor.
+  items:
+  - name: CR
+    description: control register.
+    byte_offset: 0
+    fieldset: CR
+  - name: DIN
+    description: data input register.
+    byte_offset: 4
+    access: Write
+  - name: STR
+    description: start register.
+    byte_offset: 8
+    fieldset: STR
+  - name: HRA
+    description: digest registers.
+    array:
+      len: 5
+      stride: 4
+    byte_offset: 12
+    access: Read
+  - name: IMR
+    description: interrupt enable register.
+    byte_offset: 32
+    fieldset: IMR
+  - name: SR
+    description: status register.
+    byte_offset: 36
+    fieldset: SR
+  - name: CSR
+    description: context swap registers.
+    array:
+      len: 54
+      stride: 4
+    byte_offset: 248
+  - name: HR
+    description: HASH digest register.
+    array:
+      len: 8
+      stride: 4
+    byte_offset: 784
+    access: Read
+fieldset/CR:
+  description: control register.
+  fields:
+  - name: INIT
+    description: Initialize message digest calculation.
+    bit_offset: 2
+    bit_size: 1
+  - name: DMAE
+    description: DMA enable.
+    bit_offset: 3
+    bit_size: 1
+  - name: DATATYPE
+    description: Data type selection.
+    bit_offset: 4
+    bit_size: 2
+  - name: MODE
+    description: Mode selection.
+    bit_offset: 6
+    bit_size: 1
+  - name: NBW
+    description: Number of words already pushed.
+    bit_offset: 8
+    bit_size: 4
+  - name: DINNE
+    description: DIN not empty.
+    bit_offset: 12
+    bit_size: 1
+  - name: MDMAT
+    description: Multiple DMA Transfers.
+    bit_offset: 13
+    bit_size: 1
+  - name: LKEY
+    description: Long key selection.
+    bit_offset: 16
+    bit_size: 1
+  - name: ALGO
+    description: Algorithm selection.
+    bit_offset: 17
+    bit_size: 2
+fieldset/IMR:
+  description: interrupt enable register.
+  fields:
+  - name: DINIE
+    description: Data input interrupt enable.
+    bit_offset: 0
+    bit_size: 1
+  - name: DCIE
+    description: Digest calculation completion interrupt enable.
+    bit_offset: 1
+    bit_size: 1
+fieldset/SR:
+  description: status register.
+  fields:
+  - name: DINIS
+    description: Data input interrupt status.
+    bit_offset: 0
+    bit_size: 1
+  - name: DCIS
+    description: Digest calculation completion interrupt status.
+    bit_offset: 1
+    bit_size: 1
+  - name: DMAS
+    description: DMA Status.
+    bit_offset: 2
+    bit_size: 1
+  - name: BUSY
+    description: Busy bit.
+    bit_offset: 3
+    bit_size: 1
+  - name: NBWP
+    description: Number of words already pushed.
+    bit_offset: 9
+    bit_size: 5
+  - name: DINNE
+    description: DIN not empty.
+    bit_offset: 15
+    bit_size: 1
+  - name: NBWE
+    description: Number of words expected.
+    bit_offset: 16
+    bit_size: 5
+fieldset/STR:
+  description: start register.
+  fields:
+  - name: NBLW
+    description: Number of valid bits in the last word of the message.
+    bit_offset: 0
+    bit_size: 5
+  - name: DCAL
+    description: Digest calculation.
+    bit_offset: 8
+    bit_size: 1

--- a/data/registers/icache_v1_4crr_nomstsel.yaml
+++ b/data/registers/icache_v1_4crr_nomstsel.yaml
@@ -1,0 +1,171 @@
+block/ICACHE:
+  description: Instruction Cache Control Registers.
+  items:
+  - name: CR
+    description: ICACHE control register.
+    byte_offset: 0
+    fieldset: CR
+  - name: SR
+    description: ICACHE status register.
+    byte_offset: 4
+    access: Read
+    fieldset: SR
+  - name: IER
+    description: ICACHE interrupt enable register.
+    byte_offset: 8
+    fieldset: IER
+  - name: FCR
+    description: ICACHE flag clear register.
+    byte_offset: 12
+    access: Write
+    fieldset: FCR
+  - name: HMONR
+    description: ICACHE hit monitor register.
+    byte_offset: 16
+    access: Read
+  - name: MMONR
+    description: ICACHE miss monitor register.
+    byte_offset: 20
+    access: Read
+    fieldset: MMONR
+  - name: CRR
+    description: Cluster CRR%s, container region configuration registers.
+    array:
+      len: 4
+      stride: 4
+    byte_offset: 32
+    fieldset: CRR
+fieldset/CR:
+  description: ICACHE control register.
+  fields:
+  - name: EN
+    description: EN.
+    bit_offset: 0
+    bit_size: 1
+  - name: CACHEINV
+    description: Set by software and cleared by hardware when the BUSYF flag is set (during cache maintenance operation). Writing 0 has no effect.
+    bit_offset: 1
+    bit_size: 1
+  - name: WAYSEL
+    description: This bit allows user to choose ICACHE set-associativity. It can be written by software only when cache is disabled (EN = 0).
+    bit_offset: 2
+    bit_size: 1
+    enum: WAYSEL
+  - name: HITMEN
+    description: Hit monitor enable.
+    bit_offset: 16
+    bit_size: 1
+  - name: MISSMEN
+    description: Miss monitor enable.
+    bit_offset: 17
+    bit_size: 1
+  - name: HITMRST
+    description: Hit monitor reset.
+    bit_offset: 18
+    bit_size: 1
+  - name: MISSMRST
+    description: Miss monitor reset.
+    bit_offset: 19
+    bit_size: 1
+fieldset/CRR:
+  description: ICACHE region configuration register.
+  fields:
+  - name: BASEADDR
+    description: base address for region.
+    bit_offset: 0
+    bit_size: 8
+  - name: RSIZE
+    description: size for region.
+    bit_offset: 9
+    bit_size: 3
+    enum: RSIZE
+  - name: REN
+    description: enable for region.
+    bit_offset: 15
+    bit_size: 1
+  - name: REMAPADDR
+    description: remapped address for region.
+    bit_offset: 16
+    bit_size: 11
+  - name: HBURST
+    description: output burst type for region.
+    bit_offset: 31
+    bit_size: 1
+    enum: HBURST
+fieldset/FCR:
+  description: ICACHE flag clear register.
+  fields:
+  - name: CBSYENDF
+    description: Clear busy end flag.
+    bit_offset: 1
+    bit_size: 1
+  - name: CERRF
+    description: Clear ERRF flag in SR.
+    bit_offset: 2
+    bit_size: 1
+fieldset/IER:
+  description: ICACHE interrupt enable register.
+  fields:
+  - name: BSYENDIE
+    description: Interrupt enable on busy end.
+    bit_offset: 1
+    bit_size: 1
+  - name: ERRIE
+    description: Error interrupt on cache error.
+    bit_offset: 2
+    bit_size: 1
+fieldset/MMONR:
+  description: ICACHE miss monitor register.
+  fields:
+  - name: MISSMON
+    description: Miss monitor register.
+    bit_offset: 0
+    bit_size: 16
+fieldset/SR:
+  description: ICACHE status register.
+  fields:
+  - name: BUSYF
+    description: cache busy executing a full invalidate CACHEINV operation.
+    bit_offset: 0
+    bit_size: 1
+  - name: BSYENDF
+    description: full invalidate CACHEINV operation finished.
+    bit_offset: 1
+    bit_size: 1
+  - name: ERRF
+    description: an error occurred during the operation.
+    bit_offset: 2
+    bit_size: 1
+enum/HBURST:
+  bit_size: 1
+  variants:
+  - name: Wrap
+    value: 0
+  - name: Increment
+    value: 1
+enum/RSIZE:
+  bit_size: 3
+  variants:
+  - name: MegaBytes2
+    value: 1
+  - name: MegaBytes4
+    value: 2
+  - name: MegaBytes8
+    value: 3
+  - name: MegaBytes16
+    value: 4
+  - name: MegaBytes32
+    value: 5
+  - name: MegaBytes64
+    value: 6
+  - name: MegaBytes128
+    value: 7
+enum/WAYSEL:
+  bit_size: 1
+  variants:
+  - name: DirectMapped
+    description: direct mapped cache (1-way cache)
+    value: 0
+  - name: NWaySetAssociative
+    description: n-way set associative cache (reset value)
+    value: 1

--- a/stm32-data-gen/src/perimap.rs
+++ b/stm32-data-gen/src/perimap.rs
@@ -845,6 +845,7 @@ const PERIMAP: &[(&str, (&str, &str, &str))] = &[
     ("STM32(L5|WL|WB|WB0).*:PKA:.*", ("pka", "v1c", "PKA")),
     ("STM32(L4Q|L5|WL|WB).*:PKA:.*", ("pka", "v1c", "PKA")),
     ("STM32U3.*:CCB:.*", ("ccb", "v1", "CCB")),
+    ("STM32C5A3.*:CCB:.*", ("ccb", "v2", "CCB")),
     ("STM32U3.*:HSP1:.*", ("hsp", "v1", "HSP")),
     (".*:OTFDEC:.*", ("otfdec", "v1", "OTFDEC")),
     // N6 XSPI support

--- a/stm32-data-gen/src/perimap.rs
+++ b/stm32-data-gen/src/perimap.rs
@@ -794,6 +794,7 @@ const PERIMAP: &[(&str, (&str, &str, &str))] = &[
     (".*:HASH:hash1_v2_0", ("hash", "v2", "HASH")),
     ("STM32U5.*:HASH:.*", ("hash", "v4", "HASH")),
     ("STM32WBA.*:HASH:.*", ("hash", "v4", "HASH")),
+    ("STM32C5.*:HASH:.*", ("hash", "c5", "HASH")),
     (".*:HASH:hash1_v2_2", ("hash", "v2", "HASH")),
     (".*:HASH:hash1_v4_0", ("hash", "v3", "HASH")),
     (".*:HASH:hash1_v4_0_N6", ("hash", "v3", "HASH")),

--- a/stm32-data-gen/src/perimap.rs
+++ b/stm32-data-gen/src/perimap.rs
@@ -166,7 +166,8 @@ const PERIMAP: &[(&str, (&str, &str, &str))] = &[
     (".*:I2C:i2c1_v1_0H7RS", ("i2c", "v3", "I2C")),
     (".*:I2C:i2c1_v1_0N6", ("i2c", "v3", "I2C")),
     (".*:FMPI2C:i2c2_v1_1", ("fmpi2c", "v2", "FMPI2C")),
-    ("STM32C5.*:DAC:.*", ("dac", "v8", "DAC")),
+    ("STM32C5(31|32|42).*:DAC:.*", ("dac", "v8", "DAC")),
+    ("STM32C5(51|52|62|91|93|A3).*:DAC:.*", ("dac", "v9", "DAC")),
     ("STM32F10[1357].*:DAC:dacif_v1_1F1", ("dac", "v1", "DAC")), // Original F1 are v1
     (".*:DAC:dacif_v1_1F1", ("dac", "v2", "DAC")),
     (".*:DAC:F0dacif_v1_1", ("dac", "v2", "DAC")),
@@ -758,6 +759,11 @@ const PERIMAP: &[(&str, (&str, &str, &str))] = &[
     ("STM32L4.*:GFXMMU:.*", ("gfxmmu", "v1", "GFXMMU")),
     ("STM32U5.*:GFXMMU:.*", ("gfxmmu", "v2", "GFXMMU")),
     ("STM32N6.*:GFXMMU:.*", ("gfxmmu", "n6", "GFXMMU")),
+    (
+        "STM32C5(31|32|42|51|52|62).*:ICACHE:.*",
+        ("icache", "v1_4crr_nomstsel", "ICACHE"),
+    ),
+    ("STM32C5(91|93|A3).*:ICACHE:.*", ("icache", "v1_4crr", "ICACHE")),
     ("STM32U5.*:ICACHE:.*", ("icache", "v1_3crr", "ICACHE")),
     ("STM32U3.*:ICACHE:.*", ("icache", "v1_3crr", "ICACHE")),
     ("STM32H50.*:ICACHE:.*", ("icache", "v1_0crr", "ICACHE")),

--- a/stm32-data-gen/src/perimap.rs
+++ b/stm32-data-gen/src/perimap.rs
@@ -166,6 +166,7 @@ const PERIMAP: &[(&str, (&str, &str, &str))] = &[
     (".*:I2C:i2c1_v1_0H7RS", ("i2c", "v3", "I2C")),
     (".*:I2C:i2c1_v1_0N6", ("i2c", "v3", "I2C")),
     (".*:FMPI2C:i2c2_v1_1", ("fmpi2c", "v2", "FMPI2C")),
+    ("STM32C5.*:DAC:.*", ("dac", "v8", "DAC")),
     ("STM32F10[1357].*:DAC:dacif_v1_1F1", ("dac", "v1", "DAC")), // Original F1 are v1
     (".*:DAC:dacif_v1_1F1", ("dac", "v2", "DAC")),
     (".*:DAC:F0dacif_v1_1", ("dac", "v2", "DAC")),


### PR DESCRIPTION
Add a dedicated HASH register mapping for STM32C5 devices.

The STM32C5 HASH peripheral register layout does not fully match any of the existing `hash_v*.yaml` mappings, so it requires a separate mapping.

The new `hash_c5.yaml` is based on `hash_v4.yaml` and has been updated to match the STM32C5 reference manual, including changing the `ALGO` field width from 3 bits to 2 bits.