### PR TITLE
Add dedicated flash registers for STM32F1 XL-density devices

### DIFF
--- a/data/registers/flash_f1_xl.yaml
+++ b/data/registers/flash_f1_xl.yaml
@@ -1,0 +1,229 @@
+block/FLASH:
+  description: FLASH
+  items:
+  - name: ACR
+    description: Flash access control register
+    byte_offset: 0
+    fieldset: ACR
+  - name: KEYR
+    description: Flash key register
+    byte_offset: 4
+    access: Write
+  - name: OPTKEYR
+    description: Flash option key register
+    byte_offset: 8
+    access: Write
+  - name: SR
+    description: Status register
+    byte_offset: 12
+    fieldset: SR
+  - name: CR
+    description: Control register
+    byte_offset: 16
+    fieldset: CR
+  - name: AR
+    description: Flash address register
+    byte_offset: 20
+    access: Write
+    fieldset: AR
+  - name: OBR
+    description: Option byte register
+    byte_offset: 28
+    access: Read
+    fieldset: OBR
+  - name: WRPR
+    description: Write protection register
+    byte_offset: 32
+    access: Read
+    fieldset: WRPR
+  - name: KEYR2
+    description: Bank 2 key register
+    byte_offset: 68
+    access: Write
+  - name: SR2
+    description: Bank 2 status register
+    byte_offset: 76
+    fieldset: SR
+  - name: CR2
+    description: Bank 2 control register
+    byte_offset: 80
+    fieldset: CR2
+  - name: AR2
+    description: Bank 2 address register
+    byte_offset: 84
+    access: Write
+    fieldset: AR
+fieldset/ACR:
+  description: Flash access control register
+  fields:
+  - name: LATENCY
+    description: Latency
+    bit_offset: 0
+    bit_size: 3
+    enum: LATENCY
+  - name: HLFCYA
+    description: Flash half cycle access enable
+    bit_offset: 3
+    bit_size: 1
+  - name: PRFTBE
+    description: Prefetch buffer enable
+    bit_offset: 4
+    bit_size: 1
+  - name: PRFTBS
+    description: Prefetch buffer status
+    bit_offset: 5
+    bit_size: 1
+fieldset/AR:
+  description: Flash address register
+  fields:
+  - name: FAR
+    description: Flash Address
+    bit_offset: 0
+    bit_size: 32
+fieldset/CR:
+  description: Control register
+  fields:
+  - name: PG
+    description: Programming
+    bit_offset: 0
+    bit_size: 1
+  - name: PER
+    description: Page Erase
+    bit_offset: 1
+    bit_size: 1
+  - name: MER
+    description: Mass Erase
+    bit_offset: 2
+    bit_size: 1
+  - name: OPTPG
+    description: Option byte programming
+    bit_offset: 4
+    bit_size: 1
+  - name: OPTER
+    description: Option byte erase
+    bit_offset: 5
+    bit_size: 1
+  - name: STRT
+    description: Start
+    bit_offset: 6
+    bit_size: 1
+  - name: LOCK
+    description: Lock
+    bit_offset: 7
+    bit_size: 1
+  - name: OPTWRE
+    description: Option bytes write enable
+    bit_offset: 9
+    bit_size: 1
+  - name: ERRIE
+    description: Error interrupt enable
+    bit_offset: 10
+    bit_size: 1
+  - name: EOPIE
+    description: End of operation interrupt enable
+    bit_offset: 12
+    bit_size: 1
+fieldset/CR2:
+  description: Bank 2 control register
+  fields:
+  - name: PG
+    description: Programming
+    bit_offset: 0
+    bit_size: 1
+  - name: PER
+    description: Page erase
+    bit_offset: 1
+    bit_size: 1
+  - name: MER
+    description: Bank 2 mass erase
+    bit_offset: 2
+    bit_size: 1
+  - name: STRT
+    description: Start erase
+    bit_offset: 6
+    bit_size: 1
+  - name: LOCK
+    description: Bank 2 lock
+    bit_offset: 7
+    bit_size: 1
+  - name: ERRIE
+    description: Error interrupt enable
+    bit_offset: 10
+    bit_size: 1
+  - name: EOPIE
+    description: End of operation interrupt enable
+    bit_offset: 12
+    bit_size: 1
+fieldset/OBR:
+  description: Option byte register
+  fields:
+  - name: OPTERR
+    description: Option byte error
+    bit_offset: 0
+    bit_size: 1
+  - name: RDPRT
+    description: Read protection
+    bit_offset: 1
+    bit_size: 1
+  - name: WDG_SW
+    description: WDG_SW
+    bit_offset: 2
+    bit_size: 1
+  - name: nRST_STOP
+    description: nRST_STOP
+    bit_offset: 3
+    bit_size: 1
+  - name: nRST_STDBY
+    description: nRST_STDBY
+    bit_offset: 4
+    bit_size: 1
+  - name: BFB2
+    description: Boot from bank 1 when set; otherwise check bank 2 before bank 1
+    bit_offset: 5
+    bit_size: 1
+  - name: Data0
+    description: Data0
+    bit_offset: 10
+    bit_size: 8
+  - name: Data1
+    description: Data1
+    bit_offset: 18
+    bit_size: 8
+fieldset/SR:
+  description: Status register
+  fields:
+  - name: BSY
+    description: Busy
+    bit_offset: 0
+    bit_size: 1
+  - name: PGERR
+    description: Programming error. Cleared by writing 1.
+    bit_offset: 2
+    bit_size: 1
+  - name: WRPRTERR
+    description: Write protection error. Cleared by writing 1.
+    bit_offset: 4
+    bit_size: 1
+  - name: EOP
+    description: End of operation. Cleared by writing 1.
+    bit_offset: 5
+    bit_size: 1
+fieldset/WRPR:
+  description: Write protection register
+  fields:
+  - name: WRP
+    description: Write protect
+    bit_offset: 0
+    bit_size: 32
+enum/LATENCY:
+  bit_size: 3
+  variants:
+  - name: WS0
+    description: Zero wait state, if 0 < SYSCLK≤ 24 MHz
+    value: 0
+  - name: WS1
+    description: One wait state, if 24 MHz < SYSCLK ≤ 48 MHz
+    value: 1
+  - name: WS2
+    description: Two wait states, if 48 MHz < SYSCLK ≤ 72 MHz
+    value: 2

