### PR TITLE
stm32c5: add iwdg register mapping

### DIFF
--- a/data/registers/iwdg_c5.yaml
+++ b/data/registers/iwdg_c5.yaml
@@ -1,0 +1,150 @@
+block/IWDG:
+  description: Independent watchdog
+  items:
+  - name: KR
+    description: Key register
+    byte_offset: 0
+    access: Write
+    fieldset: KR
+  - name: PR
+    description: Prescaler register
+    byte_offset: 4
+    fieldset: PR
+  - name: RLR
+    description: Reload register
+    byte_offset: 8
+    fieldset: RLR
+  - name: SR
+    description: Status register
+    byte_offset: 12
+    access: Read
+    fieldset: SR
+  - name: WINR
+    description: Window register
+    byte_offset: 16
+    fieldset: WINR
+  - name: EWCR
+    description: Early wakeup interrupt register
+    byte_offset: 20
+    fieldset: EWCR
+  - name: ICR
+    description: Interrupt clear register
+    byte_offset: 24
+    fieldset: ICR
+fieldset/EWCR:
+  description: Early wakeup interrupt register
+  fields:
+  - name: EWIT
+    description: Watchdog counter early wakeup interrupt value
+    bit_offset: 0
+    bit_size: 12
+  - name: EWIE
+    description: Watchdog early interrupt enable
+    bit_offset: 15
+    bit_size: 1
+fieldset/ICR:
+  description: Interrupt clear register
+  fields:
+  - name: EWIC
+    description: Watchdog early interrupt acknowledge
+    bit_offset: 15
+    bit_size: 1
+fieldset/KR:
+  description: Key register
+  fields:
+  - name: KEY
+    description: Key value (write only, read 0000h)
+    bit_offset: 0
+    bit_size: 16
+    enum: KEY
+fieldset/PR:
+  description: Prescaler register
+  fields:
+  - name: PR
+    description: Prescaler divider
+    bit_offset: 0
+    bit_size: 4
+    enum: PR
+fieldset/RLR:
+  description: Reload register
+  fields:
+  - name: RL
+    description: Watchdog counter reload value
+    bit_offset: 0
+    bit_size: 12
+fieldset/SR:
+  description: Status register
+  fields:
+  - name: PVU
+    description: Watchdog prescaler value update
+    bit_offset: 0
+    bit_size: 1
+  - name: RVU
+    description: Watchdog counter reload value update
+    bit_offset: 1
+    bit_size: 1
+  - name: WVU
+    description: Watchdog counter window value update
+    bit_offset: 2
+    bit_size: 1
+  - name: EWU
+    description: Watchdog interrupt comparator value update
+    bit_offset: 3
+    bit_size: 1
+  - name: ONF
+    description: Watchdog enable status bit
+    bit_offset: 8
+    bit_size: 1
+  - name: EWIF
+    description: Watchdog early interrupt flag
+    bit_offset: 15
+    bit_size: 1
+fieldset/WINR:
+  description: Window register
+  fields:
+  - name: WIN
+    description: Watchdog counter window value
+    bit_offset: 0
+    bit_size: 12
+enum/KEY:
+  bit_size: 16
+  variants:
+  - name: Enable
+    description: Enable access to PR, RLR and WINR registers (0x5555)
+    value: 21845
+  - name: Reset
+    description: Reset the watchdog value (0xAAAA)
+    value: 43690
+  - name: Start
+    description: Start the watchdog (0xCCCC)
+    value: 52428
+enum/PR:
+  bit_size: 4
+  variants:
+  - name: DivideBy4
+    description: Divider /4
+    value: 0
+  - name: DivideBy8
+    description: Divider /8
+    value: 1
+  - name: DivideBy16
+    description: Divider /16
+    value: 2
+  - name: DivideBy32
+    description: Divider /32
+    value: 3
+  - name: DivideBy64
+    description: Divider /64
+    value: 4
+  - name: DivideBy128
+    description: Divider /128
+    value: 5
+  - name: DivideBy256
+    description: Divider /256
+    value: 6
+  - name: DivideBy512
+    description: Divider /512
+    value: 7
+  - name: DivideBy1024
+    description: Divider /1024
+    value: 8

--- a/stm32-data-gen/src/perimap.rs
+++ b/stm32-data-gen/src/perimap.rs
@@ -268,6 +268,7 @@ const PERIMAP: &[(&str, (&str, &str, &str))] = &[
     ("STM32H50.*:SYSCFG:.*", ("syscfg", "h50", "SYSCFG")),
     ("STM32H5.*:SYSCFG:.*", ("syscfg", "h5", "SYSCFG")),
     ("STM32N6.*:SYSCFG:.*", ("syscfg", "n6", "SYSCFG")),
+    ("STM32C5.*:IWDG:.*", ("iwdg", "c5", "IWDG")),
     (".*:IWDG:iwdg1_v1_1", ("iwdg", "v1", "IWDG")),
     (".*:IWDG:iwdg1_v2_0", ("iwdg", "v2", "IWDG")),
     (".*:IWDG:iwdg1_v3_0", ("iwdg", "v3", "IWDG")),


### PR DESCRIPTION
## Summary

- add a dedicated STM32C5 IWDG register definition based on RM0522
- add the missing `ONF` and `ICR` fields
- place `EWIF` and `EWIC` at bit 15
- map all STM32C5 devices to the new `iwdg/c5` register block

## Testing

- `cargo test --workspace`
- `cargo run --release --bin stm32-data-gen`
- `cargo run --release --bin stm32-metapac-gen`
- built representative STM32C531, STM32C551, and STM32C5A3 PACs for `thumbv8m.main-none-eabihf`
- verified all 80 STM32C5 chip definitions map to `iwdg/c5`

closes #886.