### PR TITLE
u3: add PKA to STM32U375

### DIFF
--- a/data/extra/STM32U3.yaml
+++ b/data/extra/STM32U3.yaml
@@ -30,3 +30,15 @@ peripherals:
       kind: dlyb
       version: v1
       block: DLYB
+  # U375 has PKA but the CubeDB XML and CMSIS header omit it. Values are taken
+  # from the U385, which is the same die with PKA present.
+  # RCC attaches by name from rcc_u3.yaml. The core vector is added in interrupts.rs.
+  - name: PKA
+    address: 0x420C2000
+    registers:
+      kind: pka
+      version: v1b
+      block: PKA
+    interrupts:
+      - signal: GLOBAL
+        interrupt: PKA

--- a/stm32-data-gen/src/interrupts.rs
+++ b/stm32-data-gen/src/interrupts.rs
@@ -127,6 +127,13 @@ impl ChipInterrupts {
             }
         }
 
+        // U375 has PKA but the CubeDB XML and CMSIS header omit it. The peripheral is
+        // added in data/extra/STM32U3.yaml. Add its core vector, taken from the U385
+        // (same die with PKA present).
+        if chip_name.starts_with("STM32U375") {
+            header_irqs.entry("PKA".to_string()).or_insert(97);
+        }
+
         core.interrupts = header_irqs
             .iter()
             .map(|(k, v)| stm32_data_serde::chip::core::Interrupt {


### PR DESCRIPTION
stm32u375 has the PKA peripheral its missing in the xmls. This commit adds the PKA peripheral and its core interrupt vector for the u375. The values were copied from u385.