### PR TITLE
stm32-data-gen: add perimap metadata lookup toolSearch meta

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,9 +221,27 @@ When parsing a chip, for each peripheral a "key" string is constructed using thi
 - `CHIP`: full chip name, for example `STM32L443CC`
 - `PERIPHERAL_NAME`: peripheral name, for example `SPI3`. Corresponds to `IP.InstanceName` in the [MCU XML](https://github.com/embassy-rs/stm32-data-sources/blob/949842b4b8742e6bc70ae29a0ede14b4066db819/cubedb/mcu/STM32L443CCYx.xml#L38).
 - `IP_NAME`: IP name, for example `SPI`. Corresponds to `IP.Name` in the [MCU XML](https://github.com/embassy-rs/stm32-data-sources/blob/949842b4b8742e6bc70ae29a0ede14b4066db819/cubedb/mcu/STM32L443CCYx.xml#L38).
-- `IP_VERSION`: IP version, for example `spi2s1_v3_3_Cube`, Corresponds to `IP.Version` in the [MCU XML](https://github.com/embassy-rs/stm32-data-sources/blob/949842b4b8742e6bc70ae29a0ede14b4066db819/cubedb/mcu/STM32L443CCYx.xml#L38).
+- `IP_VERSION`: IP version, for example `spi2s1_v3_3`. Corresponds to `IP.Version` in the [MCU XML](https://github.com/embassy-rs/stm32-data-sources/blob/949842b4b8742e6bc70ae29a0ede14b4066db819/cubedb/mcu/STM32L443CCYx.xml#L38), with a trailing `_Cube` removed.
 
 `perimap` entries are regexes matching on the above "key" string. First regex that matches wins.
+
+#### Looking up perimap keys
+
+Use the `perimap-keys` tool to inspect the keys available for a chip or chip-family prefix:
+
+```bash
+cargo run --bin perimap-keys -- --chip STM32C5 --peripheral RTC
+```
+
+This prints:
+
+```text
+STM32C5:RTC:RTC:c7amba_rtc3
+```
+
+`--chip` accepts either a full chip name, such as `STM32C531KC`, or a family prefix, such as `STM32C5`. `--peripheral` accepts either an instance name, such as `ADC1`, or an IP name, such as `ADC`. When multiple source records match, the tool prints the unique keys in sorted order.
+
+The tool reads STM32C5 metadata from the CubeProgrammer DB2 JSON files and metadata for other families from the legacy CubeDB MCU XML files.
 
 The IP version is particularly useful. It is an ST-internal "IP version" that's incremented every time changes are made to the peripheral, so it
 correlates very well to changes in the peripheral's register interface.

--- a/data/registers/iwdg_c5.yaml
+++ b/data/registers/iwdg_c5.yaml
@@ -1,0 +1,150 @@
+block/IWDG:
+  description: Independent watchdog
+  items:
+  - name: KR
+    description: Key register
+    byte_offset: 0
+    access: Write
+    fieldset: KR
+  - name: PR
+    description: Prescaler register
+    byte_offset: 4
+    fieldset: PR
+  - name: RLR
+    description: Reload register
+    byte_offset: 8
+    fieldset: RLR
+  - name: SR
+    description: Status register
+    byte_offset: 12
+    access: Read
+    fieldset: SR
+  - name: WINR
+    description: Window register
+    byte_offset: 16
+    fieldset: WINR
+  - name: EWCR
+    description: Early wakeup interrupt register
+    byte_offset: 20
+    fieldset: EWCR
+  - name: ICR
+    description: Interrupt clear register
+    byte_offset: 24
+    fieldset: ICR
+fieldset/EWCR:
+  description: Early wakeup interrupt register
+  fields:
+  - name: EWIT
+    description: Watchdog counter early wakeup interrupt value
+    bit_offset: 0
+    bit_size: 12
+  - name: EWIE
+    description: Watchdog early interrupt enable
+    bit_offset: 15
+    bit_size: 1
+fieldset/ICR:
+  description: Interrupt clear register
+  fields:
+  - name: EWIC
+    description: Watchdog early interrupt acknowledge
+    bit_offset: 15
+    bit_size: 1
+fieldset/KR:
+  description: Key register
+  fields:
+  - name: KEY
+    description: Key value (write only, read 0000h)
+    bit_offset: 0
+    bit_size: 16
+    enum: KEY
+fieldset/PR:
+  description: Prescaler register
+  fields:
+  - name: PR
+    description: Prescaler divider
+    bit_offset: 0
+    bit_size: 4
+    enum: PR
+fieldset/RLR:
+  description: Reload register
+  fields:
+  - name: RL
+    description: Watchdog counter reload value
+    bit_offset: 0
+    bit_size: 12
+fieldset/SR:
+  description: Status register
+  fields:
+  - name: PVU
+    description: Watchdog prescaler value update
+    bit_offset: 0
+    bit_size: 1
+  - name: RVU
+    description: Watchdog counter reload value update
+    bit_offset: 1
+    bit_size: 1
+  - name: WVU
+    description: Watchdog counter window value update
+    bit_offset: 2
+    bit_size: 1
+  - name: EWU
+    description: Watchdog interrupt comparator value update
+    bit_offset: 3
+    bit_size: 1
+  - name: ONF
+    description: Watchdog enable status bit
+    bit_offset: 8
+    bit_size: 1
+  - name: EWIF
+    description: Watchdog early interrupt flag
+    bit_offset: 15
+    bit_size: 1
+fieldset/WINR:
+  description: Window register
+  fields:
+  - name: WIN
+    description: Watchdog counter window value
+    bit_offset: 0
+    bit_size: 12
+enum/KEY:
+  bit_size: 16
+  variants:
+  - name: Enable
+    description: Enable access to PR, RLR and WINR registers (0x5555)
+    value: 21845
+  - name: Reset
+    description: Reset the watchdog value (0xAAAA)
+    value: 43690
+  - name: Start
+    description: Start the watchdog (0xCCCC)
+    value: 52428
+enum/PR:
+  bit_size: 4
+  variants:
+  - name: DivideBy4
+    description: Divider /4
+    value: 0
+  - name: DivideBy8
+    description: Divider /8
+    value: 1
+  - name: DivideBy16
+    description: Divider /16
+    value: 2
+  - name: DivideBy32
+    description: Divider /32
+    value: 3
+  - name: DivideBy64
+    description: Divider /64
+    value: 4
+  - name: DivideBy128
+    description: Divider /128
+    value: 5
+  - name: DivideBy256
+    description: Divider /256
+    value: 6
+  - name: DivideBy512
+    description: Divider /512
+    value: 7
+  - name: DivideBy1024
+    description: Divider /1024
+    value: 8

--- a/stm32-data-gen/src/bin/perimap-keys.rs
+++ b/stm32-data-gen/src/bin/perimap-keys.rs
@@ -1,0 +1,155 @@
+use std::collections::BTreeSet;
+use std::fmt;
+use std::path::Path;
+
+use clap::Parser;
+use glob::glob;
+use serde::Deserialize;
+
+const C5_PERIPHERALS_DIR: &str = "sources/cubeprogdb2/stm32c5/Descriptors/peripherals";
+
+#[derive(Debug, Deserialize)]
+struct PeripheralFile {
+    #[serde(default)]
+    peripherals: Vec<Peripheral>,
+}
+
+#[derive(Debug, Deserialize)]
+struct Peripheral {
+    #[serde(default, rename = "digitalName")]
+    digital_name: String,
+
+    #[serde(default)]
+    name: String,
+
+    #[serde(default, rename = "peripheralType")]
+    peripheral_type: String,
+}
+
+impl fmt::Display for Peripheral {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{}:{}:{}",
+            self.name,
+            self.peripheral_type.to_ascii_uppercase(),
+            self.digital_name,
+        )
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct McuFile {
+    #[serde(default, rename = "IP")]
+    ips: Vec<Ip>,
+}
+
+#[derive(Debug, Deserialize)]
+struct Ip {
+    #[serde(rename = "@InstanceName")]
+    instance_name: String,
+
+    #[serde(rename = "@Name")]
+    name: String,
+
+    #[serde(rename = "@Version")]
+    version: String,
+}
+
+#[derive(Parser)]
+#[command(name = "perimap-keys")]
+#[command(about = "List raw peripheral metadata used to build perimap keys")]
+struct Args {
+    /// Chip name or family prefix, for example STM32C531 or STM32C0
+    #[arg(short, long)]
+    chip: String,
+
+    /// Peripheral instance or IP name, for example RTC or ADC
+    #[arg(short, long)]
+    peripheral: String,
+}
+
+fn c5_peripheral_files(chip: &str) -> &'static [&'static str] {
+    if chip.starts_with("STM32C531") || chip.starts_with("STM32C532") || chip.starts_with("STM32C542") {
+        &["D44F_peripherals.json"]
+    } else if chip.starts_with("STM32C551") || chip.starts_with("STM32C552") || chip.starts_with("STM32C562") {
+        &["D44E_peripherals.json"]
+    } else if chip.starts_with("STM32C591") || chip.starts_with("STM32C593") || chip.starts_with("STM32C5A3") {
+        &["D45A_peripherals.json"]
+    } else if chip == "STM32C5" {
+        &[
+            "D44E_peripherals.json",
+            "D44F_peripherals.json",
+            "D45A_peripherals.json",
+        ]
+    } else {
+        &[]
+    }
+}
+
+fn search_cubeprogdb2(chip: &str, peripheral_name: &str) -> anyhow::Result<BTreeSet<String>> {
+    let files = c5_peripheral_files(chip);
+    anyhow::ensure!(!files.is_empty(), "unsupported STM32C5 chip or prefix: {chip}");
+
+    let mut results = BTreeSet::new();
+
+    for file_name in files {
+        let path = Path::new(C5_PERIPHERALS_DIR).join(file_name);
+        let input = std::fs::File::open(&path)?;
+        let file: PeripheralFile = serde_json::from_reader(input)?;
+
+        for peripheral in file.peripherals {
+            if peripheral.name.eq_ignore_ascii_case(peripheral_name)
+                || peripheral.peripheral_type.eq_ignore_ascii_case(peripheral_name)
+            {
+                results.insert(peripheral.to_string());
+            }
+        }
+    }
+
+    Ok(results)
+}
+
+fn search_cubedb(chip: &str, peripheral_name: &str) -> anyhow::Result<BTreeSet<String>> {
+    let pattern = format!("sources/cubedb/mcu/{chip}*.xml");
+    let mut results = BTreeSet::new();
+
+    for path in glob(&pattern)? {
+        let path = path?;
+        let content = std::fs::read_to_string(path)?;
+        let mcu: McuFile = quick_xml::de::from_str(&content)?;
+
+        for ip in mcu.ips {
+            if ip.name.eq_ignore_ascii_case(peripheral_name) || ip.instance_name.eq_ignore_ascii_case(peripheral_name) {
+                let version = ip.version.strip_suffix("_Cube").unwrap_or(&ip.version);
+                results.insert(format!("{}:{}:{version}", ip.instance_name, ip.name));
+            }
+        }
+    }
+
+    Ok(results)
+}
+
+fn main() -> anyhow::Result<()> {
+    let args = Args::parse();
+    let chip = args.chip.to_ascii_uppercase();
+
+    let results = if chip.starts_with("STM32C5") {
+        search_cubeprogdb2(&chip, &args.peripheral)?
+    } else {
+        search_cubedb(&chip, &args.peripheral)?
+    };
+
+    anyhow::ensure!(
+        !results.is_empty(),
+        "no {} metadata found for {}",
+        args.peripheral,
+        args.chip,
+    );
+
+    for key in results {
+        println!("{chip}:{key}");
+    }
+
+    Ok(())
+}

--- a/stm32-data-gen/src/perimap.rs
+++ b/stm32-data-gen/src/perimap.rs
@@ -272,6 +272,7 @@ const PERIMAP: &[(&str, (&str, &str, &str))] = &[
     (".*:IWDG:iwdg1_v1_1", ("iwdg", "v1", "IWDG")),
     (".*:IWDG:iwdg1_v2_0", ("iwdg", "v2", "IWDG")),
     (".*:IWDG:iwdg1_v3_0", ("iwdg", "v3", "IWDG")),
+    ("STM32C5.*:WWDG:.*", ("wwdg", "v2", "WWDG")),
     (".*:WWDG:wwdg1_v1_0", ("wwdg", "v1", "WWDG")),
     (".*:WWDG:wwdg1_v2_0", ("wwdg", "v2", "WWDG")),
     (".*:JPEG:jpeg1_v1_0", ("jpeg", "v1", "JPEG")),

--- a/stm32-data-gen/src/perimap.rs
+++ b/stm32-data-gen/src/perimap.rs
@@ -268,6 +268,7 @@ const PERIMAP: &[(&str, (&str, &str, &str))] = &[
     ("STM32H50.*:SYSCFG:.*", ("syscfg", "h50", "SYSCFG")),
     ("STM32H5.*:SYSCFG:.*", ("syscfg", "h5", "SYSCFG")),
     ("STM32N6.*:SYSCFG:.*", ("syscfg", "n6", "SYSCFG")),
+    ("STM32C5.*:IWDG:.*", ("iwdg", "c5", "IWDG")),
     (".*:IWDG:iwdg1_v1_1", ("iwdg", "v1", "IWDG")),
     (".*:IWDG:iwdg1_v2_0", ("iwdg", "v2", "IWDG")),
     (".*:IWDG:iwdg1_v3_0", ("iwdg", "v3", "IWDG")),


### PR DESCRIPTION
## Summary

- add a `perimap-keys` CLI for looking up peripheral metadata
- support legacy CubeDB XML files
- support STM32C5 CubeProgrammer DB2 JSON files
- map STM32C5 device families to their descriptor files
- normalize, sort, and deduplicate generated perimap keys
- document the tool and perimap key format in the README

This makes it easier to determine the metadata used by
`peripheral_config_mapping` entries without manually searching the source
database files.

## Testing

- `cargo check --bin perimap-keys`
- `cargo clippy --bin perimap-keys -- -D warnings`
- tested RTC lookup for STM32C5, STM32C0, and STM32U5
- tested peripheral-type lookup with STM32C5 ADC