### PR TITLE
stm32-data-gen: add `sdmmc2_v1_1` to `PERIMAP`

### DIFF
--- a/stm32-data-gen/src/perimap.rs
+++ b/stm32-data-gen/src/perimap.rs
@@ -432,6 +432,7 @@ const PERIMAP: &[(&str, (&str, &str, &str))] = &[
     ("STM32WB.*:CRS:.*", ("crs", "v1", "CRS")),
     ("STM32C5.*:CRS:.*", ("crs", "v1", "CRS")),
     (".*SDMMC:sdmmc2_v1_0.*", ("sdmmc", "v2", "SDMMC")),
+    (".*SDMMC:sdmmc2_v1_1.*", ("sdmmc", "v2", "SDMMC")),
     (".*SDMMC:sdmmc2_v2_1.*", ("sdmmc", "v2", "SDMMC")),
     (".*SDMMC:sdmmc2_v3_0.*", ("sdmmc", "v3", "SDMMC")),
     ("STM32C0.*:PWR:.*", ("pwr", "c0", "PWR")),


### PR DESCRIPTION
`STM32L4R9A(G-I)Ix.xml` uses `sdmmc2_v1_1_Cube` version for SDMMC, which was not present in `PERIMAP`, which caused `SDMMC1` in `stm32-metapac` to be `*mut ()` for the MCUs covered by that XML.

Fixes https://github.com/embassy-rs/stm32-data/issues/870