### PR TITLE
hrtim: standardize X suffix

### DIFF
--- a/data/registers/hrtim_v1.yaml
+++ b/data/registers/hrtim_v1.yaml
@@ -40,14 +40,14 @@ block/HRTIM:
       - 12
       - 16
     byte_offset: 28
-    fieldset: MCMPX
+    fieldset: MCMP
   - name: TIM
     description: 'High Resolution Timer: Timing Unit'
     array:
       len: 5
       stride: 128
     byte_offset: 128
-    block: HRTIM_TIMX
+    block: HRTIM_TIM
   - name: CR1
     description: 'High Resolution Timer: Control Register 1'
     byte_offset: 896
@@ -154,7 +154,7 @@ block/HRTIM:
     byte_offset: 1008
     access: Write
     fieldset: HRTIM_BDMADR
-block/HRTIM_TIMX:
+block/HRTIM_TIM:
   description: 'High Resolution Timer: Timing Unit'
   items:
   - name: CR
@@ -1000,7 +1000,7 @@ fieldset/HRTIM_OENR:
       - 4
       - 6
       - 8
-fieldset/MCMPX:
+fieldset/MCMP:
   description: Master Timer Compare X Register
   fields:
   - name: MCMP
@@ -1892,7 +1892,7 @@ fieldset/TIMXSETR:
     description: Master Period
     bit_offset: 7
     bit_size: 1
-  - name: MSTCMPX
+  - name: MSTCMP
     description: Master Compare X
     bit_offset: 8
     bit_size: 1

--- a/data/registers/hrtim_v2.yaml
+++ b/data/registers/hrtim_v2.yaml
@@ -40,14 +40,14 @@ block/HRTIM:
       - 12
       - 16
     byte_offset: 28
-    fieldset: MCMPX
+    fieldset: MCMP
   - name: TIM
     description: 'High Resolution Timer: Timing Unit'
     array:
       len: 6
       stride: 128
     byte_offset: 128
-    block: HRTIM_TIMX
+    block: HRTIM_TIM
   - name: CR1
     description: 'High Resolution Timer: Control Register 1'
     byte_offset: 896
@@ -170,7 +170,7 @@ block/HRTIM:
     description: 'High Resolution Timer: ADC Post Scaler Register 2'
     byte_offset: 1028
     fieldset: HRTIM_ADCPS2
-block/HRTIM_TIMX:
+block/HRTIM_TIM:
   description: 'High Resolution Timer: Timing Unit'
   items:
   - name: CR
@@ -1019,7 +1019,7 @@ fieldset/HRTIM_OENR:
       - 6
       - 8
       - 10
-fieldset/MCMPX:
+fieldset/MCMP:
   description: Master Timer Compare X Register
   fields:
   - name: MCMP
@@ -1913,7 +1913,7 @@ fieldset/TIMXSETR:
     description: Master Period
     bit_offset: 7
     bit_size: 1
-  - name: MSTCMPX
+  - name: MSTCMP
     description: Master Compare X
     bit_offset: 8
     bit_size: 1


### PR DESCRIPTION
The majority of items referencing one of many timers / CMPs are not suffixed with X, but this is currently not consistent. This results in, for example, TIMXSETR containing a register named MSTCMPX, whereas TIMXRSTR has MSTCMP.