--- a/stm32-data-gen/src/perimap.rs
+++ b/stm32-data-gen/src/perimap.rs
@@ -469,6 +469,7 @@ const PERIMAP: &[(&str, (&str, &str, &str))] = &[
     ("STM32H7(A3|B3|B0).*:FLASH:.*", ("flash", "h7ab", "FLASH")),
     ("STM32H7.*:FLASH:.*", ("flash", "h7", "FLASH")),
     ("STM32F0.*:FLASH:.*", ("flash", "f0", "FLASH")),
+    ("STM32F10[13].[FG].*:FLASH:.*", ("flash", "f1_xl", "FLASH")),
     ("STM32F1.*:FLASH:.*", ("flash", "f1", "FLASH")),
     ("STM32F2.*:FLASH:.*", ("flash", "f2", "FLASH")),
     ("STM32F3.*:FLASH:.*", ("flash", "f3", "FLASH")),


### PR DESCRIPTION
Map STM32F101xF/G and STM32F103xF/G to flash_f1_xl. Add the bank 2 key, status, control and address registers, along with the BFB2 option status bit. Document the write-one-to-clear status flags.

Reference: ST PM0068 Rev 2, STM32F10xxx XL-density Flash programming, Section 2.5 and Sections 3.9-3.12.

https://www.st.com/resource/en/programming_manual/pm0068-stm32f10xxx-xldensity-flash-programming-stmicroelectronics.pdf