### PR TITLE
n6: fix HSE div2 clock source select

### DIFF
--- a/data/registers/rcc_n6.yaml
+++ b/data/registers/rcc_n6.yaml
@@ -7235,11 +7235,11 @@ fieldset/DIVLPENSR:
 fieldset/HSECFGR:
   description: RCC HSE configuration register.
   fields:
-  - name: HSEDIV2BYP
-    description: HSE div2 oscillator clock in Bypass mode.
+  - name: HSEDIV2SEL
+    description: HSE div2 clock source select.
     bit_offset: 6
     bit_size: 1
-    enum: HSEDIVBYP
+    enum: HSEDIV2SEL
   - name: HSECSSON
     description: HSE clock security system (CSS) enable.
     bit_offset: 7
@@ -10917,14 +10917,14 @@ enum/HSECSSRA:
   - name: RE_ARM
     description: Writing 1 generates a re-arm pulse for the HSECSS function.
     value: 1
-enum/HSEDIVBYP:
+enum/HSEDIV2SEL:
   bit_size: 1
   variants:
-  - name: DIV2
-    description: 'HSE: hse_div2_osc_ck = hse_osc_ck/2 (default after reset).'
-    value: 0
   - name: DIV1
-    description: 'HSE: hse_div2_osc_ck = hse_osc_ck.'
+    description: 'HSE: hse_div2_osc_ck = hse_osc_ck (default after reset).'
+    value: 0
+  - name: DIV2
+    description: 'HSE: hse_div2_osc_ck = hse_osc_ck/2.'
     value: 1
 enum/HSEDRV:
   bit_size: 2


### PR DESCRIPTION
this is needed for https://github.com/embassy-rs/embassy/pull/6951
this is largely done with AI but I did try to verify all its claims myself.

`rcc_n6.yaml` transcribes `RCC_HSECFGR` bit 6 from the ST SVD, which calls it
`HSEDIV2BYP` ("HSE div2 oscillator clock in Bypass mode") and documents value 0 as
`hse_div2_osc_ck = hse_osc_ck/2`. Every other ST source for this part disagrees on both
the name and the polarity:

- **RM0486 rev 4**, §14.10.14 *RCC HSE configuration register (RCC_HSECFGR)*, offset
  0x54, reset 0x0000 0800 — bit 6 `HSEDIV2SEL`, "HSE div2 clock source select":
  > 0: HSE: hse_div2_osc_ck = hse_osc_ck (default after reset)
  > 1: HSE: hse_div2_osc_ck = hse_osc_ck/2

  <https://www.st.com/resource/en/reference_manual/rm0486-stm32n6x5x7xx-armbased-32bit-mcus-stmicroelectronics.pdf>

- **CMSIS device header** — [`cmsis-device-n6`, `Include/stm32n657xx.h#L26439-L26441`](https://github.com/STMicroelectronics/cmsis-device-n6/blob/81fe2fe8d576ec4c55be308ac4504bd580e498e6/Include/stm32n657xx.h#L26439-L26441):
  ```c
  #define RCC_HSECFGR_HSEDIV2SEL   RCC_HSECFGR_HSEDIV2SEL_Msk   /*!< HSE div2 clock source select */

- LL driver — stm32n6xx-hal-driver, Inc/stm32n6xx_ll_rcc.h#L1746-L1774 (https://github.com/STMicroelectronics/stm32n6xx-hal-driver/blob/d88071ed0adc1991a5daed6f20ab311f80bb33b7/Inc/stm32n6xx_ll_rcc.h#L1746-L1774)
  is unambiguous about the polarity:
/* Select the HSE as hse_div2_osc_ck output clock */
LL_RCC_HSE_SelectHSEAsDiv2Clock(void)     { CLEAR_BIT(RCC->HSECFGR, RCC_HSECFGR_HSEDIV2SEL); }
/* Select the HSE divided by 2 as hse_div2_osc_ck output clock */
LL_RCC_HSE_SelectHSEDiv2AsDiv2Clock(void) { SET_BIT(RCC->HSECFGR, RCC_HSECFGR_HSEDIV2SEL); }

So the SVD is the outlier: clearing bit 6 selects the undivided oscillator output, and
that is the reset state.

This renames the field and its enum to HSEDIV2SEL and swaps the two variants so DIV1
is value 0, matching the neighbouring HSIDIV enum in the same file (DIV1 = 0 =
hsi_ck = hsi_osc_ck).