### PR TITLE
l4plus: add power control register 5

### DIFF
--- a/data/registers/pwr_l4.yaml
+++ b/data/registers/pwr_l4.yaml
@@ -46,6 +46,10 @@ block/PWR:
       stride: 8
     byte_offset: 36
     fieldset: PCR
+  - name: CR5
+    description: Power control register 5
+    byte_offset: 128
+    fieldset: CR5
 fieldset/CR1:
   description: Power control register 1
   fields:
@@ -157,6 +161,13 @@ fieldset/CR4:
   - name: VBRS
     description: VBAT battery charging resistor selection
     bit_offset: 9
+    bit_size: 1
+fieldset/CR5:
+  description: Power control register 5
+  fields:
+  - name: R1MODE
+    description: Main regulator range 1 mode
+    bit_offset: 8
     bit_size: 1
 fieldset/PCR:
   description: Power Port pull control register


### PR DESCRIPTION
stm32l4+ requires cr5 to be written to to go above 80Mhz. This commit adds a duplicate pwer_l4.yml but with cr5 added