### PR TITLE
stm32c5: add lptim1 register mapping

### DIFF
--- a/stm32-data-gen/src/perimap.rs
+++ b/stm32-data-gen/src/perimap.rs
@@ -623,6 +623,7 @@ const PERIMAP: &[(&str, (&str, &str, &str))] = &[
     ("STM32WB0[67].*:TIM1:.*", ("timer", "v3", "TIM_GP32")),
     ("STM32[CGHUW].*:HRTIM1?:.*", ("hrtim", "v1", "HRTIM")),
     // LPTIM for STM32Gx/Hx/Ux/Wx (and Cx) serials
+    ("STM32C5.*:LPTIM1:.*", ("lptim", "v2a", "LPTIM")),
     ("STM32U0.*:LPTIM.*:.*", ("lptim", "v2b", "LPTIM")),
     ("STM32(H5|U3|U5|WBA).*:LPTIM[12356]:.*", ("lptim", "v2a", "LPTIM")),
     ("STM32N6.*:LPTIM.*:.*", ("lptim", "n6", "LPTIM")),


### PR DESCRIPTION
## Summary

- map all STM32C5 LPTIM1 instances to the existing `lptim/v2a` `LPTIM` register block
- reuse the common two-channel layout shared by all STM32C5 devices
- avoid adding a redundant C5-specific register definition

The STM32C5 SVD files use different names for the input-capture and output-compare alternate views, but their register offsets and field layouts are identical across the family.

## Testing

- `cargo fmt --all -- --check`
- `cargo test --workspace`
- `cargo run --release --bin stm32-data-gen`
- `cargo run --release --bin stm32-metapac-gen`
- `cargo check --manifest-path build/stm32-metapac/Cargo.toml --features stm32c531kc --target thumbv8m.main-none-eabihf`
- verified that all 80 STM32C5 chip definitions map LPTIM1 to `lptim/v2a/LPTIM`